### PR TITLE
708 restrict access to wish raw data download

### DIFF
--- a/packages/database/src/migrations/20200623224901-RestrictWishRawDataDownloadAccess-modifies-data.js
+++ b/packages/database/src/migrations/20200623224901-RestrictWishRawDataDownloadAccess-modifies-data.js
@@ -24,7 +24,7 @@ const newDashboardGroupCode = 'WISH_Restricted_Export_Surveys';
 
 //Rename the old dashboardGroup
 const oldDashboardGroupName = 'Fiji Data Downloads';
-const newDashboardGroupName = ' WISH Fiji data downloads';
+const newDashboardGroupName = 'WISH Fiji Data Downloads';
 
 const newDashboardGroup = {
   organisationLevel: 'Country',


### PR DESCRIPTION
Issue #:
https://github.com/beyondessential/tupaia-backlog/issues/708
WISH_Export_Surveys contains sensitive data so needs to be secured.

In this change:
- create a new dashboard group for Wish with restricted access to 'Fiji Restricted Data'
- move WISH_Export_Surveys to that group

This PR is a branch name change from https://github.com/beyondessential/tupaia/pull/846