### PR TITLE
Fix default dates enlarged dialog

### DIFF
--- a/packages/web-frontend/src/actions.js
+++ b/packages/web-frontend/src/actions.js
@@ -1139,10 +1139,12 @@ export function closeEnlargedDialog() {
   };
 }
 
-export function openEnlargedDialog(viewId) {
+export function openEnlargedDialog(viewId, startDate, endDate) {
   return {
     type: OPEN_ENLARGED_DIALOG,
     viewId,
+    startDate,
+    endDate,
   };
 }
 

--- a/packages/web-frontend/src/containers/DashboardItem/index.js
+++ b/packages/web-frontend/src/containers/DashboardItem/index.js
@@ -130,8 +130,19 @@ const mapStateToProps = (state, { infoViewKey }) => {
 const mapDispatchToProps = dispatch => ({
   fetchContent: (organisationUnitCode, dashboardGroupId, viewId, infoViewKey) =>
     dispatch(fetchDashboardItemData(organisationUnitCode, dashboardGroupId, viewId, infoViewKey)),
-  onEnlarge: viewId => dispatch(openEnlargedDialog(viewId)),
   dispatch, // Necessary for merge props.
 });
 
-export default connect(mapStateToProps, mapDispatchToProps)(DashboardItem);
+const mergeProps = (stateProps, { dispatch, ...dispatchProps }, ownProps) => {
+  return {
+    ...stateProps,
+    ...dispatchProps,
+    ...ownProps,
+    onEnlarge: viewId => {
+      const { startDate, endDate } = stateProps.viewContent;
+      dispatch(openEnlargedDialog(viewId, startDate, endDate));
+    },
+  };
+};
+
+export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(DashboardItem);

--- a/packages/web-frontend/src/historyNavigation/historyMiddleware.js
+++ b/packages/web-frontend/src/historyNavigation/historyMiddleware.js
@@ -78,6 +78,8 @@ const reactToLocationChange = (store, location, previousLocation) => {
   setComponentIfUpdated(URL_COMPONENTS.PROJECT, setProject);
   setComponentIfUpdated(URL_COMPONENTS.ORG_UNIT, setOrgUnit);
   setComponentIfUpdated(URL_COMPONENTS.URL_COMPONENTS, setMeasure);
+  // Note, the signature is openEnlargedDialog(viewId, startDate, endDate),
+  // so we only pass viewId for now and leave the others undefined
   setComponentIfUpdated(URL_COMPONENTS.REPORT, openEnlargedDialog);
   setComponentIfUpdated(
     URL_COMPONENTS.MEASURE_PERIOD,

--- a/packages/web-frontend/src/reducers.js
+++ b/packages/web-frontend/src/reducers.js
@@ -735,8 +735,8 @@ function enlargedDialog(
         isVisible: true,
         isLoading: false,
         errorMessage: '',
-        startDate: null,
-        endDate: null,
+        startDate: action.startDate,
+        endDate: action.endDate,
       };
 
     case CLOSE_ENLARGED_DIALOG:
@@ -745,6 +745,8 @@ function enlargedDialog(
         isVisible: false,
         viewContent: null,
         organisationUnitName: '',
+        startDate: null,
+        endDate: null,
       };
 
     case SET_ENLARGED_DIALOG_DATE_RANGE:


### PR DESCRIPTION
### Issue #:
https://github.com/beyondessential/tupaia-backlog/issues/648

### Changes:
This line here (I think) was the catalyst for it breaking:
![image](https://user-images.githubusercontent.com/32168886/96654175-6f5f6400-1386-11eb-9d18-be69132f95f7.png)

However, that change just exposed the fact that upon opening the enlargedDialog, the startDate and endDate are null (and were explicitly set that way in the reducer. 


Edit: will create a new branch name (it can't end with `export`)

