### PR TITLE
 remove unnecessary safety check causing bug

### DIFF
--- a/packages/web-frontend/src/sagas.js
+++ b/packages/web-frontend/src/sagas.js
@@ -672,11 +672,6 @@ function* fetchMeasureInfo(measureId, organisationUnitCode, oldOrganisationUnitC
     // Don't try and fetch null measures
     yield put(cancelFetchMeasureData());
 
-    if (!organisationUnitCode) {
-      // if we've selected a null unit (somehow) clear out the measure hierarchy as well
-      yield put(clearMeasureHierarchy());
-    }
-
     return;
   }
 


### PR DESCRIPTION
### Issue #: https://github.com/beyondessential/tupaia-backlog/issues/291

### Changes:

Removed safety check causing this bug. The safety check is unnecessary as if you select a measure before the country has loaded, it will correctly display that measure once it has loaded, and the edge case where a user selects a measure and then changes org unit to an org unit that doesn't have the selected measure (all before the original country has loaded), is also taken care of by the default measure logic, which just swaps back to the default measure if it can't find the requested one.
---

### Screenshots:
