### PR TITLE
Ensure preaggregators clean up, even if one has an error

### DIFF
--- a/packages/aggregator/src/Aggregator.js
+++ b/packages/aggregator/src/Aggregator.js
@@ -18,8 +18,8 @@ export class Aggregator {
     this.dataBroker = dataBroker;
   }
 
-  close() {
-    this.dataBroker.close();
+  async close() {
+    return this.dataBroker.close();
   }
 
   // eslint-disable-next-line class-methods-use-this

--- a/packages/data-broker/src/DataBroker.js
+++ b/packages/data-broker/src/DataBroker.js
@@ -11,8 +11,8 @@ export class DataBroker {
     this.models = getModels();
   }
 
-  close() {
-    this.models.closeDatabaseConnections();
+  async close() {
+    return this.models.closeDatabaseConnections();
   }
 
   getDataSourceTypes() {

--- a/packages/database/src/DatabaseChangeChannel.js
+++ b/packages/database/src/DatabaseChangeChannel.js
@@ -15,6 +15,10 @@ export class DatabaseChangeChannel extends PGPubSub {
     this.addChannel('ping', this.notifyPingListeners);
   }
 
+  async close() {
+    return super.close();
+  }
+
   addChangeHandler(handler) {
     this.addChannel('change', handler);
   }

--- a/packages/database/src/ModelRegistry.js
+++ b/packages/database/src/ModelRegistry.js
@@ -20,9 +20,9 @@ export class ModelRegistry {
     this.generateModels();
   }
 
-  closeDatabaseConnections() {
+  async closeDatabaseConnections() {
     if (this.database.isSingleton) {
-      this.database.closeConnections();
+      await this.database.closeConnections();
     }
   }
 

--- a/packages/database/src/TupaiaDatabase.js
+++ b/packages/database/src/TupaiaDatabase.js
@@ -74,11 +74,11 @@ export class TupaiaDatabase {
   // can be replaced with 'generateTestId' by tests
   generateId = generateId;
 
-  closeConnections() {
+  async closeConnections() {
     if (this.changeChannel) {
-      this.changeChannel.close();
+      await this.changeChannel.close();
     }
-    this.connection.destroy();
+    return this.connection.destroy();
   }
 
   getOrCreateChangeChannel() {


### PR DESCRIPTION
### Issue #: Hopefully https://github.com/beyondessential/tupaia-backlog/issues/358

This ensures that even if a preaggregator errors out, the database connections are still cleaned up, so the node process will exit and stop holding onto whatever memory it has built up.