### PR TITLE
943 Refactor PSSS Header

### DIFF
--- a/packages/psss/src/components/Header.js
+++ b/packages/psss/src/components/Header.js
@@ -12,6 +12,7 @@ import { Link as RouterLink } from 'react-router-dom';
 import MuiLink from '@material-ui/core/Link';
 import { SaveAlt, LightOutlinedButton } from '@tupaia/ui-components';
 import MuiAvatar from '@material-ui/core/Avatar';
+import { FlexSpaceBetween, FlexStart } from './Layout';
 import * as COLORS from '../constants/colors';
 
 const HeaderMain = styled.header`
@@ -19,10 +20,7 @@ const HeaderMain = styled.header`
   color: ${COLORS.WHITE};
 `;
 
-const HeaderInner = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
+const HeaderInner = styled(FlexSpaceBetween)`
   height: 190px;
   padding-bottom: 1.25rem;
 `;
@@ -41,11 +39,6 @@ const HeaderBack = styled(MuiLink)`
   }
 `;
 
-const HeaderTitle = styled.div`
-  display: flex;
-  align-items: center;
-`;
-
 const Avatar = styled(MuiAvatar)`
   height: 5rem;
   width: 5rem;
@@ -60,7 +53,67 @@ const StyledH1 = styled(H1)`
   text-transform: capitalize;
 `;
 
-export const Header = ({ title, avatarUrl, back, ExportModal }) => {
+export const HeaderTitle = ({ title }) => <H1>{title}</H1>;
+
+HeaderTitle.propTypes = {
+  title: PropTypes.string.isRequired,
+};
+
+export const HeaderAvatarTitle = ({ title, avatarUrl }) => {
+  return (
+    <FlexStart>
+      <Avatar src={avatarUrl} />
+      <StyledH1>{title}</StyledH1>
+    </FlexStart>
+  );
+};
+
+HeaderAvatarTitle.propTypes = {
+  title: PropTypes.string.isRequired,
+  avatarUrl: PropTypes.string,
+};
+
+HeaderAvatarTitle.defaultProps = {
+  avatarUrl: null,
+};
+
+const SubHeading = styled(H1)`
+  font-size: 1.3rem;
+  line-height: 1.5rem;
+  font-weight: 400;
+`;
+
+const SmallAvatar = styled(MuiAvatar)`
+  height: 2.5rem;
+  width: 2.5rem;
+  margin-right: 0.8rem;
+`;
+
+const SubHeadingContainer = styled(FlexStart)`
+  margin-bottom: 0.8rem;
+`;
+
+export const HeaderTitleWithSubHeading = ({ title, subHeading, avatarUrl }) => (
+  <>
+    <SubHeadingContainer>
+      <SmallAvatar src={avatarUrl} />
+      <SubHeading variant="h3">{subHeading}</SubHeading>
+    </SubHeadingContainer>
+    <HeaderTitle title={title} />
+  </>
+);
+
+HeaderTitleWithSubHeading.propTypes = {
+  title: PropTypes.string.isRequired,
+  subHeading: PropTypes.string.isRequired,
+  avatarUrl: PropTypes.string,
+};
+
+HeaderTitleWithSubHeading.defaultProps = {
+  avatarUrl: null,
+};
+
+export const Header = ({ Title, back, ExportModal }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   return (
@@ -74,10 +127,7 @@ export const Header = ({ title, avatarUrl, back, ExportModal }) => {
                 Back to {back.title}
               </HeaderBack>
             )}
-            <HeaderTitle>
-              {avatarUrl && <Avatar src={avatarUrl} />}
-              {avatarUrl ? <StyledH1>{title}</StyledH1> : <H1>{title}</H1>}
-            </HeaderTitle>
+            {Title}
           </div>
           {ExportModal && (
             <>
@@ -94,14 +144,12 @@ export const Header = ({ title, avatarUrl, back, ExportModal }) => {
 };
 
 Header.propTypes = {
-  title: PropTypes.string.isRequired,
-  avatarUrl: PropTypes.string,
+  Title: PropTypes.any.isRequired,
   back: PropTypes.shape({ title: PropTypes.string.isRequired, url: PropTypes.string.isRequired }),
   ExportModal: PropTypes.any,
 };
 
 Header.defaultProps = {
-  avatarUrl: null,
   back: null,
   ExportModal: null,
 };

--- a/packages/psss/src/views/AlertsOutbreaksView.js
+++ b/packages/psss/src/views/AlertsOutbreaksView.js
@@ -6,7 +6,7 @@ import React from 'react';
 import { useLocation } from 'react-router-dom';
 import { WarningCloud, TabsToolbar, Virus } from '@tupaia/ui-components';
 import { Archive } from '@material-ui/icons';
-import { Header, OutbreaksExportModal, AlertsExportModal } from '../components';
+import { Header, HeaderTitle, OutbreaksExportModal, AlertsExportModal } from '../components';
 import { AlertsRoutes } from '../routes/AlertsRoutes';
 
 const links = [
@@ -34,7 +34,7 @@ export const AlertsOutbreaksView = () => {
     : AlertsExportModal;
   return (
     <>
-      <Header title="Alerts & Outbreaks" ExportModal={ExportModal} />
+      <Header Title={<HeaderTitle title="Alerts & Outbreaks" />} ExportModal={ExportModal} />
       <TabsToolbar links={links} />
       <AlertsRoutes />
     </>

--- a/packages/psss/src/views/CountriesReportsView.js
+++ b/packages/psss/src/views/CountriesReportsView.js
@@ -15,7 +15,7 @@ import {
   WarningCloud,
   Virus,
 } from '@tupaia/ui-components';
-import { Container, Main, Sidebar, Header, WeeklyReportsExportModal } from '../components';
+import { Container, Main, Sidebar, Header, HeaderTitle, WeeklyReportsExportModal } from '../components';
 import { CountriesTable } from '../containers';
 
 const StyledCardContent = styled(CardContent)`
@@ -50,7 +50,7 @@ const tabData = [
 
 export const CountriesReportsView = () => (
   <>
-    <Header title="Countries" ExportModal={WeeklyReportsExportModal} />
+    <Header Title={<HeaderTitle title="Countries" />} ExportModal={WeeklyReportsExportModal} />
     <BaseToolbar />
     <Container>
       <Main data-testid="countries-table">

--- a/packages/psss/src/views/CountryReportsView.js
+++ b/packages/psss/src/views/CountryReportsView.js
@@ -6,7 +6,7 @@ import React from 'react';
 import { PhotoAlbum } from '@material-ui/icons';
 import { useParams } from 'react-router-dom';
 import { TabsToolbar, CalendarToday } from '@tupaia/ui-components';
-import { Header, WeeklyReportsExportModal } from '../components';
+import { Header, HeaderAvatarTitle, WeeklyReportsExportModal } from '../components';
 import { CountryRoutes } from '../routes/CountryRoutes';
 import { countryFlagImage } from '../utils';
 
@@ -32,9 +32,8 @@ export const CountryReportsView = () => {
   return (
     <>
       <Header
-        title={countryName}
+        Title={<HeaderAvatarTitle title={countryName} avatarUrl={countryFlagImage('as')} />}
         back={back}
-        avatarUrl={countryFlagImage('as')}
         ExportModal={WeeklyReportsExportModal}
       />
       <TabsToolbar links={links} />


### PR DESCRIPTION
### Issue #: [943](https://github.com/beyondessential/tupaia-backlog/issues/943)

This is a preliminary PR for the upcoming UserFlows PR which makes the header more flexible. The header now takes a JSX component as a `Title` prop so that the header can easily change depending on whether the user is a `regional` or `country` user.

### Changes:

- Refactor header component and implementation in Views
