### PR TITLE
fix image uploads

### DIFF
--- a/packages/meditrak-server/src/devops/CreateThumbnail/CreateThumbnail.js
+++ b/packages/meditrak-server/src/devops/CreateThumbnail/CreateThumbnail.js
@@ -17,7 +17,7 @@ var THUMB_WIDTH = 500;
 // get reference to S3 client
 var s3 = new AWS.S3();
 
-exports.handler = function(event, context, callback) {
+exports.handler = function (event, context, callback) {
   // Read options from the event.
   console.log('Reading options from event:\n', util.inspect(event, { depth: 5 }));
   var srcBucket = event.Records[0].s3.bucket.name;
@@ -34,7 +34,7 @@ exports.handler = function(event, context, callback) {
   }
   var imageType = typeMatch[1];
   if (imageType != 'jpg' && imageType != 'png') {
-    callback('Unsupported image type: ${imageType}');
+    callback(`Unsupported image type: ${imageType}`);
     return;
   }
 
@@ -60,7 +60,7 @@ exports.handler = function(event, context, callback) {
         }
       },
       function resize(data, next) {
-        Jimp.read(data, function(err, image) {
+        Jimp.read(data, function (err, image) {
           image
             .resize(THUMB_WIDTH, Jimp.AUTO)
             .quality(60)
@@ -81,7 +81,7 @@ exports.handler = function(event, context, callback) {
         );
       },
     ],
-    function(err) {
+    function (err) {
       if (err) {
         console.error(
           'Unable to resize ' +

--- a/packages/meditrak-server/src/s3/uploadImage.js
+++ b/packages/meditrak-server/src/s3/uploadImage.js
@@ -10,10 +10,8 @@ export const uploadImage = (base64EncodedImage, fileId) => {
   const buffer = Buffer.from(base64EncodedImage.replace(/^data:image\/\w+;base64,/, ''), 'base64');
 
   const filePath = getImageFilePath();
-  const type = base64EncodedImage.split(';')[0].split('/')[1] || 'png';
-
   const fileName = fileId
-    ? `${filePath}${fileId}.${type}`
+    ? `${filePath}${fileId}.png`
     : `${filePath}${getCurrentTime()}_${getRandomInteger()}.png`;
 
   return new Promise((resolve, reject) => {
@@ -24,7 +22,7 @@ export const uploadImage = (base64EncodedImage, fileId) => {
         Key: fileName,
         Body: buffer,
         ACL: 'public-read',
-        ContentType: `image/${type}`,
+        ContentType: 'image/png',
         ContentEncoding: 'base64',
       },
       (error, data) => {


### PR DESCRIPTION
### Issue #: [960](https://github.com/beyondessential/tupaia-backlog/issues/960)

The issue was actually a regression caused by a previous feature for uploading profile images. It looks like that change was never actually needed and always saving the image as a png works fine. I regression tested the profile image uploads and they still work after this change.

### Changes:

- Fix s3 image uploads file types
- Fix create thumbnail logging
---
