### PR TITLE
Detect NaN's correctly

### DIFF
--- a/packages/web-frontend/src/utils/formatters.js
+++ b/packages/web-frontend/src/utils/formatters.js
@@ -85,7 +85,8 @@ const number = (value, { presentationOptions = {} }) => {
   return numeral(value).format(valueFormat);
 };
 
-const defaultFormatter = input => (Number.isNaN(input) ? input : truncateDecimalToPlace(2)(input));
+const defaultFormatter = input =>
+  Number.isNaN(Number(input)) ? input : truncateDecimalToPlace(2)(input);
 
 const VALUE_TYPE_TO_FORMATTER = {
   [VALUE_TYPES.TEXT]: text,


### PR DESCRIPTION
Fixes an issue where strings were showing in map overlay tooltips as `NaN`