### PR TITLE
Add COVID19 DashboardGroups to Australia

### DIFF
--- a/packages/database/src/migrations/20200324032850-AddCOVID19DashboardgroupsAusNationalState.js
+++ b/packages/database/src/migrations/20200324032850-AddCOVID19DashboardgroupsAusNationalState.js
@@ -35,7 +35,7 @@ exports.up = function(db) {
       'Public',
       'AU',
       'COVID-19',
-      'AU_Covid_National'
+      'AU_Covid_Country'
     );`,
   );
 };
@@ -44,7 +44,7 @@ exports.down = function(db) {
   return db.runSql(`
     DELETE FROM "dashboardGroup" 
     WHERE "code" = 'AU_Covid_Province' 
-    OR "code" = 'AU_Covid_National';
+    OR "code" = 'AU_Covid_Country';
   `);
 };
 


### PR DESCRIPTION
### Issue #:
No issue.

This PR adds COVID19 DashboardGroups to Australia for both national and state level