### PR TITLE
tupaia-backlog/15: Env var for disabling sync with DHIS2

### DIFF
--- a/packages/meditrak-server/src/dhis/syncWithDhis.js
+++ b/packages/meditrak-server/src/dhis/syncWithDhis.js
@@ -43,8 +43,12 @@ export async function startSyncWithDhis(models) {
     }
   });
 
-  // Start recursive sync loop
-  syncWithDhis(models, syncQueue);
+  // Start recursive sync loop (enabled by default)
+  if (process.env.DHIS_SYNC_DISABLE === 'true') {
+    console.log("DHIS2 sync is disabled")
+  } else {
+    syncWithDhis(models, syncQueue);
+  }
 }
 
 async function syncWithDhis(models, syncQueue) {


### PR DESCRIPTION
Added env var 'DHIS_SYNC_DISABLE' to toggle disabling the sync with DHIS2

### Issue 15 : [meditrak-server] Task: Add .env variable for disabling the DHIS2 sync