### PR TITLE
Add old record to change notifications

### DIFF
--- a/packages/auth/src/AccessPolicyBuilder.js
+++ b/packages/auth/src/AccessPolicyBuilder.js
@@ -14,14 +14,26 @@ export class AccessPolicyBuilder {
     this.setupCacheInvalidation();
   }
 
+  resetCachesForUser(userId) {
+    this.cachedPolicyPromises[getCacheKey(userId, true)] = null; // legacy
+    this.cachedPolicyPromises[getCacheKey(userId, false)] = null; // modern
+  }
+
   setupCacheInvalidation() {
     // if a user entity permission record is changed, make sure we rebuild the associated user's
     // access policy next time it is requested
-    this.models.userEntityPermission.addChangeHandler(({ record }) => {
-      const { user_id: userId } = record;
-      this.cachedPolicyPromises[getCacheKey(userId, true)] = null; // legacy
-      this.cachedPolicyPromises[getCacheKey(userId, false)] = null; // modern
-    });
+    this.models.userEntityPermission.addChangeHandler(
+      ({ old_record: oldRecord, new_record: newRecord }) => {
+        // present in update or delete changes
+        if (oldRecord) {
+          this.resetCachesForUser(oldRecord.user_id);
+        }
+        // present in create or update changes
+        if (newRecord) {
+          this.resetCachesForUser(newRecord.user_id);
+        }
+      },
+    );
   }
 
   async getPolicyForUser(userId, useLegacyFormat = false) {

--- a/packages/auth/src/__tests__/AccessPolicyBuilder.test.js
+++ b/packages/auth/src/__tests__/AccessPolicyBuilder.test.js
@@ -17,7 +17,11 @@ describe('AccessPolicyBuilder', () => {
   const models = {
     userEntityPermission: {
       addChangeHandler: onPermissionsChanged => {
-        notifyPermissionsChange = userId => onPermissionsChanged({ record: { user_id: userId } });
+        notifyPermissionsChange = userId =>
+          onPermissionsChanged({
+            old_record: { user_id: userId },
+            new_record: { user_id: userId },
+          });
       },
     },
   };

--- a/packages/database/src/DatabaseChangeChannel.js
+++ b/packages/database/src/DatabaseChangeChannel.js
@@ -34,7 +34,8 @@ export class DatabaseChangeChannel extends PGPubSub {
         type: 'update',
         record_type: recordType,
         handler_key: specificHandlerKey,
-        record,
+        old_record: record,
+        new_record: record,
       }),
     );
   }

--- a/packages/database/src/DatabaseModel.js
+++ b/packages/database/src/DatabaseModel.js
@@ -10,11 +10,6 @@ export class DatabaseModel {
 
   constructor(database) {
     this.database = database;
-    // Add change handler to database if defined, and this is the singleton instance of the model
-    const { onChange } = this.constructor;
-    if (this.database.isSingleton && onChange) {
-      this.addChangeHandler(change => onChange(change, this));
-    }
 
     // this.schema contains information about the columns on the table in the database, e.g.:
     // { id: { type: 'text', maxLength: null, nullable: false, defaultValue: null } }

--- a/packages/database/src/migrations/20201008205444-IncludeOldRecordInChangeNotifications-modifies-schema.js
+++ b/packages/database/src/migrations/20201008205444-IncludeOldRecordInChangeNotifications-modifies-schema.js
@@ -1,0 +1,140 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function (db) {
+  return db.runSql(`
+    CREATE OR REPLACE FUNCTION public.notification() RETURNS trigger
+      LANGUAGE plpgsql
+    AS $$
+    DECLARE
+    new_json_record JSONB;
+    old_json_record JSONB;
+    BEGIN
+    IF TG_OP = 'UPDATE' AND OLD = NEW THEN
+      RETURN NULL;
+    END IF;
+    IF TG_OP = 'UPDATE' THEN
+      old_json_record := public.scrub_geo_data(
+        to_jsonb(OLD),
+        TG_TABLE_NAME
+      );
+    END IF;
+    IF TG_OP = 'INSERT' OR TG_OP = 'UPDATE' THEN
+      new_json_record := public.scrub_geo_data(
+        to_jsonb(NEW),
+        TG_TABLE_NAME
+      );
+      PERFORM pg_notify(
+        'change',
+        json_build_object(
+          'record_type',
+          TG_TABLE_NAME,
+          'record_id',
+          NEW.id,
+          'type',
+          'update',
+          'old_record',
+          old_json_record,
+          'new_record',
+          new_json_record
+        )::text
+    );
+      RETURN NEW;
+    END IF;
+    IF TG_OP = 'DELETE' THEN
+      old_json_record := public.scrub_geo_data(
+        to_jsonb(OLD),
+        TG_TABLE_NAME
+      );
+      PERFORM pg_notify(
+      'change',
+      json_build_object(
+        'record_type',
+        TG_TABLE_NAME,
+        'record_id',
+        OLD.id,
+        'type',
+        'delete',
+        'old_record',
+        old_json_record,
+        'new_record',
+        NULL
+    )::text);
+      RETURN OLD;
+    END IF;
+    END;
+    $$;
+  `);
+};
+
+exports.down = function (db) {
+  return db.runSql(`
+    CREATE OR REPLACE FUNCTION public.notification() RETURNS trigger
+      LANGUAGE plpgsql
+      AS $$
+    DECLARE
+    json_record TEXT;
+    BEGIN
+    IF TG_OP = 'UPDATE' AND OLD = NEW THEN
+      RETURN NULL;
+    END IF;
+    IF TG_OP = 'INSERT' OR TG_OP = 'UPDATE' THEN
+      json_record := to_jsonb(NEW);
+      PERFORM pg_notify(
+        'change',
+        json_build_object(
+          'record_type',
+          TG_TABLE_NAME,
+          'record_id',
+          NEW.id,
+          'type',
+          'update',
+          'record',
+          public.scrub_geo_data(
+            json_record::jsonb,
+            TG_TABLE_NAME
+          )
+        )::text
+    );
+      RETURN NEW;
+    END IF;
+    IF TG_OP = 'DELETE' THEN
+      json_record := to_jsonb(OLD);
+      PERFORM pg_notify(
+      'change',
+      json_build_object(
+        'record_type',
+        TG_TABLE_NAME,
+        'record_id',
+        OLD.id,
+        'type',
+        'delete',
+        'record',
+        public.scrub_geo_data(
+          json_record::jsonb,
+          TG_TABLE_NAME
+        )
+    )::text);
+      RETURN OLD;
+    END IF;
+    END;
+    $$;
+  `);
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/packages/database/src/migrations/20201008205444-IncludeOldRecordInChangeNotifications-modifies-schema.js
+++ b/packages/database/src/migrations/20201008205444-IncludeOldRecordInChangeNotifications-modifies-schema.js
@@ -39,13 +39,13 @@ exports.up = function (db) {
     END IF;
 
     -- set up the old and new records
-    IF OLD IS NOT NULL THEN
+    IF TG_OP <> 'INSERT' THEN
       old_json_record := public.scrub_geo_data(
         to_jsonb(OLD),
         TG_TABLE_NAME
       );
     END IF;
-    IF NEW IS NOT NULL THEN
+    IF TG_OP <> 'DELETE' THEN
       new_json_record := public.scrub_geo_data(
         to_jsonb(NEW),
         TG_TABLE_NAME

--- a/packages/database/src/migrations/20201008205444-IncludeOldRecordInChangeNotifications-modifies-schema.js
+++ b/packages/database/src/migrations/20201008205444-IncludeOldRecordInChangeNotifications-modifies-schema.js
@@ -27,7 +27,7 @@ exports.up = function (db) {
     BEGIN
 
     -- if nothing has changed, no need to trigger a notification
-    IF OLD = NEW THEN
+    IF TG_OP = 'UPDATE' AND OLD = NEW THEN
       RETURN NULL;
     END IF;
 

--- a/packages/database/src/modelClasses/Indicator.js
+++ b/packages/database/src/modelClasses/Indicator.js
@@ -19,21 +19,22 @@ export class IndicatorModel extends DatabaseModel {
   }
 }
 
-const onChangeUpdateDataElement = async ({ type: changeType, record }, models) => {
-  const { code } = record;
-
+const onChangeUpdateDataElement = async (
+  { type: changeType, new_record: newRecord, old_record: oldRecord },
+  models,
+) => {
   switch (changeType) {
     case 'update':
       return models.dataSource.findOrCreate(
         {
-          code,
+          code: newRecord.code,
           type: models.dataSource.getTypes().DATA_ELEMENT,
           service_type: models.dataSource.SERVICE_TYPES.INDICATOR,
         },
         {},
       );
     case 'delete':
-      return models.dataSource.delete({ code });
+      return models.dataSource.delete({ code: oldRecord.code });
     default:
       throw new Error(`Non supported change type: ${changeType}`);
   }

--- a/packages/database/src/modelClasses/Indicator.js
+++ b/packages/database/src/modelClasses/Indicator.js
@@ -25,6 +25,12 @@ const onChangeUpdateDataElement = async (
 ) => {
   switch (changeType) {
     case 'update':
+      if (oldRecord && oldRecord.code !== newRecord.code) {
+        await models.dataSource.delete({
+          code: oldRecord.code,
+          type: models.dataSource.getTypes().DATA_ELEMENT,
+        });
+      }
       return models.dataSource.findOrCreate(
         {
           code: newRecord.code,

--- a/packages/database/src/tests/cachers/EntityHierarchyCacher.fixtures.js
+++ b/packages/database/src/tests/cachers/EntityHierarchyCacher.fixtures.js
@@ -289,6 +289,64 @@ export const HIERARCHY_STORM_AFTER_PARENT_ID_CHANGES = expandEntityRelations([
   ['abb', 'aab', 1],
 ]);
 
+// test moves the aba -> aaa entity relation over to hierarchy ocean, dropping aaa from hierarchy
+// storm
+//      a
+//      aa
+//      ab
+//   aba  abb
+//        aab
+export const HIERARCHY_STORM_AFTER_RELATION_HIERARCHY_CHANGED = expandEntityRelations([
+  // ancestor entity a
+  ['a', 'aa', 1],
+  ['a', 'ab', 2],
+  ['a', 'aba', 3],
+  ['a', 'abb', 3],
+  ['a', 'aab', 4],
+  // ancestor entity aa
+  ['aa', 'ab', 1],
+  ['aa', 'aba', 2],
+  ['aa', 'abb', 2],
+  ['aa', 'aab', 3],
+  // ancestor entity ab
+  ['ab', 'aba', 1],
+  ['ab', 'abb', 1],
+  ['ab', 'aab', 2],
+  // ancestor entity abb
+  ['abb', 'aab', 1],
+]);
+
+// test changes the parent_id of the aba -> aaa entity to abb
+// storm
+//      a
+//      aa
+//      ab
+//   aba  abb
+//      aaa aab
+export const HIERARCHY_STORM_AFTER_RELATION_PARENT_ID_CHANGED = expandEntityRelations([
+  // ancestor entity a
+  ['a', 'aa', 1],
+  ['a', 'ab', 2],
+  ['a', 'aba', 3],
+  ['a', 'abb', 3],
+  ['a', 'aaa', 4],
+  ['a', 'aab', 4],
+  // ancestor entity aa
+  ['aa', 'ab', 1],
+  ['aa', 'aba', 2],
+  ['aa', 'abb', 2],
+  ['aa', 'aaa', 3],
+  ['aa', 'aab', 3],
+  // ancestor entity ab
+  ['ab', 'aba', 1],
+  ['ab', 'abb', 1],
+  ['ab', 'aaa', 2],
+  ['ab', 'aab', 2],
+  // ancestor entity abb
+  ['abb', 'aab', 1],
+  ['abb', 'aaa', 1],
+]);
+
 // test moves aab to below aa, and ab to below aab, resulting in:
 //      a
 //      aa

--- a/packages/database/src/tests/cachers/EntityHierarchyCacher.fixtures.js
+++ b/packages/database/src/tests/cachers/EntityHierarchyCacher.fixtures.js
@@ -316,14 +316,13 @@ export const HIERARCHY_STORM_AFTER_RELATION_HIERARCHY_CHANGED = expandEntityRela
   ['abb', 'aab', 1],
 ]);
 
-// test changes the parent_id of the aba -> aaa entity to abb
-// storm
+// test changes the parent_id of the aba -> aaa entity relation to abb
 //      a
 //      aa
 //      ab
 //   aba  abb
 //      aaa aab
-export const HIERARCHY_STORM_AFTER_RELATION_PARENT_ID_CHANGED = expandEntityRelations([
+export const HIERARCHY_STORM_AFTER_RELATION_PARENT_ID_CHANGED_1 = expandEntityRelations([
   // ancestor entity a
   ['a', 'aa', 1],
   ['a', 'ab', 2],
@@ -346,6 +345,15 @@ export const HIERARCHY_STORM_AFTER_RELATION_PARENT_ID_CHANGED = expandEntityRela
   ['abb', 'aab', 1],
   ['abb', 'aaa', 1],
 ]);
+
+// test changes the parent_id of the ab -> aa entity relation to a
+// because this means aa now links to its canonical children again, the other entity relations
+// linking aaa to aba and aab to abb get ignored, as those entities have appeared earlier in the
+// hierarchy, so this ends up looking exactly like our full canonical hierarchy in the ocean project
+//          a
+//    aa         ab
+// aaa  aab   aba  abb
+export const HIERARCHY_STORM_AFTER_RELATION_PARENT_ID_CHANGED_2 = [...INITIAL_HIERARCHY_OCEAN];
 
 // test moves aab to below aa, and ab to below aab, resulting in:
 //      a

--- a/packages/database/src/tests/cachers/EntityHierarchyCacher.test.js
+++ b/packages/database/src/tests/cachers/EntityHierarchyCacher.test.js
@@ -25,7 +25,8 @@ import {
   HIERARCHY_OCEAN_AFTER_PARENT_ID_CHANGES,
   HIERARCHY_STORM_AFTER_PARENT_ID_CHANGES,
   HIERARCHY_STORM_AFTER_RELATION_HIERARCHY_CHANGED,
-  HIERARCHY_STORM_AFTER_RELATION_PARENT_ID_CHANGED,
+  HIERARCHY_STORM_AFTER_RELATION_PARENT_ID_CHANGED_1,
+  HIERARCHY_STORM_AFTER_RELATION_PARENT_ID_CHANGED_2,
   HIERARCHY_STORM_AFTER_MULTIPLE_RELATIONS_CHANGED,
   HIERARCHY_STORM_AFTER_ENTITY_RELATION_ADDED,
   HIERARCHY_OCEAN_AFTER_ENTITIES_CREATED,
@@ -171,20 +172,38 @@ describe('EntityHierarchyCacher', () => {
     );
   });
 
-  it('deletes a subtree and rebuilds when an entity relation parent_id changes', async () => {
-    // change the parent of the aba -> aaa entity to abb
-    await models.entityRelation.update(
-      {
-        parent_id: 'entity_aba_test',
-        child_id: 'entity_aaa_test',
-        entity_hierarchy_id: 'hierarchy_storm_test',
-      },
-      { parent_id: 'entity_abb_test' },
-    );
-    await assertRelationsMatch(
-      'project_storm_test',
-      HIERARCHY_STORM_AFTER_RELATION_PARENT_ID_CHANGED,
-    );
+  describe('deletes a subtree and rebuilds when an entity relation parent_id changes', async () => {
+    it('handles a change low down in the hierarchy', async () => {
+      // change the parent of the aba -> aaa entity to abb
+      await models.entityRelation.update(
+        {
+          parent_id: 'entity_aba_test',
+          child_id: 'entity_aaa_test',
+          entity_hierarchy_id: 'hierarchy_storm_test',
+        },
+        { parent_id: 'entity_abb_test' },
+      );
+      await assertRelationsMatch(
+        'project_storm_test',
+        HIERARCHY_STORM_AFTER_RELATION_PARENT_ID_CHANGED_1,
+      );
+    });
+
+    it('handles a change higher up in the hierarchy', async () => {
+      // change the parent of the aa -> ab entity to a
+      await models.entityRelation.update(
+        {
+          parent_id: 'entity_aa_test',
+          child_id: 'entity_ab_test',
+          entity_hierarchy_id: 'hierarchy_storm_test',
+        },
+        { parent_id: 'entity_a_test' },
+      );
+      await assertRelationsMatch(
+        'project_storm_test',
+        HIERARCHY_STORM_AFTER_RELATION_PARENT_ID_CHANGED_2,
+      );
+    });
   });
 
   it('deletes and rebuilds a subtree if entity relation records are changed', async () => {

--- a/packages/database/src/tests/cachers/EntityHierarchyCacher.test.js
+++ b/packages/database/src/tests/cachers/EntityHierarchyCacher.test.js
@@ -24,6 +24,8 @@ import {
   HIERARCHY_STORM_AFTER_MULTIPLE_RELATIONS_DELETED,
   HIERARCHY_OCEAN_AFTER_PARENT_ID_CHANGES,
   HIERARCHY_STORM_AFTER_PARENT_ID_CHANGES,
+  HIERARCHY_STORM_AFTER_RELATION_HIERARCHY_CHANGED,
+  HIERARCHY_STORM_AFTER_RELATION_PARENT_ID_CHANGED,
   HIERARCHY_STORM_AFTER_MULTIPLE_RELATIONS_CHANGED,
   HIERARCHY_STORM_AFTER_ENTITY_RELATION_ADDED,
   HIERARCHY_OCEAN_AFTER_ENTITIES_CREATED,
@@ -151,6 +153,38 @@ describe('EntityHierarchyCacher', () => {
     await models.entity.updateById('entity_abb_test', { parent_id: 'entity_aaa_test' });
     await assertRelationsMatch('project_ocean_test', HIERARCHY_OCEAN_AFTER_PARENT_ID_CHANGES);
     await assertRelationsMatch('project_storm_test', HIERARCHY_STORM_AFTER_PARENT_ID_CHANGES);
+  });
+
+  it('deletes a subtree when an entity relation record changes hierarchy', async () => {
+    // move aba -> aaa to be in the ocean hierarchy
+    await models.entityRelation.update(
+      {
+        parent_id: 'entity_aba_test',
+        child_id: 'entity_aaa_test',
+        entity_hierarchy_id: 'hierarchy_storm_test',
+      },
+      { entity_hierarchy_id: 'hierarchy_ocean_test' },
+    );
+    await assertRelationsMatch(
+      'project_storm_test',
+      HIERARCHY_STORM_AFTER_RELATION_HIERARCHY_CHANGED,
+    );
+  });
+
+  it('deletes a subtree and rebuilds when an entity relation parent_id changes', async () => {
+    // move aba -> aaa to be in the ocean hierarchy
+    await models.entityRelation.update(
+      {
+        parent_id: 'entity_aba_test',
+        child_id: 'entity_aaa_test',
+        entity_hierarchy_id: 'hierarchy_storm_test',
+      },
+      { parent_id: 'entity_abb_test' },
+    );
+    await assertRelationsMatch(
+      'project_storm_test',
+      HIERARCHY_STORM_AFTER_RELATION_PARENT_ID_CHANGED,
+    );
   });
 
   it('deletes and rebuilds a subtree if entity relation records are changed', async () => {

--- a/packages/database/src/tests/cachers/EntityHierarchyCacher.test.js
+++ b/packages/database/src/tests/cachers/EntityHierarchyCacher.test.js
@@ -172,7 +172,7 @@ describe('EntityHierarchyCacher', () => {
   });
 
   it('deletes a subtree and rebuilds when an entity relation parent_id changes', async () => {
-    // move aba -> aaa to be in the ocean hierarchy
+    // change the parent of the aba -> aaa entity to abb
     await models.entityRelation.update(
       {
         parent_id: 'entity_aba_test',

--- a/packages/meditrak-server/src/database/models/AccessRequest.js
+++ b/packages/meditrak-server/src/database/models/AccessRequest.js
@@ -9,17 +9,16 @@ export class AccessRequestModel extends CommonAccessRequestModel {
   notifiers = [onApproveCreateUserCountryPermission];
 }
 
-async function onApproveCreateUserCountryPermission(
-  {
-    record: {
-      approved,
-      user_id: userId,
-      entity_id: entityId,
-      permission_group_id: permissionGroupId,
-    },
-  },
-  models,
-) {
+async function onApproveCreateUserCountryPermission({ type, new_record: newRecord }, models) {
+  if (type === 'delete') return;
+
+  const {
+    approved,
+    user_id: userId,
+    entity_id: entityId,
+    permission_group_id: permissionGroupId,
+  } = newRecord;
+
   const data = {
     user_id: userId,
     entity_id: entityId,

--- a/packages/meditrak-server/src/database/models/Answer.js
+++ b/packages/meditrak-server/src/database/models/Answer.js
@@ -126,11 +126,10 @@ export class AnswerModel extends DatabaseModel {
   types = ANSWER_TYPES;
 }
 
-const onChangeRunQuestionHook = async ({ type: changeType, new_record: newRecord }, model) => {
+const onChangeRunQuestionHook = async ({ type: changeType, new_record: newRecord }, models) => {
   if (changeType === 'delete') return;
-
-  const answer = await model.generateInstance(newRecord);
   try {
+    const answer = await models.answer.generateInstance(newRecord);
     await answer.runHook();
   } catch (e) {
     winston.error(e);

--- a/packages/meditrak-server/src/database/models/Answer.js
+++ b/packages/meditrak-server/src/database/models/Answer.js
@@ -117,20 +117,22 @@ class AnswerType extends DatabaseType {
 }
 
 export class AnswerModel extends DatabaseModel {
+  notifiers = [onChangeRunQuestionHook];
+
   get DatabaseTypeClass() {
     return AnswerType;
   }
 
   types = ANSWER_TYPES;
-
-  static onChange = async ({ type: changeType, record }, model) => {
-    if (changeType === 'delete') return;
-
-    const answer = await model.generateInstance(record);
-    try {
-      await answer.runHook();
-    } catch (e) {
-      winston.error(e);
-    }
-  };
 }
+
+const onChangeRunQuestionHook = async ({ type: changeType, new_record: newRecord }, model) => {
+  if (changeType === 'delete') return;
+
+  const answer = await model.generateInstance(newRecord);
+  try {
+    await answer.runHook();
+  } catch (e) {
+    winston.error(e);
+  }
+};

--- a/packages/meditrak-server/src/database/models/Question.js
+++ b/packages/meditrak-server/src/database/models/Question.js
@@ -35,14 +35,19 @@ export class QuestionModel extends DatabaseModel {
   }
 }
 
-const onChangeUpdateDataElement = async ({ type: changeType, record }, models) => {
-  const { code, data_source_id: dataSourceId } = record;
-
+const onChangeUpdateDataElement = async (
+  { type: changeType, old_record: oldRecord, new_record: newRecord },
+  models,
+) => {
   switch (changeType) {
-    case 'update':
+    case 'update': {
+      const { code, data_source_id: dataSourceId } = newRecord;
       return models.dataSource.updateById(dataSourceId, { code });
-    case 'delete':
+    }
+    case 'delete': {
+      const { data_source_id: dataSourceId } = oldRecord;
       return models.dataSource.deleteById(dataSourceId);
+    }
     default:
       throw new Error(`Non supported change type: ${changeType}`);
   }

--- a/packages/meditrak-server/src/database/models/Survey.js
+++ b/packages/meditrak-server/src/database/models/Survey.js
@@ -21,8 +21,8 @@ class SurveyType extends DatabaseType {
       `
       SELECT q.* FROM question q
       JOIN survey_screen_component ssc ON ssc.question_id  = q.id
-      JOIN survey_screen ss ON ss.id = ssc.screen_id 
-      JOIN survey s ON s.id = ss.survey_id 
+      JOIN survey_screen ss ON ss.id = ssc.screen_id
+      JOIN survey s ON s.id = ss.survey_id
       WHERE s.code = ?
     `,
       [this.code],
@@ -50,14 +50,19 @@ export class SurveyModel extends DatabaseModel {
   isDeletableViaApi = true;
 }
 
-const onChangeUpdateDataGroup = async ({ type: changeType, record }, models) => {
-  const { code, data_source_id: dataSourceId } = record;
-
+const onChangeUpdateDataGroup = async (
+  { type: changeType, old_record: oldRecord, new_record: newRecord },
+  models,
+) => {
   switch (changeType) {
-    case 'update':
+    case 'update': {
+      const { code, data_source_id: dataSourceId } = newRecord;
       return models.dataSource.updateById(dataSourceId, { code });
-    case 'delete':
+    }
+    case 'delete': {
+      const { data_source_id: dataSourceId } = oldRecord;
       return models.dataSource.deleteById(dataSourceId);
+    }
     default:
       throw new Error(`Non supported change type: ${changeType}`);
   }

--- a/packages/meditrak-server/src/database/models/SurveyResponse.js
+++ b/packages/meditrak-server/src/database/models/SurveyResponse.js
@@ -109,7 +109,7 @@ export class SurveyResponseModel extends DatabaseModel {
 
 const onChangeUpdateUserReward = async (
   { type: changeType, record_id: recordId, new_record: newRecord },
-  model,
+  models,
 ) => {
   const modelDetails = {
     type: 'SurveyResponse',
@@ -117,9 +117,9 @@ const onChangeUpdateUserReward = async (
   };
 
   if (changeType === 'delete') {
-    model.otherModels.userReward.delete(modelDetails);
+    models.userReward.delete(modelDetails);
   } else {
-    model.otherModels.userReward.updateOrCreate(modelDetails, {
+    models.userReward.updateOrCreate(modelDetails, {
       ...modelDetails,
       coconuts: 1,
       user_id: newRecord.user_id,

--- a/packages/meditrak-server/src/database/models/SurveyResponse.js
+++ b/packages/meditrak-server/src/database/models/SurveyResponse.js
@@ -50,6 +50,8 @@ class SurveyResponseType extends DatabaseType {
 }
 
 export class SurveyResponseModel extends DatabaseModel {
+  notifiers = [onChangeUpdateUserReward];
+
   get DatabaseTypeClass() {
     return SurveyResponseType;
   }
@@ -103,22 +105,25 @@ export class SurveyResponseModel extends DatabaseModel {
     if (result.length === 0) return false;
     return result[0].count === '1';
   }
-
-  static onChange = async ({ type: changeType, record }, model) => {
-    const modelDetails = {
-      type: 'SurveyResponse',
-      record_id: record.id,
-    };
-
-    if (changeType === 'delete') {
-      model.otherModels.userReward.delete(modelDetails);
-    } else {
-      model.otherModels.userReward.updateOrCreate(modelDetails, {
-        ...modelDetails,
-        coconuts: 1,
-        user_id: record.user_id,
-        creation_date: record.end_time,
-      });
-    }
-  };
 }
+
+const onChangeUpdateUserReward = async (
+  { type: changeType, record_id: recordId, new_record: newRecord },
+  model,
+) => {
+  const modelDetails = {
+    type: 'SurveyResponse',
+    record_id: recordId,
+  };
+
+  if (changeType === 'delete') {
+    model.otherModels.userReward.delete(modelDetails);
+  } else {
+    model.otherModels.userReward.updateOrCreate(modelDetails, {
+      ...modelDetails,
+      coconuts: 1,
+      user_id: newRecord.user_id,
+      creation_date: newRecord.end_time,
+    });
+  }
+};

--- a/packages/meditrak-server/src/database/models/UserEntityPermission.js
+++ b/packages/meditrak-server/src/database/models/UserEntityPermission.js
@@ -18,15 +18,18 @@ export class UserEntityPermissionModel extends CommonUserEntityPermissionModel {
  * hold off and pool several changes for the same user (e.g. if they're being granted permission
  * to three countries at once), but this is good enough.
  */
-async function onUpsertSendPermissionGrantEmail({ type: changeType, record }, models) {
+async function onUpsertSendPermissionGrantEmail(
+  { type: changeType, new_record: newRecord },
+  models,
+) {
   if (changeType === 'delete') {
     return; // Don't notify the user of permissions being taken away
   }
 
   // Get details of permission granted
-  const user = await models.user.findById(record.user_id);
-  const entity = await models.entity.findById(record.entity_id);
-  const permissionGroup = await models.permissionGroup.findById(record.permission_group_id);
+  const user = await models.user.findById(newRecord.user_id);
+  const entity = await models.entity.findById(newRecord.entity_id);
+  const permissionGroup = await models.permissionGroup.findById(newRecord.permission_group_id);
 
   // Compose message to send
   const message = `Hi ${user.first_name},

--- a/packages/meditrak-server/src/dhis/DhisChangeDetailGenerator.js
+++ b/packages/meditrak-server/src/dhis/DhisChangeDetailGenerator.js
@@ -94,6 +94,6 @@ export class DhisChangeDetailGenerator extends ChangeDetailGenerator {
       ...surveyResponseDetailsById,
     };
 
-    return updateChanges.map(c => JSON.stringify(detailsByChangeId[c.record.id]));
+    return updateChanges.map(c => JSON.stringify(detailsByChangeId[c.record_id]));
   };
 }

--- a/packages/meditrak-server/src/externalApiSync/SyncQueueChangesManipulator.js
+++ b/packages/meditrak-server/src/externalApiSync/SyncQueueChangesManipulator.js
@@ -28,10 +28,7 @@ export class SyncQueueChangesManipulator {
   getRecords = changes =>
     changes.map(change => {
       const { old_record: oldRecord, new_record: newRecord, type } = change;
-      if (type === DELETE) {
-        return oldRecord;
-      }
-      return newRecord;
+      return type === DELETE ? oldRecord : newRecord;
     });
 
   getRecordsFromChangesForModel = (changes, model) =>

--- a/packages/meditrak-server/src/externalApiSync/SyncQueueChangesManipulator.js
+++ b/packages/meditrak-server/src/externalApiSync/SyncQueueChangesManipulator.js
@@ -25,7 +25,14 @@ export class SyncQueueChangesManipulator {
   getIdsFromChangesForModel = (changes, model) =>
     this.getRecordIds(this.getChangesForRecordType(changes, model.databaseType));
 
-  getRecords = changes => changes.map(c => c.record);
+  getRecords = changes =>
+    changes.map(change => {
+      const { old_record: oldRecord, new_record: newRecord, type } = change;
+      if (type === DELETE) {
+        return oldRecord;
+      }
+      return newRecord;
+    });
 
   getRecordsFromChangesForModel = (changes, model) =>
     this.getRecords(this.getChangesForRecordType(changes, model.databaseType));

--- a/packages/meditrak-server/src/tests/dhis/DhisChangeDetailGenerator.test.js
+++ b/packages/meditrak-server/src/tests/dhis/DhisChangeDetailGenerator.test.js
@@ -13,13 +13,20 @@ import {
   TONGA_SURVEY_RESPONSE,
 } from './DhisChangeDetailGenerator.fixtures';
 
-const buildChange = (type, record) => ({
-  record_type: type,
-  record: {
-    id: generateTestId(),
-    ...record,
-  },
-});
+const buildChange = (type, record) => {
+  const recordId = generateTestId();
+  return {
+    record_type: type,
+    new_record: {
+      id: recordId,
+      ...record,
+    },
+    old_record: {
+      id: recordId,
+      ...record,
+    },
+  };
+};
 
 const generator = new DhisChangeDetailGenerator(MODELS);
 

--- a/packages/meditrak-server/src/tests/dhis/DhisChangeDetailGenerator.test.js
+++ b/packages/meditrak-server/src/tests/dhis/DhisChangeDetailGenerator.test.js
@@ -22,10 +22,7 @@ const buildChange = (type, { id, ...record }) => {
       id: recordId,
       ...record,
     },
-    old_record: {
-      id: recordId,
-      ...record,
-    },
+    old_record: null,
   };
 };
 

--- a/packages/meditrak-server/src/tests/dhis/DhisChangeDetailGenerator.test.js
+++ b/packages/meditrak-server/src/tests/dhis/DhisChangeDetailGenerator.test.js
@@ -13,10 +13,11 @@ import {
   TONGA_SURVEY_RESPONSE,
 } from './DhisChangeDetailGenerator.fixtures';
 
-const buildChange = (type, record) => {
-  const recordId = generateTestId();
+const buildChange = (type, { id, ...record }) => {
+  const recordId = id || generateTestId();
   return {
     record_type: type,
+    record_id: recordId,
     new_record: {
       id: recordId,
       ...record,


### PR DESCRIPTION
The commits, in order, achieve the following:
1. Added two tests to catch edge cases of modifying an entity relation record
2. Modified change notification to include `old_record` and `new_record` instead of just `record` (which was previously old for deletes and new for creates/updates)
3. Update every instance of `record` being used within a change to deal with either `old_record` or `new_record` (or both!) instead (plus deprecated `onChange` in favour of `notifiers`)
4. Get new edge case tests passing by handling old and new records in the hierarchy cacher