### PR TITLE
Do not capture coverage in test script

### DIFF
--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "build": "babel src --out-dir dist --copy-files --ignore '**/migrations'",
-    "test": "nyc --reporter=lcov mocha",
+    "test": "mocha",
     "migrate": "babel-node ./src/migrate.js up --migrations-dir ./src/migrations -v",
     "migrate-down": "babel-node ./src/migrate.js  down --migrations-dir ./src/migrations -v",
     "migrate-create": "read -p \"Enter migration name: \" MIGRATION_NAME && babel-node ./src/migrate.js create ${MIGRATION_NAME} --migrations-dir ./src/migrations -v",

--- a/packages/meditrak-server/package.json
+++ b/packages/meditrak-server/package.json
@@ -75,7 +75,7 @@
   },
   "scripts": {
     "lint": "eslint --ext .js  --ignore-pattern __tests__/",
-    "test": "nyc --reporter=lcov mocha",
+    "test": "mocha",
     "test-coverage": "nyc mocha",
     "build": "babel-node src -s -D dist",
     "prestart": "npm run -s build",

--- a/packages/web-config-server/package.json
+++ b/packages/web-config-server/package.json
@@ -13,7 +13,7 @@
     "start-dev": "npm run -s dev",
     "start-verbose": "LOG_LEVEL=debug npm run start-dev",
     "prestart": "npm run -s build",
-    "test": "nyc --reporter=lcov mocha",
+    "test": "mocha",
     "test-coverage": "nyc mocha",
     "validate": "babel-node scripts/validate/index.js"
   },


### PR DESCRIPTION
Because it adds a lot of overhead. `yarn test-coverage` should be used instead