### PR TITLE
Lazy instantiate change channel

### DIFF
--- a/packages/database/src/TupaiaDatabase.js
+++ b/packages/database/src/TupaiaDatabase.js
@@ -95,6 +95,7 @@ export class TupaiaDatabase {
   }
 
   async waitForChangeChannel() {
+    this.getOrCreateChangeChannel();
     return this.changeChannelPromise;
   }
 


### PR DESCRIPTION
Addressing https://github.com/beyondessential/tupaia-backlog/issues/125

Prior to merging our large set of changes recently, a new `pubsub` connection was only established for a database that was constructed without a `transactingConnection`. Recently I refactored how `pubsub` gets handled, and it was being created with every db, even those that used a transacting connection (i.e. temporary TupaiaDatabase instances meant to run inside a transaction), and never being closed.

This PR initialises the changeChannel even more lazily than it was in the past, meaning we don't make unnecessary pubsub connections, either during transactions or in places where TupaiaDatabase is used without needing change detection (i.e. web-config-server, which is currently also making a pubsub connection for no reason at all.)