### PR TITLE
Fix e2e migrations breaking: delete any survey responses attached to the entity being deleted

### DIFF
--- a/packages/database/src/migrations/20201019011335-RemoveRedundantDataInFijiEntity-modifies-data.js
+++ b/packages/database/src/migrations/20201019011335-RemoveRedundantDataInFijiEntity-modifies-data.js
@@ -6,31 +6,37 @@ var seed;
 const redundantEntityName = 'Colonial War Memorial Hospital ';
 
 /**
-  * We receive the dbmigrate dependency from dbmigrate initially.
-  * This enables us to not have to rely on NODE_PATH.
-  */
-exports.setup = function(options, seedLink) {
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
   dbm = options.dbmigrate;
   type = dbm.dataType;
   seed = seedLink;
 };
 
-exports.up = async function(db) {
+exports.up = async function (db) {
+  await db.runSql(`
+    delete from survey_response
+    using entity
+    where entity_id = entity.id and entity.name = '${redundantEntityName}';
+  `);
+
   await db.runSql(`
       delete from entity
-      where name = '${redundantEntityName}'
+      where name = '${redundantEntityName}';
   `);
 
   return db.runSql(`
       delete from clinic
-      where name = '${redundantEntityName}'
+      where name = '${redundantEntityName}';
   `);
 };
 
-exports.down = function(db) {
+exports.down = function (db) {
   return null;
 };
 
 exports._meta = {
-  "version": 1
+  version: 1,
 };


### PR DESCRIPTION
While this is updating a migration that has already been released, a strict no-no, in this case it's ok because we don't care about the change running on production. In production, the migration will be marked as already run, so the change will have no effect. In e2e test environments, it will run with the change, so those environments will be fixed.
