### PR TITLE
794 fix optionset import

### DIFF
--- a/packages/meditrak-server/src/database/models/Option.js
+++ b/packages/meditrak-server/src/database/models/Option.js
@@ -4,20 +4,19 @@
  **/
 
 import { DatabaseModel, DatabaseType, TYPES } from '@tupaia/database';
+import { hasContent } from '@tupaia/utils';
 
 class OptionType extends DatabaseType {
   static databaseType = TYPES.OPTION;
 
   static fieldValidators = new Map()
     .set('value', [
-       async (value) => {
-        const checkIsEmpty = value => value === undefined || value === null || value.length === 0;
-          if (checkIsEmpty(value)) {
-            return 'Value cannot be empty'; 
-          }
-          else {           
-           return null;
-          };
+      value => {
+        try {
+          return hasContent(value) && null;
+        } catch (error) {
+          return error.message;
+        }
       },
       async (value, model) => {
         const foundConflict = await findFieldConflict('value', value, model);

--- a/packages/meditrak-server/src/database/models/Option.js
+++ b/packages/meditrak-server/src/database/models/Option.js
@@ -4,14 +4,23 @@
  **/
 
 import { DatabaseModel, DatabaseType, TYPES } from '@tupaia/database';
-import { hasContent } from '@tupaia/utils';
 
 class OptionType extends DatabaseType {
   static databaseType = TYPES.OPTION;
 
   static fieldValidators = new Map()
     .set('value', [
-      hasContent,
+       async (value) => {
+     //  console.log('In fieldvalidators, the value is ' + value);
+    //   console.log('hasContent: ' + hasContent(value));
+        const checkIsEmpty = value => value === undefined || value === null || value.length === 0;
+          if (checkIsEmpty(value)) {
+            return 'Value cannot be empty'; 
+          }
+          else {           
+           return null;
+          };
+      },
       async (value, model) => {
         const foundConflict = await findFieldConflict('value', value, model);
         if (foundConflict) return 'Found duplicate values in option set';

--- a/packages/meditrak-server/src/database/models/Option.js
+++ b/packages/meditrak-server/src/database/models/Option.js
@@ -11,8 +11,6 @@ class OptionType extends DatabaseType {
   static fieldValidators = new Map()
     .set('value', [
        async (value) => {
-     //  console.log('In fieldvalidators, the value is ' + value);
-    //   console.log('hasContent: ' + hasContent(value));
         const checkIsEmpty = value => value === undefined || value === null || value.length === 0;
           if (checkIsEmpty(value)) {
             return 'Value cannot be empty'; 


### PR DESCRIPTION
Addresses: https://github.com/beyondessential/tupaia-backlog/issues/794

I'm sure theres a way to do this same functionality using `hasContent` (which I removed from this file) but I couldn't figure out how. This code works but I'm happy to do it a cleaner way if there's an obvious solution