### PR TITLE
Only connect to pubsub for singleton models

### DIFF
--- a/packages/database/src/ModelRegistry.js
+++ b/packages/database/src/ModelRegistry.js
@@ -12,7 +12,7 @@ export class ModelRegistry {
   constructor(database, modelClasses) {
     this.database = database;
     this.modelClasses = modelClasses;
-    this.generateModels(database.isSingleton);
+    this.generateModels();
   }
 
   closeDatabaseConnections() {
@@ -25,15 +25,14 @@ export class ModelRegistry {
     return this.database.connectionPromise;
   }
 
-  generateModels(isSingleton) {
+  generateModels() {
     // Add models
     Object.entries(this.modelClasses).forEach(([modelName, ModelClass]) => {
       // Create a singleton instance of each model, passing through the change handler if there is
       // one statically defined on the ModelClass and this is the singleton (non transacting)
       // database instance
-      const onChange = isSingleton ? ModelClass.onChange : null;
       const modelKey = getModelKey(modelName);
-      this[modelKey] = new ModelClass(this.database, onChange);
+      this[modelKey] = new ModelClass(this.database);
     });
     // Inject other models into each model
     Object.keys(this.modelClasses).forEach(modelName => {


### PR DESCRIPTION
We were still making more db connections than we needed

This was an existing issue for the Answer and SurveyResponse models (those with an `onChange`), but my recent addition of the cache highlighted it by making every model require a pubsub connection.