### PR TITLE
925 admin panel date picker fixes

### DIFF
--- a/packages/admin-panel/src/pages/resources/SocialFeedPage.js
+++ b/packages/admin-panel/src/pages/resources/SocialFeedPage.js
@@ -7,6 +7,7 @@ import React from 'react';
 import Typography from '@material-ui/core/Typography';
 import PropTypes from 'prop-types';
 import { ResourcePage } from './ResourcePage';
+import moment from 'moment';
 
 const FIELDS = [
   {
@@ -26,6 +27,10 @@ const FIELDS = [
   {
     Header: 'Creation date',
     source: 'creation_date',
+    accessor: row =>
+      moment(row.creation_date)
+        .local()
+        .toString(),
     editConfig: {
       type: 'datetime-local',
     },

--- a/packages/admin-panel/src/pages/resources/SurveyResponsesPage.js
+++ b/packages/admin-panel/src/pages/resources/SurveyResponsesPage.js
@@ -3,10 +3,9 @@
  * Copyright (c) 2017 Beyond Essential Systems Pty Ltd
  */
 
-import { utcMoment } from '@tupaia/utils';
-
 import React from 'react';
 import PropTypes from 'prop-types';
+import moment from 'moment';
 import { ResourcePage } from './ResourcePage';
 
 const surveyName = {
@@ -24,7 +23,10 @@ const assessorName = {
 const date = {
   Header: 'Date of Survey',
   source: 'end_time',
-  accessor: row => utcMoment(row.end_time).format('ddd MMM DD YYYY HH:mm:ss Z'),
+  accessor: row =>
+    moment(row.end_time)
+      .local()
+      .toString(),
   filterable: false,
   editable: false,
 };
@@ -33,7 +35,9 @@ const dateOfData = {
   Header: 'Date of Data',
   source: 'submission_time',
   accessor: row =>
-    utcMoment(row.submission_time || row.end_time).format('ddd MMM DD YYYY HH:mm:ss Z'),
+    moment(row.submission_time || row.end_time)
+      .local()
+      .toString(),
   filterable: false,
   editConfig: {
     type: 'datetime-local',

--- a/packages/admin-panel/src/widgets/InputField.js
+++ b/packages/admin-panel/src/widgets/InputField.js
@@ -136,10 +136,15 @@ export const InputField = ({
         <DateTimePicker
           label={label}
           helperText={secondaryLabel}
+          format="yyyy-MM-dd HH:mm"
           value={
             value && moment(value).isValid ? moment(value).format('YYYY-MM-DDTHH:mm') : new Date()
           }
-          onChange={date => onChange(inputKey, date.toISOString())}
+          onChange={date => {
+            if (date && moment(date).isValid()) {
+              onChange(inputKey, moment(date).toISOString());
+            }
+          }}
           disabled={disabled}
         />
       );

--- a/packages/ui-components/src/components/Inputs/DatePicker.js
+++ b/packages/ui-components/src/components/Inputs/DatePicker.js
@@ -20,12 +20,12 @@ import { DAY_MONTH_YEAR_DATE_FORMAT, AM_PM_DATE_FORMAT } from '../../constants';
 const StyledDatePicker = styled(MuiDatePicker)`
   .MuiInputBase-input {
     padding-left: 0;
-    color: ${props => props.theme.palette.text.tertiary};
+    color: ${props => props.theme.palette.text.secondary};
   }
 
   .MuiButtonBase-root.MuiIconButton-root {
     top: -1px;
-    color: ${props => props.theme.palette.text.tertiary};
+    color: ${props => props.theme.palette.text.secondary};
     padding: 0.5rem;
   }
 `;

--- a/packages/ui-components/src/components/Inputs/TextField.js
+++ b/packages/ui-components/src/components/Inputs/TextField.js
@@ -53,6 +53,16 @@ export const TextField = styled(BaseTextField)`
     }
   }
 
+  // disabled
+  .MuiInputBase-input.Mui-disabled {
+    color: ${props => props.theme.palette.text.secondary};
+    background-color: ${props => props.theme.palette.grey['100']};
+  }
+
+  .MuiOutlinedInput-root.Mui-disabled .MuiOutlinedInput-notchedOutline {
+    border-color: ${props => props.theme.palette.grey['400']};
+  }
+
   // Hover state
   .MuiOutlinedInput-root:hover .MuiOutlinedInput-notchedOutline {
     border-color: ${props => props.theme.palette.grey['400']};


### PR DESCRIPTION
### Issue #: [Relates to 925](https://github.com/beyondessential/tupaia-backlog/issues/925)

### Changes:

- Make the date picker and the dates in the admin-panel tables show local dates (this is essentially reverting the admin panel to existing behaviour)

This ensures that the dates are accurate and consistent across AdminPanel. ie when you set a Date and Time using the date-picker the same value shows up in the table. Also the date in the tables is the 100% correct date and is formatted to show the timezone information using +/- hours GMT. However the issue remains that it is formatted differently to other places on Tupaia.org which can cause confusion. 

##### Problems with using timezone from server with date
I tried to incorporate the timezone from the recordData into the dates in the datePicker and table. There were a couple of problems with this approach though.
1. Cannot easily set a timeZone per instance of MaterialUI date-picker
2. FeedItem does not have a timezone associated with it

---

### Screenshots:

![Screen Shot 2020-08-25 at 3 50 04 PM](https://user-images.githubusercontent.com/12807916/91120871-b7e20480-e6ea-11ea-9c4e-7b843fe56407.png)
![Screen Shot 2020-08-25 at 3 50 11 PM](https://user-images.githubusercontent.com/12807916/91120878-badcf500-e6ea-11ea-942e-05535549db07.png)

