### PR TITLE
278 exclude submissiondate and primaryentity rows from survey response exportation

### DIFF
--- a/packages/meditrak-server/src/routes/exportSurveyResponses.js
+++ b/packages/meditrak-server/src/routes/exportSurveyResponses.js
@@ -8,7 +8,7 @@ import moment from 'moment';
 import fs from 'fs';
 import { truncateString } from 'sussol-utilities';
 import { DatabaseError, ValidationError } from '@tupaia/utils';
-import { ANSWER_TYPES } from '../database/models/Answer';
+import { ANSWER_TYPES, NON_DATA_ELEMENT_ANSWER_TYPES } from '../database/models/Answer';
 import { findAnswersInSurveyResponse, findQuestionsInSurvey } from '../dataAccessors';
 const FILE_LOCATION = 'exports';
 const FILE_PREFIX = 'survey_response_export';
@@ -158,7 +158,7 @@ export async function exportSurveyResponses(req, res) {
       const permissionGroup = await currentSurvey.getPermissionGroup();
       const hasSurveyAccess = accessPolicy.allows(country.code, permissionGroup.name);
       if (!hasSurveyAccess) {
-        exportData = [[`You do not have export access to ${currentSurvey.name}`]];
+        const exportData = [[`You do not have export access to ${currentSurvey.name}`]];
         addDataToSheet(currentSurvey.name, exportData);
         continue;
       }
@@ -258,31 +258,27 @@ export async function exportSurveyResponses(req, res) {
         }
 
         // Add the questions info and answers to be exported
-        let exportRow = INFO_ROW_HEADERS.length + 1; // The starting row pointer
+        let exportRow = INFO_ROW_HEADERS.length + 1; // Add one to make up for header row
         for (let questionIndex = 0; questionIndex < questions.length; questionIndex++) {
           // Set up the left columns with info about the questions
           const question = questions[questionIndex];
           const questionInfo = infoColumnKeys.map(columnKey => question[columnKey]);
           const questionType = questionInfo[1];
           // Exclude 'SubmissionDate' and 'PrimaryEntity' rows from survey response export since these have no answers
-          if (
-            questionType !== ANSWER_TYPES.SUBMISSION_DATE &&
-            questionType !== ANSWER_TYPES.PRIMARY_ENTITY
-          ) {
-            exportData[exportRow] = questionInfo;
+          if (NON_DATA_ELEMENT_ANSWER_TYPES.includes(questionType)) continue;
+          exportData[exportRow] = questionInfo;
 
-            // Add the answers on the right columns to the exportData
-            for (
-              let surveyResponseIndex = 0;
-              surveyResponseIndex < surveyResponseAnswers.length;
-              surveyResponseIndex++
-            ) {
-              const answer = surveyResponseAnswers[surveyResponseIndex][question.id];
-              const exportColumn = infoColumnKeys.length + surveyResponseIndex;
-              exportData[exportRow][exportColumn] = answer || '';
-            }
-            exportRow++; // Add one to make up for header row
+          // Add the answers on the right columns to the exportData
+          for (
+            let surveyResponseIndex = 0;
+            surveyResponseIndex < surveyResponseAnswers.length;
+            surveyResponseIndex++
+          ) {
+            const answer = surveyResponseAnswers[surveyResponseIndex][question.id];
+            const exportColumn = infoColumnKeys.length + surveyResponseIndex;
+            exportData[exportRow][exportColumn] = answer || '';
           }
+          exportRow++;
         }
       }
       addDataToSheet(currentSurvey.name, exportData);

--- a/packages/meditrak-server/src/routes/exportSurveyResponses.js
+++ b/packages/meditrak-server/src/routes/exportSurveyResponses.js
@@ -265,7 +265,12 @@ export async function exportSurveyResponses(req, res) {
           const questionInfo = infoColumnKeys.map(columnKey => question[columnKey]);
           const questionType = questionInfo[1];
           // Exclude 'SubmissionDate' and 'PrimaryEntity' rows from survey response export since these have no answers
-          if (NON_DATA_ELEMENT_ANSWER_TYPES.includes(questionType)) continue;
+          if (
+            NON_DATA_ELEMENT_ANSWER_TYPES.includes(questionType) &&
+            questionType !== ANSWER_TYPES.INSTRUCTION
+          ) {
+            continue;
+          }
           exportData[exportRow] = questionInfo;
 
           // Add the answers on the right columns to the exportData


### PR DESCRIPTION
### Issue #:
[Implements from beyondessential/tupaia-backlog/issues/278](https://github.com/beyondessential/tupaia-backlog/issues/278) 

When exporting survey response (xlsx file) in admin panel, 'SubmissionDate' and 'PrimaryEntity' rows are redundant since these have no answers. 

### Changes:
Add a condition checking while outputing xlsx file on meditrak-server.

---

### Screenshots:
Before:
![image](https://user-images.githubusercontent.com/31789355/93323722-51b75000-f858-11ea-96db-f619c359741f.png)


After:
![image](https://user-images.githubusercontent.com/31789355/93304312-2cb6e300-f840-11ea-81c8-2975020782aa.png)

[Survey Response (before).xlsx](https://github.com/beyondessential/tupaia/files/5230298/Survey.Response.before.xlsx)
[Survey Response (after).xlsx](https://github.com/beyondessential/tupaia/files/5230299/Survey.Response.after.xlsx)
