### PR TITLE
Avoid change time conflicts in large sync queue updates

### DIFF
--- a/packages/database/src/migrations/20200129211641-AvoidChangeTimeConflicts.js
+++ b/packages/database/src/migrations/20200129211641-AvoidChangeTimeConflicts.js
@@ -16,7 +16,8 @@ exports.setup = function(options, seedLink) {
 
 exports.up = function(db) {
   return db.runSql(`
-    ALTER SEQUENCE change_time_seq
+    ALTER SEQUENCE public.change_time_seq
+    START 100
     MINVALUE 100; -- because we use this as a decimal, 1 - 99 clash with later values e.g. 0.200 = 0.20 = 0.2
 
     CREATE OR REPLACE FUNCTION public.update_change_time() RETURNS trigger


### PR DESCRIPTION
There were two issues:
- Despite change_time_seq giving us a three digit number, we were only dividing by 100, so it was overwriting the final digit of the timestamp before the decimal, leaving only two decimal places, and not giving us as much precision as expected
- Because it is used as a decimal, any trailing 0 was being cut off change_time_seq, meaning there were potential clashes between e.g. 0.9, 0.90, 0.900
