### PR TITLE
Fix undefined org unit issue

### DIFF
--- a/packages/web-frontend/src/reducers/orgUnitReducers.js
+++ b/packages/web-frontend/src/reducers/orgUnitReducers.js
@@ -37,11 +37,11 @@ export const cachedSelectOrgUnitAndDescendants = createCachedSelector(
   [state => state, (_, code) => code],
   (state, code) => {
     const orgUnit = selectOrgUnit(state, code);
-    const children = cachedSelectOrgUnitChildren(state, code);
-    if (children.length < 1) {
-      return [orgUnit];
+    if (!orgUnit) {
+      return [];
     }
 
+    const children = cachedSelectOrgUnitChildren(state, code);
     const descendants = children.reduce(
       (array, child) => [
         ...array,


### PR DESCRIPTION
Fixes an issue which arises if an `orgUnit` is undefined. Maybe this is a smell for something else going on, although in the specific instance where I encountered the bug, the selected orgUnit was eventually loaded. Hopefully it's just a concurrency issue.

Normally I would investigate this further but I am not that familiar with this new section of the code