### PR TITLE
Add root folder to tupaia workspace

### DIFF
--- a/tupaia-packages.code-workspace
+++ b/tupaia-packages.code-workspace
@@ -1,6 +1,10 @@
 {
   "folders": [
     {
+      "name": "root",
+      "path": "."
+    },
+    {
       "name": "access-policy",
       "path": "packages/access-policy"
     },
@@ -60,5 +64,10 @@
       "name": "web-frontend",
       "path": "packages/web-frontend"
     }
-  ]
+  ],
+  "settings": {
+    "files.exclude": {
+      "packages/": true
+    }
+  }
 }


### PR DESCRIPTION
My biggest frustration with our vscode workspace is that you can't easily get to the root config files (e.g. package.json, codeship deployment, etc.). This fixes that.