### PR TITLE
539: Fix Map Legend still displaying after switching project

### DIFF
--- a/packages/web-frontend/src/sagas.js
+++ b/packages/web-frontend/src/sagas.js
@@ -774,22 +774,18 @@ function* watchFetchMeasureSuccess() {
 }
 
 function* fetchMeasureInfoForNewOrgUnit(action) {
-  const { organisationUnitCode } = action.organisationUnit;
+  const { organisationUnitCode, countryCode } = action.organisationUnit;
   const { measureId, oldOrgUnitCountry } = yield select(state => ({
     measureId: state.map.measureInfo.measureId,
     oldOrgUnitCountry: state.map.measureInfo.currentCountry,
   }));
-  const country = yield select(selectOrgUnitCountry, organisationUnitCode);
-  const countryCode = country ? country.organisationUnitCode : undefined;
-  if (oldOrgUnitCountry) {
-    if (oldOrgUnitCountry === countryCode) {
-      // We are in the same country as before, no need to refetch measureData
-      return;
-    }
+  if (oldOrgUnitCountry === countryCode) {
+    // We are in the same country as before, no need to refetch measureData
+    return;
+  }
 
-    if (measureId) {
-      yield put(changeMeasure(measureId, organisationUnitCode));
-    }
+  if (measureId) {
+    yield put(changeMeasure(measureId, organisationUnitCode));
   }
 }
 


### PR DESCRIPTION
### Issue https://github.com/beyondessential/tupaia-backlog/issues/539:

This bug was caused as the the `currentOrganisationUnitCode` can become out of sync when changing org unit. By moving the responses to an orgUnit change to `CHANGE_ORG_UNIT_SUCCESS`, this timing issue no longer occurs. Admittedly, there is a now a bit more of a noticable starting lag when switching org units (especially to large ones like Australia or  Laos), but in turn it seems the country data itself loads a bit faster.