### PR TITLE
555: Fixed a small issue when browser size is reduced, the title covers

### DIFF
--- a/packages/web-frontend/src/styles/index.js
+++ b/packages/web-frontend/src/styles/index.js
@@ -241,7 +241,7 @@ export const DASHBOARD_STYLES = {
     opacity: 0.5,
   },
   floatingHeader: {
-    position: 'fixed',
+    position: 'absolute',
     background: DARK_BLUE,
     boxSizing: 'border-box',
     color: WHITE,


### PR DESCRIPTION
     the map in tupaia

### Issue #:
https://github.com/beyondessential/tupaia-web/issues/555

### Changes:
I changed the floating header title position from 'fixed' to 'absolute' so that it is always positioned relatively to the dashboard, not the whole window (which I think caused the issue). Hope this is the right fix...

---

### Screenshots:
Relevant screenshots for this PR can be found here: https://github.com/beyondessential/tupaia-web/issues/555#issuecomment-682313225
