### PR TITLE
1399 remove hello from country modal

### DIFF
--- a/packages/admin-panel/src/pages/resources/CountriesPage.js
+++ b/packages/admin-panel/src/pages/resources/CountriesPage.js
@@ -70,6 +70,7 @@ export const CountriesPage = ({ getHeaderEl }) => (
     endpoint="countries"
     columns={COLUMNS}
     expansionTabs={EXPANSION_CONFIG}
+    editConfig={{ title: 'Create New Country' }}
     createConfig={CREATE_CONFIG}
     filteredExportConfig={FILTERED_EXPORT_CONFIG}
     getHeaderEl={getHeaderEl}


### PR DESCRIPTION
Addresses: https://github.com/beyondessential/tupaia-backlog/issues/1399

Basically when you create a new country the modal says "Hello" (the default EditModal.js message) and this change fixes that happening here