### PR TITLE
Reinstate private field

### DIFF
--- a/packages/access-policy/package.json
+++ b/packages/access-policy/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@tupaia/access-policy",
+  "private": true,
   "version": "3.0.0",
   "description": "Methods for parsing Tupaia access policy",
   "main": "dist/index.js",

--- a/packages/admin-panel/package.json
+++ b/packages/admin-panel/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@tupaia/admin-panel",
+  "private": true,
   "version": "1.0.0",
   "dependencies": {
     "@material-ui/core": "^4.9.11",

--- a/packages/aggregator/package.json
+++ b/packages/aggregator/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@tupaia/aggregator",
+  "private": true,
   "version": "1.0.0",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@tupaia/auth",
+  "private": true,
   "version": "1.0.0",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/data-api/package.json
+++ b/packages/data-api/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@tupaia/data-api",
+  "private": true,
   "version": "1.0.0",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/data-broker/package.json
+++ b/packages/data-broker/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@tupaia/data-broker",
+  "private": true,
   "version": "1.0.0",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@tupaia/database",
+  "private": true,
   "version": "1.0.0",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/devops/package.json
+++ b/packages/devops/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@tupaia/devops",
+  "private": true,
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/dhis-api/package.json
+++ b/packages/dhis-api/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@tupaia/dhis-api",
+  "private": true,
   "version": "1.0.0",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/eslint-config-typescript/package.json
+++ b/packages/eslint-config-typescript/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@tupaia/eslint-config-typescript",
+  "private": true,
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {

--- a/packages/export-chart-lambda/package.json
+++ b/packages/export-chart-lambda/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@tupaia/export-chart-lambda",
+  "private": true,
   "version": "1.0.2",
   "description": "Lambda Function for Tupaia Chart Export",
   "main": "index.js",

--- a/packages/meditrak-app/package.json
+++ b/packages/meditrak-app/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@tupaia/meditrak-app",
+  "private": true,
   "version": "1.8.107",
   "workspaces": {
     "nohoist": [

--- a/packages/meditrak-server/src/devops/CreateThumbnail/package.json
+++ b/packages/meditrak-server/src/devops/CreateThumbnail/package.json
@@ -1,5 +1,6 @@
 {
   "name": "tupaia-resize-images",
+  "private": true,
   "version": "1.0.0",
   "description": "Based off of Amazon documentation at http://docs.aws.amazon.com/lambda/latest/dg/with-s3-example-deployment-pkg.html",
   "main": "index.js",

--- a/packages/psss/package.json
+++ b/packages/psss/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@tupaia/psss",
+  "private": true,
   "version": "0.1.0",
   "description": "Pacific Syndromic Surveillance System",
   "author": "Beyond Essential Systems <admin@tupaia.org> (https://beyondessential.com.au)",

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@tupaia/ui-components",
+  "private": true,
   "version": "1.0.0",
   "main": "dist/index.js",
   "description": "A library of user interface components for the Tupaia project.",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@tupaia/utils",
+  "private": true,
   "version": "1.0.0",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/web-config-server/package.json
+++ b/packages/web-config-server/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@tupaia/web-config-server",
+  "private": true,
   "version": "0.0.0",
   "description": "Config server for tupaia.org",
   "main": "dist",

--- a/packages/web-frontend/package.json
+++ b/packages/web-frontend/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@tupaia/web-frontend",
+  "private": true,
   "version": "1.0.0",
   "dependencies": {
     "@babel/polyfill": "^7.0.0",


### PR DESCRIPTION
### Issue #:
[No issue]

I had removed the `private` field when open sourcing our codebase. This was a wrong interpretation of the field: it actually refers to whether the package can be published in the npm registry, not whether it is "Open source".

We really only need this for `meditrak-app`, since the package must be `private` for the `workspaces.nohoist` field in `meditrak-app/package.json` to work. But I thought we should keep using `private` in all `package.json`, since we wouldn't want our monorepo ending up in npm anyway.