### PR TITLE
194: Fixed a small issue that the linked measures are not in the correct order

### DIFF
--- a/packages/web-config-server/src/apiV1/measureData.js
+++ b/packages/web-config-server/src/apiV1/measureData.js
@@ -1,3 +1,5 @@
+import keyBy from 'lodash.keyby';
+
 import { CustomError } from '@tupaia/utils';
 import { getMeasureBuilder } from '/apiV1/measureBuilders/getMeasureBuilder';
 import { getDhisApiInstance } from '/dhis';
@@ -130,7 +132,18 @@ export default class extends DataAggregatingRouteHandler {
   buildResponse = async () => {
     const { code } = this.entity;
     const { measureId } = this.query;
-    const overlays = await MapOverlay.find({ id: measureId.split(',') });
+    const measureIds = measureId.split(',');
+    const overlayResults = await MapOverlay.find({ id: measureIds });
+
+    //Re-order the overlays array to follow the order in measureIds
+    const overlaysById = keyBy(overlayResults, 'id');
+    const overlays = [];
+
+    measureIds.forEach(id => {
+      if (overlaysById[id]) {
+        overlays.push(overlaysById[id]);
+      }
+    });
 
     // check permission
     await Promise.all(


### PR DESCRIPTION
### Issue: https://github.com/beyondessential/tupaia-backlog/issues/194
The order of info and legends of linked overlays are not matched between dev and prod

Relevant screenshots for this PR can be found here: https://github.com/beyondessential/tupaia-backlog/issues/194#issuecomment-679740697

### Changes:

- Fixed a small issue that the linked measures are not in the correct order. This is because all the records of map overlays were updated. I think that messed with the default order when the map overlays are returned. So I sort the returned overlay results to match with the measureIds
