### PR TITLE
Use jest plugin in typescript eslint config

### DIFF
--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -1,6 +1,10 @@
 module.exports = {
-  extends: ['plugin:@typescript-eslint/recommended', 'plugin:prettier/recommended'],
+  extends: [
+    'plugin:@typescript-eslint/recommended',
+    'plugin:jest/recommended',
+    'plugin:prettier/recommended',
+  ],
   parser: '@typescript-eslint/parser',
-  plugins: ['@typescript-eslint'],
+  plugins: ['@typescript-eslint', 'jest'],
   root: true,
 };


### PR DESCRIPTION
Assuming that we will prefer using `jest` over `mocha` in future packages, I added `eslint-plugin-jest` in the shared typescript configuration for eslint.