### PR TITLE
1358 fix login form renders twice

### DIFF
--- a/packages/web-frontend/cypress/support/actions.js
+++ b/packages/web-frontend/cypress/support/actions.js
@@ -6,7 +6,7 @@
 import { TEST_USER } from '../constants';
 
 const getTestUserPassword = () => {
-  const password = Cypress.env('CYPRESS_TEST_USER_PASSWORD');
+  const password = Cypress.env('TEST_USER_PASSWORD');
   if (!password) {
     throw new Error(
       'Please specify a value for CYPRESS_TEST_USER_PASSWORD in packages/web-frontend/.env',

--- a/packages/web-frontend/cypress/support/actions.js
+++ b/packages/web-frontend/cypress/support/actions.js
@@ -6,7 +6,7 @@
 import { TEST_USER } from '../constants';
 
 const getTestUserPassword = () => {
-  const password = Cypress.env('TEST_USER_PASSWORD');
+  const password = Cypress.env('CYPRESS_TEST_USER_PASSWORD');
   if (!password) {
     throw new Error(
       'Please specify a value for CYPRESS_TEST_USER_PASSWORD in packages/web-frontend/.env',

--- a/packages/web-frontend/cypress/support/commands.js
+++ b/packages/web-frontend/cypress/support/commands.js
@@ -31,10 +31,6 @@ Cypress.Commands.add('login', () => {
   cy.visit('/');
   cy.wait('@getUser').then(({ response }) => {
     if (response.body.name === PUBLIC_USER) {
-      // TODO This is a temporary hack to make sure that the login form is stable
-      // Remove it when https://github.com/beyondessential/tupaia-backlog/issues/1358 is fixed
-      cy.wait('@projects');
-
       submitLoginForm();
       cy.wait('@getUser').then(() => {
         closeOverlay();


### PR DESCRIPTION
### Issue #: [1358 fix login form renders twice](https://github.com/beyondessential/tupaia-backlog/issues/1358)

I tested the login form and it no longer loads twice. I believe the changes I made to the App.js and login flow in the sagas fixed this ([1528](https://github.com/beyondessential/tupaia/pull/1528)). However it could have been something else that fixed it - I'm not 100% sure to be honest but the main thing is that it works. I removed the hack that was in place in the end-to-end tests and ran them and the login flow works as expected.

**Notes on End To End Testing**
Setting up and running the tests went really smoothly for me. It is awesome to see these tests in working - great work @kael89! On the dev branch the tests were failing after login but on the most up to date branch [1574](https://github.com/beyondessential/tupaia/pull/1574) the tests ran perfectly (I stopped the tests after about 5 minutes).

I did note an issue with the `CYPRESS_TEST_USER_PASSWORD` env variable. It was wrongly named in the `actions.js` (which I've fixed in this PR) and also cypress was not picking up the password variable from my `.env` file after I added it. When I added the env variable to the `cypress.json` file it worked ([as described here](https://docs.cypress.io/guides/guides/environment-variables.html#Option-1-configuration-file)). 

PS. When I ran `cypress:generate-config` the password variable worked fine from the `.env` file.

