### PR TITLE
Add build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Tupaia
 
+[![Codeship Status for beyondessential/tupaia](https://app.codeship.com/projects/70159bc0-0dac-0138-fdcb-260b82737f4e/status?branch=master)](https://app.codeship.com/projects/379708)
+
 > This is a [mono-repo](https://github.com/babel/babel/blob/master/doc/design/monorepo.md)
 
 It is set up using `yarn workspaces`, meaning any command you would normally run inside a package can

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tupaia
 
-[![Codeship Status for beyondessential/tupaia](https://app.codeship.com/projects/70159bc0-0dac-0138-fdcb-260b82737f4e/status?branch=master)](https://app.codeship.com/projects/379708)
+[![Codeship Status for beyondessential/tupaia#dev](https://app.codeship.com/projects/70159bc0-0dac-0138-fdcb-260b82737f4e/status?branch=dev)](https://app.codeship.com/projects/379708)
 
 > This is a [mono-repo](https://github.com/babel/babel/blob/master/doc/design/monorepo.md)
 

--- a/tupaia-packages.code-workspace
+++ b/tupaia-packages.code-workspace
@@ -80,11 +80,13 @@
   "settings": {
     "cSpell.language": "en-GB",
     "cSpell.words": [
+      "Codeship",
       "DHIS",
       "MediTrak",
       "Tongatapu",
       "Tupaia",
       "analytics",
+      "beyondessential",
       "cacheable",
       "cleanup",
       "deleters",
@@ -108,10 +110,10 @@
       "preaggregators",
       "promisify",
       "singularise",
-      "Tongatapu",
-      "Tupaia",
-      "updaters",
+      "spec",
+      "specs",
       "testid",
+      "updaters",
       "upsert"
     ],
     "eslint.validate": ["typescript", "typescriptreact"],


### PR DESCRIPTION
### Issue #:
[No issue]

The status is for `master`, let me know if we should use `dev` instead. Next steps would be adding code coverage reports for individual packages (especially internal ones such as `data-broker`, `aggregator` etc)

It looks like this:

![image](https://user-images.githubusercontent.com/20692464/91675596-44c00e80-eb80-11ea-838c-627f2cf78bf8.png)


