### PR TITLE
update dev thumbnails

### DIFF
--- a/packages/web-frontend/src/utils/getFacilityThumbnailUrl.js
+++ b/packages/web-frontend/src/utils/getFacilityThumbnailUrl.js
@@ -12,9 +12,7 @@ export const getFacilityThumbnailUrl = orgUnit => {
     return null;
   }
 
-  // TODO handle dev uploads as thumbnails https://github.com/beyondessential/tupaia-backlog/issues/960
-  if (photoUrl.includes('dev_uploads')) {
-    return photoUrl;
-  }
-  return photoUrl.replace('/uploads/', '/thumbnails/uploads/').replace('.png', '.jpg');
+  const dir = photoUrl.includes('dev_uploads') ? 'dev_uploads' : 'uploads';
+
+  return photoUrl.replace(`/${dir}/`, `/thumbnails/${dir}/`).replace('.png', '.jpg');
 };


### PR DESCRIPTION
### Issue #: [960](https://github.com/beyondessential/tupaia-backlog/issues/960)

### Changes:

- Update the thumbnail url to use the dev thumbnails

Note: To make this change work, I first updated the aws lambda trigger for CreateThumbnail to pick up uploads to the `dev_uploads` folder

---

### Screenshots:
![Screen Shot 2020-11-03 at 2 41 04 PM](https://user-images.githubusercontent.com/12807916/97937414-8620a480-1de3-11eb-881d-979c608016aa.png)
