### PR TITLE
remove all value_metadata instances and always use name_metadata

### DIFF
--- a/packages/web-config-server/src/apiV1/dataBuilders/generic/percentage/percentagesOfEventCounts.js
+++ b/packages/web-config-server/src/apiV1/dataBuilders/generic/percentage/percentagesOfEventCounts.js
@@ -52,7 +52,7 @@ export class PercentagesOfEventCountsBuilder extends DataBuilder {
       return {
         name,
         value: divideValues(numerator, denominator),
-        value_metadata: {
+        [`${name}_metadata`]: {
           numerator,
           denominator,
         },

--- a/packages/web-config-server/src/apiV1/dataBuilders/generic/percentage/percentagesOfValueCounts.js
+++ b/packages/web-config-server/src/apiV1/dataBuilders/generic/percentage/percentagesOfValueCounts.js
@@ -44,8 +44,10 @@ export class PercentagesOfValueCountsBuilder extends DataBuilder {
       const data = {
         value: divideValues(numerator, denominator),
         name,
-        numerator,
-        denominator,
+        [`${name}_metadata`]: {
+          numerator,
+          denominator,
+        },
       };
 
       dataClasses.push(data);

--- a/packages/web-frontend/src/components/View/ChartWrapper/PieChart.js
+++ b/packages/web-frontend/src/components/View/ChartWrapper/PieChart.js
@@ -173,7 +173,7 @@ export class PieChart extends PureComponent {
 
     const textAnchor = isLabelOnRight ? 'start' : 'end';
     const valueTypeForLabel = labelType || valueType;
-    const metadataForLabel = data.find(m => m.name === name).value_metadata;
+    const metadataForLabel = data.find(m => m.name === name)[`${name}_metadata`];
 
     return (
       <g>

--- a/packages/web-frontend/src/components/View/ChartWrapper/Tooltip.js
+++ b/packages/web-frontend/src/components/View/ChartWrapper/Tooltip.js
@@ -55,7 +55,9 @@ const MultiValueTooltip = ({
 
 const SingleValueTooltip = ({ valueType, payload, periodGranularity, labelType }) => {
   const data = payload[0].payload;
-  const { name, value, timestamp, value_metadata: metadata } = data;
+  const { name, value, timestamp } = data;
+  const metadata = data[`${name}_metadata`];
+
   const valueTypeForLabel = labelType || valueType;
 
   return (

--- a/packages/web-frontend/src/components/View/SingleValueWrapper.js
+++ b/packages/web-frontend/src/components/View/SingleValueWrapper.js
@@ -26,14 +26,15 @@ import { formatDataValue } from '../../utils';
 
 export class SingleValueWrapper extends PureComponent {
   render() {
-    const { name, valueType, value, total, value_metadata } = this.props.viewContent;
+    const { name, valueType, value, total } = this.props.viewContent;
+    const metadata = this.props.viewContent[`${name}_metadata`];
     const { style } = this.props;
 
     return (
       <div style={VIEW_STYLES.viewContainer}>
         <div style={VIEW_STYLES.title}>{name}</div>
         <div style={{ ...VIEW_STYLES.data, ...(style ? style : {}) }}>
-          {formatDataValue(value, valueType, { ...value_metadata, total })}
+          {formatDataValue(value, valueType, { ...metadata, total })}
         </div>
       </div>
     );


### PR DESCRIPTION
### Issue #: https://github.com/beyondessential/tupaia-backlog/issues/30

### Changes:

- Instead of using value_metadata for single value reports, just always use name_metadata for consistency across the codebase

---

### Screenshots:

Relevant screenshots for this PR can be found here: https://github.com/beyondessential/tupaia-backlog/issues/30#issuecomment-682397493
