### PR TITLE
172: hotfix no meditrak device id error

### DIFF
--- a/packages/meditrak-server/src/database/models/RefreshToken.js
+++ b/packages/meditrak-server/src/database/models/RefreshToken.js
@@ -9,7 +9,9 @@ class RefreshTokenType extends DatabaseType {
   static databaseType = TYPES.REFRESH_TOKEN;
 
   async meditrakDevice() {
-    return this.otherModels.meditrakDevice.findById(this.meditrak_device_id);
+    return (
+      this.meditrak_device_id && this.otherModels.meditrakDevice.findById(this.meditrak_device_id)
+    );
   }
 }
 


### PR DESCRIPTION
### Issue #:

https://github.com/beyondessential/tupaia-backlog/issues/172

### Changes:
* Do not assume that a `meditrak_device_id` will be stored for every `refresh_token`. This should be true for new logins after https://github.com/beyondessential/meditrak-server/issues/512 is implemented, but not for older logins.
