### PR TITLE
66: Added versioning for export-chart-lamba

### DIFF
--- a/packages/export-chart-lambda/README.md
+++ b/packages/export-chart-lambda/README.md
@@ -6,21 +6,38 @@ Lambda function for exporting charts from Tupaia.
 
 The lambda is in [our aws lambda configurations](https://ap-southeast-2.console.aws.amazon.com/lambda/home?region=ap-southeast-2#/functions/export-charts-v2) with the name `export-charts-v2`.
 
-It runs happily with the following settings:  
+It runs happily with the following settings:
+
 1. Execution role - chart-exporter
 2. Runtime - Node.js12.x
 3. Handler - index.handler
 4. Memory - 1024 MB
 5. Timeout - 5 mins
 
-In order to update the lambda code, run `yarn package` from this package's root directory and upload the package.zip via the [aws lambda function web-console](https://ap-southeast-2.console.aws.amazon.com/lambda/home?region=ap-southeast-2#/functions/export-charts-v2)
-
-
 **Lambda Layers**  
-The lambda is also configured with the following layers:  
+The lambda is also configured with the following layers:
+
 | Merge order | Name              | Layer version | Version ARN                                                          |
 | ----------- | ----------------- | ------------- | -------------------------------------------------------------------- |
 | 1           | chrome-aws-lambda | 8             | arn:aws:lambda:ap-southeast-2:764866452798:layer:chrome-aws-lambda:8 |
 | 2           | ghostscript       | 1             | arn:aws:lambda:ap-southeast-2:764866452798:layer:ghostscript:1       |
 
 These layers provide the chrome and ghostscript binaries to run the core logic of the lambda code.
+
+## Development
+
+In order to update the lambda code, make your code changes here in this package. Once changes are complete, run `yarn package` from this package's root directory and upload the package.zip via the [aws lambda function web-console](https://ap-southeast-2.console.aws.amazon.com/lambda/home?region=ap-southeast-2#/functions/export-charts-v2).
+
+You can also edit the code directly within the [aws lambda function web-console](https://ap-southeast-2.console.aws.amazon.com/lambda/home?region=ap-southeast-2#/functions/export-charts-v2), however you must ensure that the code base here is kept in sync with whatever the lambda code is.
+
+In order to get tupaia to make use of the code changes you made, switch the lamba version the web-config-server uses to `'$LATEST'`
+
+**Versioning**  
+Before merging into dev, you must create a new lambda version for the code changes you've made. Do this by:
+
+1. For our internal tracking, update the version in this package's package.json file (eg. '1.0.0' => '1.0.1')
+2. Run `yarn package` and upload the latest package.zip to the [aws lambda function web-console](https://ap-southeast-2.console.aws.amazon.com/lambda/home?region=ap-southeast-2#/functions/export-charts-v2)
+3. In the [aws lambda function web-console](https://ap-southeast-2.console.aws.amazon.com/lambda/home?region=ap-southeast-2#/functions/export-charts-v2), create a new version (Actions -> Publish new version) and give it a description containing the new package version (eg. 'v1.0.0: Export Chart Lambda')
+4. In the web-config-server (and anywhere else that makes use of this lambda) update the lamba version (note: this is assigned by aws and does not match the version we use in package.json)
+5. Push these changes up to your feature branch, and you're ready to merge  
+   Note: A lamba version's code cannot be changed after its creation, so ensure that you have code approval before creating the version.

--- a/packages/web-config-server/src/export/exportChartScreenshot.js
+++ b/packages/web-config-server/src/export/exportChartScreenshot.js
@@ -4,6 +4,12 @@ import winston from 'winston';
 const AWS_LAMBDA_CONFIG = {
   region: 'ap-southeast-2',
   apiVersion: '2015-03-31',
+  lambdaName: 'export-charts-v2',
+
+  // The specific lambda version to use. For testing changes to the lamba code you may set it to '$LATEST'.
+  // However DO NOT commit '$LATEST' to dev/master!!! Create a new lamba version with your code instead.
+  // See @tupaia/export-chart-lamba package for more information on lamba development and versioning.
+  lambdaVersion: '1',
 };
 
 /*
@@ -15,7 +21,7 @@ export const exportChartScreenshot = async (
   sessionValue,
   email,
 ) => {
-  const { region, apiVersion } = AWS_LAMBDA_CONFIG;
+  const { region, apiVersion, lambdaName, lambdaVersion } = AWS_LAMBDA_CONFIG;
 
   AWS.config.update({ region });
 
@@ -36,7 +42,7 @@ export const exportChartScreenshot = async (
   const chartUrl = `${process.env.EXPORT_URL}/${exportUrl}`;
   winston.info(`Exporting chart ${exportUrl}`);
   const pullParams = {
-    FunctionName: 'export-charts-v2',
+    FunctionName: `${lambdaName}:${lambdaVersion}`,
     InvocationType: 'Event',
     LogType: 'None',
     Payload: JSON.stringify({


### PR DESCRIPTION
### Issue [#66: Add: versioning for export-chart-lamba](https://github.com/beyondessential/tupaia-backlog/issues/66)

Added lamba versioning so that we can work on the export-chart-lamba without breaking prod. Mainly want a review of the versioning process outlined in https://github.com/beyondessential/tupaia/compare/66-export-chart-lambda-versioning?expand=1#diff-45527db97264c26fec51541052ac3f60

Does this seem workable?