### PR TITLE
Add build types flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build-admin-panel": "yarn workspace @tupaia/admin-panel build",
     "build-web-frontend": "yarn workspace @tupaia/web-frontend build",
     "build-internal-dependencies": "./scripts/bash/buildInternalDependencies.sh",
+    "build-internal-dependencies:dev": "./scripts/bash/buildInternalDependencies.sh --withTypes",
     "migrate": "yarn workspace @tupaia/database migrate",
     "migrate-create": "yarn workspace @tupaia/database migrate-create",
     "migrate-down": "yarn workspace @tupaia/database migrate-down",

--- a/packages/aggregator/package.json
+++ b/packages/aggregator/package.json
@@ -4,8 +4,8 @@
   "main": "dist/index.js",
   "private": true,
   "scripts": {
-    "build": "yarn build:js && tsc",
-    "build:js": "babel src --out-dir dist --ignore 'src/tests/**' --config-file '../../babel.config.json'",
+    "build": "babel src --out-dir dist --ignore 'src/tests/**' --config-file '../../babel.config.json'",
+    "build:ts": "tsc",
     "test": "mocha",
     "test-coverage": "cross-env NODE_ENV=test nyc mocha"
   },

--- a/packages/data-broker/package.json
+++ b/packages/data-broker/package.json
@@ -4,8 +4,8 @@
   "main": "dist/index.js",
   "private": true,
   "scripts": {
-    "build": "yarn build:js && tsc",
-    "build:js": "babel src --out-dir dist --ignore 'src/tests/**' --config-file '../../babel.config.json'",
+    "build": "babel src --out-dir dist --ignore 'src/tests/**' --config-file '../../babel.config.json'",
+    "build:ts": "tsc",
     "test": "mocha",
     "test-coverage": "cross-env NODE_ENV=test nyc mocha"
   },

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -4,8 +4,8 @@
   "main": "dist/index.js",
   "private": true,
   "scripts": {
-    "build": "yarn build:js && tsc",
-    "build:js": "babel src --out-dir dist --ignore '**/migrations','src/tests/**' --config-file '../../babel.config.json'",
+    "build": "babel src --out-dir dist --ignore '**/migrations','src/tests/**' --config-file '../../babel.config.json'",
+    "build:ts": "tsc",
     "test": "mocha",
     "test-coverage": "cross-env NODE_ENV=test nyc mocha",
     "migrate": "babel-node ./src/migrate.js up --migrations-dir ./src/migrations -v --config-file '../../babel.config.json'",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -4,8 +4,8 @@
   "main": "dist/index.js",
   "private": true,
   "scripts": {
-    "build": "yarn build:js && tsc",
-    "build:js": "babel src --out-dir dist --ignore 'src/tests/**' --config-file '../../babel.config.json'",
+    "build": "babel src --out-dir dist --ignore 'src/tests/**' --config-file '../../babel.config.json'",
+    "build:ts": "tsc",
     "test": "mocha",
     "test-coverage": "cross-env NODE_ENV=test nyc mocha"
   },

--- a/scripts/bash/buildInternalDependencies.sh
+++ b/scripts/bash/buildInternalDependencies.sh
@@ -1,8 +1,48 @@
 #!/bin/bash
+
 DIR=`dirname "$0"`
-concurrent_build_commands=""
-for PACKAGE in $(${DIR}/getInternalDependencies.sh); do
-  concurrent_build_commands="${concurrent_build_commands} \"yarn workspace @tupaia/${PACKAGE} build $1\"" # $1 may pass in --watch
+
+USAGE="Usage: buildInternalDependencies.sh [--watch] [--withTypes]"
+
+watch=false
+with_types=false
+while [ "$1" != "" ]; do
+  case $1 in
+      --watch)
+        shift
+        watch=true
+        ;;
+      --withTypes)
+        shift
+        with_types=true
+        shift
+        ;;
+      -h | --help )
+        echo -e "$USAGE\n";
+        exit
+        ;;
+      * )
+        echo -e "$USAGE\n"
+        exit 1
+  esac
 done
+
+[[ $watch = "true" ]] && build_args="--watch" || build_args=""
+[[ $watch = "true" ]] && build_ts_args="--watch" || build_ts_args=""
+
+concurrent_build_commands=""
+
+# Build dependencies
+for PACKAGE in $(${DIR}/getInternalDependencies.sh); do
+  concurrent_build_commands="${concurrent_build_commands} \"yarn workspace @tupaia/${PACKAGE} build $build_args\""
+done
+
+# Build types
+if [ $with_types == "true" ]; then
+  for PACKAGE in $(${DIR}/getTypedInternalDependencies.sh); do
+    concurrent_build_commands="${concurrent_build_commands} \"yarn workspace @tupaia/${PACKAGE} build:ts $build_ts_args\""
+  done
+fi
+
 echo yarn concurrently ${concurrent_build_commands}
 eval "yarn concurrently ${concurrent_build_commands}"

--- a/scripts/bash/getTypedInternalDependencies.sh
+++ b/scripts/bash/getTypedInternalDependencies.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "aggregator" "data-broker" "database" "utils"


### PR DESCRIPTION
So the issue with the base branch not building was caused by `tsconfig.dependency.json` being referenced by `tsconfig.json` in typed dependencies, but not being copied over in our `full-testable-package.Dockerfile`.

A quick solution would be to just copy this file and follow my existing logic, which would build types during our build process. However, I thought it would be cleaner to support type building as an optional feature of our build process. This was implemented using an option flag.