### PR TITLE
Fix dependency version

### DIFF
--- a/packages/web-frontend/package.json
+++ b/packages/web-frontend/package.json
@@ -51,7 +51,7 @@
     "@testing-library/react": "^10.0.6",
     "@testing-library/user-event": "^12.0.11",
     "autoprefixer": "7.1.0",
-    "babel-jest": "^26..1.0",
+    "babel-jest": "^26.1.0",
     "babel-preset-react-app": "^9.1.2",
     "case-sensitive-paths-webpack-plugin": "1.1.4",
     "chalk": "1.1.3",

--- a/tupaia-packages.code-workspace
+++ b/tupaia-packages.code-workspace
@@ -78,6 +78,7 @@
     }
   ],
   "settings": {
+    "cSpell.language": "en-GB",
     "cSpell.words": [
       "DHIS",
       "MediTrak",


### PR DESCRIPTION
### Issue #:
[No issue]

Also adds a workspace setting for the language used for Spell Checking. I set it to `en-GB` since it seems to be the one we mostly use, until we make a final decision. It still allows for American spelling (`organization`, `color` etc)