### PR TITLE
Invalidate soft cache on change to entity relation

### DIFF
--- a/packages/database/src/DatabaseModel.js
+++ b/packages/database/src/DatabaseModel.js
@@ -31,13 +31,11 @@ export class DatabaseModel {
       });
 
       // if this model has caching that depends on other models, also add invalidation for them
-      if (this.cacheDependencies) {
-        this.cacheDependencies.forEach(databaseType => {
-          this.database.addChangeHandlerForCollection(databaseType, () => {
-            this.cache = {};
-          });
+      this.cacheDependencies.forEach(databaseType => {
+        this.database.addChangeHandlerForCollection(databaseType, () => {
+          this.cache = {};
         });
-      }
+      });
 
       // invalidate cached schema for this model on any change to db schema
       this.database.addSchemaChangeHandler(() => {
@@ -45,6 +43,11 @@ export class DatabaseModel {
         this.fieldNames = null;
       });
     }
+  }
+
+  // can be overridden by any subclass that needs cache invalidation when a related table changes
+  get cacheDependencies() {
+    return [];
   }
 
   // functionArguments should receive the 'arguments' object

--- a/packages/database/src/DatabaseModel.js
+++ b/packages/database/src/DatabaseModel.js
@@ -18,17 +18,29 @@ export class DatabaseModel {
     this.schema = null;
 
     this.cache = {};
+    this.cachedFunctionInvalidationCancellers = {};
 
     // If this model uses the singleton database, it is probably long running, so be sure to
     // invalidate the cache any time a change is detected. Non-singleton models are those created
     // during transactions, so are short lived and unlikely to need cache invalidation - thus we
     // avoid making an additional connection to pubsub and just leave their cache untouched
     if (this.database.isSingleton) {
+      // fully reset cache on any change to this model's records
       this.database.addChangeHandlerForCollection(this.DatabaseTypeClass.databaseType, () => {
-        this.cache = {}; // invalidate cache on any change
+        this.cache = {};
       });
+
+      // if this model has caching that depends on other models, also add invalidation for them
+      if (this.cacheDependencies) {
+        this.cacheDependencies.forEach(databaseType => {
+          this.database.addChangeHandlerForCollection(databaseType, () => {
+            this.cache = {};
+          });
+        });
+      }
+
+      // invalidate cached schema for this model on any change to db schema
       this.database.addSchemaChangeHandler(() => {
-        // invalidate cached schema for this model on any change to db schema
         this.schema = null;
         this.fieldNames = null;
       });

--- a/packages/database/src/migrations/20201009035426-AddImmutableTableTrigger-modifies-schema.js
+++ b/packages/database/src/migrations/20201009035426-AddImmutableTableTrigger-modifies-schema.js
@@ -31,7 +31,7 @@ exports.up = function (db) {
 
 exports.down = function (db) {
   return db.runSql(`
-    DROP FUNCTION IF EXISTS immutable_table();
+    DROP FUNCTION IF EXISTS immutable_table() CASCADE;
   `);
 };
 

--- a/packages/database/src/modelClasses/Entity.js
+++ b/packages/database/src/modelClasses/Entity.js
@@ -217,6 +217,14 @@ export class EntityModel extends DatabaseModel {
     return EntityType;
   }
 
+  // Some cached functions within Entity need to be invalidated if an entity relation is changed,
+  // and therefore the hierarchy cache has been rebuilt.
+  // Note: we don't use ancestor_descendant_relation as the dependency, as adding change triggers
+  // to that table slows down the rebuilds considerably (40s -> 200s for full initial build)
+  get cacheDependencies() {
+    return [TYPES.ENTITY_RELATION];
+  }
+
   customColumnSelectors = {
     region: fieldName => `ST_AsGeoJSON(${fieldName})`,
     point: fieldName => `ST_AsGeoJSON(${fieldName})`,


### PR DESCRIPTION
The soft cache was being correctly invalidated when an entity was modified, but some of the cached functions also depend on ancestor_descendant_relation. This adds invalidation when entity_relation changes, so that the soft cache doesn't end up with a stale version of the hierarchy.