### PR TITLE
538: Fix bugs caused by canonical hierarchy selection not returning Entity objects

### DIFF
--- a/packages/web-config-server/src/models/helpers/EntityHierarchyBuilder.js
+++ b/packages/web-config-server/src/models/helpers/EntityHierarchyBuilder.js
@@ -82,7 +82,7 @@ export class EntityHierarchyBuilder {
 
   async getDescendantsCanonically(entityId) {
     const canonicalTypes = Object.values(this.models.entity.orgUnitEntityTypes).join("','");
-    return this.models.entity.database.executeSql(
+    const results = await this.models.entity.database.executeSql(
       `
         WITH RECURSIVE descendants AS (
           SELECT *, 0 AS generation
@@ -100,5 +100,6 @@ export class EntityHierarchyBuilder {
     `,
       [entityId],
     );
+    return results.map(result => this.models.entity.load(result));
   }
 }


### PR DESCRIPTION
### Issue https://github.com/beyondessential/tupaia-backlog/issues/538:
The nonCanonical entity descendants fetch returns `Entity` objects, whereas the canonical fetch returned plain row objects. This inconsistency between canonical entity fetches and non-canonical probably caused a number of small bugs.

Truth be told the proper fix for this is to clean up all instances where descendants fetches are being performed without a hierarchy id, but that's for the future~~~