### PR TITLE
add dump.sql to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 *.pem
 codeship_deploy_key.pub
 codeship_deploy_key
+dump.sql


### PR DESCRIPTION
### Issue #: N/A

### Changes:

- add dump downloaded by new script to .gitignore so doesn't have to move/delete it after running script

---

### Screenshots:
