### PR TITLE
Allow region import

### DIFF
--- a/packages/meditrak-server/src/routes/importEntities/updateOrganisationUnitsFromSheet.js
+++ b/packages/meditrak-server/src/routes/importEntities/updateOrganisationUnitsFromSheet.js
@@ -75,7 +75,7 @@ export async function updateOrganisationUnitsFromSheet(transactingModels, countr
       image_url: imageUrl,
       longitude,
       latitude,
-      region,
+      geojson,
       type_name: typeName,
       category_code: categoryCode,
       facility_type: facilityType,
@@ -132,8 +132,8 @@ export async function updateOrganisationUnitsFromSheet(transactingModels, countr
     if (longitude && latitude) {
       await transactingModels.entity.updatePointCoordinates(code, { longitude, latitude });
     }
-    if (region) {
-      await transactingModels.entity.updateRegionCoordinates(code, JSON.parse(region));
+    if (geojson) {
+      await transactingModels.entity.updateRegionCoordinates(code, JSON.parse(geojson));
     }
   }
   return country;


### PR DESCRIPTION
Allows the implementation of [133 - Update PG village regions](https://github.com/beyondessential/tupaia-backlog/issues/133)

Specs: a region must be specified in the entity import spreadsheet. Its contents should be in GeoJson format

Example spreadsheet here: https://github.com/beyondessential/tupaia-backlog/issues/133#issuecomment-682373812

