### PR TITLE
Add clear error message when a program is missing from DHIS2

### DIFF
--- a/packages/meditrak-server/src/dhis/pushers/data/event/EventBuilder.js
+++ b/packages/meditrak-server/src/dhis/pushers/data/event/EventBuilder.js
@@ -64,7 +64,11 @@ export class EventBuilder {
 
   async enrollTrackedEntityAndGetTrackerEventFields(entity, programCode) {
     const trackedEntityId = entity.getDhisId();
-    const { id: programId, programStages } = await this.fetchProgram(programCode);
+    const program = await this.fetchProgram(programCode);
+    if (!program) {
+      throw new Error(`Program ${programCode} was not found on DHIS2`);
+    }
+    const { id: programId, programStages } = program;
     const { code: orgUnitCode } = await entity.fetchClosestOrganisationUnit();
     const { id: orgUnitDhisId } = await this.fetchOrganisationUnit(orgUnitCode);
     await enrollTrackedEntityInProgramIfNotEnrolled(this.api, {


### PR DESCRIPTION
I was seeing a lot of `1|meditrak | warn: Cannot read property 'id' of null` in the pm2 logs of `meditrak-server`. It was because of https://github.com/beyondessential/tupaia-backlog/issues/959, but it would be nice to make the issue more obvious in future.