### PR TITLE
Define visualisations per project

### DIFF
--- a/packages/database/src/migrations/20200522022756-VisualisationsDefinedPerProject.js
+++ b/packages/database/src/migrations/20200522022756-VisualisationsDefinedPerProject.js
@@ -1,0 +1,52 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+const LAOS_SCHOOLS_PROJECT_CODE = 'laos_schools';
+
+const addProjectCodesColumn = async (db, tableName, defaultProjectCodes) =>
+  db.runSql(`
+    ALTER TABLE "${tableName}" ADD COLUMN "projectCodes" TEXT[] DEFAULT '{}';
+
+    UPDATE "${tableName}"
+    SET "projectCodes" = '{${defaultProjectCodes.map(c => `"${c}"`).join(',')}}';
+
+    UPDATE "${tableName}"
+    SET "projectCodes" = '{"${LAOS_SCHOOLS_PROJECT_CODE}"}'
+    WHERE "userGroup" LIKE 'Laos Schools%';
+`);
+
+const removeProjectCodesColumn = async (db, tableName) =>
+  db.runSql(`
+    ALTER TABLE "${tableName}" DROP COLUMN "projectCodes";
+  `);
+
+exports.up = async function(db) {
+  const projectRecords = (await db.runSql(`SELECT code FROM project;`)).rows;
+  const projectCodesExceptLaos = projectRecords
+    .map(r => r.code)
+    .filter(c => c !== LAOS_SCHOOLS_PROJECT_CODE);
+  await addProjectCodesColumn(db, 'mapOverlay', projectCodesExceptLaos);
+  await addProjectCodesColumn(db, 'dashboardGroup', projectCodesExceptLaos);
+};
+
+exports.down = async function(db) {
+  await removeProjectCodesColumn(db, 'mapOverlay');
+  await removeProjectCodesColumn(db, 'dashboardGroup');
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/packages/web-config-server/src/apiV1/dashboard.js
+++ b/packages/web-config-server/src/apiV1/dashboard.js
@@ -6,7 +6,7 @@ export default class extends RouteHandler {
   static PermissionsChecker = PermissionsChecker;
 
   buildResponse = async () => {
-    const { entity } = this;
+    const { entity, query } = this;
     const { code: entityCode, name: entityName } = entity;
     const organisationLevel = entity.getOrganisationLevel();
     const userGroups = await this.req.getUserGroups(entityCode);
@@ -17,6 +17,7 @@ export default class extends RouteHandler {
       userGroups,
       organisationLevel,
       entity,
+      query.projectCode,
     );
 
     // Aggregate dashboardGroups into api response format

--- a/packages/web-config-server/src/apiV1/measures.js
+++ b/packages/web-config-server/src/apiV1/measures.js
@@ -8,7 +8,7 @@ export default class extends RouteHandler {
   static PermissionsChecker = PermissionsChecker;
 
   buildResponse = async () => {
-    const { entity } = this;
+    const { entity, query } = this;
     const { code: entityCode, name: entityName } = entity;
     const userGroups = await this.req.getUserGroups(entityCode);
 
@@ -26,6 +26,12 @@ export default class extends RouteHandler {
             sql: '"countryCodes" IS NULL OR :countryCode = ANY("countryCodes")',
             parameters: {
               countryCode,
+            },
+          },
+          [AND]: {
+            projectCodes: {
+              comparator: '@>',
+              comparisonValue: [query.projectCode],
             },
           },
         },

--- a/packages/web-config-server/src/models/DashboardGroup.js
+++ b/packages/web-config-server/src/models/DashboardGroup.js
@@ -16,16 +16,21 @@ export class DashboardGroup extends BaseModel {
     'organisationUnitCode',
     'dashboardReports',
     'name',
+    'projectCodes',
   ];
 
   // Return dashboardGroup with matching userGroups, organisationLevel and organisationUnits
-  static async getDashboardGroups(userGroups = [], organisationLevel, entity) {
+  static async getDashboardGroups(userGroups = [], organisationLevel, entity, projectCode) {
     const ancestorCodes = await entity.getAncestorCodes(true);
     const entityCodes = [...ancestorCodes, entity.code];
     const results = await DashboardGroup.find({
       organisationLevel,
       userGroup: userGroups, // Passing an array will cause the database to do an 'IN'
       organisationUnitCode: entityCodes, // As above, an array uses 'IN'
+      projectCodes: {
+        comparator: '@>',
+        comparisonValue: [projectCode],
+      },
     });
     const dashboardGroups = {};
     results.forEach(dashboardGroup => {

--- a/packages/web-config-server/src/tests/permissions.test.js
+++ b/packages/web-config-server/src/tests/permissions.test.js
@@ -98,18 +98,20 @@ describe('UserHasAccess', function() {
   });
 
   xit('should only retrieve public level dashboards for Tonga org units unless Access Policy otherwise specifies', async () => {
-    const tongaDashboardResponse = await app.get('dashboard?organisationUnitCode=TO').expect(200);
+    const tongaDashboardResponse = await app
+      .get('dashboard?organisationUnitCode=TO&projectCode=explore')
+      .expect(200);
     expect(tongaDashboardResponse.body).to.have.all.keys('General');
     expect(tongaDashboardResponse.body).to.not.have.any.keys('PEHS');
 
     const niuasDashboardResponse = await app
-      .get('dashboard?organisationUnitCode=TO_Niuas')
+      .get('dashboard?organisationUnitCode=TO_Niuas&projectCode=explore')
       .expect(200);
     expect(niuasDashboardResponse.body).to.have.all.keys('General');
     expect(niuasDashboardResponse.body).to.not.have.any.keys('PEHS');
 
     const tongatapuDashboardResponse = await app
-      .get('dashboard?organisationUnitCode=TO_Tongatapu')
+      .get('dashboard?organisationUnitCode=TO_Tongatapu&projectCode=explore')
       .expect(200);
     expect(tongatapuDashboardResponse.body).to.have.all.keys('General', 'PEHS');
   });
@@ -120,13 +122,13 @@ describe('UserHasAccess', function() {
   });
   xit('should not have access to donor level measure group for organisation unit that does not have any donor level permissions', async () => {
     const niuasDashboardResponse = await app
-      .get('measures?organisationUnitCode=TO_Niuas')
+      .get('measures?organisationUnitCode=TO_Niuas&projectCode=explore')
       .expect(200);
     expect(niuasDashboardResponse.body.measures).to.not.have.property('Facility equipment');
   });
   xit('should have access to donor level measure group for nested organisation unit with donor level permissions', async () => {
     const tongaDashboardResponse = await app
-      .get('measures?organisationUnitCode=TO_Tongatapu')
+      .get('measures?organisationUnitCode=TO_Tongatapu&projectCode=explore')
       .expect(200);
 
     expect(tongaDashboardResponse.body.measures).to.have.property('Facility equipment');

--- a/packages/web-frontend/src/sagas.js
+++ b/packages/web-frontend/src/sagas.js
@@ -525,7 +525,8 @@ function* watchOrgUnitChangeAndFetchIt() {
  */
 function* fetchDashboard(action) {
   const { organisationUnitCode } = action.organisationUnit;
-  const requestResourceUrl = `dashboard?organisationUnitCode=${organisationUnitCode}`;
+  const projectCode = (yield select(selectActiveProject)).code;
+  const requestResourceUrl = `dashboard?organisationUnitCode=${organisationUnitCode}&projectCode=${projectCode}`;
 
   try {
     const dashboard = yield call(request, requestResourceUrl, fetchDashboardError);
@@ -803,7 +804,8 @@ function* fetchMeasures(action) {
   const { organisationUnitCode } = action.organisationUnit;
   const state = yield select();
   if (selectIsProject(state, organisationUnitCode)) yield put(clearMeasure());
-  const requestResourceUrl = `measures?organisationUnitCode=${organisationUnitCode}`;
+  const projectCode = (yield select(selectActiveProject)).code;
+  const requestResourceUrl = `measures?organisationUnitCode=${organisationUnitCode}&projectCode=${projectCode}`;
   try {
     const measures = yield call(request, requestResourceUrl);
     yield put(fetchMeasuresSuccess(measures));


### PR DESCRIPTION
Implements the fundamentals required for https://github.com/beyondessential/tupaia-backlog/issues/575 (but more migrations required to set up all projects correctly)

This takes a fairly safe approach to start with, still allowing all dashboards and map overlays for every project, other than the new Laos schools ones.

@michaelnunan is compiling a thorough list of exactly which map overlays and dashboard groups should be associated with each project, and we can migrate others when that is done.