### PR TITLE
Stub email sending in meditrak-server tests

### DIFF
--- a/packages/meditrak-server/src/tests/scaffolding.test.js
+++ b/packages/meditrak-server/src/tests/scaffolding.test.js
@@ -1,9 +1,11 @@
 import moment from 'moment';
+import sinon from 'sinon';
 
 import { clearTestData } from '@tupaia/database';
 import { getIsProductionEnvironment } from '../devops';
 import { resetTestData } from './testUtilities';
 import { getModels } from './getModels';
+import * as SendEmail from '../utilities/sendEmail';
 
 const testStartTime = moment().format('YYYY-MM-DD HH:mm:ss');
 
@@ -17,10 +19,13 @@ before(async () => {
     throw new Error('Never run the test suite on the production server, it messes with data!');
   }
 
+  sinon.stub(SendEmail, 'sendEmail');
+
   await resetTestData();
 });
 
 after(async () => {
   const models = getModels();
+  SendEmail.sendEmail.restore();
   await clearTestData(models.database, testStartTime);
 });


### PR DESCRIPTION
Noticed today that the testers get smashed with emails from automated tests - this stops that.