### PR TITLE
Use percentage string input directly

### DIFF
--- a/packages/web-frontend/src/utils/formatters.js
+++ b/packages/web-frontend/src/utils/formatters.js
@@ -52,6 +52,11 @@ const boolean = (value, { presentationOptions = {} }) => {
 };
 
 const percentage = value => {
+  // eslint-disable-next-line no-restricted-globals
+  if (isNaN(value)) {
+    return value;
+  }
+
   const percentageValue = value * 100;
 
   let decimalPrecision = 0;


### PR DESCRIPTION
### Issue #:
Addresses the `NaN` issue here: https://github.com/beyondessential/tupaia-backlog/issues/218#issuecomment-602278979

### Changes:

Allows us to render a string value  as a percentage (useful for rendering "No data" or other custom values that the back end would possibly return)

### Screenshots:

Relevant screenshots for this PR can be found here: https://github.com/beyondessential/tupaia-backlog/issues/218#issuecomment-682367316