### PR TITLE
added default sorting by field source, ascending

### DIFF
--- a/packages/admin-panel/src/autocomplete/actions.js
+++ b/packages/admin-panel/src/autocomplete/actions.js
@@ -37,7 +37,7 @@ export const changeSearchTerm = (reduxId, endpoint, column, searchTerm, parentRe
     const response = await api.get(makeSubstitutionsInString(endpoint, parentRecord), {
       filter: JSON.stringify(filter),
       pageSize: MAX_AUTOCOMPLETE_RESULTS,
-      sort: JSON.stringify([`${reduxId} ASC`]),
+      sort: JSON.stringify([`${column} ASC`]),
     });
     dispatch({
       type: AUTOCOMPLETE_RESULTS_CHANGE,


### PR DESCRIPTION
### Issue: [tupaia-backlog#592](https://github.com/beyondessential/tupaia-backlog/issues/592)

### Changes:

- Sort results by source field ascending in the Autocomplete component
