### PR TITLE
[URGENT PROD CRASH] use value instead of name for single tooltip metadata

### DIFF
--- a/packages/web-frontend/src/components/View/ChartWrapper/Tooltip.js
+++ b/packages/web-frontend/src/components/View/ChartWrapper/Tooltip.js
@@ -56,7 +56,7 @@ const MultiValueTooltip = ({
 const SingleValueTooltip = ({ valueType, payload, periodGranularity, labelType }) => {
   const data = payload[0].payload;
   const { name, value, timestamp } = data;
-  const metadata = data[`${name}_metadata`];
+  const metadata = data.value_metadata;
 
   const valueTypeForLabel = labelType || valueType;
 


### PR DESCRIPTION
### Issue #: https://github.com/beyondessential/tupaia-backlog/issues/41

### Changes:

- single value tooltips always use 'value' not the 'name' 

---

### Screenshots:
