### PR TITLE
Handle facility status period more nicely

### DIFF
--- a/packages/web-config-server/src/aggregator/QueryBuilder.js
+++ b/packages/web-config-server/src/aggregator/QueryBuilder.js
@@ -2,7 +2,7 @@
  * Tupaia Config Server
  * Copyright (c) 2019 Beyond Essential Systems Pty Ltd
  */
-import { getDefaultPeriod } from '/dhis/getDefaultPeriod';
+import { getDefaultPeriod } from '/utils';
 import { Entity } from '/models';
 
 export class QueryBuilder {

--- a/packages/web-config-server/src/apiV1/dataBuilders/modules/covid/valuesPer100kPerPeriodByOrgUnit.js
+++ b/packages/web-config-server/src/apiV1/dataBuilders/modules/covid/valuesPer100kPerPeriodByOrgUnit.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2019 Beyond Essential Systems Pty Ltd
  */
 import { periodToTimestamp, periodToDisplayString, reduceToDictionary } from '@tupaia/utils';
-import { getDefaultPeriod } from '/dhis/getDefaultPeriod';
+import { getDefaultPeriod } from '/utils';
 import { DataBuilder } from '/apiV1/dataBuilders/DataBuilder';
 import groupBy from 'lodash.groupby';
 

--- a/packages/web-config-server/src/apiV1/dataBuilders/modules/disaster/compareValuesByDisasterDate.js
+++ b/packages/web-config-server/src/apiV1/dataBuilders/modules/disaster/compareValuesByDisasterDate.js
@@ -1,5 +1,5 @@
 import { convertDateRangeToPeriodString, utcMoment, reduceToDictionary } from '@tupaia/utils';
-import { EARLIEST_DATA_DATE } from '/dhis';
+import { EARLIEST_DATA_DATE } from '/utils';
 
 export const compareValuesByDisasterDate = async (
   { dataBuilderConfig, viewJson, query },

--- a/packages/web-config-server/src/apiV1/utils/getFacilityStatuses.js
+++ b/packages/web-config-server/src/apiV1/utils/getFacilityStatuses.js
@@ -1,4 +1,9 @@
-import { getDefaultPeriod, EARLIEST_DATA_DATE } from '/dhis';
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
+ */
+import { convertPeriodStringToDateRange, convertDateRangeToPeriodString } from '@tupaia/utils';
+import { getDefaultPeriod, EARLIEST_DATA_DATE } from '/utils';
 
 // Request to calculate number of operational facilities with new query
 const getFacilitiesData = async (aggregator, parentCode, period, shouldOnlyReturnCurrentStatus) => {
@@ -25,22 +30,18 @@ const getFacilitiesData = async (aggregator, parentCode, period, shouldOnlyRetur
 export const getFacilityStatuses = async (
   aggregator,
   parentCode,
-  period = getDefaultPeriod(),
+  period,
   shouldOnlyReturnCurrentStatus = false,
 ) => {
   // Have to add on earlier years to make sure that the 'LAST' aggregation type gets information
   // from them and carries them into the defined period as the most recent values, otherwise it
   // is lazy and just assumes there is no most recent value
-  let previousYears = '';
-  const currentYear = new Date().getFullYear();
-  for (let year = EARLIEST_DATA_DATE.year(); year <= currentYear; year++) {
-    previousYears = `${previousYears}${year};`;
-  }
-  const periodPlusEveryYear = `${previousYears}${period}`;
+  const [, endDate] = convertPeriodStringToDateRange(period || getDefaultPeriod());
+  const fullPeriod = convertDateRangeToPeriodString(EARLIEST_DATA_DATE, endDate);
   const facilitiesData = await getFacilitiesData(
     aggregator,
     parentCode,
-    periodPlusEveryYear,
+    fullPeriod,
     shouldOnlyReturnCurrentStatus,
   );
 

--- a/packages/web-config-server/src/dhis/index.js
+++ b/packages/web-config-server/src/dhis/index.js
@@ -1,2 +1,6 @@
-export { getDefaultPeriod, EARLIEST_DATA_DATE } from './getDefaultPeriod';
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
+ */
+
 export { getDhisApiInstance } from './getDhisApiInstance';

--- a/packages/web-config-server/src/utils/getDefaultPeriod.js
+++ b/packages/web-config-server/src/utils/getDefaultPeriod.js
@@ -1,3 +1,8 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
+ */
+
 import { utcMoment, convertDateRangeToPeriods } from '@tupaia/utils';
 
 export const EARLIEST_DATA_DATE = utcMoment('2017-01-01'); // Tupaia started in 2017

--- a/packages/web-config-server/src/utils/index.js
+++ b/packages/web-config-server/src/utils/index.js
@@ -1,1 +1,7 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
+ */
+
+export { getDefaultPeriod, EARLIEST_DATA_DATE } from './getDefaultPeriod';
 export { handleError } from './handleError';


### PR DESCRIPTION
Now that we're fetching data internally, this error (which would have always existed) has become obvious.

There are actually two errors fixed in here

The main one is that when `null` is passed as the period, the periods being requested would include null on the end, e.g. `2018;2019;2020;null`. That results in a bad end date, which causes issues like this one reported by Tonga this morning https://github.com/beyondessential/tupaia-backlog/issues/579

The second one is more subtle. Basically the end date of the period being requested should be respected, but it was being clobbered. Will make a note inline.