### PR TITLE
Process surveys one at a time

### DIFF
--- a/packages/database/src/migrations/20200518035909-UseTupaiaAsDataServiceForLaosSchoolsSurveys.js
+++ b/packages/database/src/migrations/20200518035909-UseTupaiaAsDataServiceForLaosSchoolsSurveys.js
@@ -102,12 +102,11 @@ const LAOS_SCHOOLS_SURVEY_GROUP = 'School Surveys';
 
 exports.up = async function(db) {
   const surveys = await selectSurveysBySurveyGroup(db, LAOS_SCHOOLS_SURVEY_GROUP);
-  await Promise.all(
-    surveys.map(async ({ code: surveyCode }) => {
-      const questions = await selectQuestionsBySurveyCode(db, surveyCode);
-      await insertDataSources(db, questions, surveyCode);
-    }),
-  );
+  for (let i = 0; i < surveys.length; i++) {
+    const surveyCode = surveys[i].code;
+    const questions = await selectQuestionsBySurveyCode(db, surveyCode);
+    await insertDataSources(db, questions, surveyCode);
+  }
 };
 
 exports.down = async function(db) {


### PR DESCRIPTION
Damn, I also thought of changing this but it worked at the time

New surveys are still being added too, which makes me a bit worried about the complete effectiveness of this migration. Although if no new migrations are added, I can manually run it down and up