### PR TITLE
add message when refresh token change password fails

### DIFF
--- a/packages/web-frontend/src/reducers.js
+++ b/packages/web-frontend/src/reducers.js
@@ -304,14 +304,17 @@ function changePassword(
         isRequestingChangePassword: true,
         changePasswordFailedMessage: '',
       };
-    case FETCH_CHANGE_PASSWORD_ERROR:
+    case FETCH_CHANGE_PASSWORD_ERROR: {
+      const errorMessage =
+        state.passwordResetToken.length > 0
+          ? 'This password reset link has already been used.'
+          : 'Something went wrong during password change, please check the form and try again';
       return {
         ...state,
         isRequestingChangePassword: false,
-        changePasswordFailedMessage:
-          action.error ||
-          'Something went wrong during password change, please check the form and try again',
+        changePasswordFailedMessage: action.error || errorMessage,
       };
+    }
     case FETCH_CHANGE_PASSWORD_SUCCESS:
       return {
         ...state,


### PR DESCRIPTION
### Issue #: https://github.com/beyondessential/tupaia-backlog/issues/987

### Changes:

- Update message user gets when they get an error while changing their password with a refresh token

---

### Screenshots:
