### PR TITLE
Fix terminal color output for MacOS

### DIFF
--- a/packages/devops/scripts/ci/deployBackend.sh
+++ b/packages/devops/scripts/ci/deployBackend.sh
@@ -3,8 +3,8 @@ PACKAGE=$1
 DIR=$(dirname "$0")
 DEPLOYMENT_URL=$(${DIR}/determineDeploymentUrl.sh)
 if curl --output /dev/null --silent --head --fail $DEPLOYMENT_URL; then
-  echo "Deployment for ${CI_BRANCH} exists, updating with latest changes"
-  ssh ubuntu@$DEPLOYMENT_URL "cd tupaia && yarn workspace @tupaia/${PACKAGE} build && pm2 restart ${PACKAGE} --time;"
+    echo "Deployment for ${CI_BRANCH} exists, updating with latest changes"
+    ssh ubuntu@$DEPLOYMENT_URL "cd tupaia && yarn workspace @tupaia/${PACKAGE} build && pm2 restart ${PACKAGE} --time;"
 else
-  echo "No deployment exists for ${CI_BRANCH}, cancelling update"
+    echo "No deployment exists for ${CI_BRANCH}, cancelling update"
 fi

--- a/packages/devops/scripts/ci/deployBackend.sh
+++ b/packages/devops/scripts/ci/deployBackend.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 PACKAGE=$1
-DIR=`dirname "$0"`
+DIR=$(dirname "$0")
 DEPLOYMENT_URL=$(${DIR}/determineDeploymentUrl.sh)
 if curl --output /dev/null --silent --head --fail $DEPLOYMENT_URL; then
   echo "Deployment for ${CI_BRANCH} exists, updating with latest changes"

--- a/packages/devops/scripts/ci/deployFrontend.sh
+++ b/packages/devops/scripts/ci/deployFrontend.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 PACKAGE=$1
-DIR=`dirname "$0"`
+DIR=$(dirname "$0")
 DEPLOYMENT_URL=$(${DIR}/determineDeploymentUrl.sh)
 if curl --output /dev/null --silent --head --fail $DEPLOYMENT_URL; then
-  echo "Deployment for ${CI_BRANCH} exists, updating with latest changes"
-  ssh ubuntu@$DEPLOYMENT_URL "cd tupaia; yarn workspace @tupaia/${PACKAGE} build"
+    echo "Deployment for ${CI_BRANCH} exists, updating with latest changes"
+    ssh ubuntu@$DEPLOYMENT_URL "cd tupaia; yarn workspace @tupaia/${PACKAGE} build"
 else
-  echo "No deployment exists for ${CI_BRANCH}, cancelling update"
+    echo "No deployment exists for ${CI_BRANCH}, cancelling update"
 fi

--- a/packages/devops/scripts/ci/determineDeploymentUrl.sh
+++ b/packages/devops/scripts/ci/determineDeploymentUrl.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-if [[ $CI_BRANCH == "master" ]];then
-   echo "tupaia.org"
+if [[ $CI_BRANCH == "master" ]]; then
+    echo "tupaia.org"
 else
-   echo "${CI_BRANCH}.tupaia.org"
+    echo "${CI_BRANCH}.tupaia.org"
 fi

--- a/packages/devops/scripts/ci/pullLatest.sh
+++ b/packages/devops/scripts/ci/pullLatest.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-DIR=`dirname "$0"`
+DIR=$(dirname "$0")
 DEPLOYMENT_URL=$(${DIR}/determineDeploymentUrl.sh)
 if curl --output /dev/null --silent --head --fail $DEPLOYMENT_URL; then
   echo "Deployment for ${CI_BRANCH} exists, updating with latest changes"

--- a/packages/devops/scripts/ci/pullLatest.sh
+++ b/packages/devops/scripts/ci/pullLatest.sh
@@ -2,9 +2,9 @@
 DIR=$(dirname "$0")
 DEPLOYMENT_URL=$(${DIR}/determineDeploymentUrl.sh)
 if curl --output /dev/null --silent --head --fail $DEPLOYMENT_URL; then
-  echo "Deployment for ${CI_BRANCH} exists, updating with latest changes"
-  /bin/bash -c "ssh-keyscan -H ${DEPLOYMENT_URL} >> /root/.ssh/known_hosts"
-  ssh ubuntu@${DEPLOYMENT_URL} "
+    echo "Deployment for ${CI_BRANCH} exists, updating with latest changes"
+    /bin/bash -c "ssh-keyscan -H ${DEPLOYMENT_URL} >> /root/.ssh/known_hosts"
+    ssh ubuntu@${DEPLOYMENT_URL} "
     cd tupaia
     git stash
     git fetch
@@ -15,5 +15,5 @@ if curl --output /dev/null --silent --head --fail $DEPLOYMENT_URL; then
     yarn
   "
 else
-  echo "No deployment exists for ${CI_BRANCH}, cancelling update"
+    echo "No deployment exists for ${CI_BRANCH}, cancelling update"
 fi

--- a/packages/devops/scripts/ci/runMigrations.sh
+++ b/packages/devops/scripts/ci/runMigrations.sh
@@ -2,8 +2,8 @@
 DIR=$(dirname "$0")
 DEPLOYMENT_URL=$(${DIR}/determineDeploymentUrl.sh)
 if curl --output /dev/null --silent --head --fail $DEPLOYMENT_URL; then
-  echo "Deployment for ${CI_BRANCH} exists, running migrations"
-  ssh ubuntu@$DEPLOYMENT_URL "cd tupaia; yarn migrate;"
+	echo "Deployment for ${CI_BRANCH} exists, running migrations"
+	ssh ubuntu@$DEPLOYMENT_URL "cd tupaia; yarn migrate;"
 else
-  echo "No deployment exists for ${CI_BRANCH}, cancelling update"
+	echo "No deployment exists for ${CI_BRANCH}, cancelling update"
 fi

--- a/packages/devops/scripts/ci/runMigrations.sh
+++ b/packages/devops/scripts/ci/runMigrations.sh
@@ -2,8 +2,8 @@
 DIR=$(dirname "$0")
 DEPLOYMENT_URL=$(${DIR}/determineDeploymentUrl.sh)
 if curl --output /dev/null --silent --head --fail $DEPLOYMENT_URL; then
-	echo "Deployment for ${CI_BRANCH} exists, running migrations"
-	ssh ubuntu@$DEPLOYMENT_URL "cd tupaia; yarn migrate;"
+    echo "Deployment for ${CI_BRANCH} exists, running migrations"
+    ssh ubuntu@$DEPLOYMENT_URL "cd tupaia; yarn migrate;"
 else
-	echo "No deployment exists for ${CI_BRANCH}, cancelling update"
+    echo "No deployment exists for ${CI_BRANCH}, cancelling update"
 fi

--- a/packages/devops/scripts/ci/runMigrations.sh
+++ b/packages/devops/scripts/ci/runMigrations.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-DIR=`dirname "$0"`
+DIR=$(dirname "$0")
 DEPLOYMENT_URL=$(${DIR}/determineDeploymentUrl.sh)
 if curl --output /dev/null --silent --head --fail $DEPLOYMENT_URL; then
   echo "Deployment for ${CI_BRANCH} exists, running migrations"

--- a/packages/devops/scripts/ci/setupTestDatabase.sh
+++ b/packages/devops/scripts/ci/setupTestDatabase.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-DIR=`dirname "$0"`
+DIR=$(dirname "$0")
 ${DIR}/waitForPostgres.sh
 psql -h $CI_TEST_DB_URL -p 5432 -U postgres -d postgres -c "CREATE ROLE $CI_TEST_DB_USER LOGIN SUPERUSER PASSWORD '$CI_TEST_DB_PASSWORD'"
 psql -h $CI_TEST_DB_URL -p 5432 -U postgres -d postgres -c "CREATE DATABASE $CI_TEST_DB_NAME WITH OWNER $CI_TEST_DB_USER"

--- a/packages/devops/scripts/ci/testBackend.sh
+++ b/packages/devops/scripts/ci/testBackend.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-DIR=`dirname "$0"`
+DIR=$(dirname "$0")
 ${DIR}/setupTestDatabase.sh
 PACKAGE=$1
 yarn workspace @tupaia/${PACKAGE} test

--- a/packages/devops/scripts/ci/testFrontend.sh
+++ b/packages/devops/scripts/ci/testFrontend.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-DIR=`dirname "$0"`
+DIR=$(dirname "$0")
 PACKAGE=$1
 yarn workspace @tupaia/${PACKAGE} test

--- a/packages/devops/scripts/ci/testInternalDependencies.sh
+++ b/packages/devops/scripts/ci/testInternalDependencies.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-DIR=`dirname "$0"`
+DIR=$(dirname "$0")
 for PACKAGE in $(${DIR}/../../../../scripts/bash/getInternalDependencies.sh); do
   # skip database, data-api and auth packages - they get tested separately as they require db access
   if [[ "$PACKAGE" == "database" || "$PACKAGE" == "data-api" || "$PACKAGE" == "auth" ]]; then

--- a/packages/devops/scripts/ci/testInternalDependencies.sh
+++ b/packages/devops/scripts/ci/testInternalDependencies.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 DIR=$(dirname "$0")
 for PACKAGE in $(${DIR}/../../../../scripts/bash/getInternalDependencies.sh); do
-  # skip database, data-api and auth packages - they get tested separately as they require db access
-  if [[ "$PACKAGE" == "database" || "$PACKAGE" == "data-api" || "$PACKAGE" == "auth" ]]; then
-    continue
-  fi
-  echo Testing ${PACKAGE}
-  if ! yarn workspace @tupaia/${PACKAGE} test; then
-    exit 1 # the tests for this internal depencency failed
-  fi
+    # skip database, data-api and auth packages - they get tested separately as they require db access
+    if [[ "$PACKAGE" == "database" || "$PACKAGE" == "data-api" || "$PACKAGE" == "auth" ]]; then
+        continue
+    fi
+    echo Testing ${PACKAGE}
+    if ! yarn workspace @tupaia/${PACKAGE} test; then
+        exit 1 # the tests for this internal depencency failed
+    fi
 done

--- a/packages/devops/scripts/ci/updateCiEnvVars.sh
+++ b/packages/devops/scripts/ci/updateCiEnvVars.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 rm -f .env
 for PACKAGE in "meditrak-server" "admin-panel" "web-frontend" "web-config-server" "devops" "database"; do
-  cat ./packages/${PACKAGE}/.env >> .env
+    cat ./packages/${PACKAGE}/.env >>.env
 done
 jet encrypt .env ci-env-vars.encrypted

--- a/packages/devops/scripts/ci/utils.sh
+++ b/packages/devops/scripts/ci/utils.sh
@@ -1,22 +1,24 @@
-ANSI_COLOR_GREEN="\e[32m"
-ANSI_COLOR_RED="\e[31m"
-ANSI_COLOR_RESET="\e[0m"
-ANSI_COLOR_YELLOW="\e[33m"
+COLOR_RESET=0
+COLOR_RED=31
+COLOR_GREEN=32
+COLOR_YELLOW=33
+
+function ansi_color() {
+  echo "\033[$1m"
+}
 
 function log_with_color() {
-  text=$1
-  color=$2
-  echo -e "$2$1$ANSI_COLOR_RESET"
+  echo -e "$(ansi_color $2)$1$(ansi_color $COLOR_RESET)"
 }
 
 function log_error() {
-  log_with_color "$1" $ANSI_COLOR_RED
+  log_with_color "$1" $COLOR_RED
 }
 
 function log_warn() {
-  log_with_color "$1" $ANSI_COLOR_YELLOW
+  log_with_color "$1" $COLOR_YELLOW
 }
 
 function log_success() {
-  log_with_color "$1" $ANSI_COLOR_GREEN
+  log_with_color "$1" $COLOR_GREEN
 }

--- a/packages/devops/scripts/ci/utils.sh
+++ b/packages/devops/scripts/ci/utils.sh
@@ -4,21 +4,21 @@ COLOR_GREEN=32
 COLOR_YELLOW=33
 
 function ansi_color() {
-  echo "\033[$1m"
+    echo "\033[$1m"
 }
 
 function log_with_color() {
-  echo -e "$(ansi_color $2)$1$(ansi_color $COLOR_RESET)"
+    echo -e "$(ansi_color $2)$1$(ansi_color $COLOR_RESET)"
 }
 
 function log_error() {
-  log_with_color "$1" $COLOR_RED
+    log_with_color "$1" $COLOR_RED
 }
 
 function log_warn() {
-  log_with_color "$1" $COLOR_YELLOW
+    log_with_color "$1" $COLOR_YELLOW
 }
 
 function log_success() {
-  log_with_color "$1" $COLOR_GREEN
+    log_with_color "$1" $COLOR_GREEN
 }

--- a/packages/devops/scripts/ci/validateBranchName.sh
+++ b/packages/devops/scripts/ci/validateBranchName.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DIR=`dirname "$0"`
+DIR=$(dirname "$0")
 . ${DIR}/utils.sh
 
 MAX_LENGTH=56
@@ -11,7 +11,7 @@ function get_branch_name() {
     local branch_name="$CI_BRANCH"
     if [[ $branch_name == "" ]]; then
         # Get currently checked out branch
-        branch_name=`git rev-parse --abbrev-ref HEAD`
+        branch_name=$(git rev-parse --abbrev-ref HEAD)
     fi
 
     echo $branch_name
@@ -20,11 +20,10 @@ function get_branch_name() {
 function validate_name_ending() {
     local branch_name=$1
 
-    for reserved_ending in ${RESERVED_ENDINGS[@]}
-    do
+    for reserved_ending in ${RESERVED_ENDINGS[@]}; do
         if [[ "$branch_name" == *$reserved_ending ]]; then
             log_error "❌ Invalid branch name ending: '$reserved_ending'"
-            exit 1;
+            exit 1
         fi
     done
 }
@@ -35,7 +34,7 @@ function validate_name_length() {
 
     if [[ $name_length -gt MAX_LENGTH ]]; then
         log_error "❌ Branch name is too long, must be $MAX_LENGTH characters max"
-        exit 1;
+        exit 1
     fi
 }
 
@@ -44,14 +43,13 @@ function validate_name_chars() {
 
     if [[ $branch_name =~ [A-Z] ]]; then
         log_error "❌ Branch name cannot contain uppercase characters"
-        exit 1;
+        exit 1
     fi
 
-    for character in ${INVALID_CHARS[@]}	
-    do	
-        if [[ "$branch_name" == *"$character"* ]]; then	
-            log_error "❌ Invalid character in branch name: '$character'"	
-            exit 1;	
+    for character in ${INVALID_CHARS[@]}; do
+        if [[ "$branch_name" == *"$character"* ]]; then
+            log_error "❌ Invalid character in branch name: '$character'"
+            exit 1
         fi
     done
 }
@@ -62,4 +60,4 @@ validate_name_length $branch_name
 validate_name_chars $branch_name
 
 log_success "✔ Branch name is valid!"
-exit 0;
+exit 0

--- a/packages/devops/scripts/ci/validateTests.sh
+++ b/packages/devops/scripts/ci/validateTests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DIR=`dirname "$0"`
+DIR=$(dirname "$0")
 ROOT="${DIR}/../../../../"
 
 node ${ROOT}/scripts/node/validateTests

--- a/packages/devops/scripts/ci/waitForPostgres.sh
+++ b/packages/devops/scripts/ci/waitForPostgres.sh
@@ -2,14 +2,14 @@
 RETRIES=50
 
 args=(
-	--host "$CI_TEST_DB_URL"
-	--username "postgres"
-	--dbname "postgres"
-	--quiet --no-align --tuples-only
+    --host "$CI_TEST_DB_URL"
+    --username "postgres"
+    --dbname "postgres"
+    --quiet --no-align --tuples-only
 )
 
 until select="$(echo 'SELECT PostGIS_full_version()' | psql "${args[@]}")" && [[ "$select" == *"2.5."* ]] || [ $RETRIES -eq 0 ]; do
-  echo "Waiting for postgres server, $((RETRIES--)) remaining attempts..."
-	echo $select
-  sleep 1
+    echo "Waiting for postgres server, $((RETRIES--)) remaining attempts..."
+    echo $select
+    sleep 1
 done

--- a/packages/devops/scripts/deployment/startup.sh
+++ b/packages/devops/scripts/deployment/startup.sh
@@ -7,7 +7,7 @@ export PATH=/home/ubuntu/.local/bin:/home/ubuntu/.yarn/bin:/home/ubuntu/.config/
 # Set the home directory of the user
 export HOME_DIRECTORY="/home/ubuntu/tupaia"
 
-DIR=`dirname "$0"`
+DIR=$(dirname "$0")
 export STAGE=$(${DIR}/../utility/detectStage.sh)
 echo "Starting up instance for ${STAGE}"
 
@@ -17,5 +17,3 @@ ${HOME_DIRECTORY}/packages/devops/scripts/deployment/deployLatestRepositories.sh
 
 # Set nginx config and start the service running
 ${HOME_DIRECTORY}/packages/devops/scripts/deployment/configureNginx.sh
-
-

--- a/packages/devops/scripts/utility/detectStage.sh
+++ b/packages/devops/scripts/utility/detectStage.sh
@@ -2,7 +2,7 @@
 
 # Get the stage tag of this ec2 instance from AWS
 TAG_NAME="Stage"
-INSTANCE_ID="`wget -qO- http://instance-data/latest/meta-data/instance-id`"
-REGION="`wget -qO- http://instance-data/latest/meta-data/placement/availability-zone | sed -e 's:\([0-9][0-9]*\)[a-z]*\$:\\1:'`"
-STAGE="`aws ec2 describe-tags --filters "Name=resource-id,Values=$INSTANCE_ID" "Name=key,Values=$TAG_NAME" --region $REGION --output=text | cut -f5`"
+INSTANCE_ID="$(wget -qO- http://instance-data/latest/meta-data/instance-id)"
+REGION="$(wget -qO- http://instance-data/latest/meta-data/placement/availability-zone | sed -e 's:\([0-9][0-9]*\)[a-z]*\$:\\1:')"
+STAGE="$(aws ec2 describe-tags --filters "Name=resource-id,Values=$INSTANCE_ID" "Name=key,Values=$TAG_NAME" --region $REGION --output=text | cut -f5)"
 echo $STAGE

--- a/packages/devops/scripts/utility/renewSslCertificate.sh
+++ b/packages/devops/scripts/utility/renewSslCertificate.sh
@@ -3,13 +3,13 @@
 # Exit when any command fails
 set -e
 
-DIR=`dirname "$0"`
+DIR=$(dirname "$0")
 STAGE=$(${DIR}/detectStage.sh)
 AWS_PROFILE=certbot
 
-if [[ $STAGE == "production" ]];then
-  echo "Renewing certificates on production"
-  /usr/local/bin/certbot-auto renew --no-self-upgrade --dns-route53 --non-interactive --server https://acme-v02.api.letsencrypt.org/directory --post-hook "sudo service nginx reload"
+if [[ $STAGE == "production" ]]; then
+    echo "Renewing certificates on production"
+    /usr/local/bin/certbot-auto renew --no-self-upgrade --dns-route53 --non-interactive --server https://acme-v02.api.letsencrypt.org/directory --post-hook "sudo service nginx reload"
 else
-  echo "Not renewing certificates on ${STAGE}"
+    echo "Not renewing certificates on ${STAGE}"
 fi

--- a/packages/web-config-server/run_preaggregation.sh
+++ b/packages/web-config-server/run_preaggregation.sh
@@ -4,7 +4,7 @@
 PATH=$PATH:/home/ubuntu/.nvm/versions/node/v9.11.0/bin
 
 # Get script directory so that yarn knows where the root package.json is, no matter where it's called from
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd $SCRIPT_DIR
 
 # Run the preaggregation

--- a/scripts/bash/backendStartDev.sh
+++ b/scripts/bash/backendStartDev.sh
@@ -9,7 +9,7 @@ set -e
 # $2 - optionally provide '-s' or '--skip-internal' to skip the build and watch of internal dependencies
 ##
 
-DIR=`dirname "$0"`
+DIR=$(dirname "$0")
 watch_flags=""
 start_server="nodemon -w src --exec \"babel-node src --inspect=${1} --config-file '../../babel.config.json'\""
 

--- a/scripts/bash/backendStartDev.sh
+++ b/scripts/bash/backendStartDev.sh
@@ -15,15 +15,15 @@ start_server="nodemon -w src --exec \"babel-node src --inspect=${1} --config-fil
 
 echo "Starting server"
 if [[ ${2} == '--skip-internal' || ${2} == '-s' ]]; then
-  echo "Skipping internal dependency build and watch"
-  eval ${start_server}
+    echo "Skipping internal dependency build and watch"
+    eval ${start_server}
 else
-  echo "Internal dependencies are under watch for hot reload (use --skip-internal or -s for faster startup times)"
-  for PACKAGE in $(${DIR}/getInternalDependencies.sh); do
-    watch_flags="${watch_flags} --watch ../${PACKAGE}/dist"
-  done
-  # add the watch flags to the server start process, as well as a 1 second delay to debounce the
-  # many restarts that otherwise happen during the initial build of internal dependencies
-  start_server="${start_server} --delay 1 ${watch_flags}"
-  yarn concurrently "${DIR}/buildInternalDependencies.sh --watch --withTypes" "eval ${start_server}"
+    echo "Internal dependencies are under watch for hot reload (use --skip-internal or -s for faster startup times)"
+    for PACKAGE in $(${DIR}/getInternalDependencies.sh); do
+        watch_flags="${watch_flags} --watch ../${PACKAGE}/dist"
+    done
+    # add the watch flags to the server start process, as well as a 1 second delay to debounce the
+    # many restarts that otherwise happen during the initial build of internal dependencies
+    start_server="${start_server} --delay 1 ${watch_flags}"
+    yarn concurrently "${DIR}/buildInternalDependencies.sh --watch --withTypes" "eval ${start_server}"
 fi

--- a/scripts/bash/buildInternalDependencies.sh
+++ b/scripts/bash/buildInternalDependencies.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DIR=`dirname "$0"`
+DIR=$(dirname "$0")
 
 CONCURRENT_BUILD_BATCH_SIZE=2
 
@@ -10,22 +10,23 @@ watch=false
 with_types=false
 while [ "$1" != "" ]; do
   case $1 in
-      --watch)
-        shift
-        watch=true
-        ;;
-      --withTypes)
-        shift
-        with_types=true
-        shift
-        ;;
-      -h | --help )
-        echo -e "$USAGE\n";
-        exit
-        ;;
-      * )
-        echo -e "$USAGE\n"
-        exit 1
+  --watch)
+    shift
+    watch=true
+    ;;
+  --withTypes)
+    shift
+    with_types=true
+    shift
+    ;;
+  -h | --help)
+    echo -e "$USAGE\n"
+    exit
+    ;;
+  *)
+    echo -e "$USAGE\n"
+    exit 1
+    ;;
   esac
 done
 
@@ -53,7 +54,7 @@ if [[ $watch == "true" ]]; then
 else
   echo "Concurrently building internal dependencies in batches of ${CONCURRENT_BUILD_BATCH_SIZE}"
   total_build_commands=${#build_commands[@]}
-  for ((start_index=0; start_index<${total_build_commands}; start_index+=${CONCURRENT_BUILD_BATCH_SIZE})); do
+  for ((start_index = 0; start_index < ${total_build_commands}; start_index += ${CONCURRENT_BUILD_BATCH_SIZE})); do
     echo "yarn concurrently ${build_commands[@]:${start_index}:${CONCURRENT_BUILD_BATCH_SIZE}}"
     eval "yarn concurrently ${build_commands[@]:${start_index}:${CONCURRENT_BUILD_BATCH_SIZE}}"
   done

--- a/scripts/bash/buildInternalDependencies.sh
+++ b/scripts/bash/buildInternalDependencies.sh
@@ -9,25 +9,25 @@ USAGE="Usage: buildInternalDependencies.sh [--watch] [--withTypes]"
 watch=false
 with_types=false
 while [ "$1" != "" ]; do
-  case $1 in
-  --watch)
-    shift
-    watch=true
-    ;;
-  --withTypes)
-    shift
-    with_types=true
-    shift
-    ;;
-  -h | --help)
-    echo -e "$USAGE\n"
-    exit
-    ;;
-  *)
-    echo -e "$USAGE\n"
-    exit 1
-    ;;
-  esac
+    case $1 in
+    --watch)
+        shift
+        watch=true
+        ;;
+    --withTypes)
+        shift
+        with_types=true
+        shift
+        ;;
+    -h | --help)
+        echo -e "$USAGE\n"
+        exit
+        ;;
+    *)
+        echo -e "$USAGE\n"
+        exit 1
+        ;;
+    esac
 done
 
 [[ $watch = "true" ]] && build_args="--watch" || build_args=""
@@ -37,25 +37,25 @@ build_commands=()
 
 # Build dependencies
 for PACKAGE in $(${DIR}/getInternalDependencies.sh); do
-  build_commands+=("\"yarn workspace @tupaia/${PACKAGE} build $build_args\"")
+    build_commands+=("\"yarn workspace @tupaia/${PACKAGE} build $build_args\"")
 done
 
 # Build types
 if [ $with_types == "true" ]; then
-  for PACKAGE in $(${DIR}/getTypedInternalDependencies.sh); do
-    build_commands+=("\"yarn workspace @tupaia/${PACKAGE} build:ts $build_ts_args\"")
-  done
+    for PACKAGE in $(${DIR}/getTypedInternalDependencies.sh); do
+        build_commands+=("\"yarn workspace @tupaia/${PACKAGE} build:ts $build_ts_args\"")
+    done
 fi
 
 if [[ $watch == "true" ]]; then
-  echo "Concurrently building and watching all internal dependencies"
-  echo "yarn concurrently ${build_commands[@]}"
-  eval "yarn concurrently ${build_commands[@]}"
+    echo "Concurrently building and watching all internal dependencies"
+    echo "yarn concurrently ${build_commands[@]}"
+    eval "yarn concurrently ${build_commands[@]}"
 else
-  echo "Concurrently building internal dependencies in batches of ${CONCURRENT_BUILD_BATCH_SIZE}"
-  total_build_commands=${#build_commands[@]}
-  for ((start_index = 0; start_index < ${total_build_commands}; start_index += ${CONCURRENT_BUILD_BATCH_SIZE})); do
-    echo "yarn concurrently ${build_commands[@]:${start_index}:${CONCURRENT_BUILD_BATCH_SIZE}}"
-    eval "yarn concurrently ${build_commands[@]:${start_index}:${CONCURRENT_BUILD_BATCH_SIZE}}"
-  done
+    echo "Concurrently building internal dependencies in batches of ${CONCURRENT_BUILD_BATCH_SIZE}"
+    total_build_commands=${#build_commands[@]}
+    for ((start_index = 0; start_index < ${total_build_commands}; start_index += ${CONCURRENT_BUILD_BATCH_SIZE})); do
+        echo "yarn concurrently ${build_commands[@]:${start_index}:${CONCURRENT_BUILD_BATCH_SIZE}}"
+        eval "yarn concurrently ${build_commands[@]:${start_index}:${CONCURRENT_BUILD_BATCH_SIZE}}"
+    done
 fi

--- a/scripts/bash/dumpDb.sh
+++ b/scripts/bash/dumpDb.sh
@@ -17,26 +17,27 @@ if [ "$identity_file" == "" ]; then
 fi
 
 while [ "$2" != "" ]; do
-  case $2 in
-      -s | --server)
+    case $2 in
+    -s | --server)
         shift
         server=$2
         shift
         ;;
-      -t | --target)
+    -t | --target)
         shift
         target_dir=$2
         shift
         ;;
-      -h | --help )
+    -h | --help)
         echo "Will download a dump of the latest Tupaia database into the specified target path"
-        echo $USAGE;
+        echo $USAGE
         exit
         ;;
-      * )
+    *)
         echo $USAGE
         exit 1
-  esac
+        ;;
+    esac
 done
 
 domain=$server.tupaia.org
@@ -45,14 +46,16 @@ dump_file_path="/var/lib/postgresql/$DUMP_FILE_NAME"
 
 echo "Creating dump file in $domain..."
 ssh -o StrictHostKeyChecking=no -i $identity_file $host \
-  "sudo -u postgres bash -c \"pg_dump tupaia > $dump_file_path\""
-
+    "sudo -u postgres bash -c \"pg_dump tupaia > $dump_file_path\""
 
 echo "Compressing dump file"
 ssh -o StrictHostKeyChecking=no -i $identity_file $host \
-  "sudo gzip -f $dump_file_path"
+    "sudo gzip -f $dump_file_path"
 
-target_path="$(cd "$target_dir"; pwd)/$DUMP_FILE_NAME.gz"
+target_path="$(
+    cd "$target_dir"
+    pwd
+)/$DUMP_FILE_NAME.gz"
 echo "Downloading dump file into '$target_path'..."
 scp -i $identity_file "$host:$dump_file_path.gz" $target_dir
 

--- a/scripts/bash/storeDotEnvOnParameterStore.sh
+++ b/scripts/bash/storeDotEnvOnParameterStore.sh
@@ -10,21 +10,21 @@ while [[ $# -gt 0 ]]; do
   key="$1"
 
   case $key in
-      --package-name)
-      PACKAGE_NAME="$2"
-      shift # past argument
-      shift # past value
-      ;;
-      --environment)
-      ENVIRONMENT="$2"
-      shift # past argument
-      shift # past value
-      ;;
-      --path-to-package)
-      PATH_TO_PACKAGE="$2"
-      shift # past argument
-      shift # past value
-      ;;
+  --package-name)
+    PACKAGE_NAME="$2"
+    shift # past argument
+    shift # past value
+    ;;
+  --environment)
+    ENVIRONMENT="$2"
+    shift # past argument
+    shift # past value
+    ;;
+  --path-to-package)
+    PATH_TO_PACKAGE="$2"
+    shift # past argument
+    shift # past value
+    ;;
   esac
 done
 set -- "${POSITIONAL[@]}" # restore positional parameters
@@ -41,7 +41,7 @@ fi
 
 cd $PATH_TO_PACKAGE
 while read PARAMETER; do
-  IFS== read PARAMETER_NAME PARAMETER_VALUE <<< $PARAMETER
+  IFS== read PARAMETER_NAME PARAMETER_VALUE <<<$PARAMETER
   PARAMETER_VALUE="${PARAMETER_VALUE%\"}" # Remove leading quote
   PARAMETER_VALUE="${PARAMETER_VALUE#\"}" # Remove trailing quote
   PARAMETER_QUALIFIED_NAME="/$PACKAGE_NAME/$ENVIRONMENT/$PARAMETER_NAME"

--- a/scripts/bash/storeDotEnvOnParameterStore.sh
+++ b/scripts/bash/storeDotEnvOnParameterStore.sh
@@ -7,46 +7,46 @@
 # Getting command line arguments, taken from https://stackoverflow.com/questions/192249/how-do-i-parse-command-line-arguments-in-bash
 POSITIONAL=()
 while [[ $# -gt 0 ]]; do
-  key="$1"
+    key="$1"
 
-  case $key in
-  --package-name)
-    PACKAGE_NAME="$2"
-    shift # past argument
-    shift # past value
-    ;;
-  --environment)
-    ENVIRONMENT="$2"
-    shift # past argument
-    shift # past value
-    ;;
-  --path-to-package)
-    PATH_TO_PACKAGE="$2"
-    shift # past argument
-    shift # past value
-    ;;
-  esac
+    case $key in
+    --package-name)
+        PACKAGE_NAME="$2"
+        shift # past argument
+        shift # past value
+        ;;
+    --environment)
+        ENVIRONMENT="$2"
+        shift # past argument
+        shift # past value
+        ;;
+    --path-to-package)
+        PATH_TO_PACKAGE="$2"
+        shift # past argument
+        shift # past value
+        ;;
+    esac
 done
 set -- "${POSITIONAL[@]}" # restore positional parameters
 
 if [[ -z $PACKAGE_NAME || -z $ENVIRONMENT ]]; then
-  echo "Please specify both --package-name and --environment (and optionally, --path-to-package)"
-  exit 0
+    echo "Please specify both --package-name and --environment (and optionally, --path-to-package)"
+    exit 0
 fi
 
 if [[ -z $PATH_TO_PACKAGE ]]; then
-  # Use default path to package, based on ubuntu server setup
-  PATH_TO_PACKAGE="/home/ubuntu/tupaia/packages/${PACKAGE_NAME}"
+    # Use default path to package, based on ubuntu server setup
+    PATH_TO_PACKAGE="/home/ubuntu/tupaia/packages/${PACKAGE_NAME}"
 fi
 
 cd $PATH_TO_PACKAGE
 while read PARAMETER; do
-  IFS== read PARAMETER_NAME PARAMETER_VALUE <<<$PARAMETER
-  PARAMETER_VALUE="${PARAMETER_VALUE%\"}" # Remove leading quote
-  PARAMETER_VALUE="${PARAMETER_VALUE#\"}" # Remove trailing quote
-  PARAMETER_QUALIFIED_NAME="/$PACKAGE_NAME/$ENVIRONMENT/$PARAMETER_NAME"
-  echo "Saving $PARAMETER_NAME as $PARAMETER_QUALIFIED_NAME"
-  CLI_INPUT_JSON="{\"Name\":\"${PARAMETER_QUALIFIED_NAME}\",\"Value\":\"${PARAMETER_VALUE}\",\"Type\":\"SecureString\",\"KeyId\":\"alias/meditrak-server-encryption-key\",\"Overwrite\":true}"
-  CLI_COMMAND="aws ssm put-parameter --cli-input-json '$CLI_INPUT_JSON'"
-  eval $CLI_COMMAND
+    IFS== read PARAMETER_NAME PARAMETER_VALUE <<<$PARAMETER
+    PARAMETER_VALUE="${PARAMETER_VALUE%\"}" # Remove leading quote
+    PARAMETER_VALUE="${PARAMETER_VALUE#\"}" # Remove trailing quote
+    PARAMETER_QUALIFIED_NAME="/$PACKAGE_NAME/$ENVIRONMENT/$PARAMETER_NAME"
+    echo "Saving $PARAMETER_NAME as $PARAMETER_QUALIFIED_NAME"
+    CLI_INPUT_JSON="{\"Name\":\"${PARAMETER_QUALIFIED_NAME}\",\"Value\":\"${PARAMETER_VALUE}\",\"Type\":\"SecureString\",\"KeyId\":\"alias/meditrak-server-encryption-key\",\"Overwrite\":true}"
+    CLI_COMMAND="aws ssm put-parameter --cli-input-json '$CLI_INPUT_JSON'"
+    eval $CLI_COMMAND
 done <.env

--- a/scripts/bash/updateParameterStoreEnvVars.sh
+++ b/scripts/bash/updateParameterStoreEnvVars.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 DIR=$(dirname "$0")
 for PACKAGE in "meditrak-server" "admin-panel" "web-frontend" "web-config-server"; do
-  echo "Storing .env contents on parameter store for ${ENVIRONMENT} ${PACKAGE}"
-  ${DIR}/storeDotEnvOnParameterStore.sh --package-name ${PACKAGE} --environment ${ENVIRONMENT}
+    echo "Storing .env contents on parameter store for ${ENVIRONMENT} ${PACKAGE}"
+    ${DIR}/storeDotEnvOnParameterStore.sh --package-name ${PACKAGE} --environment ${ENVIRONMENT}
 done

--- a/scripts/bash/updateParameterStoreEnvVars.sh
+++ b/scripts/bash/updateParameterStoreEnvVars.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-DIR=`dirname "$0"`
+DIR=$(dirname "$0")
 for PACKAGE in "meditrak-server" "admin-panel" "web-frontend" "web-config-server"; do
   echo "Storing .env contents on parameter store for ${ENVIRONMENT} ${PACKAGE}"
   ${DIR}/storeDotEnvOnParameterStore.sh --package-name ${PACKAGE} --environment ${ENVIRONMENT}

--- a/scripts/bash/validate.sh
+++ b/scripts/bash/validate.sh
@@ -2,11 +2,11 @@
 
 set -e
 
-DIR=`dirname "$0"`
+DIR=$(dirname "$0")
 . ${DIR}/../../packages/devops/scripts/ci/utils.sh
 
 yarn -s workspace @tupaia/devops -s validate-branch-name
 yarn -s workspace @tupaia/devops -s validate-tests
-if [[ $? > 0 ]] ; then
+if [[ $? > 0 ]]; then
   log_warn "Exclusive (.only) tests found in your code. The CI/CD build will fail if you push those"
 fi

--- a/scripts/bash/validate.sh
+++ b/scripts/bash/validate.sh
@@ -8,5 +8,5 @@ DIR=$(dirname "$0")
 yarn -s workspace @tupaia/devops -s validate-branch-name
 yarn -s workspace @tupaia/devops -s validate-tests
 if [[ $? > 0 ]]; then
-  log_warn "Exclusive (.only) tests found in your code. The CI/CD build will fail if you push those"
+    log_warn "Exclusive (.only) tests found in your code. The CI/CD build will fail if you push those"
 fi

--- a/tupaia-packages.code-workspace
+++ b/tupaia-packages.code-workspace
@@ -138,6 +138,7 @@
       "dbaeumer.vscode-eslint",
       "eamodio.gitlens",
       "esbenp.prettier-vscode",
+      "foxundermoon.shell-format",
       "streetsidesoftware.code-spell-checker",
       "visualstudioexptteam.vscodeintellicode",
       "wayou.vscode-todo-highlight"


### PR DESCRIPTION
### Issue #:
[No issue]

### Changes:
* Replaced `\e` with `\033` as an terminal escape character, since the latter doesn't work in MacOS
* Used the [shell-format](https://marketplace.visualstudio.com/items?itemName=foxundermoon.shell-format) VSCode extension to format existing shell scripts.
* Indented scripts to consistently use 4 spaces