### PR TITLE
Always fill until the current period for FINAL_EACH_X_FILL_EMPTY_X aggregation types

### DIFF
--- a/packages/aggregator/src/analytics/aggregateAnalytics/aggregateAnalytics.js
+++ b/packages/aggregator/src/analytics/aggregateAnalytics/aggregateAnalytics.js
@@ -37,7 +37,7 @@ export const aggregateAnalytics = (
         analytics,
         {
           ...aggregationConfig,
-          fillEmptyValues: true,
+          fillEmptyPeriodsTilNow: true,
         },
         DAY,
       );
@@ -56,7 +56,7 @@ export const aggregateAnalytics = (
         analytics,
         {
           ...aggregationConfig,
-          fillEmptyValues: true,
+          fillEmptyPeriodsTilNow: true,
         },
         MONTH,
       );
@@ -67,7 +67,7 @@ export const aggregateAnalytics = (
         analytics,
         {
           ...aggregationConfig,
-          fillEmptyValues: true,
+          fillEmptyPeriodsTilNow: true,
         },
         QUARTER,
       );
@@ -78,7 +78,7 @@ export const aggregateAnalytics = (
         analytics,
         {
           ...aggregationConfig,
-          fillEmptyValues: true,
+          fillEmptyPeriodsTilNow: true,
         },
         YEAR,
       );

--- a/packages/aggregator/src/analytics/aggregateAnalytics/aggregations/getFinalValuePerPeriod.js
+++ b/packages/aggregator/src/analytics/aggregateAnalytics/aggregations/getFinalValuePerPeriod.js
@@ -107,12 +107,8 @@ class FinalValueAggregator {
     this.cache = cache;
   }
 
-  getContinuousValues(analytics, aggregationPeriod, fillEmptyValuesTilCurrentPeriod) {
-    const periods = getContinuousPeriodsForAnalytics(
-      analytics,
-      aggregationPeriod,
-      fillEmptyValuesTilCurrentPeriod,
-    );
+  getContinuousValues(analytics, aggregationPeriod) {
+    const periods = getContinuousPeriodsForAnalytics(analytics, aggregationPeriod, true);
 
     const values = [];
     this.cache.iterateOrganisationUnitCache(organisationUnitCache => {
@@ -146,8 +142,7 @@ class FinalValueAggregator {
 
 export const getFinalValuePerPeriod = (analytics, aggregationConfig, aggregationPeriod) => {
   const defaultOptions = {
-    fillEmptyValues: false,
-    fillEmptyValuesTilCurrentPeriod: false,
+    fillEmptyPeriodsTilNow: false,
     preferredPeriodType: PERIOD_TYPES.YEAR,
   };
 
@@ -155,11 +150,7 @@ export const getFinalValuePerPeriod = (analytics, aggregationConfig, aggregation
   const cache = new FinalValueCache(analytics, aggregationPeriod, options.preferredPeriodType);
   const valueAggregator = new FinalValueAggregator(cache);
 
-  return options.fillEmptyValues
-    ? valueAggregator.getContinuousValues(
-        analytics,
-        aggregationPeriod,
-        options.fillEmptyValuesTilCurrentPeriod,
-      )
+  return options.fillEmptyPeriodsTilNow
+    ? valueAggregator.getContinuousValues(analytics, aggregationPeriod)
     : valueAggregator.getDistinctValues();
 };

--- a/packages/web-config-server/src/apiV1/dataBuilders/modules/covid/valuesPer100kPerPeriodByOrgUnit.js
+++ b/packages/web-config-server/src/apiV1/dataBuilders/modules/covid/valuesPer100kPerPeriodByOrgUnit.js
@@ -28,7 +28,6 @@ class ValuesPer100kPerPeriodByOrgUnitBuilder extends DataBuilder {
       [populationDataElement],
       {},
       this.aggregator.aggregationTypes.FINAL_EACH_DAY_FILL_EMPTY_DAYS,
-      { fillEmptyValuesTilCurrentPeriod: true },
     );
 
     this.query.period = originalQueryPeriod;

--- a/packages/web-config-server/src/apiV1/utils/getFacilityStatuses.js
+++ b/packages/web-config-server/src/apiV1/utils/getFacilityStatuses.js
@@ -10,9 +10,6 @@ const getFacilitiesData = async (aggregator, parentCode, period, shouldOnlyRetur
   const aggregationType = shouldOnlyReturnCurrentStatus
     ? aggregator.aggregationTypes.MOST_RECENT
     : aggregator.aggregationTypes.FINAL_EACH_MONTH_FILL_EMPTY_MONTHS;
-  const extraParams = shouldOnlyReturnCurrentStatus
-    ? { aggregationType }
-    : { aggregationType, aggregationConfig: { fillEmptyValuesTilCurrentPeriod: true } };
 
   const { results } = await aggregator.fetchAnalytics(
     ['BCD1'],
@@ -22,7 +19,7 @@ const getFacilitiesData = async (aggregator, parentCode, period, shouldOnlyRetur
       entityAggregation: { dataSourceEntityType: 'facility' },
     },
     {},
-    { ...extraParams },
+    { aggregationType },
   );
   return results;
 };


### PR DESCRIPTION
### Issue #: https://github.com/beyondessential/tupaia-backlog/issues/831

### Changes:
A [recent change](https://github.com/beyondessential/tupaia/pull/300#discussion_r398993860) made aggregations that fill empty periods only fill until the latest period within the analytics. That makes sense for the use case in that PR (aggregation type `SUM_PREVIOUS_EACH_DAY`), but not for the original use cases of getting continuous analytics: the aggregation types `FINAL_EACH_MONTH_FILL_EMPTY_MONTHS` etc.

In https://github.com/beyondessential/tupaia/pull/447 @chris-bes introduced a flag to fix it for a specific report that was broken, but actually that was just the start - a number of reports were broken.

In every case I can find, the use of these aggregation types should run right up until the current period, so now it's not even a toggle, it's just the way they work.

Notes from my analysis of where it is being used:

- FINAL_EACH_DAY_FILL_EMPTY_DAYS
  - valuesPer100kPerPeriodByOrgUnit: already switches it to fill til current period
- FINAL_EACH_MONTH_FILL_EMPTY_MONTHS
  - getFacilityStatuses: already switches it to fill til current period
- FINAL_EACH_MONTH_FILL_EMPTY_MONTHS, FINAL_EACH_YEAR_FILL_EMPTY_YEARS
  - percentagesPerPeriod: TO_CH_DM_HTN_Incidence, TO_CH_DM_HTN_Prevalence, TO_RH_Descriptive_FP01_02 only ones to use with fillEmptyDenominatorValues, and these should all have fill til current period
- FINAL_EACH_MONTH_FILL_EMPTY_MONTHS, FINAL_EACH_QUARTER_FILL_EMPTY_QUARTERS, FINAL_EACH_YEAR_FILL_EMPTY_YEARS
  - percentagesOfValueCountsPerPeriod: UNFPA_Delivery_Services_Stock only one to use with fillEmptyDenominatorValues, should use fill til current period