### PR TITLE
339: No longer spreading state array each time we insert orgUnit

### DIFF
--- a/packages/web-frontend/src/reducers/orgUnitReducers.js
+++ b/packages/web-frontend/src/reducers/orgUnitReducers.js
@@ -70,7 +70,8 @@ const insertOrgUnit = (state, orgUnit) => {
     return state;
   }
 
-  return { ...state, [orgUnit.organisationUnitCode]: orgUnit };
+  state[orgUnit.organisationUnitCode] = orgUnit;
+  return state;
 };
 
 const addOrgUnitToMap = (state, orgUnit) => {


### PR DESCRIPTION
### Issue https://github.com/beyondessential/tupaia-backlog/issues/339:

One line change but a world of difference. Previously, we spread the entire orgUnitMap for each insert we performed. This could be ~5000 times (for an object which may contain >20,000 key/values).

Now we only spread once at the start (in order to create a new object for this to be a pure function), then we just insert into that object and return.

Performance improvement 500x-1000x faster

Further improvement would be to break the orgUnitMap into per-country sections, and only operate on one given country at a time.