### PR TITLE
Fix UI bug affecting heatmap map overlay legend and added no data legend

### DIFF
--- a/packages/web-frontend/src/components/Marker/markerColors.js
+++ b/packages/web-frontend/src/components/Marker/markerColors.js
@@ -6,10 +6,10 @@
  */
 
 import moment from 'moment';
-import { BREWER_PALETTE } from '../../styles';
+import { BREWER_PALETTE, MAP_COLORS } from '../../styles';
 import { SCALE_TYPES } from '../../utils/measures';
 
-const HEATMAP_UNKNOWN_COLOR = '#000';
+const HEATMAP_UNKNOWN_COLOR = MAP_COLORS.NO_DATA;
 /**
  * Helper function just to point the spectrum type to the correct colours
  *
@@ -22,14 +22,17 @@ const HEATMAP_UNKNOWN_COLOR = '#000';
  * @returns {style} css hsl string, e.g. `hsl(value, 100%, 50%)`
  */
 export function resolveSpectrumColour(scaleType, value, min, max, noDataColour) {
+  if (value === null || (isNaN(value) && scaleType !== SCALE_TYPES.TIME))
+    return noDataColour || HEATMAP_UNKNOWN_COLOR;
+
   switch (scaleType) {
     default:
       return getHeatmapColor(value && normaliseToPercentage(value, min, max));
     case SCALE_TYPES.PERFORMANCE:
-      return getPerformanceHeatmapColor(value, noDataColour);
+      return getPerformanceHeatmapColor(value);
     case SCALE_TYPES.PERFORMANCE_DESC: {
       const percentage = value || value === 0 ? 1 - normaliseToPercentage(value, min, max) : null;
-      return getPerformanceHeatmapColor(percentage, noDataColour);
+      return getPerformanceHeatmapColor(percentage);
     }
     case SCALE_TYPES.TIME:
       // if the value passed is a date locate it in the [min, max] range
@@ -48,8 +51,7 @@ const normaliseToPercentage = (value, min, max) => {
  * @param {number} value Number in range [0..1] representing percentage
  * @returns {style} css hsl string, e.g. `hsl(value, 100%, 50%)`
  */
-export function getPerformanceHeatmapColor(value, noDataColour) {
-  if (value === null) return noDataColour || HEATMAP_UNKNOWN_COLOR;
+export function getPerformanceHeatmapColor(value) {
   return `hsl(${Math.floor(value * 100)}, 100%, 50%)`;
 }
 
@@ -81,7 +83,6 @@ export function getTimeHeatmapColor(value, noDataColour) {
  * @returns {style} css rgb string, e.g. `rgb(0,0,0)`
  */
 export function getHeatmapColor(value) {
-  if (value === null) return HEATMAP_UNKNOWN_COLOR;
   let rgb = [0, 0, 0];
 
   if (value < 0.15) rgb = [255, 255, 204];


### PR DESCRIPTION
### Issue https://github.com/beyondessential/tupaia-backlog/issues/142:

2 changes:
1. Fixed bug where countries with certain data (flattenedMeasureData of all 0s) displayed a heatmap scale from 0 to 0 by hard coding minimum and maximum for performance scales to 0 and 1 respectively.
2. Added No data legend icon for performance scale.

### Changes:

- Example: https://github.com/beyondessential/tupaia-backlog/issues/142#issuecomment-682375909

---

### Screenshots:
