### PR TITLE
Use hierarchy id for dataSourceEntities of the same level (hotfix)

### DIFF
--- a/packages/web-config-server/src/apiV1/DataAggregatingRouteHandler.js
+++ b/packages/web-config-server/src/apiV1/DataAggregatingRouteHandler.js
@@ -32,7 +32,7 @@ export class DataAggregatingRouteHandler extends RouteHandler {
     let dataSourceEntities = [];
     if (entityType) {
       const ancestor = await entity.getAncestorOfType(entityType);
-      if (ancestor && ancestor.type != entityType) {
+      if (ancestor && ancestor.type !== entity.type) {
         dataSourceEntities = [ancestor];
       } else {
         dataSourceEntities = await entity.getDescendantsOfType(entityType, hierarchyId);


### PR DESCRIPTION
### Issue #:
https://github.com/beyondessential/tupaia-backlog/issues/721

For some reason getAllAncestors doesn't accept a hierarchy id which means that it struggles with schools (they don't get returned with a country code). This goes back to the default behavior. before https://github.com/beyondessential/tupaia/pull/810.

