### PR TITLE
Allow specify timezone on entity import

### DIFF
--- a/packages/meditrak-server/src/routes/importEntities/getEntityObjectValidator.js
+++ b/packages/meditrak-server/src/routes/importEntities/getEntityObjectValidator.js
@@ -10,6 +10,7 @@ import {
   constructIsOneOf,
   constructThisOrThatHasContent,
   isPlainObject,
+  isValidTz,
 } from '@tupaia/utils';
 
 const constructEntityFieldValidators = models => ({
@@ -26,6 +27,7 @@ const constructEntityFieldValidators = models => ({
     },
   ],
   attributes: [constructIsEmptyOr(isPlainObject)],
+  timezone: [constructIsEmptyOr(isValidTz)],
 });
 
 const constructSpecificEntityTypeValidators = (entityType, models) => {

--- a/packages/meditrak-server/src/routes/importEntities/updateCountryEntities.js
+++ b/packages/meditrak-server/src/routes/importEntities/updateCountryEntities.js
@@ -79,6 +79,7 @@ export async function updateCountryEntities(transactingModels, countryName, enti
       category_code: categoryCode,
       facility_type: facilityType,
       attributes = {},
+      timezone,
     } = entityObject;
     if (codes.includes(code)) {
       throw new ImportValidationError(
@@ -103,6 +104,7 @@ export async function updateCountryEntities(transactingModels, countryName, enti
         code,
         name,
         geographical_area_id: parentGeographicalArea.id,
+        timezone,
       };
       const newFacility = await transactingModels.facility.updateOrCreate(
         { code },
@@ -128,6 +130,7 @@ export async function updateCountryEntities(transactingModels, countryName, enti
           dhis: { isDataRegional: true },
         },
         attributes,
+        timezone,
       },
     );
     if (longitude && latitude) {

--- a/packages/utils/src/validation/validatorFunctions.js
+++ b/packages/utils/src/validation/validatorFunctions.js
@@ -211,3 +211,10 @@ export const constructThisOrThatHasContent = otherFieldKey => (value, object) =>
   }
   return true;
 };
+
+export const isValidTz = value => {
+  if (moment.tz.names().indexOf(value) === -1) {
+    throw new Error(`Invalid timezone ${value}`);
+  }
+  return true;
+};


### PR DESCRIPTION
### Issue #: https://github.com/beyondessential/tupaia-backlog/issues/993

### Changes:

- Allow specify timezone on entity import in admin panel

---

### Example import files:
https://drive.google.com/drive/folders/1y1tfIe_t5Pb8yYGsXOthdL9RXmRD90Of?usp=sharing
