### PR TITLE
Safety check on entity.parent_id

### DIFF
--- a/packages/meditrak-server/src/dhis/pushers/entity/OrganisationUnitPusher.js
+++ b/packages/meditrak-server/src/dhis/pushers/entity/OrganisationUnitPusher.js
@@ -160,7 +160,7 @@ export class OrganisationUnitPusher extends EntityPusher {
         constructGroupDetails,
         organisationUnitId,
       );
-      ancestor = await this.models.entity.findById(ancestor.parent_id);
+      ancestor = ancestor.parent_id && (await this.models.entity.findById(ancestor.parent_id));
     }
 
     // Add to the facility type organisation unit group for the country


### PR DESCRIPTION
Happened to see this throwing errors for countries that are inside the Pacific (and so include World in the while loop, which has no parent id)
