### PR TITLE
Updated web-config-server/README.md to reflect requirements on windows

### DIFF
--- a/packages/web-config-server/README.md
+++ b/packages/web-config-server/README.md
@@ -24,7 +24,11 @@ The project requires importing an initial database dump. This can be obtained fr
 on Slack. Import the dump by running:
 
 ```bash
-psql tupaia -U tupaia < tupaia_dump.sql
+yarn refresh-database tupaia_dump.sql
+```
+or on windows, first DROP and recreate the tupaia database, then run:
+```bash
+psql -U tupaia < tupaia_dump.sql
 ```
 
 ## Development


### PR DESCRIPTION
Updated the default database creation steps to use the `refresh-database` yarn task. Since this command currently does not work on windows, added custom steps for windows.

### Changes:
- packages/web-config-server/README.md