### PR TITLE
Fix wrong Aggregator tests

### DIFF
--- a/packages/aggregator/src/tests/Aggregator/Aggregator.test.js
+++ b/packages/aggregator/src/tests/Aggregator/Aggregator.test.js
@@ -67,10 +67,10 @@ describe('Aggregator', () => {
 
     it('`aggregationOptions` parameter is optional', async () => {
       const assertErrorIsNotThrown = async emptyAggregationOptions =>
-        expect(aggregator.fetchAnalytics('POP01', fetchOptions, emptyAggregationOptions)).to
-          .eventually.not.be.rejected;
+        expect(aggregator.fetchAnalytics('POP01', fetchOptions, emptyAggregationOptions)).to.not.be
+          .rejected;
 
-      return Promise.all([undefined, null, {}].map(assertErrorIsNotThrown));
+      return Promise.all([undefined, {}].map(assertErrorIsNotThrown));
     });
 
     it('supports string code input', async () => {
@@ -107,16 +107,20 @@ describe('Aggregator', () => {
       );
     });
 
-    it('returns a response with processed results, metadata and the provided period', async () => {
+    it('returns a response with processed results, metadata and period data', async () => {
       const { metadata } = RESPONSE_BY_SOURCE_TYPE[DATA_ELEMENT];
       const period = '20160214';
 
-      expect(
+      return expect(
         aggregator.fetchAnalytics(['POP01', 'POP02'], { period }, aggregationOptions),
       ).to.eventually.deep.equal({
         results: FILTERED_ANALYTICS,
         metadata,
-        period,
+        period: {
+          earliestAvailable: '20200214',
+          latestAvailable: '20200214',
+          requested: '20160214',
+        },
       });
     });
   });


### PR DESCRIPTION
No card for this, just realized those tests are wrong (false negatives) while working on something else.

We must be very careful when writing tests for async functionality so that we don't write tests that don't actually run. I guess using a TDD approach helps against that, since you see your tests fail first, and then you  have to make them pass.