### PR TITLE
1374 fix default date is wrong in map overlays (2)

### DIFF
--- a/packages/web-frontend/src/components/DateRangePicker/DateRangePicker.js
+++ b/packages/web-frontend/src/components/DateRangePicker/DateRangePicker.js
@@ -132,7 +132,10 @@ export const DateRangePicker = ({
   );
 
   useEffect(() => {
-    onSetDates(roundedCurrentStartDate, roundedCurrentEndDate);
+    // Prevent set dates to the same dates
+    if (!(initialStartDate && initialEndDate)) {
+      onSetDates(roundedCurrentStartDate, roundedCurrentEndDate);
+    }
   }, []);
 
   // Number of periods to move may be negative if changing to the previous period

--- a/packages/web-frontend/src/containers/MeasureBar/Control.js
+++ b/packages/web-frontend/src/containers/MeasureBar/Control.js
@@ -109,6 +109,7 @@ const ExpandedContent = styled.div`
 export const Control = ({
   emptyMessage,
   selectedMeasure,
+  defaultDates,
   isMeasureLoading,
   onUpdateMeasurePeriod,
   children,
@@ -128,6 +129,10 @@ export const Control = ({
     const period = GRANULARITY_CONFIG[periodGranularity].momentUnit;
     onUpdateMeasurePeriod(moment(startDate).startOf(period), moment(endDate).endOf(period));
   };
+
+  let { startDate, endDate } = selectedMeasure;
+  if (!startDate && defaultDates.startDate) startDate = defaultDates.startDate;
+  if (!endDate && defaultDates.endDate) endDate = defaultDates.endDate;
 
   return (
     <Container>
@@ -158,8 +163,8 @@ export const Control = ({
         <MeasureDatePicker expanded={isExpanded}>
           <DateRangePicker
             granularity={selectedMeasure.periodGranularity}
-            startDate={selectedMeasure.startDate}
-            endDate={selectedMeasure.endDate}
+            startDate={startDate}
+            endDate={endDate}
             onSetDates={updateMeasurePeriod}
             isLoading={isMeasureLoading}
           />
@@ -183,6 +188,10 @@ Control.propTypes = {
     startDate: PropTypes.shape({}),
     endDate: PropTypes.shape({}),
   }),
+  defaultDates: PropTypes.shape({
+    startDate: PropTypes.string,
+    endDate: PropTypes.string,
+  }).isRequired,
   emptyMessage: PropTypes.string.isRequired,
   children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,
   isMeasureLoading: PropTypes.bool,

--- a/packages/web-frontend/src/containers/MeasureBar/Control.js
+++ b/packages/web-frontend/src/containers/MeasureBar/Control.js
@@ -130,9 +130,11 @@ export const Control = ({
     onUpdateMeasurePeriod(moment(startDate).startOf(period), moment(endDate).endOf(period));
   };
 
+  // Map overlays always have initial dates, so DateRangePicker always has dates on initialisation,
+  // and uses those rather than calculating it's own defaults
   let { startDate, endDate } = selectedMeasure;
-  if (!startDate && defaultDates.startDate) startDate = defaultDates.startDate;
-  if (!endDate && defaultDates.endDate) endDate = defaultDates.endDate;
+  if (!startDate) startDate = defaultDates.startDate;
+  if (!endDate) endDate = defaultDates.endDate;
 
   return (
     <Container>
@@ -189,8 +191,8 @@ Control.propTypes = {
     endDate: PropTypes.shape({}),
   }),
   defaultDates: PropTypes.shape({
-    startDate: PropTypes.string,
-    endDate: PropTypes.string,
+    startDate: PropTypes.object,
+    endDate: PropTypes.object,
   }).isRequired,
   emptyMessage: PropTypes.string.isRequired,
   children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,

--- a/packages/web-frontend/src/containers/MeasureBar/index.js
+++ b/packages/web-frontend/src/containers/MeasureBar/index.js
@@ -27,6 +27,7 @@ import {
   selectCurrentProject,
   selectMeasureBarItemById,
 } from '../../selectors';
+import { getDefaultDates } from '../../utils/periodGranularities';
 
 export class MeasureBar extends Component {
   constructor(props) {
@@ -141,10 +142,13 @@ export class MeasureBar extends Component {
     const orgName = currentOrganisationUnitName || 'Your current selection';
     const emptyMessage = `Select an area with valid data. ${orgName} has no map overlays available.`;
 
+    const defaultDates = getDefaultDates(currentMeasure);
+
     return (
       <Control
         emptyMessage={emptyMessage}
         selectedMeasure={currentMeasure}
+        defaultDates={defaultDates}
         isMeasureLoading={isMeasureLoading}
         onUpdateMeasurePeriod={onUpdateMeasurePeriod}
       >


### PR DESCRIPTION
(Reopening a PR that was accidentally closed https://github.com/beyondessential/tupaia/pull/1436)

### Issue #: https://github.com/beyondessential/tupaia-backlog/issues/1374

### Changes:
- Measures use correct default date
- Prevent set dates to the same dates (this prevents multiple requests)

