### PR TITLE
Limit yaxis of bar percentage graph to 100%

### DIFF
--- a/packages/web-frontend/src/components/View/ChartWrapper/CartesianChart.js
+++ b/packages/web-frontend/src/components/View/ChartWrapper/CartesianChart.js
@@ -263,7 +263,7 @@ export class CartesianChart extends PureComponent {
         key={yAxisId}
         yAxisId={yAxisId}
         orientation={orientation}
-        domain={[0, 'auto']}
+        domain={valueType === PERCENTAGE ? [0, 'dataMax'] : [0, 'auto']}
         allowDataOverflow={valueType === PERCENTAGE}
         // The above 2 props stop floating point imprecision making Y axis go above 100% in stacked charts.
         label={data.yName}


### PR DESCRIPTION
### Issue #:
https://github.com/beyondessential/tupaia-backlog/issues/104
