### PR TITLE
Use the start of 2017 for the default period

### DIFF
--- a/packages/web-config-server/src/dhis/getDefaultPeriod.js
+++ b/packages/web-config-server/src/dhis/getDefaultPeriod.js
@@ -1,7 +1,7 @@
 import { utcMoment } from '@tupaia/utils';
 import { convertDateRangeToPeriods } from '@tupaia/dhis-api';
 
-export const EARLIEST_DATA_DATE = utcMoment('2017-05-03'); // First survey submitted to Tupaia
+export const EARLIEST_DATA_DATE = utcMoment('2017-01-01'); // Tupaia started in 2017
 const MAXIMUM_MONTHS_TO_LOOK_BACK = 60; // Last 5 years
 
 // Assemble a default date range using monthly granularity.


### PR DESCRIPTION
Now we push data using different period types, annual data from 2017 wasn't being picked up using a period that started 03/05/2017

Addressing https://github.com/beyondessential/tupaia-backlog/issues/107#issuecomment-589885499