### PR TITLE
1429 update link generation and existed links data for feed items

### DIFF
--- a/packages/database/src/migrations/20201026223059-UpdateLinkOnFeedItems-modifies-data.js
+++ b/packages/database/src/migrations/20201026223059-UpdateLinkOnFeedItems-modifies-data.js
@@ -1,0 +1,36 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function(db) {
+  /**
+   * Update value with key `link` in `template_variables`
+   */
+  return db.runSql(`
+    update feed_item
+    set template_variables = regexp_replace (
+                      template_variables :: text,
+                      '(?<=https:\\/\\/mobile.tupaia.org\\/)(country|facility)',
+                      'explore')::json
+  `);
+};
+
+exports.down = function(db) {
+  return null;
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/packages/database/src/migrations/20201026223059-UpdateLinkOnFeedItems-modifies-data.js
+++ b/packages/database/src/migrations/20201026223059-UpdateLinkOnFeedItems-modifies-data.js
@@ -22,7 +22,7 @@ exports.up = function(db) {
     update feed_item
     set template_variables = regexp_replace (
                       template_variables :: text,
-                      '(?<=https:\\/\\/mobile.tupaia.org\\/)(country|facility)',
+                      '(?<=https:\/\/mobile.tupaia.org\/)(country|facility)',
                       'explore')::json
   `);
 };

--- a/packages/meditrak-server/src/social/feedScraper.js
+++ b/packages/meditrak-server/src/social/feedScraper.js
@@ -79,8 +79,8 @@ const addLatestSurveyFeedItems = async models => {
       );
       const imageUrl = photoAnswer ? photoAnswer.text : null;
       const link = facilityCode
-        ? `https://mobile.tupaia.org/facility/${facilityCode}`
-        : `https://mobile.tupaia.org/country/${countryCode}`;
+        ? `https://mobile.tupaia.org/explore/${facilityCode}`
+        : `https://mobile.tupaia.org/explore/${countryCode}`;
 
       await models.feedItem.create({
         type,


### PR DESCRIPTION
### Issue #:
[Update the link generation on social feed items](https://github.com/beyondessential/tupaia-backlog/issues/1429#issuecomment-716313917)

### Changes:

1. Update value with key `link` in `template_variables` in `feed_item` table, from legacy link format: `https:\\mobile.tupaia.org\facility\{faclitycode}` or `https:\\mobile.tupaia.org\country\{countrycode}`
to `https:\\mobile.tupaia.org\explore\{code}` 

2. Update the link generation in `meditrak-server` 
