### PR TITLE
906 key data elements by code 2

### DIFF
--- a/packages/web-config-server/src/preaggregation/preaggregators/vaccineStockOnHand.js
+++ b/packages/web-config-server/src/preaggregation/preaggregators/vaccineStockOnHand.js
@@ -60,9 +60,9 @@ const buildVaccineMetadata = async (aggregator, dhisApi, data) => {
       facilityVaccineListCode
     ].dataElements.map(de => stripFromString(de.code, prependString));
 
-    metadata[facilityCode] = originalDataElementCodes.reduce((orginalToPreaggregated, code) => {
+    metadata[facilityCode] = originalDataElementCodes.reduce((originalToPreaggregated, code) => {
       return {
-        ...orginalToPreaggregated,
+        ...originalToPreaggregated,
         [code]: preaggregatedDataElementCode(code),
       };
     }, {});


### PR DESCRIPTION
Supercedes https://github.com/beyondessential/tupaia/pull/966 because that one had a squash and merge from dev that broke things.

### Issue #: https://github.com/beyondessential/tupaia-backlog/issues/906

The preaggregator was assuming the data would be returned keyed by data element id, but actually it's keyed by code now, using the new events api.

Also fixed some eslint complaints