### PR TITLE
fix editing of data in survey screen component

### DIFF
--- a/packages/meditrak-server/src/dataAccessors/editSurveyScreenComponent.js
+++ b/packages/meditrak-server/src/dataAccessors/editSurveyScreenComponent.js
@@ -6,7 +6,7 @@
 export const editSurveyScreenComponent = async (models, id, updatedData) => {
   const screenComponentFields = await models.surveyScreenComponent.fetchFieldNames();
   const updatedScreenComponentData = screenComponentFields.reduce((current, fieldName) => {
-    if (!updatedData[fieldName]) {
+    if (!(fieldName in updatedData)) {
       return current;
     }
     if (fieldName === 'config') {
@@ -17,7 +17,7 @@ export const editSurveyScreenComponent = async (models, id, updatedData) => {
   const questionFields = await models.question.fetchFieldNames();
   const updatedQuestionData = questionFields.reduce(
     (current, fieldName) =>
-      updatedData[fieldName] ? { ...current, [fieldName]: updatedData[fieldName] } : current,
+      fieldName in updatedData ? { ...current, [fieldName]: updatedData[fieldName] } : current,
     {},
   );
   const updates = [];

--- a/packages/meditrak-server/src/routes/getRecords.js
+++ b/packages/meditrak-server/src/routes/getRecords.js
@@ -45,6 +45,7 @@ const CUSTOM_FINDERS = {
     TYPES.SURVEY,
     TYPES.SURVEY_SCREEN_COMPONENT,
   )]: findSurveyScreenComponentsInSurvey,
+  [TYPES.SURVEY_SCREEN_COMPONENT]: findSurveyScreenComponentsInSurvey,
   [createMultiResourceKey(TYPES.SURVEY_RESPONSE, TYPES.ANSWER)]: findAnswersInSurveyResponse,
   [createMultiResourceKey(TYPES.COUNTRY, TYPES.SURVEY)]: findSurveysInCountry,
   [createMultiResourceKey(TYPES.COUNTRY, TYPES.ENTITY)]: findEntitiesInCountry,


### PR DESCRIPTION
### Issue #: [Ability to edit question and details labels](https://github.com/beyondessential/tupaia-admin/issues/60#issuecomment-647908926)

### Changes:
A change in the way custom finders are configured in getRecrds.js, meant the dataAccessor for getting survey screen component data was not getting called. Fixed by adding the missing config in getRecords.js.

I also updated the editSurveyScreenComponent dataAccessor to properly check for changed data.


