### PR TITLE
Convert dhis sync log data from dataElement to code for survey responses

### DIFF
--- a/packages/database/src/migrations/20200122003753-ConvertDataElementToCodeInSyncLog.js
+++ b/packages/database/src/migrations/20200122003753-ConvertDataElementToCodeInSyncLog.js
@@ -19,7 +19,8 @@ exports.up = function(db) {
     UPDATE dhis_sync_log
     SET data = REPLACE(data, '"dataElement":', '"code":')
     WHERE data IS NOT NULL
-    AND record_type = 'answer' OR record_type = 'survey_response';
+    AND (record_type = 'answer' OR record_type = 'survey_response')
+    AND dhis_reference IS NULL;
   `);
 };
 
@@ -28,7 +29,8 @@ exports.down = function(db) {
     UPDATE dhis_sync_log
     SET data = REPLACE(data, '"code":', '"dataElement":')
     WHERE data IS NOT NULL
-    AND record_type = 'answer' OR record_type = 'survey_response';
+    AND (record_type = 'answer' OR record_type = 'survey_response')
+    AND dhis_reference IS NULL;
   `);
 };
 


### PR DESCRIPTION
Fixes the errors I was seeing for "delete" pushes. They were actually deletes caused by updates to survey responses, which was trying to delete the old BCD1SurveyDate data value from dhis2 BUT BCD1SurveyDate was stored under "dataElement" rather than "code" in the sync log