### PR TITLE
Allow routes to respond with an error before permissions are checked

### DIFF
--- a/packages/meditrak-server/src/permissions/permissions.js
+++ b/packages/meditrak-server/src/permissions/permissions.js
@@ -41,6 +41,7 @@ export const ensurePermissionCheck = async (req, res, next) => {
     // allow errors to be sent without a permissions check
     if (res.statusCode < 200 || res.statusCode >= 300) {
       res.send(...args);
+      return;
     }
     res.status(501).send({
       error: 'No permission check was implemented for this endpoint',


### PR DESCRIPTION
@chris-bes what do you think of this? I think there could be errors thrown before a permissions check has been run, for e.g. when developing if I stuffed up the permissions check itself 😅 