### PR TITLE
Ignore undefined date bounds in tupaia api option translation

### DIFF
--- a/packages/data-broker/src/services/tupaia/translation.js
+++ b/packages/data-broker/src/services/tupaia/translation.js
@@ -18,7 +18,7 @@ export const translateOptionsForTupaiaDataApi = ({ period, ...restOfOptions }) =
   const [startDate, endDate] = convertPeriodStringToDateRange(period);
   return {
     ...restOfOptions,
-    // if start/end dates are also provided (and not null or undefined), favour them over period
+    // if start/end dates are also provided (and not null, undefined, or 0), favour them over period
     startDate: restOfOptions.startDate || startDate,
     endDate: restOfOptions.endDate || endDate,
   };


### PR DESCRIPTION
We convert the period into a start and end date when pulling data internally, but these start and end dates were being clobbered by incoming options that included `{ startDate: undefined, endDate: undefined }`, so actually periods weren't being respected at all!

Makes me nervous about other bugs ... if only we had time for your integration tests @kael89 (although it may have even required e2e given that the undefined date bounds were coming right from web-config-server, and it wouldn't have been an obvious case to think of testing)