### PR TITLE
1137: changed external link in disaster response modal

### DIFF
--- a/packages/web-frontend/src/containers/OverlayDiv/components/Disaster.js
+++ b/packages/web-frontend/src/containers/OverlayDiv/components/Disaster.js
@@ -134,7 +134,7 @@ class Disaster extends Component {
      */
     const tupaiaResource = {
       title: `${location} Disaster Response Information`,
-      url: `https://info.tupaia.org/disaster-response-${countryCode}/`,
+      url: 'https://sdd.spc.int/disasters-data',
     };
 
     return (


### PR DESCRIPTION
### Issue #:
https://github.com/beyondessential/tupaia-web/issues/1137

### Changes:

- Changed the external link in disaster response modal

---

### Screenshots:
