### PR TITLE
1420: Parameterise report e2e tests

### DIFF
--- a/packages/web-frontend/cypress.env.example.json
+++ b/packages/web-frontend/cypress.env.example.json
@@ -1,5 +1,4 @@
 {
   "USER_EMAIL": "",
-  "USER_PASSWORD": "",
-  "USER_NAME": ""
+  "USER_PASSWORD": ""
 }

--- a/packages/web-frontend/cypress/config/dashboardReports.example.jsonc
+++ b/packages/web-frontend/cypress/config/dashboardReports.example.jsonc
@@ -1,29 +1,14 @@
 /**
  * Example for: `dashboardReports.json`
  *
- * Use `yarn cypress:generate-config` to generate this file and populate it with multiple
- * project/group/report combinations using the database. You can also populate it with manual data.
+ * There are two ways to populate this file:
+ * 1. Using the default config generation script: `yarn workspace @tupaia/web-frontend cypress:generate-config`
+ * 2. Providing manual data as in this example
  */
 
 [
-  {
-    "project": "Explore",
-    "dashboardGroup": "General",
-    "name": "Medicines Availability by Country"
-  },
-  {
-    "project": "Explore",
-    "dashboardGroup": "General",
-    "name": "Number of Operational Facilities Surveyed by Country"
-  },
-  {
-    "project": "Strive PNG",
-    "dashboardGroup": "Strive PNG",
-    "name": "Weekly # of cases by health facility (all sites)"
-  },
-  {
-    "project": "COVID-19 Australia",
-    "dashboardGroup": "COVID-19",
-    "name": "COVID-19 Total tests per capita"
-  }
+  "/explore/explore/General?report=28",
+  "/explore/explore/General?report=29",
+  "/strive/PG/STRIVE PNG?report=PG_Strive_PNG_Weekly_Febrile_Illness_RDT_Positive_By_Facility_National",
+  "/covidau/AU/COVID-19?report=COVID_Tests_Per_Capita"
 ]

--- a/packages/web-frontend/cypress/config/orgUnitMap.json
+++ b/packages/web-frontend/cypress/config/orgUnitMap.json
@@ -1,0 +1,175 @@
+{
+  "covidau": {
+    "project": "AU"
+  },
+  "disaster": {
+    "project": "disaster"
+  },
+  "explore": {
+    "project": "explore"
+  },
+  "fanafana": {
+    "project": "TO"
+  },
+  "imms": {
+    "project": "imms"
+  },
+  "laos_eoc": {
+    "project": "LA"
+  },
+  "strive": {
+    "project": "PG"
+  },
+  "unfpa": {
+    "project": "unfpa"
+  },
+  "wish": {
+    "project": "FJ"
+  },
+  "AS": {
+    "country": "AS"
+  },
+  "AU": {
+    "country": "AU",
+    "district": "AU_Australian Capital Territory",
+    "sub_district": "AU_Australian Capital Territory_Unincorporated"
+  },
+  "CI": {
+    "country": "CI",
+    "district": "CI_Abidjan",
+    "facility": "CI_ABIDJAN01"
+  },
+  "CK": {
+    "country": "CK",
+    "district": "CK_Northern Islands",
+    "sub_district": "CK_Northern Islands_Manihiki",
+    "facility": "CK_aituH"
+  },
+  "DL": {
+    "country": "DL",
+    "district": "DL_North",
+    "sub_district": "DL_North_Hufflepuff",
+    "facility": "DL_1"
+  },
+  "DL_3": {
+    "facility": "DL_3"
+  },
+  "FJ": {
+    "country": "FJ",
+    "district": "FJ_Central",
+    "sub_district": "FJ_PROV_Ba",
+    "facility": "FJ_001",
+    "village": "FJ_DAM"
+  },
+  "FM": {
+    "country": "FM",
+    "district": "FM_Etten",
+    "facility": "FM_001"
+  },
+  "GU": {
+    "country": "GU"
+  },
+  "KH": {
+    "country": "KH",
+    "district": "KH_Batheay",
+    "facility": "KH_7 Makara_hc"
+  },
+  "KI": {
+    "country": "KI",
+    "district": "KI_Gilbert Islands",
+    "sub_district": "KI_Gilbert Islands_Abaiang",
+    "facility": "KI_ABRD14"
+  },
+  "LA": {
+    "country": "LA",
+    "district": "LA_Attapue",
+    "sub_district": "LA_Anouvong District",
+    "facility": "LA_ATPHO",
+    "village": "LA_vil_1001002",
+    "school": "LA_sch_1001001"
+  },
+  "MH": {
+    "country": "MH",
+    "district": "MH_Ailuk",
+    "facility": "MH_001"
+  },
+  "MP": {
+    "country": "MP"
+  },
+  "NC": {
+    "country": "NC"
+  },
+  "NR": {
+    "country": "NR",
+    "district": "NR_Denigomodu District",
+    "facility": "NR_NaoeroPHC"
+  },
+  "NU": {
+    "country": "NU"
+  },
+  "PF": {
+    "country": "PF"
+  },
+  "PG": {
+    "country": "PG",
+    "district": "PG_Madang",
+    "facility": "PG_MADANG01",
+    "village": "PG_ALO_ABV"
+  },
+  "PH": {
+    "country": "PH",
+    "district": "PH_Davao",
+    "sub_district": "PH_Davao_Davao City",
+    "facility": "PH_12084"
+  },
+  "PI": {
+    "country": "PI"
+  },
+  "PW": {
+    "country": "PW"
+  },
+  "SB": {
+    "country": "SB",
+    "district": "SB_Central Province",
+    "facility": "SB_100101"
+  },
+  "TK": {
+    "country": "TK",
+    "district": "TK_Atafu",
+    "facility": "TK_Ataf"
+  },
+  "TL": {
+    "country": "TL",
+    "district": "TL_Aileu",
+    "facility": "TL_AIL-005-3"
+  },
+  "TO": {
+    "country": "TO",
+    "district": "TO_Eua",
+    "facility": "TO_CPMS",
+    "village": "TO_Eua_Angaha"
+  },
+  "TV": {
+    "country": "TV"
+  },
+  "VE": {
+    "country": "VE",
+    "district": "VE_Amazonas",
+    "facility": "VE_ADS0000"
+  },
+  "VU": {
+    "country": "VU",
+    "district": "VU_Malampa",
+    "sub_district": "VU_Malampa_MAL01",
+    "facility": "VU_1180"
+  },
+  "WF": {
+    "country": "WF"
+  },
+  "WS": {
+    "country": "WS",
+    "district": "WS_Savaii",
+    "facility": "WS_001",
+    "village": "WS_001_Afia"
+  }
+}

--- a/packages/web-frontend/cypress/constants.js
+++ b/packages/web-frontend/cypress/constants.js
@@ -4,5 +4,4 @@
  */
 
 export const CONFIG_ROOT = 'cypress/config';
-export const EXPLORE_PROJECT = 'explore';
 export const PUBLIC_USER = 'public';

--- a/packages/web-frontend/cypress/e2e/dashboardReports.spec.js
+++ b/packages/web-frontend/cypress/e2e/dashboardReports.spec.js
@@ -3,79 +3,13 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
-import {
-  closeOpenDialogs,
-  EmptyConfigError,
-  expandDashboardItem,
-  preserveUserSession,
-  selectDashboardGroup,
-  selectProject,
-} from '../support';
+import { EmptyConfigError, preserveUserSession } from '../support';
 import config from '../config/dashboardReports.json';
 
-/**
- * This is a workaround in case a dashboard is left open due to a previous test failing
- * Normally we would close the dashboard anyway using an `after` block,
- * but this is not currently possible due to a Cypress bug
- *
- * @see https://github.com/cypress-io/cypress/issues/2831
- */
-const closeDialogsBecauseOfCypressBug = () => {
-  closeOpenDialogs();
-};
-
-const validateConfig = () => {
+describe('Dashboard reports', () => {
   if (config.length === 0) {
     throw new EmptyConfigError('dashboardReports');
   }
-};
-
-describe('Dashboard reports', () => {
-  const testReport = report => {
-    describe(report.name, () => {
-      before(() => {
-        closeDialogsBecauseOfCypressBug();
-        expandDashboardItem(report.name);
-      });
-
-      it('enlarged dialog', () => {
-        cy.findByTestId('enlarged-dialog').snapshotHtml({ name: 'html' });
-      });
-    });
-  };
-
-  const testReportsForGroup = (groupName, reports) => {
-    describe(`Group: ${groupName}`, () => {
-      before(() => {
-        closeDialogsBecauseOfCypressBug();
-        selectDashboardGroup(groupName);
-      });
-
-      reports.forEach(testReport);
-    });
-  };
-
-  const testReportsForProject = (project, reports) => {
-    describe(`Project: ${project}`, () => {
-      const reportsByGroup = Cypress._.groupBy(reports, 'dashboardGroup');
-
-      before(() => {
-        cy.server();
-        cy.route(/\/dashboard/).as('dashboard');
-
-        closeDialogsBecauseOfCypressBug();
-        selectProject(project);
-        cy.wait('@dashboard');
-      });
-
-      Object.entries(reportsByGroup).forEach(([groupName, reportsForGroup]) =>
-        testReportsForGroup(groupName, reportsForGroup),
-      );
-    });
-  };
-
-  validateConfig();
-  const reportsByProject = Cypress._.groupBy(config, 'project');
 
   before(() => {
     cy.login();
@@ -85,7 +19,14 @@ describe('Dashboard reports', () => {
     preserveUserSession();
   });
 
-  Object.entries(reportsByProject).forEach(([project, reportsForProject]) => {
-    testReportsForProject(project, reportsForProject);
+  config.forEach(url => {
+    it(url, () => {
+      cy.server();
+      cy.route(/\/dashboard/).as('dashboard');
+
+      cy.visit(url);
+      cy.wait('@dashboard');
+      cy.findByTestId('enlarged-dialog').snapshotHtml({ name: 'html' });
+    });
   });
 });

--- a/packages/web-frontend/cypress/scripts/generateConfig.js
+++ b/packages/web-frontend/cypress/scripts/generateConfig.js
@@ -14,12 +14,12 @@ const writeConfigFile = (fileName, contents) =>
   writeFileSync(getConfigPath(fileName), JSON.stringify(contents, null, 2));
 
 const generateConfig = async logger => {
-  logger.info('Generating e2e test config');
+  logger.verbose('Generating e2e test config...\n');
   const database = new TupaiaDatabase();
 
-  const dashboardReportConfig = await generateDashboardReportConfig(database);
+  const dashboardReportConfig = await generateDashboardReportConfig({ database, logger });
   writeConfigFile('dashboardReports', dashboardReportConfig);
-  logger.info('✔ Dashboard reports');
+  logger.success('✔ Dashboard reports\n');
 };
 
 const run = () => {
@@ -31,7 +31,6 @@ const run = () => {
       process.exit(1);
     })
     .then(() => {
-      logger.info('Done!');
       process.exit(0);
     });
 };

--- a/packages/web-frontend/cypress/scripts/generateDashboardReportConfig.js
+++ b/packages/web-frontend/cypress/scripts/generateDashboardReportConfig.js
@@ -3,44 +3,129 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
-const getDashboardReportIdToGroup = async database => {
-  const dashboardGroups = await database.executeSql(`SELECT * from "dashboardGroup"`);
+import { snake } from 'case';
 
-  const reportIdToGroup = {};
-  dashboardGroups.forEach(dashboardGroup => {
-    dashboardGroup.dashboardReports.forEach(reportId => {
-      reportIdToGroup[reportId] = dashboardGroup;
+import orgUnitMap from '../config/orgUnitMap.json';
+import { CONFIG_ROOT } from '../constants';
+
+const ORG_UNIT_MAP_PATH = `${CONFIG_ROOT}/orgUnitMap.json`;
+
+const WARNING_TYPES = {
+  NO_GROUP: 'noGroup',
+  NO_PROJECT: 'noProject',
+  NO_ORG_UNIT_MAP_ENTRY: 'noOrgUnitMapEntry',
+};
+
+const WARNING_TYPE_TO_MESSAGE = {
+  [WARNING_TYPES.NO_GROUP]: 'not attached to any dashboard group',
+  [WARNING_TYPES.NO_PROJECT]: 'not attached to any projects',
+  [WARNING_TYPES.NO_ORG_UNIT_MAP_ENTRY]: `no valid org unit map entry found in '${ORG_UNIT_MAP_PATH}'`,
+};
+
+const logWarningsForSkippedReports = (logger, skippedReportsByWarnType) => {
+  Object.entries(skippedReportsByWarnType).forEach(([warnType, reportIds]) => {
+    if (reportIds.length === 0) {
+      return;
+    }
+    const message = WARNING_TYPE_TO_MESSAGE[warnType];
+    if (!message) {
+      throw new Error(`Dev error: no message defined for warning category: '${warnType}'`);
+    }
+    logger.warn(`Skipping the following reports - ${message}:`);
+    reportIds.sort().forEach(reportId => {
+      logger.warn(`  ${reportId}`);
     });
   });
-  return reportIdToGroup;
+};
+
+const createUrl = (report, urlParams) => {
+  const { projectCode, orgUnitCode, dashboardGroup } = urlParams;
+  return `/${projectCode}/${orgUnitCode}/${dashboardGroup.name}?report=${report.id}`;
+};
+
+const selectUrlParams = dashboardGroups => {
+  for (const dashboardGroup of dashboardGroups) {
+    const {
+      organisationUnitCode: dashboardOrgUnitCode,
+      organisationLevel: dashboardLevel,
+    } = dashboardGroup;
+
+    const level = snake(dashboardLevel);
+    const orgUnitCode = orgUnitMap?.[dashboardOrgUnitCode]?.[level];
+    const [projectCode] = dashboardGroup.projectCodes;
+
+    if (orgUnitCode && projectCode) {
+      return { dashboardGroup, orgUnitCode, projectCode };
+    }
+  }
+
+  return undefined;
+};
+
+const getUrlsForReports = (reports, reportIdToGroups) => {
+  const skippedReports = {
+    [WARNING_TYPES.NO_GROUP]: [],
+    [WARNING_TYPES.NO_PROJECT]: [],
+    [WARNING_TYPES.NO_ORG_UNIT_MAP_ENTRY]: [],
+  };
+
+  const urls = reports
+    .map(report => {
+      const groupsForReport = reportIdToGroups[report.id];
+      if (!groupsForReport) {
+        skippedReports[WARNING_TYPES.NO_GROUP].push(report.id);
+        return null;
+      }
+      if (!groupsForReport.some(dg => dg.projectCodes)) {
+        skippedReports[WARNING_TYPES.NO_PROJECT].push(report.id);
+        return null;
+      }
+      const urlParams = selectUrlParams(groupsForReport);
+      if (!urlParams) {
+        skippedReports[WARNING_TYPES.NO_ORG_UNIT_MAP_ENTRY].push(report.id);
+        return null;
+      }
+
+      return createUrl(report, urlParams);
+    })
+    .filter(u => u)
+    .sort();
+
+  return { urls, skippedReports };
+};
+
+const getDashboardReportIdToGroups = async database => {
+  const dashboardGroups = await database.executeSql(`SELECT * from "dashboardGroup"`);
+
+  const reportIdToGroups = {};
+  dashboardGroups.forEach(dashboardGroup => {
+    dashboardGroup.dashboardReports.forEach(reportId => {
+      if (!reportIdToGroups[reportId]) {
+        reportIdToGroups[reportId] = [];
+      }
+      reportIdToGroups[reportId].push(dashboardGroup);
+    });
+  });
+  return reportIdToGroups;
 };
 
 /**
  * We generate the least amount of config required to test each report once.
  * 1. For each report, use the last dashboard group that includes it
  * 2. For each dashboard group, use the first project that includes it
+ * 3. For each dashboard group, use an organisation unit from the orgUnitMap config
+ * that matches the group's org unit code and level
  */
-export const generateDashboardReportConfig = async database => {
-  const dashboardReports = await database.executeSql(
+export const generateDashboardReportConfig = async ({ database, logger }) => {
+  logger.verbose('Generating dashboard report config...');
+
+  const reports = await database.executeSql(
     `SELECT id, "viewJson"->>'name' as name from "dashboardReport"`,
   );
-  const reportIdToGroup = await getDashboardReportIdToGroup(database);
+  const reportIdToGroups = await getDashboardReportIdToGroups(database);
+  const { urls, skippedReports } = getUrlsForReports(reports, reportIdToGroups);
+  logWarningsForSkippedReports(logger, skippedReports);
+  logger.info(`Report urls created: ${urls.length}, skipped: ${reports.length - urls.length}`);
 
-  return dashboardReports
-    .map(report => {
-      const dashboardGroup = reportIdToGroup[report.id];
-      if (!dashboardGroup) {
-        // The report is not attached to any group, thus it won't be displayed
-        return null;
-      }
-      const [projectCode] = dashboardGroup.projectCodes;
-      if (!projectCode) {
-        // The group is not attached to any project, thus it won't be displayed
-        return null;
-      }
-
-      return `/${projectCode}/${dashboardGroup.organisationUnitCode}/${dashboardGroup.name}?report=${report.id}`;
-    })
-    .filter(r => r)
-    .sort();
+  return urls;
 };

--- a/packages/web-frontend/cypress/scripts/generateDashboardReportConfig.js
+++ b/packages/web-frontend/cypress/scripts/generateDashboardReportConfig.js
@@ -3,16 +3,6 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
-import { reduceToDictionary } from '@tupaia/utils';
-
-const getProjectCodeToName = async database => {
-  const projects = await database.executeSql(`
-    SELECT p.code, e.name FROM project p
-    JOIN entity e on e.id = p.entity_id
-  `);
-  return reduceToDictionary(projects, 'code', 'name');
-};
-
 const getDashboardReportIdToGroup = async database => {
   const dashboardGroups = await database.executeSql(`SELECT * from "dashboardGroup"`);
 
@@ -35,13 +25,6 @@ export const generateDashboardReportConfig = async database => {
     `SELECT id, "viewJson"->>'name' as name from "dashboardReport"`,
   );
   const reportIdToGroup = await getDashboardReportIdToGroup(database);
-  const projectCodeToName = await getProjectCodeToName(database);
-
-  const createConfigEntry = ({ report, dashboardGroup, projectCode }) => ({
-    project: projectCodeToName[projectCode],
-    dashboardGroup: dashboardGroup.name,
-    name: report.name,
-  });
 
   return dashboardReports
     .map(report => {
@@ -56,7 +39,8 @@ export const generateDashboardReportConfig = async database => {
         return null;
       }
 
-      return createConfigEntry({ report, dashboardGroup, projectCode });
+      return `/${projectCode}/${dashboardGroup.organisationUnitCode}/${dashboardGroup.name}?report=${report.id}`;
     })
-    .filter(r => r);
+    .filter(r => r)
+    .sort();
 };

--- a/packages/web-frontend/cypress/support/actions.js
+++ b/packages/web-frontend/cypress/support/actions.js
@@ -3,9 +3,6 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
-import { EXPLORE_PROJECT } from '../constants';
-import { equalStringsI } from './utils';
-
 export const submitLoginForm = () => {
   cy.findAllByText(/Sign in/)
     .closest('form')
@@ -23,49 +20,4 @@ export const submitLoginForm = () => {
 
 export const closeOverlay = () => {
   cy.findByTestId('overlay-close-btn').click();
-};
-
-export const closeOpenDialogs = () => {
-  cy.get('body').click(0, 0);
-};
-
-export const closeEnlargedDialog = () => {
-  cy.findByTestId('enlarged-dialog-close-btn').click();
-};
-
-export const selectProject = name => {
-  cy.findByTextI(Cypress.env('USER_NAME')).click();
-  cy.findByTextI('View projects').click();
-
-  if (equalStringsI(name, EXPLORE_PROJECT)) {
-    cy.findByTextI('I just want to explore').click();
-    return;
-  }
-
-  cy.findByTextI(name).closestByTestId('project-card').findByTextI('View Project').click();
-};
-
-export const selectDashboardGroup = name => {
-  cy.findByTestId('dropdown-menu')
-    .invoke('text')
-    .then(selectedName => {
-      if (equalStringsI(selectedName, name)) {
-        return;
-      }
-
-      toggleDropdownMenu();
-      cy.findByTestId('dropdown-menu-items').findByTextI(name).click();
-    });
-};
-
-const toggleDropdownMenu = () => {
-  cy.findByTestId('dropdown-menu').findByRole('button').click();
-};
-
-export const expandDashboardItem = name => {
-  cy.findByTestId('dashboard-group')
-    .findByTextI(name)
-    .closestByTestId('view')
-    .findByRole('button')
-    .click();
 };

--- a/packages/web-frontend/cypress/support/helpers.js
+++ b/packages/web-frontend/cypress/support/helpers.js
@@ -13,7 +13,8 @@ export class EmptyConfigError extends Error {
   constructor(fileName) {
     const path = getConfigPath(fileName);
     const examplePath = getConfigExamplePath(fileName);
-    const message = `Test config error: ${path} contains no test data. Either use \`yarn cypress:generate-config\` to populate this file, or populate it with manual data. See ${examplePath} for an example`;
+    const generationCommand = '`yarn workspace @tupaia/web-frontend cypress:generate-config`';
+    const message = `Test config error: ${path} contains no test data. Either use ${generationCommand} to populate this file, or populate it with manual data. See ${examplePath} for an example`;
 
     super(message);
     this.name = 'EmptyConfigError';

--- a/packages/web-frontend/cypress/support/utils.js
+++ b/packages/web-frontend/cypress/support/utils.js
@@ -8,8 +8,6 @@ import { html as beautifyHtml } from 'js-beautify';
 
 const HTML_ATTRS_TO_STRIP_FROM_SNAPSHOTS = ['clip-path', 'id', 'data-reactid', 'data-testid'];
 
-export const equalStringsI = (a, b) => a.toLowerCase().localeCompare(b.toLowerCase()) === 0;
-
 /**
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
  */

--- a/packages/web-frontend/src/components/DropDownMenu.js
+++ b/packages/web-frontend/src/components/DropDownMenu.js
@@ -71,7 +71,7 @@ export class DropDownMenu extends PureComponent {
         open={!!anchorEl}
         anchorEl={anchorEl}
         onClose={this.handleCloseMenu}
-        MenuListProps={{ 'data-testid': 'dropdown-menu-items', style: menuListStyle }}
+        MenuListProps={{ style: menuListStyle }}
       >
         {options.map(option => (
           <MenuItem
@@ -88,7 +88,7 @@ export class DropDownMenu extends PureComponent {
 
   render() {
     return (
-      <div data-testid="dropdown-menu">
+      <div>
         {this.renderListComponent()}
         {this.renderMenuComponent()}
       </div>

--- a/packages/web-frontend/src/containers/DashboardGroup/index.js
+++ b/packages/web-frontend/src/containers/DashboardGroup/index.js
@@ -79,7 +79,6 @@ export default class DashboardGroup extends Component {
 
     return (
       <GridWrapper
-        data-testid="dashboard-group"
         innerRef={gridElement => {
           this.gridElement = gridElement;
         }}

--- a/packages/web-frontend/src/containers/EnlargedDialog/EnlargedDialogContent.js
+++ b/packages/web-frontend/src/containers/EnlargedDialog/EnlargedDialogContent.js
@@ -140,7 +140,6 @@ export class EnlargedDialogContent extends PureComponent {
           </IconButton>
         ) : null}
         <IconButton
-          data-testid="enlarged-dialog-close-btn"
           style={styles.toolbarButton}
           iconStyle={styles.toolbarButtonIcon}
           onClick={onCloseOverlay}

--- a/packages/web-frontend/src/containers/OverlayDiv/components/ProjectPage/ProjectCard.js
+++ b/packages/web-frontend/src/containers/OverlayDiv/components/ProjectPage/ProjectCard.js
@@ -99,7 +99,7 @@ export const ProjectCard = ({
   accessType,
 }) => {
   return (
-    <Card data-testid="project-card">
+    <Card>
       <Header>
         <img alt="project background" src={imageUrl} />
         {logoUrl && (

--- a/scripts/node/Script.js
+++ b/scripts/node/Script.js
@@ -70,11 +70,19 @@ class Script {
   };
 
   logSuccess = (message = '') => {
-    logger.info(message);
+    logger.success(message);
   };
 
   logInfo = (message = '') => {
     logger.info(message);
+  };
+
+  logVerbose = (message = '') => {
+    logger.verbose(message);
+  };
+
+  logDebug = (message = '') => {
+    logger.debug(message);
   };
 
   log = (message = '') => {

--- a/scripts/node/testAll.js
+++ b/scripts/node/testAll.js
@@ -38,10 +38,10 @@ class TestAllScript extends Script {
 
   printEnabledOptionsInfo() {
     if (this.args.bail) {
-      this.log('Bail mode is on');
+      this.logInfo('Bail mode is on');
     }
     if (this.args.silent) {
-      this.log('Silent mode is on');
+      this.logInfo('Silent mode is on');
     }
   }
 

--- a/scripts/node/utilities.js
+++ b/scripts/node/utilities.js
@@ -7,11 +7,26 @@ const { exec } = require('child_process');
 const { promisify } = require('util');
 const winston = require('winston');
 
-const configureWinston = () =>
-  winston.configure({
+const LOG_LEVEL_CONFIG = {
+  error: 'red',
+  warn: 'yellow',
+  success: 'green',
+  info: 'cyan',
+  verbose: 'dim white',
+  debug: 'gray',
+};
+
+const createLogger = () => {
+  winston.addColors(LOG_LEVEL_CONFIG);
+  const levels = Object.fromEntries(
+    Object.entries(LOG_LEVEL_CONFIG).map(([level], i) => [level, i]),
+  );
+
+  return winston.createLogger({
+    levels,
     transports: [
       new winston.transports.Console({
-        level: 'verbose',
+        level: 'debug',
         format: winston.format.combine(
           winston.format.colorize({ all: true }),
           winston.format.printf(({ message }) => message),
@@ -19,15 +34,15 @@ const configureWinston = () =>
       }),
     ],
   });
+};
 
-let isWinstonConfigured = false;
+let logger;
 
 const getLoggerInstance = () => {
-  if (!isWinstonConfigured) {
-    configureWinston();
-    isWinstonConfigured = true;
+  if (!logger) {
+    logger = createLogger();
   }
-  return winston;
+  return logger;
 };
 
 const executeCommand = async command => {

--- a/scripts/node/validateTests.js
+++ b/scripts/node/validateTests.js
@@ -117,7 +117,7 @@ const run = async () => {
       logger.error(formatExclusiveTests(exclusiveTests).join('\n'));
       process.exit(1);
     } else {
-      logger.info('✔ All tests are valid!');
+      logger.success('✔ All tests are valid!');
       process.exit(0);
     }
   });


### PR DESCRIPTION
### Issue #:
[1420: Parameterise report e2e tests](https://github.com/beyondessential/tupaia-backlog/issues/1420) - only the first requirement (**organisation unit** parameters)

### Changes:

* Did a major refactor of the report snapshot capturing logic. Instead of using the UI to navigate to a report, we use a direct URL now.

  **Pros:**
  ✔ Much easier testing logic!
  ✔ Works for all types of reports, both expandable and not
  ✔The url can be used to identify a specific test setup, since it contains most information about a report's selected parameters. Example: `/covidau/AU/COVID-19?report=COVID_AU_Total_Cases_Each_State_Per_Day`

  **Cons:**
❌We loose the benefit of using a more realistic user path, which would be clicking around portal components to get to a report.

  It then occurred to me: the scope of those tests are not dashboard navigation, but data accuracy! We can add a new test suite for testing the report navigation. If we do, we'll probably do it once per report type and not once per the 300+ reports that we want to test here.


* Added specific logger levels and colors

---

### Screenshots:

`yarn cypress:generate-config` prints (using my slightly outdated local DB):
<img src="https://user-images.githubusercontent.com/20692464/96056257-cae6a900-0ed1-11eb-9570-a35e317a0386.JPG" width="700" />


And creates the following file:

```jsonc
// dashboardReports.json

[
  "/covidau/AU/COVID-19?report=COVID_AU_Total_Cases_Each_State_Per_Day",
  "/covidau/AU/COVID-19?report=COVID_New_Cases_By_State",
  "/covidau/AU/COVID-19?report=COVID_Tests_Per_Capita",
  "/covidau/AU/COVID-19?report=COVID_Total_Cases_By_State",
  "/covidau/AU_Australian Capital Territory/COVID-19?report=COVID_Compose_Cumulative_Deaths_Vs_Cases",
  "/covidau/AU_Australian Capital Territory/COVID-19?report=COVID_Compose_Daily_Deaths_Vs_Cases",
   /* ...etc */
]
```


