### PR TITLE
Switch Bonriki East Facility over to using MS1 API instead of DHIS

### DIFF
--- a/packages/database/src/migrations/20200207044948-AddBonrikiEastToMs1Api.js
+++ b/packages/database/src/migrations/20200207044948-AddBonrikiEastToMs1Api.js
@@ -16,14 +16,14 @@ exports.setup = function(options, seedLink) {
 
 exports.up = function(db) {
   return db.runSql(`
-    UPDATE entity SET metadata = '{"ms1": {"distributionId": "2516"}}'
+    UPDATE entity SET metadata = jsonb_set(metadata, '{ms1}', '{"distributionId": "2516"}')
       WHERE code = 'KI_BonE02';
   `);
 };
 
 exports.down = function(db) {
   return db.runSql(`
-    UPDATE entity SET metadata = '{"dhis": {"isDataRegional": true}}'
+    UPDATE entity SET metadata = metadata::jsonb - 'ms1'
       WHERE code = 'KI_BonE02';
   `);
 };


### PR DESCRIPTION
### Issue https://github.com/beyondessential/ms1-api/issues/14:

Fairly simple migration to change the datasource for Bonriki East to the MS1 api

Distribution ID was taken directly from the Production MS1 Database