### PR TITLE
953 invalidate hierarchy cache correctly

### DIFF
--- a/packages/web-config-server/src/models/helpers/EntityHierarchyBuilder.js
+++ b/packages/web-config-server/src/models/helpers/EntityHierarchyBuilder.js
@@ -14,9 +14,9 @@ export class EntityHierarchyBuilder {
     entityRelationModel.addChangeHandler(this.invalidateCache);
   }
 
-  invalidateCache() {
+  invalidateCache = () => {
     this.cachedPromises = {};
-  }
+  };
 
   getCacheKey = (entityId, hierarchyId = 'canonical') => `${entityId}_${hierarchyId}`;
 


### PR DESCRIPTION
### Issue #:
https://github.com/beyondessential/tupaia-backlog/issues/953

### Changes:
A case of exactly what we were talking about during dev chat - the `this` that was bound to `invalidateCache` was the wrong `this`, so it wasn't being invalidated at all - ever!

Note: I've set the base to 954 to save on testing.