### PR TITLE
Speed up full build and cache

### DIFF
--- a/packages/database/src/DatabaseModel.js
+++ b/packages/database/src/DatabaseModel.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 import { DatabaseError } from '@tupaia/utils';
+import { runDatabaseFunctionInBatches } from './utilities/runDatabaseFunctionInBatches';
 
 export class DatabaseModel {
   otherModels = {};
@@ -132,14 +133,9 @@ export class DatabaseModel {
     if (!ids) {
       throw new Error(`Cannot search for ${this.databaseType} by id without providing the ids`);
     }
-    const records = [];
-    const batchSize = this.database.maxBindingsPerQuery;
-    for (let i = 0; i < ids.length; i += batchSize) {
-      const batchOfIds = ids.slice(i, i + batchSize);
-      const batchOfRecords = await this.find({ id: batchOfIds, ...criteria });
-      records.push(...batchOfRecords);
-    }
-    return records;
+    return runDatabaseFunctionInBatches(ids, async batchOfIds =>
+      this.find({ id: batchOfIds, ...criteria }),
+    );
   }
 
   async findOne(dbConditions, customQueryOptions = {}) {

--- a/packages/database/src/TupaiaDatabase.js
+++ b/packages/database/src/TupaiaDatabase.js
@@ -268,11 +268,15 @@ export class TupaiaDatabase {
   async createMany(recordType, records) {
     // generate ids for any records that don't have them
     const sanitizedRecords = records.map(r => (r.id ? r : { id: this.generateId(), ...r }));
-    await this.query({
-      recordType,
-      queryMethod: QUERY_METHODS.INSERT,
-      queryMethodParameter: sanitizedRecords,
-    });
+    const batchSize = this.maxBindingsPerQuery;
+    for (let i = 0; i < sanitizedRecords.length; i += batchSize) {
+      const batchOfRecords = sanitizedRecords.slice(i, i + batchSize);
+      await this.query({
+        recordType,
+        queryMethod: QUERY_METHODS.INSERT,
+        queryMethodParameter: batchOfRecords,
+      });
+    }
     return sanitizedRecords;
   }
 

--- a/packages/database/src/cachers/EntityHierarchyCacher.js
+++ b/packages/database/src/cachers/EntityHierarchyCacher.js
@@ -17,10 +17,8 @@ export class EntityHierarchyCacher {
   async buildAndCacheAll() {
     // projects are the root entities of every full tree, so start with them
     const projects = await this.models.project.all();
-    // iterate through projects in serial, as each one is quite resource intensive
-    for (const project of projects) {
-      await this.buildAndCacheProject(project);
-    }
+    const projectTasks = projects.map(async project => this.buildAndCacheProject(project));
+    await Promise.all(projectTasks);
   }
 
   async buildAndCacheProject(project) {

--- a/packages/database/src/cachers/EntityHierarchyCacher.js
+++ b/packages/database/src/cachers/EntityHierarchyCacher.js
@@ -83,7 +83,7 @@ export class EntityHierarchyCacher {
     }
 
     // check whether this generation/hierarchy combo has already been cached to avoid doing it again
-    // on startup, or when two projects share a hierarchy (at time of writing none do, but db schema
+    // on start up, or when two projects share a hierarchy (at time of writing none do, but db schema
     // makes it possible)
     const numberAlreadyCached = await this.models.ancestorDescendantRelation.count({
       entity_hierarchy_id: hierarchyId,

--- a/packages/database/src/cachers/EntityHierarchyCacher.js
+++ b/packages/database/src/cachers/EntityHierarchyCacher.js
@@ -61,11 +61,7 @@ export class EntityHierarchyCacher {
     }
 
     // if there is another generation, keep recursing through the hierarchy
-    await this.fetchAndCacheDescendants(
-      hierarchyId,
-      childIdsToAncestorIds,
-      entityRelationChildCount === 0,
-    );
+    await this.fetchAndCacheDescendants(hierarchyId, childIdsToAncestorIds);
   }
 
   async checkChildrenAlreadyCached(hierarchyId, parentIds, childCount) {

--- a/packages/database/src/cachers/EntityHierarchyCacher.js
+++ b/packages/database/src/cachers/EntityHierarchyCacher.js
@@ -95,12 +95,17 @@ export class EntityHierarchyCacher {
     });
   }
 
-  async countCanonicalChildren(entityIds) {
+  getCanonicalChildrenCriteria(entityId) {
     const canonicalTypes = Object.values(ORG_UNIT_ENTITY_TYPES);
-    return this.models.entity.count({
-      parent_id: entityIds,
+    return {
+      parent_id: entityId,
       type: canonicalTypes,
-    });
+    };
+  }
+
+  async countCanonicalChildren(entityIds) {
+    const criteria = this.getCanonicalChildrenCriteria(entityIds);
+    return this.models.entity.count(criteria);
   }
 
   async getRelationsViaEntityRelation(hierarchyId, parentIds) {
@@ -112,11 +117,8 @@ export class EntityHierarchyCacher {
   }
 
   async getRelationsCanonically(entityId) {
-    const canonicalTypes = Object.values(ORG_UNIT_ENTITY_TYPES);
-    const children = await this.models.entity.find(
-      { parent_id: entityId, type: canonicalTypes },
-      { columns: ['id', 'parent_id'] },
-    );
+    const criteria = this.getCanonicalChildrenCriteria(entityId);
+    const children = await this.models.entity.find(criteria, { columns: ['id', 'parent_id'] });
     return children.map(c => ({ child_id: c.id, parent_id: c.parent_id }));
   }
 

--- a/packages/database/src/cachers/EntityHierarchyCacher.js
+++ b/packages/database/src/cachers/EntityHierarchyCacher.js
@@ -11,9 +11,6 @@ export class EntityHierarchyCacher {
     this.generationsVisited = new Set();
   }
 
-  getGenerationKey = (entities, hierarchyId) =>
-    `${entities.map(e => e.code).join('-')}/${hierarchyId}`;
-
   async buildAndCacheAll() {
     // projects are the root entities of every full tree, so start with them
     const projects = await this.models.project.all();

--- a/packages/database/src/cachers/EntityHierarchyCacher.js
+++ b/packages/database/src/cachers/EntityHierarchyCacher.js
@@ -95,16 +95,16 @@ export class EntityHierarchyCacher {
     });
   }
 
-  getCanonicalChildrenCriteria(entityIds) {
+  getCanonicalChildrenCriteria(parentIds) {
     const canonicalTypes = Object.values(ORG_UNIT_ENTITY_TYPES);
     return {
-      parent_id: entityIds,
+      parent_id: parentIds,
       type: canonicalTypes,
     };
   }
 
-  async countCanonicalChildren(entityIds) {
-    const criteria = this.getCanonicalChildrenCriteria(entityIds);
+  async countCanonicalChildren(parentIds) {
+    const criteria = this.getCanonicalChildrenCriteria(parentIds);
     return this.models.entity.count(criteria);
   }
 

--- a/packages/database/src/cachers/EntityHierarchyCacher.js
+++ b/packages/database/src/cachers/EntityHierarchyCacher.js
@@ -18,8 +18,7 @@ export class EntityHierarchyCacher {
     // projects are the root entities of every full tree, so start with them
     const projects = await this.models.project.all();
     // iterate through projects in serial, as each one is quite resource intensive
-    for (let i = 0; i < projects.length; i++) {
-      const project = projects[i];
+    for (const project of projects) {
       await this.buildAndCacheProject(project);
     }
   }

--- a/packages/database/src/migrations/20201002193222-AddEntityParentIdIndex-modifies-schema.js
+++ b/packages/database/src/migrations/20201002193222-AddEntityParentIdIndex-modifies-schema.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function (db) {
+  return db.addIndex('entity', 'entity_parent_id_key', ['parent_id']);
+};
+
+exports.down = function (db) {
+  return db.removeIndex('entity', 'entity_parent_id_key');
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/packages/database/src/tests/cachers/EntityHierarchyCacher.fixtures.js
+++ b/packages/database/src/tests/cachers/EntityHierarchyCacher.fixtures.js
@@ -3,19 +3,18 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
-// canonical hierarchy is a - k, with each entity having the previous letter as its parent
+// canonical hierarchy splits into two children at each of two generations
+//          a
+//    aa         ab
+// aaa  aab   aba  abb
 const ENTITIES = [
   { id: 'entity_a_test', name: 'Entity A', parent_id: null },
-  { id: 'entity_b_test', name: 'Entity B', parent_id: 'entity_a_test' },
-  { id: 'entity_c_test', name: 'Entity C', parent_id: 'entity_b_test' },
-  { id: 'entity_d_test', name: 'Entity D', parent_id: 'entity_c_test' },
-  { id: 'entity_e_test', name: 'Entity E', parent_id: 'entity_d_test' },
-  { id: 'entity_f_test', name: 'Entity F', parent_id: 'entity_e_test' },
-  { id: 'entity_g_test', name: 'Entity G', parent_id: 'entity_f_test' },
-  { id: 'entity_h_test', name: 'Entity H', parent_id: 'entity_g_test' },
-  { id: 'entity_i_test', name: 'Entity I', parent_id: 'entity_h_test' },
-  { id: 'entity_j_test', name: 'Entity J', parent_id: 'entity_i_test' },
-  { id: 'entity_k_test', name: 'Entity K', parent_id: 'entity_j_test' },
+  { id: 'entity_aa_test', name: 'Entity AA', parent_id: 'entity_a_test' },
+  { id: 'entity_ab_test', name: 'Entity AB', parent_id: 'entity_a_test' },
+  { id: 'entity_aaa_test', name: 'Entity AAA', parent_id: 'entity_aa_test' },
+  { id: 'entity_aab_test', name: 'Entity AAB', parent_id: 'entity_aa_test' },
+  { id: 'entity_aba_test', name: 'Entity ABA', parent_id: 'entity_ab_test' },
+  { id: 'entity_abb_test', name: 'Entity ABB', parent_id: 'entity_ab_test' },
 ];
 
 // two hierarchies to play with
@@ -38,37 +37,32 @@ const PROJECTS = [
 ];
 
 // - project a follows the canonical hierarchy exactly
-// - project b lifts all entities from c to g (inclusive) up to a single generation below b,
-//   then from h as a child of c, with the canonical hierarchy continuing the chain below that
+// - project b moves the ab subtree to live below aa, to replace aaa and aab, and then aaa below
+//   aba, and aab below abb
+//      a
+//      aa
+//      ab
+//   aba  abb
+//   aaa  aab
 const ENTITY_RELATIONS = [
   {
-    parent_id: 'entity_b_test',
-    child_id: 'entity_c_test',
+    parent_id: 'entity_a_test',
+    child_id: 'entity_aa_test',
     entity_hierarchy_id: 'hierarchy_b_test',
   },
   {
-    parent_id: 'entity_b_test',
-    child_id: 'entity_d_test',
+    parent_id: 'entity_aa_test',
+    child_id: 'entity_ab_test',
     entity_hierarchy_id: 'hierarchy_b_test',
   },
   {
-    parent_id: 'entity_b_test',
-    child_id: 'entity_e_test',
+    parent_id: 'entity_aba_test',
+    child_id: 'entity_aaa_test',
     entity_hierarchy_id: 'hierarchy_b_test',
   },
   {
-    parent_id: 'entity_b_test',
-    child_id: 'entity_f_test',
-    entity_hierarchy_id: 'hierarchy_b_test',
-  },
-  {
-    parent_id: 'entity_b_test',
-    child_id: 'entity_g_test',
-    entity_hierarchy_id: 'hierarchy_b_test',
-  },
-  {
-    parent_id: 'entity_c_test',
-    child_id: 'entity_h_test',
+    parent_id: 'entity_abb_test',
+    child_id: 'entity_aab_test',
     entity_hierarchy_id: 'hierarchy_b_test',
   },
 ];
@@ -82,108 +76,42 @@ export const TEST_DATA = {
 
 export const EXPECTED_INITIAL_ANCESTOR_DESCENDANT_RELATIONS = {
   project_a_test: [
-    // ancestor entity a (all other entities are descendants)
-    { ancestor_id: 'entity_a_test', descendant_id: 'entity_b_test', generational_distance: 1 },
-    { ancestor_id: 'entity_a_test', descendant_id: 'entity_c_test', generational_distance: 2 },
-    { ancestor_id: 'entity_a_test', descendant_id: 'entity_d_test', generational_distance: 3 },
-    { ancestor_id: 'entity_a_test', descendant_id: 'entity_e_test', generational_distance: 4 },
-    { ancestor_id: 'entity_a_test', descendant_id: 'entity_f_test', generational_distance: 5 },
-    { ancestor_id: 'entity_a_test', descendant_id: 'entity_g_test', generational_distance: 6 },
-    { ancestor_id: 'entity_a_test', descendant_id: 'entity_h_test', generational_distance: 7 },
-    { ancestor_id: 'entity_a_test', descendant_id: 'entity_i_test', generational_distance: 8 },
-    { ancestor_id: 'entity_a_test', descendant_id: 'entity_j_test', generational_distance: 9 },
-    { ancestor_id: 'entity_a_test', descendant_id: 'entity_k_test', generational_distance: 10 },
-    // ancestor entity b (the nine entities below b)
-    { ancestor_id: 'entity_b_test', descendant_id: 'entity_c_test', generational_distance: 1 },
-    { ancestor_id: 'entity_b_test', descendant_id: 'entity_d_test', generational_distance: 2 },
-    { ancestor_id: 'entity_b_test', descendant_id: 'entity_e_test', generational_distance: 3 },
-    { ancestor_id: 'entity_b_test', descendant_id: 'entity_f_test', generational_distance: 4 },
-    { ancestor_id: 'entity_b_test', descendant_id: 'entity_g_test', generational_distance: 5 },
-    { ancestor_id: 'entity_b_test', descendant_id: 'entity_h_test', generational_distance: 6 },
-    { ancestor_id: 'entity_b_test', descendant_id: 'entity_i_test', generational_distance: 7 },
-    { ancestor_id: 'entity_b_test', descendant_id: 'entity_j_test', generational_distance: 8 },
-    { ancestor_id: 'entity_b_test', descendant_id: 'entity_k_test', generational_distance: 9 },
-    // ancestor entity c (the eight entities below c)
-    { ancestor_id: 'entity_c_test', descendant_id: 'entity_d_test', generational_distance: 1 },
-    { ancestor_id: 'entity_c_test', descendant_id: 'entity_e_test', generational_distance: 2 },
-    { ancestor_id: 'entity_c_test', descendant_id: 'entity_f_test', generational_distance: 3 },
-    { ancestor_id: 'entity_c_test', descendant_id: 'entity_g_test', generational_distance: 4 },
-    { ancestor_id: 'entity_c_test', descendant_id: 'entity_h_test', generational_distance: 5 },
-    { ancestor_id: 'entity_c_test', descendant_id: 'entity_i_test', generational_distance: 6 },
-    { ancestor_id: 'entity_c_test', descendant_id: 'entity_j_test', generational_distance: 7 },
-    { ancestor_id: 'entity_c_test', descendant_id: 'entity_k_test', generational_distance: 8 },
-    // ancestor entity d (the seven entities below d)
-    { ancestor_id: 'entity_d_test', descendant_id: 'entity_e_test', generational_distance: 1 },
-    { ancestor_id: 'entity_d_test', descendant_id: 'entity_f_test', generational_distance: 2 },
-    { ancestor_id: 'entity_d_test', descendant_id: 'entity_g_test', generational_distance: 3 },
-    { ancestor_id: 'entity_d_test', descendant_id: 'entity_h_test', generational_distance: 4 },
-    { ancestor_id: 'entity_d_test', descendant_id: 'entity_i_test', generational_distance: 5 },
-    { ancestor_id: 'entity_d_test', descendant_id: 'entity_j_test', generational_distance: 6 },
-    { ancestor_id: 'entity_d_test', descendant_id: 'entity_k_test', generational_distance: 7 },
-    // ancestor entity e (the six entities below e)
-    { ancestor_id: 'entity_e_test', descendant_id: 'entity_f_test', generational_distance: 1 },
-    { ancestor_id: 'entity_e_test', descendant_id: 'entity_g_test', generational_distance: 2 },
-    { ancestor_id: 'entity_e_test', descendant_id: 'entity_h_test', generational_distance: 3 },
-    { ancestor_id: 'entity_e_test', descendant_id: 'entity_i_test', generational_distance: 4 },
-    { ancestor_id: 'entity_e_test', descendant_id: 'entity_j_test', generational_distance: 5 },
-    { ancestor_id: 'entity_e_test', descendant_id: 'entity_k_test', generational_distance: 6 },
-    // ancestor entity f (the five entities below f)
-    { ancestor_id: 'entity_f_test', descendant_id: 'entity_g_test', generational_distance: 1 },
-    { ancestor_id: 'entity_f_test', descendant_id: 'entity_h_test', generational_distance: 2 },
-    { ancestor_id: 'entity_f_test', descendant_id: 'entity_i_test', generational_distance: 3 },
-    { ancestor_id: 'entity_f_test', descendant_id: 'entity_j_test', generational_distance: 4 },
-    { ancestor_id: 'entity_f_test', descendant_id: 'entity_k_test', generational_distance: 5 },
-    // ancestor entity g (the four entities below g)
-    { ancestor_id: 'entity_g_test', descendant_id: 'entity_h_test', generational_distance: 1 },
-    { ancestor_id: 'entity_g_test', descendant_id: 'entity_i_test', generational_distance: 2 },
-    { ancestor_id: 'entity_g_test', descendant_id: 'entity_j_test', generational_distance: 3 },
-    { ancestor_id: 'entity_g_test', descendant_id: 'entity_k_test', generational_distance: 4 },
-    // ancestor entity h (the three entities below h)
-    { ancestor_id: 'entity_h_test', descendant_id: 'entity_i_test', generational_distance: 1 },
-    { ancestor_id: 'entity_h_test', descendant_id: 'entity_j_test', generational_distance: 2 },
-    { ancestor_id: 'entity_h_test', descendant_id: 'entity_k_test', generational_distance: 3 },
-    // ancestor entity i ("j" and "k")
-    { ancestor_id: 'entity_i_test', descendant_id: 'entity_j_test', generational_distance: 1 },
-    { ancestor_id: 'entity_i_test', descendant_id: 'entity_k_test', generational_distance: 2 },
-    // ancestor entity j (just "k")
-    { ancestor_id: 'entity_j_test', descendant_id: 'entity_k_test', generational_distance: 1 },
+    // ancestor entity a
+    { ancestor_id: 'entity_a_test', descendant_id: 'entity_aa_test', generational_distance: 1 },
+    { ancestor_id: 'entity_a_test', descendant_id: 'entity_ab_test', generational_distance: 1 },
+    { ancestor_id: 'entity_a_test', descendant_id: 'entity_aaa_test', generational_distance: 2 },
+    { ancestor_id: 'entity_a_test', descendant_id: 'entity_aab_test', generational_distance: 2 },
+    { ancestor_id: 'entity_a_test', descendant_id: 'entity_aba_test', generational_distance: 2 },
+    { ancestor_id: 'entity_a_test', descendant_id: 'entity_abb_test', generational_distance: 2 },
+    // ancestor entity aa
+    { ancestor_id: 'entity_aa_test', descendant_id: 'entity_aaa_test', generational_distance: 1 },
+    { ancestor_id: 'entity_aa_test', descendant_id: 'entity_aab_test', generational_distance: 1 },
+    // ancestor entity ab
+    { ancestor_id: 'entity_ab_test', descendant_id: 'entity_aba_test', generational_distance: 1 },
+    { ancestor_id: 'entity_ab_test', descendant_id: 'entity_abb_test', generational_distance: 1 },
   ],
   project_b_test: [
-    // ancestor entity a (all other entities are descendants through some tree)
-    { ancestor_id: 'entity_a_test', descendant_id: 'entity_b_test', generational_distance: 1 },
-    { ancestor_id: 'entity_a_test', descendant_id: 'entity_c_test', generational_distance: 2 },
-    { ancestor_id: 'entity_a_test', descendant_id: 'entity_d_test', generational_distance: 2 },
-    { ancestor_id: 'entity_a_test', descendant_id: 'entity_e_test', generational_distance: 2 },
-    { ancestor_id: 'entity_a_test', descendant_id: 'entity_f_test', generational_distance: 2 },
-    { ancestor_id: 'entity_a_test', descendant_id: 'entity_g_test', generational_distance: 2 },
-    { ancestor_id: 'entity_a_test', descendant_id: 'entity_h_test', generational_distance: 3 },
-    { ancestor_id: 'entity_a_test', descendant_id: 'entity_i_test', generational_distance: 4 },
-    { ancestor_id: 'entity_a_test', descendant_id: 'entity_j_test', generational_distance: 5 },
-    { ancestor_id: 'entity_a_test', descendant_id: 'entity_k_test', generational_distance: 6 },
-    // ancestor entity b (all entities other than a are below b through some tree)
-    { ancestor_id: 'entity_b_test', descendant_id: 'entity_c_test', generational_distance: 1 },
-    { ancestor_id: 'entity_b_test', descendant_id: 'entity_d_test', generational_distance: 1 },
-    { ancestor_id: 'entity_b_test', descendant_id: 'entity_e_test', generational_distance: 1 },
-    { ancestor_id: 'entity_b_test', descendant_id: 'entity_f_test', generational_distance: 1 },
-    { ancestor_id: 'entity_b_test', descendant_id: 'entity_g_test', generational_distance: 1 },
-    { ancestor_id: 'entity_b_test', descendant_id: 'entity_h_test', generational_distance: 2 },
-    { ancestor_id: 'entity_b_test', descendant_id: 'entity_i_test', generational_distance: 3 },
-    { ancestor_id: 'entity_b_test', descendant_id: 'entity_j_test', generational_distance: 4 },
-    { ancestor_id: 'entity_b_test', descendant_id: 'entity_k_test', generational_distance: 5 },
-    // entities d, e, f, and g have no descendants in this hierarchy, but c has h attached via entity relation,
-    // and all of h's descendants below that)
-    { ancestor_id: 'entity_c_test', descendant_id: 'entity_h_test', generational_distance: 1 },
-    { ancestor_id: 'entity_c_test', descendant_id: 'entity_i_test', generational_distance: 2 },
-    { ancestor_id: 'entity_c_test', descendant_id: 'entity_j_test', generational_distance: 3 },
-    { ancestor_id: 'entity_c_test', descendant_id: 'entity_k_test', generational_distance: 4 },
-    // ancestor entity h (the three entities below h)
-    { ancestor_id: 'entity_h_test', descendant_id: 'entity_i_test', generational_distance: 1 },
-    { ancestor_id: 'entity_h_test', descendant_id: 'entity_j_test', generational_distance: 2 },
-    { ancestor_id: 'entity_h_test', descendant_id: 'entity_k_test', generational_distance: 3 },
-    // ancestor entity i ("j" and "k")
-    { ancestor_id: 'entity_i_test', descendant_id: 'entity_j_test', generational_distance: 1 },
-    { ancestor_id: 'entity_i_test', descendant_id: 'entity_k_test', generational_distance: 2 },
-    // ancestor entity j (just "k")
-    { ancestor_id: 'entity_j_test', descendant_id: 'entity_k_test', generational_distance: 1 },
+    // ancestor entity a
+    { ancestor_id: 'entity_a_test', descendant_id: 'entity_aa_test', generational_distance: 1 },
+    { ancestor_id: 'entity_a_test', descendant_id: 'entity_ab_test', generational_distance: 2 },
+    { ancestor_id: 'entity_a_test', descendant_id: 'entity_aba_test', generational_distance: 3 },
+    { ancestor_id: 'entity_a_test', descendant_id: 'entity_abb_test', generational_distance: 3 },
+    { ancestor_id: 'entity_a_test', descendant_id: 'entity_aaa_test', generational_distance: 4 },
+    { ancestor_id: 'entity_a_test', descendant_id: 'entity_aab_test', generational_distance: 4 },
+    // ancestor entity aa
+    { ancestor_id: 'entity_aa_test', descendant_id: 'entity_ab_test', generational_distance: 1 },
+    { ancestor_id: 'entity_aa_test', descendant_id: 'entity_aba_test', generational_distance: 2 },
+    { ancestor_id: 'entity_aa_test', descendant_id: 'entity_abb_test', generational_distance: 2 },
+    { ancestor_id: 'entity_aa_test', descendant_id: 'entity_aaa_test', generational_distance: 3 },
+    { ancestor_id: 'entity_aa_test', descendant_id: 'entity_aab_test', generational_distance: 3 },
+    // ancestor entity ab
+    { ancestor_id: 'entity_ab_test', descendant_id: 'entity_aba_test', generational_distance: 1 },
+    { ancestor_id: 'entity_ab_test', descendant_id: 'entity_abb_test', generational_distance: 1 },
+    { ancestor_id: 'entity_ab_test', descendant_id: 'entity_aaa_test', generational_distance: 2 },
+    { ancestor_id: 'entity_ab_test', descendant_id: 'entity_aab_test', generational_distance: 2 },
+    // ancestor entity aba
+    { ancestor_id: 'entity_aba_test', descendant_id: 'entity_aaa_test', generational_distance: 1 },
+    // ancestor entity abb
+    { ancestor_id: 'entity_abb_test', descendant_id: 'entity_aab_test', generational_distance: 1 },
   ],
 };

--- a/packages/database/src/tests/cachers/EntityHierarchyCacher.test.js
+++ b/packages/database/src/tests/cachers/EntityHierarchyCacher.test.js
@@ -17,31 +17,42 @@ describe('EntityHierarchyCacher', () => {
   const models = getTestModels();
   const hierarchyCacher = new EntityHierarchyCacher(models);
 
+  const buildAndCacheProject = async projectCode => {
+    const project = await models.project.findOne({ code: projectCode });
+    await hierarchyCacher.buildAndCacheProject(project);
+  };
+  const assertRelationsMatch = async (projectCode, relations) => {
+    const project = await models.project.findOne({ code: projectCode });
+    const { entity_hierarchy_id: hierarchyId } = project;
+    const relationsForProject = await models.ancestorDescendantRelation.find({
+      entity_hierarchy_id: hierarchyId,
+    });
+    expect(
+      relationsForProject.map(r => ({
+        ancestor_id: r.ancestor_id,
+        descendant_id: r.descendant_id,
+        generational_distance: r.generational_distance,
+      })),
+    ).to.deep.equalInAnyOrder(relations);
+  };
+
   before(async () => {
     await populateTestData(models, TEST_DATA);
   });
 
   describe('buildAndCacheProject', async () => {
-    const assertProjectRelationsCorrectlyBuilt = async (projectCode, hierarchyId) => {
-      const project = await models.project.findOne({ code: projectCode });
-      await hierarchyCacher.buildAndCacheProject(project);
-      const relationsForProject = await models.ancestorDescendantRelation.find({
-        entity_hierarchy_id: hierarchyId,
-      });
-
-      expect(
-        relationsForProject.map(r => ({
-          ancestor_id: r.ancestor_id,
-          descendant_id: r.descendant_id,
-          generational_distance: r.generational_distance,
-        })),
-      ).to.deep.equalInAnyOrder(EXPECTED_INITIAL_ANCESTOR_DESCENDANT_RELATIONS[projectCode]);
+    const assertProjectRelationsCorrectlyBuilt = async projectCode => {
+      await buildAndCacheProject(projectCode);
+      await assertRelationsMatch(
+        projectCode,
+        EXPECTED_INITIAL_ANCESTOR_DESCENDANT_RELATIONS[projectCode],
+      );
     };
     it('handles a hierarchy that is fully canonical', async () => {
-      await assertProjectRelationsCorrectlyBuilt('project_a_test', 'hierarchy_a_test');
+      await assertProjectRelationsCorrectlyBuilt('project_a_test');
     });
     it('handles a hierarchy that has entity relation links', async () => {
-      await assertProjectRelationsCorrectlyBuilt('project_b_test', 'hierarchy_b_test');
+      await assertProjectRelationsCorrectlyBuilt('project_b_test');
     });
   });
 });

--- a/packages/database/src/utilities/runDatabaseFunctionInBatches.js
+++ b/packages/database/src/utilities/runDatabaseFunctionInBatches.js
@@ -1,0 +1,20 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
+ */
+
+// some part of knex or node-pg struggles with too many bindings, so we batch them in some places
+export const MAX_BINDINGS_PER_QUERY = 2500; // errors occurred at around 5000 bindings in testing
+
+export async function runDatabaseFunctionInBatches(arrayToBeBatched, databaseFunction) {
+  const result = [];
+  const batchSize = MAX_BINDINGS_PER_QUERY;
+  for (let i = 0; i < arrayToBeBatched.length; i += batchSize) {
+    const batch = arrayToBeBatched.slice(i, i + batchSize);
+    const resultForBatch = await databaseFunction(batch);
+    if (Array.isArray(resultForBatch)) {
+      result.push(...resultForBatch);
+    }
+  }
+  return result;
+}

--- a/tupaia-packages.code-workspace
+++ b/tupaia-packages.code-workspace
@@ -92,6 +92,7 @@
       "analytics",
       "beyondessential",
       "cacheable",
+      "cachers",
       "cleanup",
       "debouncing",
       "deleters",


### PR DESCRIPTION
From ~18 minutes down to ~40 seconds for a full run

@kael89 I'm sorry about the number of times you've had to re-review this same section of code. My motivations here was that I realised that the cache invalidation logic for handling each individual case was becoming quite complex, and that if I could get the time for a full run down by enough, we could just re-run the full build whenever something changed, simplifying things greatly.