### PR TITLE
TB-35: Fix for frontend crash when highlighting pie charts in PEHS dashboard

### DIFF
--- a/packages/web-frontend/src/components/View/ChartWrapper/PieChart.js
+++ b/packages/web-frontend/src/components/View/ChartWrapper/PieChart.js
@@ -124,7 +124,7 @@ export class PieChart extends PureComponent {
       };
 
   renderActiveShape = props => {
-    const { valueType, labelType, data } = this.props.viewContent;
+    const { valueType, labelType } = this.props.viewContent;
     const {
       cx,
       cy,
@@ -134,9 +134,9 @@ export class PieChart extends PureComponent {
       startAngle,
       endAngle,
       fill,
-      percent,
       value,
       name,
+      originalItem,
     } = props;
 
     const RADIAN = Math.PI / 180;
@@ -173,7 +173,7 @@ export class PieChart extends PureComponent {
 
     const textAnchor = isLabelOnRight ? 'start' : 'end';
     const valueTypeForLabel = labelType || valueType;
-    const metadataForLabel = data.find(m => m.name === name)[`${name}_metadata`];
+    const metadataForLabel = originalItem[`${name}_metadata`];
 
     return (
       <g>


### PR DESCRIPTION
This issue was a funny one. A very simple fix, there was a lookup we were performing that error-ed out when it failed to find anything. The fix was to use an existing reference to the object we were looking for instead of searching for it.

However I didn't quite understand why the lookup was failing for these charts, so I did a little bit of digging. It seems as though the unexpected behaviour was caused by a little bit of logic in `src/components/View/ChartWrapper/PieChart.js#getValidData`. In that function we make a check for:
```
let label = this.getPresentationOption(name, 'label');
if (!label) label = name;
```

This check renames each data element being passed to the `PieChart` component to its corresponding `label` in the `presentationOptions` if present. The PEHS charts have `label`s defined in their `presentationOptions`, whereas other pie charts do not. I believe any charts with `label`s configured in their `presentationOptions` would have had this same crash.

### Issue [#35: Pie chart drill down crashes site](https://github.com/beyondessential/tupaia-backlog/issues/35):

### Changes:
- Removed loop over existing data to find original item which caused crash when searching for wrong key