### PR TITLE
1354 display more useful error message on login for nonvalidated emai…

### DIFF
--- a/packages/web-frontend/src/actions.js
+++ b/packages/web-frontend/src/actions.js
@@ -225,7 +225,6 @@ export function fetchUserLoginError(errors) {
   return {
     type: FETCH_LOGIN_ERROR,
     errors,
-    errorMessage: 'Wrong e-mail or password',
   };
 }
 

--- a/packages/web-frontend/src/reducers.js
+++ b/packages/web-frontend/src/reducers.js
@@ -175,7 +175,7 @@ function authentication(
         ...state,
         isUserLoggedIn: false,
         isRequestingLogin: false,
-        loginFailedMessage: 'Wrong e-mail or password',
+        loginFailedMessage: action.errors.error,
         errors: action.errors,
       };
     case FETCH_RESET_TOKEN_LOGIN_ERROR:

--- a/packages/web-frontend/src/reducers.js
+++ b/packages/web-frontend/src/reducers.js
@@ -175,7 +175,7 @@ function authentication(
         ...state,
         isUserLoggedIn: false,
         isRequestingLogin: false,
-        loginFailedMessage: action.errors.error,
+        loginFailedMessage: 'Wrong e-mail or password',
         errors: action.errors,
       };
     case FETCH_RESET_TOKEN_LOGIN_ERROR:

--- a/packages/web-frontend/src/sagas.js
+++ b/packages/web-frontend/src/sagas.js
@@ -243,7 +243,7 @@ function* attemptUserLogin(action) {
     yield put(findLoggedIn(LOGIN_TYPES.MANUAL, response.emailVerified));
   } catch (error) {
     const errorMessage = error.response ? yield error.response.json() : {};
-    if (errorMessage.details && errorMessage.details === 'Email address not yet verified') {
+    if (errorMessage.error && errorMessage.error === 'Email address not yet verified') {
       yield put(displayUnverified());
     } else yield put(error.errorFunction(errorMessage));
   }

--- a/packages/web-frontend/src/sagas.js
+++ b/packages/web-frontend/src/sagas.js
@@ -243,7 +243,7 @@ function* attemptUserLogin(action) {
     yield put(findLoggedIn(LOGIN_TYPES.MANUAL, response.emailVerified));
   } catch (error) {
     const errorMessage = error.response ? yield error.response.json() : {};
-    if (errorMessage.error && errorMessage.error === 'Email address not yet verified') {
+    if (errorMessage?.error === 'Email address not yet verified') {
       yield put(displayUnverified());
     } else yield put(error.errorFunction(errorMessage));
   }


### PR DESCRIPTION
Addresses: https://github.com/beyondessential/tupaia-backlog/issues/1354

To be honest I'm not sure what a reducer is - making this one line change to this file seemed to fix the issue (from the perspective of the front end) but I'm not sure if I have to change things in other places too (there seems to be something related to this in `actions.js` but I'm not sure what the relationship between the two files is & I'm not sure if I had to make a change to that file too since just changing this one file seemed to solve the issue)

Basically this change means that the error message that is displayed to the front end comes from the error supplied by the `auth` package (rather than the hardcoded string that it used to display)