### PR TITLE
194: Fixed incorrect destructuring

### DIFF
--- a/packages/web-config-server/src/apiV1/measureData.js
+++ b/packages/web-config-server/src/apiV1/measureData.js
@@ -340,8 +340,7 @@ export default class extends DataAggregatingRouteHandler {
 
 function translateMeasureOptionSet(measureOptions, mapOverlay) {
   const {
-    presentationOptions: { customColors },
-    displayType,
+    presentationOptions: { customColors, displayType },
   } = mapOverlay;
 
   if (!measureOptions) {


### PR DESCRIPTION
### Issue: https://github.com/beyondessential/tupaia-backlog/issues/194

### Changes:

- Fixed incorrect destructuring. `displayType` column has been dropped and now sit in `presentationOptions`.
