### PR TITLE
project-level-view: Removed permission check for project enties

### DIFF
--- a/packages/web-config-server/src/apiV1/organisationUnit.js
+++ b/packages/web-config-server/src/apiV1/organisationUnit.js
@@ -77,7 +77,9 @@ export default class extends RouteHandler {
   async filterForAccess(entities) {
     return (
       await Promise.all(
-        entities.map(async entity => (await this.checkUserHasEntityAccess(entity)) && entity),
+        entities
+          .filter(entity => entity)
+          .map(async entity => (await this.checkUserHasEntityAccess(entity)) && entity),
       )
     ).filter(entity => entity);
   }

--- a/packages/web-config-server/src/apiV1/permissions/PermissionsChecker.js
+++ b/packages/web-config-server/src/apiV1/permissions/PermissionsChecker.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 import { PermissionsError } from '@tupaia/utils';
+import { ENTITY_TYPES } from '/models/Entity';
 
 export class PermissionsChecker {
   constructor(query, userHasAccess, entity) {
@@ -16,7 +17,15 @@ export class PermissionsChecker {
       throw new PermissionsError('Tried to access an entity that does not exist');
     }
 
-    if (this.entity.code !== 'World' && !(await this.userHasAccess(this.entity))) {
+    if (this.entity.code === 'World') {
+      return; // Don't restrict access to World
+    }
+
+    if (this.entity.type === ENTITY_TYPES.PROJECT) {
+      return; // Don't restrict access to Project entities
+    }
+
+    if (!(await this.userHasAccess(this.entity))) {
       throw new PermissionsError(`No access to selected entity ${this.entity.code}`);
     }
   }

--- a/packages/web-frontend/src/selectors.js
+++ b/packages/web-frontend/src/selectors.js
@@ -70,8 +70,8 @@ const safeGet = (cache, args) => (cache.keySelector(...args) ? cache(...args) : 
 
 const selectCountriesAsOrgUnits = createSelector([state => state.orgUnits.orgUnitMap], orgUnitMap =>
   Object.entries(orgUnitMap)
-    .map(([countryCode, countryHierarchy]) => countryHierarchy[countryCode])
-    .filter(country => country.type === 'Country'),
+    .map(([countryCode, countryHierarchy]) => getOrgUnitFromCountry(countryHierarchy, countryCode))
+    .filter(country => country && country.type === 'Country'),
 );
 
 const getOrgUnitFromMeasureData = (measureData, code) =>


### PR DESCRIPTION
After chatting about this with @edmofro we felt it would be best to remove any permission check on the project entity itself, and instead allow for the UX and data permission checks to prevent users accessing projects that they don't have access to.

From my brief testing, there doesn't seem to be a way for users to access projects they don't have access to via manually setting the URL 👍 