### PR TITLE
Rename tupaia event fields to match the DHIS ones

### DIFF
--- a/packages/data-broker/.vscode/settings.json
+++ b/packages/data-broker/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "cSpell.words": ["analytics", "cleanup", "Dhis", "Tupaia"]
+  "cSpell.words": ["analytics", "cleanup", "Dhis", "eventdate", "oucode", "Tupaia"]
 }

--- a/packages/data-broker/src/services/dhis/buildAnalytics/buildAnalyticsFromDhisEventAnalytics.js
+++ b/packages/data-broker/src/services/dhis/buildAnalytics/buildAnalyticsFromDhisEventAnalytics.js
@@ -2,8 +2,10 @@
  * Tupaia
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
+
 import flatten from 'lodash.flatten';
 
+import { dateStringToPeriod } from '@tupaia/dhis-api';
 import { buildEventsFromDhisEventAnalytics } from './buildEventsFromDhisEventAnalytics';
 
 export const buildAnalyticsFromDhisEventAnalytics = (dhisEventAnalytics, dataElementCodes = []) => {
@@ -17,10 +19,10 @@ export const buildAnalyticsFromDhisEventAnalytics = (dhisEventAnalytics, dataEle
 
 const eventsToAnalytics = events =>
   flatten(
-    events.map(({ period, organisationUnit, values }) =>
-      Object.entries(values).map(([dataElement, value]) => ({
-        period,
-        organisationUnit,
+    events.map(({ eventDate, orgUnit, dataValues }) =>
+      Object.entries(dataValues).map(([dataElement, value]) => ({
+        period: dateStringToPeriod(eventDate),
+        organisationUnit: orgUnit,
         dataElement,
         value,
       })),

--- a/packages/data-broker/src/services/dhis/buildAnalytics/buildEventsFromDhisEventAnalytics.js
+++ b/packages/data-broker/src/services/dhis/buildAnalytics/buildEventsFromDhisEventAnalytics.js
@@ -3,18 +3,17 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
-import { dateStringToPeriod } from '@tupaia/dhis-api';
 import { getSortByKey } from '@tupaia/utils';
 import { sanitizeValue } from './sanitizeValue';
 
 /*
- * @typedef {{ eventId, organisationUnit, period, values: Object }} Event
+ * @typedef {{ event, orgUnit, eventDate, dataValues: Object }} Event
  */
 
 const METADATA_DIMENSION_TRANSLATION = {
-  psi: 'eventId',
-  oucode: 'organisationUnit',
-  eventdate: 'period',
+  psi: 'event',
+  oucode: 'orgUnit',
+  eventdate: 'eventDate',
 };
 
 const createDimensionTranslator = dataElementCodes => dimension => {
@@ -34,16 +33,16 @@ export const buildEventsFromDhisEventAnalytics = (dhisEventAnalytics, dataElemen
 
   const events = [];
   rows.forEach(row => {
-    const event = { values: {} };
+    const event = { dataValues: {} };
     row.forEach((value, columnIndex) => {
       const { dimension, valueType } = columnSpecs[columnIndex];
       if (!dimension) {
         return;
       }
 
-      const formattedValue = formatValue({ dimension, value, valueType });
+      const formattedValue = sanitizeValue(value, valueType);
       if (dataElementCodes.includes(dimension)) {
-        event.values[dimension] = formattedValue;
+        event.dataValues[dimension] = formattedValue;
       } else {
         event[dimension] = formattedValue;
       }
@@ -52,11 +51,8 @@ export const buildEventsFromDhisEventAnalytics = (dhisEventAnalytics, dataElemen
     events.push(event);
   });
 
-  return events.sort(getSortByKey('period'));
+  return events.sort(getSortByKey(METADATA_DIMENSION_TRANSLATION.eventdate));
 };
-
-const formatValue = ({ dimension, value, valueType }) =>
-  dimension === 'period' ? dateStringToPeriod(value) : sanitizeValue(value, valueType);
 
 const getColumnSpecs = (headers, dataElementCodes) => {
   const columnSpecs = new Array(headers.length).fill({});

--- a/packages/data-broker/src/tests/services/dhis/DhisService/testPull/testPullEvents.js
+++ b/packages/data-broker/src/tests/services/dhis/DhisService/testPull/testPullEvents.js
@@ -182,10 +182,10 @@ export const testPullEvents = () => {
     it('directly returns the buildEventsFromDhisEventAnalytics() results', () => {
       const events = [
         {
-          eventId: 'event1_dhisId',
-          period: '20200206',
-          organisationUnit: 'TO_Nukuhc',
-          values: {
+          event: 'event1_dhisId',
+          eventDate: '2020-02-06T10:18:00.000',
+          orgUnit: 'TO_Nukuhc',
+          dataValues: {
             POP01: 1,
             POP02: 2,
           },

--- a/packages/data-broker/src/tests/services/dhis/buildAnalytics/buildAnalytics.fixtures.js
+++ b/packages/data-broker/src/tests/services/dhis/buildAnalytics/buildAnalytics.fixtures.js
@@ -33,7 +33,7 @@ export const EVENT_ANALYTICS_WITH_DATA_VALUES = {
   rows: [
     [
       'event1_dhisId',
-      '2020-02-06 10:18:00.0',
+      '2020-02-06T10:18:00.000',
       'Nukunuku',
       'TO_Nukuhc',
       'nukunuku_dhisId',
@@ -42,7 +42,7 @@ export const EVENT_ANALYTICS_WITH_DATA_VALUES = {
     ],
     [
       'event2_dhisId',
-      '2020-02-07 14:33:00.0',
+      '2020-02-07T14:33:00.000',
       'Haveluloto',
       'TO_HvlMCH',
       'houma_dhisId',
@@ -74,8 +74,8 @@ export const EVENT_ANALYTICS_NO_DATA_VALUES = {
   width: 5,
   height: 2,
   rows: [
-    ['event1_dhisId', '2020-02-06 10:18:00.0', 'Nukunuku', 'TO_Nukuhc', 'nukunuku_dhisId'],
-    ['event2_dhisId', '2020-02-06 14:33:00.0', 'Haveluloto', 'TO_HvlMCH', 'houma_dhisId'],
+    ['event1_dhisId', '2020-02-06T10:18:00.000', 'Nukunuku', 'TO_Nukuhc', 'nukunuku_dhisId'],
+    ['event2_dhisId', '2020-02-07T14:33:00.000', 'Haveluloto', 'TO_HvlMCH', 'houma_dhisId'],
   ],
 };
 

--- a/packages/data-broker/src/tests/services/dhis/buildAnalytics/buildEventsFromDhisEventAnalytics.test.js
+++ b/packages/data-broker/src/tests/services/dhis/buildAnalytics/buildEventsFromDhisEventAnalytics.test.js
@@ -19,16 +19,16 @@ describe('buildEventsFromDhisEventAnalytics()', () => {
   it('builds events containing no data values', () => {
     expect(buildEventsFromDhisEventAnalytics(EVENT_ANALYTICS.noDataValues)).to.deep.equal([
       {
-        eventId: 'event1_dhisId',
-        organisationUnit: 'TO_Nukuhc',
-        period: '20200206',
-        values: {},
+        event: 'event1_dhisId',
+        orgUnit: 'TO_Nukuhc',
+        eventDate: '2020-02-06T10:18:00.000',
+        dataValues: {},
       },
       {
-        eventId: 'event2_dhisId',
-        organisationUnit: 'TO_HvlMCH',
-        period: '20200206',
-        values: {},
+        event: 'event2_dhisId',
+        orgUnit: 'TO_HvlMCH',
+        eventDate: '2020-02-07T14:33:00.000',
+        dataValues: {},
       },
     ]);
   });
@@ -38,19 +38,19 @@ describe('buildEventsFromDhisEventAnalytics()', () => {
       buildEventsFromDhisEventAnalytics(EVENT_ANALYTICS.withDataValues, ['BCD1', 'BCD2']),
     ).to.deep.equal([
       {
-        eventId: 'event1_dhisId',
-        organisationUnit: 'TO_Nukuhc',
-        period: '20200206',
-        values: {
+        event: 'event1_dhisId',
+        orgUnit: 'TO_Nukuhc',
+        eventDate: '2020-02-06T10:18:00.000',
+        dataValues: {
           BCD1: 10,
           BCD2: 'Comment 1',
         },
       },
       {
-        eventId: 'event2_dhisId',
-        organisationUnit: 'TO_HvlMCH',
-        period: '20200207',
-        values: {
+        event: 'event2_dhisId',
+        orgUnit: 'TO_HvlMCH',
+        eventDate: '2020-02-07T14:33:00.000',
+        dataValues: {
           BCD1: 20,
           BCD2: 'Comment 2',
         },

--- a/packages/web-config-server/src/apiV1/dataBuilders/generic/count/countEvents.js
+++ b/packages/web-config-server/src/apiV1/dataBuilders/generic/count/countEvents.js
@@ -26,7 +26,7 @@ import { getSortByKey } from '@tupaia/utils/dist/object';
 
 export class CountEventsBuilder extends DataBuilder {
   async build() {
-    const events = await this.fetchEvents({ dataValueFormat: 'object' });
+    const events = await this.fetchEvents({ useDeprecatedApi: false });
     const data = await this.buildData(events);
 
     return { data };

--- a/packages/web-config-server/src/apiV1/dataBuilders/generic/count/countEventsPerPeriod.js
+++ b/packages/web-config-server/src/apiV1/dataBuilders/generic/count/countEventsPerPeriod.js
@@ -30,7 +30,7 @@ class CountEventsPerPeriodBuilder extends DataPerPeriodBuilder {
   groupResultsByPeriod = groupEventsByPeriod;
 
   async fetchResults() {
-    return this.fetchEvents({ dataValueFormat: 'object' });
+    return this.fetchEvents({ useDeprecatedApi: false });
   }
 }
 


### PR DESCRIPTION
For the "Tupaia" events, I initially went for a schema like
`{ eventId, period, organisationUnit, values: {} }`
to match the Tupaia analytics schema of
`{ period, organisationUnit, dataElement, value }`

Trying to migrate existing data builders to the new event api, I realized that a lot of the existing code relies on the DHIS events schema. So I changed the "Tupaia" event schema to

`{ event, eventDate, orgUnit, dataValues: {} }`

and now they work like a charm!

---

**EDIT:** One difference would be the structure of `dataValues`. For the DHIS events, it is
```js
{
  dataValues: [
    { lastUpdated, storedBy, created, dataElement, value, providedElsewhere  }
  ]
}
```
We have added support for a custom `dataValueFormat = 'object'` parameter, so in practice we use
```js
{
  dataValues: {
    STR_CRF169: { lastUpdated, storedBy, /* ...etc */ } }
  }
}
```
Our practical experience till now has shown that we only use a data element key => value association, thus a structure like 
```js
{
  dataValues: { STR_CRF169: 1, STR_CRF165: 'Positive' }
}
```

has been used here

