### PR TITLE
Add a base jest config in root

### DIFF
--- a/jest.config.base.json
+++ b/jest.config.base.json
@@ -1,0 +1,7 @@
+{
+  "clearMocks": true,
+  "transform": { "^.+\\.jsx?$": "../../jestTransformer.js" },
+  "testMatch": ["<rootDir>/src/__tests__/**/**.test.js"],
+  "transformIgnorePatterns": ["/node_modules/"],
+  "testEnvironment": "node"
+}


### PR DESCRIPTION
Add a `jest.config.base.json` in root. It is resuable in sub pacakges while jest testing. 

If any pacakges need extension jest config, you can easily add a custom jest config under sub pacakge.