### PR TITLE
Skip existing data_source records

### DIFF
--- a/packages/database/.vscode/settings.json
+++ b/packages/database/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "cSpell.words": ["migrator"]
+  "cSpell.words": ["migrator", "Tupaia"]
 }

--- a/packages/database/src/migrations/20200518035909-UseTupaiaAsDataServiceForLaosSchoolsSurveys.js
+++ b/packages/database/src/migrations/20200518035909-UseTupaiaAsDataServiceForLaosSchoolsSurveys.js
@@ -36,31 +36,47 @@ const selectQuestionsBySurveyCode = async (db, surveyCode) => {
   return questions;
 };
 
-const insertDataSources = async (db, questions, surveyCode) => {
-  const dataGroupId = generateId();
+/**
+ * @return {Promise<string>} The id of the found/created record
+ */
+const findOrCreateDataSource = async (db, dataSourceData) => {
+  const dataSourceResults = await db.runSql(
+    `SELECT * FROM data_source WHERE code = '${dataSourceData.code}' AND type = '${dataSourceData.type}'`,
+  );
+  const [dataSource] = dataSourceResults.rows;
+  if (dataSource) {
+    return dataSource.id;
+  }
+
+  const dataSourceId = generateId();
   await insertObject(db, 'data_source', {
-    id: dataGroupId,
+    ...dataSourceData,
+    id: dataSourceId,
+    service_type: 'tupaia',
+  });
+
+  return dataSourceId;
+};
+
+const insertDataSources = async (db, questions, surveyCode) => {
+  const dataGroupId = await findOrCreateDataSource(db, {
     code: surveyCode,
     type: 'dataGroup',
     service_type: 'tupaia',
   });
 
-  await Promise.all(
-    questions.map(async question => {
-      const dataElementId = generateId();
-      await insertObject(db, 'data_source', {
-        id: dataElementId,
-        code: question.code,
-        type: 'dataElement',
-        service_type: 'tupaia',
-      });
-      await insertObject(db, 'data_element_data_group', {
-        id: generateId(),
-        data_element_id: dataElementId,
-        data_group_id: dataGroupId,
-      });
-    }),
-  );
+  for (let i = 0; i < questions.length; i++) {
+    const dataElementId = await findOrCreateDataSource(db, {
+      code: questions[i].code,
+      type: 'dataElement',
+      service_type: 'tupaia',
+    });
+    await insertObject(db, 'data_element_data_group', {
+      id: generateId(),
+      data_element_id: dataElementId,
+      data_group_id: dataGroupId,
+    });
+  }
 };
 
 const deleteDataSources = async (db, surveyCode) => {


### PR DESCRIPTION
Some question codes are used in more than one Laos Schools surveys (eg, `BCD29_event` is used by both `SFL` and `SWL`). This caused the existing migration to fail, since
* There is a unique `code && type` constraint for the data_source table
* The existing migration attempted to create a new record for each question in Laos Schools surveys