### PR TITLE
Use codes for org units in immsFridgeBreaches

### DIFF
--- a/packages/web-config-server/src/preaggregation/preaggregators/immsFridgeBreaches.js
+++ b/packages/web-config-server/src/preaggregation/preaggregators/immsFridgeBreaches.js
@@ -84,7 +84,7 @@ class FridgeBreachAggregator {
   }
 
   /**
-   * @param {Event[]} events A collection of events with `uid` used as organisation unit identifier
+   * @param {Event[]} events A collection of events
    * @returns {EventData[]}
    */
   async aggregate(events) {
@@ -152,18 +152,16 @@ class FridgeBreachAggregator {
       {
         programCodes: [FRIDGE_DAILY_PROGRAM_CODE],
         organisationUnitCode: WORLD,
-        orgUnitIdScheme: 'uid',
-        period: 'LAST_5_YEARS;THIS_YEAR',
       },
     );
     const analyticsByOrgUnit = groupBy(results, 'organisationUnit');
 
     const temperaturesByOrgUnit = {};
-    Object.entries(analyticsByOrgUnit).forEach(([orgUnitId, analyticsForOrgUnit]) => {
-      temperaturesByOrgUnit[orgUnitId] = {};
+    Object.entries(analyticsByOrgUnit).forEach(([orgUnitCode, analyticsForOrgUnit]) => {
+      temperaturesByOrgUnit[orgUnitCode] = {};
 
       analyticsForOrgUnit.forEach(({ dataElement: dataElementCode, value }) => {
-        temperaturesByOrgUnit[orgUnitId][dataElementCode] = value;
+        temperaturesByOrgUnit[orgUnitCode][dataElementCode] = value;
       });
     });
 
@@ -304,10 +302,7 @@ class AggregatedEventPusher {
 }
 
 const getEvents = async (aggregator, programCode) =>
-  aggregator.fetchEvents(programCode, {
-    organisationUnitCode: WORLD,
-    orgUnitIdScheme: 'uid',
-  });
+  aggregator.fetchEvents(programCode, { organisationUnitCode: WORLD });
 
 export const immsFridgeBreaches = async (aggregator, dhisApi) => {
   winston.info(`Starting to aggregate ${AGGREGATION_NAME}`);


### PR DESCRIPTION
D'oh, I should've followed your advice and changed org unit to code! Turns out it wasn't just nicer code, it was necessary code - the orgUnitIdScheme wasn't being respected on `fetchAnalytics` (nor, it turns out, is `period` - `fetchAnalytics` expects a start and end date when fetching for events.)

Part of https://github.com/beyondessential/tupaia-backlog/issues/107#issuecomment-590159781