### PR TITLE
Don't initialise sum with 0

### DIFF
--- a/packages/aggregator/src/analytics/aggregateAnalytics/aggregations/sumEachDataElement.js
+++ b/packages/aggregator/src/analytics/aggregateAnalytics/aggregations/sumEachDataElement.js
@@ -13,7 +13,11 @@
 export const sumEachDataElement = analytics => {
   const sumsPerDataElement = {};
   analytics.forEach(({ dataElement, value }) => {
-    sumsPerDataElement[dataElement] = (sumsPerDataElement[dataElement] || 0) + value;
+    if (!sumsPerDataElement[dataElement]) {
+      sumsPerDataElement[dataElement] = value; // we set to value rather than 0 as sometimes it is a text value
+    } else {
+      sumsPerDataElement[dataElement] += value;
+    }
   });
   return Object.entries(sumsPerDataElement).map(([dataElement, value]) => ({ dataElement, value }));
 };


### PR DESCRIPTION
As it's sometimes used for text, e.g. https://github.com/beyondessential/tupaia-backlog/issues/182#issuecomment-597418463

Another option would be to switch to a different aggregation type for that report, rather than SUM_MOST_RECENT_PER_FACILITY (which is currently set for all tableOfDataValues reports). However, there may be more instances of this that we haven't caught, and this is certainly the easiest solution.