### PR TITLE
check for boolean values in admin panel convert search term to filter

### DIFF
--- a/packages/admin-panel/src/table/columnTypes/columnFilters.js
+++ b/packages/admin-panel/src/table/columnTypes/columnFilters.js
@@ -8,16 +8,17 @@ import React from 'react';
  * Makes boolean fields work with the database filter
  * https://github.com/tannerlinsley/react-table/tree/v6/examples/custom-filtering
  */
-export const BooleanSelectFilter = ({ filter, onChange }) => {
-  return (
-    <select
-      onChange={event => onChange(event.target.value)}
-      style={{ width: '100%' }}
-      value={filter ? filter.value : ''}
-    >
-      <option value="">Show All</option>
-      <option value="true">Yes</option>
-      <option value="false">No</option>
-    </select>
-  );
-};
+export const BooleanSelectFilter = ({ filter, onChange }) => (
+  <select
+    onChange={event => {
+      const boolValue = event.target.value === 'true';
+      onChange(boolValue);
+    }}
+    style={{ width: '100%' }}
+    value={filter ? filter.value : ''}
+  >
+    <option value="">Show All</option>
+    <option value="true">Yes</option>
+    <option value="false">No</option>
+  </select>
+);

--- a/packages/admin-panel/src/utilities/convertSearchTermToFilter.js
+++ b/packages/admin-panel/src/utilities/convertSearchTermToFilter.js
@@ -6,7 +6,7 @@
 export const convertSearchTermToFilter = (unprocessedFilterObject = {}) => {
   const filterObject = {};
   Object.entries(unprocessedFilterObject).forEach(([key, value]) => {
-    if (value === 'true' || value === 'false' || typeof value !== 'string') {
+    if (typeof value !== 'string') {
       filterObject[key] = value;
       return;
     }


### PR DESCRIPTION
### Issue #: [Attempting to filter Surveys by putting a value in the "Repeating" field generates an error ](https://github.com/beyondessential/tupaia-admin/issues/105#issuecomment-646446474)

### Changes:

- Check for true and false strings when converting search term to filter

html select options can only have strings as values so there is no way to ensure that the value being passed to convertSearchTermToFilter.js is an actual boolean value.

---

### Screenshots:

Relevant screenshots for this PR can be found here: https://github.com/beyondessential/tupaia-admin/issues/105#issuecomment-680597069

