### PR TITLE
560: Added IHR Report dashboard group to Explore project

### DIFF
--- a/packages/database/src/migrations/20200521062959-AddIHRDashboardGroupToExplore.js
+++ b/packages/database/src/migrations/20200521062959-AddIHRDashboardGroupToExplore.js
@@ -1,0 +1,33 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = async function(db) {
+  return db.runSql(`
+      INSERT INTO "dashboardGroup"("organisationLevel","userGroup","organisationUnitCode","dashboardReports","name","code")
+      VALUES
+      (E'Project',E'Public',E'explore',E'{WHO_SURVEY,WHO_IHR_SPAR_WPRO,WHO_IHR_SPAR_NST,WHO_IHR_JEE_WPRO}',E'IHR Report',E'Explore_Project_IHR_Report');
+`);
+};
+
+exports.down = function(db) {
+  return db.runSql(`
+    DELETE FROM "dashboardGroup" where "code" = 'Explore_Project_IHR_Report';
+  `);
+};
+
+exports._meta = {
+  version: 1,
+};


### PR DESCRIPTION
### Issue https://github.com/beyondessential/tupaia-backlog/issues/560:

Pretty easy fix here, seems we just forgot to include this dashboard report when migrating to `Explore`.

Note: there still exists an entry for `World` in the dashboard group table, however I didn't want to remove it right now. Created https://github.com/beyondessential/tupaia-backlog/issues/561 to deal with cleanups of `World`


Relevant screenshots for this PR can be found here: https://github.com/beyondessential/tupaia-backlog/issues/560#issuecomment-681617874
