### PR TITLE
Remove `record` from function signature in notification

### DIFF
--- a/packages/meditrak-server/src/database/models/MeditrakDevice.js
+++ b/packages/meditrak-server/src/database/models/MeditrakDevice.js
@@ -17,12 +17,12 @@ export class MeditrakDeviceModel extends DatabaseModel {
   }
 }
 
-const onUpsertSanitizeConfig = async (change, record, models) => {
+const onUpsertSanitizeConfig = async (change, models) => {
   if (change.type === 'delete') {
     return;
   }
 
-  const meditrakDevice = await models.meditrakDevice.findById(record.id);
+  const meditrakDevice = await models.meditrakDevice.findById(change.record_id);
   if (meditrakDevice.app_version && meditrakDevice.config.unsupportedTypes) {
     delete meditrakDevice.config.unsupportedTypes;
     await meditrakDevice.save();


### PR DESCRIPTION
A bug I noticed when testing something else
