### PR TITLE
Update sortOrder to set change covid overlay default

### DIFF
--- a/packages/database/src/migrations/20200712224256-ChangeDefaultCovidOverlayToStateTotalCases-modifies-data.js
+++ b/packages/database/src/migrations/20200712224256-ChangeDefaultCovidOverlayToStateTotalCases-modifies-data.js
@@ -14,19 +14,16 @@ exports.setup = function(options, seedLink) {
   seed = seedLink;
 };
 
-const mapOverlayId = 'COVID_AU_HOSPITALS_AND_TESTING_SITES';
 const defaultMapOverlayId = 'COVID_AU_State_Total_Number_Confirmed_Cases';
 
 exports.up = function(db) {
   return db.runSql(`
-    UPDATE "mapOverlay" SET "sortOrder" = 1 WHERE id = '${mapOverlayId}';
     UPDATE "project" SET "default_measure" = '${defaultMapOverlayId}' WHERE "code" = 'covidau'; 
   `);
 };
 
 exports.down = function(db) {
   return db.runSql(`
-    UPDATE "mapOverlay" SET "sortOrder" = 0 WHERE id = '${mapOverlayId}'; 
     UPDATE "project" SET "default_measure" = '126,171' WHERE "code" = 'covidau';
   `);
 };


### PR DESCRIPTION
[878](https://github.com/beyondessential/tupaia-backlog/issues/878) Change the default map-overlay for COVID-19 project to Total confirmed cases by state.

Simple migration to update sortOrder of Covid-19 map overlays to set national overlay to default.

Relevant screenshots for this PR can be found here: https://github.com/beyondessential/tupaia-backlog/issues/878#issuecomment-679848435
