### PR TITLE
758: Dev partner support overlay changes

### DIFF
--- a/packages/database/src/migrations/20200706073546-UpdateMajorDevelopmentPartnerOverlayToDevelopmentPartnerSupportOverlay.js
+++ b/packages/database/src/migrations/20200706073546-UpdateMajorDevelopmentPartnerOverlayToDevelopmentPartnerSupportOverlay.js
@@ -1,0 +1,46 @@
+'use strict';
+
+import { arrayToDbString } from '../utilities';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+const MAP_OVERLAY_IDS = [
+  'Laos_Schools_Major_Dev_Partner_Province',
+  'Laos_Schools_Major_Dev_Partner_District',
+];
+
+const OLD_OVERLAY_NAME = 'Major Development Partner';
+
+const NEW_OVERLAY_NAME = 'Development partner support';
+
+exports.up = async function(db) {
+  return db.runSql(`
+    UPDATE "mapOverlay"
+    SET name = '${NEW_OVERLAY_NAME}'
+    WHERE id in (${arrayToDbString(MAP_OVERLAY_IDS)});
+  `);
+};
+
+exports.down = async function(db) {
+  return db.runSql(`
+    UPDATE "mapOverlay"
+    SET name = '${OLD_OVERLAY_NAME}'
+    WHERE id in (${arrayToDbString(MAP_OVERLAY_IDS)});
+  `);
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/packages/web-frontend/src/containers/Map/ConnectedPolygon.js
+++ b/packages/web-frontend/src/containers/Map/ConnectedPolygon.js
@@ -12,7 +12,7 @@ import { connect } from 'react-redux';
 import styled from 'styled-components';
 
 import { AreaTooltip } from './AreaTooltip';
-import { MAP_COLORS } from '../../styles';
+import { MAP_COLORS, BREWER_PALETTE } from '../../styles';
 import { changeOrgUnit } from '../../actions';
 import {
   selectOrgUnit,
@@ -107,10 +107,13 @@ class ConnectedPolygon extends Component {
     };
 
     if (shade) {
+      //To match with the color in markerIcon.js which uses BREWER_PALETTE
+      const color = BREWER_PALETTE[shade] || shade;
+
       // Work around: color should go through the styled components
       // but there is a rendering bug between Styled Components + Leaflet
       return (
-        <ShadedPolygon {...defaultProps} color={shade}>
+        <ShadedPolygon {...defaultProps} color={color}>
           {tooltip}
         </ShadedPolygon>
       );


### PR DESCRIPTION
### Issue: https://github.com/beyondessential/tupaia-backlog/issues/758

### Changes:

-  Fixed an issue that the colors of shaded polygons did not match with the legend colors.

-  Changed the name of dev partner support overlay

### Screenshots:

Relevant screenshots for this PR can be found here: https://github.com/beyondessential/tupaia-backlog/issues/758#issuecomment-679853895
