### PR TITLE
540: On initial load the World bounds are off centered

### DIFF
--- a/packages/web-frontend/src/defaults.js
+++ b/packages/web-frontend/src/defaults.js
@@ -12,7 +12,7 @@
  */
 
 export const initialOrgUnit = {
-  type: 'project',
+  type: 'Project',
   organisationUnitCode: 'explore',
   name: 'Explore',
   parent: {},
@@ -20,7 +20,10 @@ export const initialOrgUnit = {
     type: 'no-coordinates',
     coordinates: '',
     bounds: [
-      [6.5, 110],
+      // Note: There's a little bit of a hack going on here, the bounds[0] are actually [6.5, 110]
+      // However in order to trigger the map to re-render we set them slightly adjusted as [6.5001, 110]
+      // See: https://github.com/beyondessential/tupaia-backlog/issues/540#issuecomment-631314721
+      [6.5001, 110],
       [-40, 204.5],
     ],
   },


### PR DESCRIPTION
### Issue https://github.com/beyondessential/tupaia-backlog/issues/540#issuecomment-631238331:

In truth the real fix here should be to find out what's going wrong in the rendering/css logic that allows for the map to get the center wrong on the initial load. However, given the time constraints, this hack for the static initial project bounds to slightly not match the actual bounds should cause a re-render of the map when the project entity loads