### PR TITLE
Ensure dev is pulled if spun up from a branch that doesn't exist

### DIFF
--- a/packages/devops/scripts/deployment/deployLatestRepositories.sh
+++ b/packages/devops/scripts/deployment/deployLatestRepositories.sh
@@ -18,10 +18,10 @@ fi
 # Get latest code and dependencies
 echo "Checking out ${BRANCH}, or dev if that doesn't exist"
 cd ${HOME_DIRECTORY}
-git fetch
-git checkout dev # Ensure we have dev as our default, if the specified branch doesn't exist
-git checkout $BRANCH
 git fetch --all
+git checkout dev # Ensure we have dev as our default, if the specified branch doesn't exist
+git reset --hard origin/dev
+git checkout $BRANCH # Now try the requested branch
 git reset --hard origin/${BRANCH}
 yarn install
 


### PR DESCRIPTION
@avaek had an issue where he tried to spin up a deployment based on a branch that didn't exist (on purpose, so that he could test something based on dev but not using dev.tupaia.org), but it didn't deploy properly. The reason was that it didn't check out the latest dev, but a really old version.