### PR TITLE
Fix to allow for 'w' in branch names again

### DIFF
--- a/packages/devops/configs/servers.conf
+++ b/packages/devops/configs/servers.conf
@@ -203,7 +203,7 @@ server {
 
   listen       443 ssl;
   listen       [::]:443 ssl;
-  server_name  tupaia.org www.tupaia.org ~^(?<subdomain>.[^www]+)\.tupaia\.org$;
+  server_name  tupaia.org www.tupaia.org ~^(?<subdomain>((?!^www).)+)\.tupaia\.org$;
   root         /home/ubuntu/tupaia/packages/web-frontend/builds/desktop;
   set $mobile_rewrite do_not_perform;
   set $hostred '';


### PR DESCRIPTION
### Issue https://github.com/beyondessential/tupaia-backlog/issues/64

Fixed up the regex in servers.conf to allow for 'w's in branch names. Now we should only disallow branches with 'www' in the start of their name.