### PR TITLE
428: Fix org unit permissions not updating on user login/logout

### DIFF
--- a/packages/web-frontend/src/reducers/orgUnitReducers.js
+++ b/packages/web-frontend/src/reducers/orgUnitReducers.js
@@ -7,7 +7,13 @@
 
 import { combineReducers } from 'redux';
 
-import { FETCH_ORG_UNIT, FETCH_ORG_UNIT_SUCCESS, FETCH_ORG_UNIT_ERROR } from '../actions';
+import {
+  FETCH_ORG_UNIT,
+  FETCH_ORG_UNIT_SUCCESS,
+  FETCH_ORG_UNIT_ERROR,
+  FETCH_LOGIN_SUCCESS,
+  FETCH_LOGOUT_SUCCESS,
+} from '../actions';
 
 function orgUnitMap(state = {}, action) {
   switch (action.type) {
@@ -17,6 +23,10 @@ function orgUnitMap(state = {}, action) {
       return addOrgUnitToMap(state, action.organisationUnit);
     case FETCH_ORG_UNIT_ERROR:
       return updateLoading(state, action.organisationUnitCode, false);
+    case FETCH_LOGIN_SUCCESS:
+      return {}; // Clear org units on login incase of permission change
+    case FETCH_LOGOUT_SUCCESS:
+      return {}; // Clear org units on logout incase of permission change
     default: {
       return state;
     }
@@ -25,6 +35,8 @@ function orgUnitMap(state = {}, action) {
 
 function orgUnitFetchError(state = '', action) {
   switch (action.type) {
+    case FETCH_ORG_UNIT_SUCCESS:
+      return '';
     case FETCH_ORG_UNIT_ERROR:
       return action.errorMessage;
     default:

--- a/packages/web-frontend/src/sagas.js
+++ b/packages/web-frontend/src/sagas.js
@@ -895,26 +895,15 @@ function* watchAttemptAttemptDrillDown() {
   yield takeLatest(ATTEMPT_DRILL_DOWN, fetchDrillDownData);
 }
 
-function* updatePermissionsToMatchUser() {
-  // Update the location navigation hierarchy to match countries available to this user
-  yield put(fetchOrgUnit({ organisationUnitCode: 'World' }));
-
-  // Refresh current organisation unit so that dashboards, measures etc. will
-  // match current user permissions
-  const state = yield select();
-  const { currentOrganisationUnit } = state.global;
-  const { organisationUnitCode } = currentOrganisationUnit;
-
-  // By default the current organisation does not have an org unit code as it
-  // is an empty object, so must not be loaded.
-  if (organisationUnitCode) {
-    yield put(changeOrgUnit(organisationUnitCode, false));
-  }
+function* navigateToWorldOnUserChange() {
+  // On user login/logout, we should just navigate back to world, as we don't know if they have permissions
+  // to the currently selected orgUnit
+  yield put(changeOrgUnit('World', true));
 }
 
 function* watchUserChangesAndUpdatePermissions() {
-  yield takeLatest(FETCH_LOGOUT_SUCCESS, updatePermissionsToMatchUser);
-  yield takeLatest(FETCH_LOGIN_SUCCESS, updatePermissionsToMatchUser);
+  yield takeLatest(FETCH_LOGOUT_SUCCESS, navigateToWorldOnUserChange);
+  yield takeLatest(FETCH_LOGIN_SUCCESS, navigateToWorldOnUserChange);
 }
 
 function* fetchEnlargedDialogViewContentForPeriod(action) {

--- a/packages/web-frontend/src/selectors.js
+++ b/packages/web-frontend/src/selectors.js
@@ -161,7 +161,13 @@ export const selectAllMeasuresWithDisplayInfo = createSelector(
     state => state.map.measureInfo.hiddenMeasures,
   ],
   (country, measureData, currentCountry, measureLevel, measureOptions, hiddenMeasures) => {
-    if (!measureLevel || !currentCountry || !measureData || currentCountry === 'World') {
+    if (
+      !measureLevel ||
+      !currentCountry ||
+      !measureData ||
+      currentCountry === 'World' ||
+      !country
+    ) {
       return [];
     }
 


### PR DESCRIPTION
### Issue https://github.com/beyondessential/tupaia-backlog/issues/428:

The change here is to clear the orgUnitMap whenever the user logs in or out

I also chose to change the logic to navigate to 'World' upon login/logout. This helps avoid awkward UI issues that occur when the new user doesn't have or logout user doesn't have permissions to the current country. I also feel that in both cases this may be beneficial UX regardless as it makes sense that the current org unit state is cleared between sessions.
