### PR TITLE
205 Fix null data latestAchievedVsTargetPercentage databuilder

### DIFF
--- a/packages/web-config-server/src/apiV1/dataBuilders/generic/comparison/latestAchievedVsTargetPercentage.js
+++ b/packages/web-config-server/src/apiV1/dataBuilders/generic/comparison/latestAchievedVsTargetPercentage.js
@@ -20,6 +20,7 @@ export const latestAchievedVsTargetPercentage = async (
       target: 0,
     },
   );
+  if (totals.target === 0) return { data: [] };
 
   const percentAchieved = totals.achieved / totals.target;
   const percentRemainder = 1 - percentAchieved;


### PR DESCRIPTION
### Issue #:
https://github.com/beyondessential/tupaia-backlog/issues/205

You were correct Andrew :). What you said was exactly the issue.

### Changes:
For the latestAchievedVsTargetPercentage databuilder, return no data if the denominator is 0.

