### PR TITLE
Delete Public Health Services Entity

### DIFF
--- a/packages/database/src/migrations/20201026232410-DeleteEntityPublicHealthService-modifies-data.js
+++ b/packages/database/src/migrations/20201026232410-DeleteEntityPublicHealthService-modifies-data.js
@@ -1,0 +1,36 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+const Public_Health_Services = 'Public Health Services'
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function(db) {
+  await db.runSql(`
+      delete from entity
+      where name = '${Public_Health_Services}'
+  `);
+
+  return db.runSql(`
+      delete from clinic
+      where name = '${Public_Health_Services}'
+  `);
+};
+
+exports.down = function(db) {
+  return null;
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/packages/database/src/migrations/20201026232410-DeleteEntityPublicHealthService-modifies-data.js
+++ b/packages/database/src/migrations/20201026232410-DeleteEntityPublicHealthService-modifies-data.js
@@ -15,7 +15,7 @@ exports.setup = function(options, seedLink) {
   seed = seedLink;
 };
 
-exports.up = function(db) {
+exports.up = async function(db) {
   await db.runSql(`
       delete from entity
       where name = '${Public_Health_Services}'


### PR DESCRIPTION
### Issue #:
[Safely archive Public Health Service, Tonga](https://github.com/beyondessential/tupaia-backlog/issues/1397)

### Changes:
Here are the manual steps:
1. Delete the survey responses which belong to Public Health Service
2. Hard delete the datavalues for Public Health Service on DHIS2
3. Do migration to delete `Public Health Services` from the clinic and entity tables (this PR)
