### PR TITLE
Delete unsupportedTypes when it becomes out of sync

### DIFF
--- a/packages/database/.vscode/settings.json
+++ b/packages/database/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cSpell.words": ["upsert"]
+}

--- a/packages/meditrak-server/src/database/DatabaseType.js
+++ b/packages/meditrak-server/src/database/DatabaseType.js
@@ -140,4 +140,9 @@ export class DatabaseType {
       this.id = records[0].id;
     }
   }
+
+  /**
+   * Template method
+   */
+  async afterUpsert() {}
 }

--- a/packages/meditrak-server/src/database/models/MeditrakDevice.js
+++ b/packages/meditrak-server/src/database/models/MeditrakDevice.js
@@ -9,6 +9,13 @@ import { TYPES } from '..';
 
 export class MeditrakDeviceType extends DatabaseType {
   static databaseType = TYPES.MEDITRAK_DEVICE;
+
+  async afterUpsert() {
+    if (this.app_version && this.config.unsupportedTypes) {
+      delete this.config.unsupportedTypes;
+      await this.save();
+    }
+  }
 }
 
 export class MeditrakDeviceModel extends DatabaseModel {


### PR DESCRIPTION
Final PR for https://github.com/beyondessential/meditrak-server/issues/512

`unsupportedTypes` becomes out of sync when the app version is identified for a device.

This is a detail, and from one hand perhaps not worth the risk of refactoring critical methods of `DatabaseModel`. But on the other hand, this kind of functionality is new and may prove useful in other future occurrences.