### PR TITLE
Update to allow survey import againt world

### DIFF
--- a/packages/meditrak-server/src/dhis/ChangeValidator.js
+++ b/packages/meditrak-server/src/dhis/ChangeValidator.js
@@ -2,6 +2,7 @@
  * Tupaia MediTrak
  * Copyright (c) 2019 Beyond Essential Systems Pty Ltd
  */
+import { ENTITY_TYPES } from '../database/models/Entity';
 
 export class ChangeValidator {
   constructor(models) {
@@ -31,9 +32,7 @@ export class ChangeValidator {
       const answer = await this.models.answer.findOne({ id: change.record_id });
       if (!answer) {
         throw new Error(
-          `No answer found matching change record with record id ${
-            change.record_id
-          }, it has probably been updated then deleted in quick succession`,
+          `No answer found matching change record with record id ${change.record_id}, it has probably been updated then deleted in quick succession`,
         );
       }
       surveyResponse = await this.models.surveyResponse.findOne({ id: answer.survey_response_id });
@@ -46,7 +45,10 @@ export class ChangeValidator {
     const { integration_metadata: integrationMetadata } = survey;
     if (!integrationMetadata.dhis2) return false;
 
-    const { id: countryId } = await surveyResponse.country();
+    // If the survey is logging data against world we don't need to check demo land
+    const surveyEntity = await surveyResponse.entity();
+    if (surveyEntity.type === ENTITY_TYPES.WORLD) return true;
+    const { id: countryId } = await surveyEntity.country();
 
     const demoLand = await this.models.country.findOne({ name: 'Demo Land' });
     const publicPermissionGroup = await this.models.permissionGroup.findOne({ name: 'Public' });

--- a/packages/meditrak-server/src/ms1/startSyncWithMs1.js
+++ b/packages/meditrak-server/src/ms1/startSyncWithMs1.js
@@ -5,6 +5,7 @@
 import { get } from 'lodash';
 import { HttpError } from '@tupaia/utils';
 
+import { ENTITY_TYPES } from '../database/models/Entity';
 import { ExternalApiSyncQueue } from '../database/ExternalApiSyncQueue';
 import { Ms1Api } from './api/Ms1Api';
 import { addToSyncLog } from './addToSyncLog';
@@ -29,9 +30,13 @@ export async function startSyncWithMs1(models) {
     const surveyResponse = await models.surveyResponse.findOne({ id: change.record_id });
     if (!surveyResponse) return false;
 
-    // ditch if demoland
-    const { id: countryId } = await surveyResponse.country();
-    if (countryId === demoLand.id) return false;
+    // If the survey is logging data against world we don't need to check demo land
+    const surveyEntity = await surveyResponse.entity();
+    if (surveyEntity.type !== ENTITY_TYPES.WORLD) {
+      // ditch if demoland
+      const { id: countryId } = await surveyEntity.country();
+      if (countryId === demoLand.id) return false;
+    }
 
     // Get survey record
     const survey = await models.survey.findById(surveyResponse.survey_id);


### PR DESCRIPTION
### Issue #:
https://github.com/beyondessential/tupaia-backlog/issues/46

### Changes:
This is a small change to allow survey imports against World. The initial survey still needs to logged against a country - this only works when importing surveys from the admin pael

Have tested the data gets to dhis2 and can be retrieved and displayed in a data builder after that
