### PR TITLE
Fix many countries appearing in second access request

### DIFF
--- a/packages/web-frontend/src/containers/Form/index.js
+++ b/packages/web-frontend/src/containers/Form/index.js
@@ -31,7 +31,7 @@ export class Form extends React.Component {
       if (!React.isValidElement(child)) throw new Error('Invalid Field element as child of Form');
 
       const { name, defaultValue } = child.props;
-      if (defaultValue !== null) defaultValues[name] = defaultValue; // should allow falsy values as defaults
+      if (defaultValue !== null && defaultValue !== undefined) defaultValues[name] = defaultValue; // should allow falsy values as defaults
     });
 
     this.state = {


### PR DESCRIPTION
### Issue #: https://github.com/beyondessential/tupaia-backlog/issues/702

On the second render of the request access form, the child react components existed but had a default value of `undefined`