### PR TITLE
1132: Add create handler for /userEntityPermissions route

### DIFF
--- a/packages/meditrak-server/src/app/addRoutesToApp.js
+++ b/packages/meditrak-server/src/app/addRoutesToApp.js
@@ -17,6 +17,7 @@ import routes from '../routes';
 const {
   authenticate,
   countChanges,
+  createUserEntityPermissions,
   deleteRecord,
   deleteUserEntityPermissions,
   editRecord,
@@ -159,6 +160,7 @@ export function addRoutesToApp(app) {
   app.post('(/v[0-9]+)/import/optionSets', upload.single('optionSets'), importOptionSets);
   app.post('(/v[0-9]+)?/user', registerUserAccount);
   app.post('(/v[0-9]+)?/userAccount', createUserAccount);
+  app.post('(/v[0-9]+)?/userEntityPermissions', createUserEntityPermissions);
   app.post('(/v[0-9]+)/me/requestCountryAccess', requestCountryAccess);
   app.post('(/v[0-9]+)/me/changePassword', changePassword);
   app.post('(/v[0-9]+)/surveyResponse', surveyResponse);

--- a/packages/meditrak-server/src/routes/index.js
+++ b/packages/meditrak-server/src/routes/index.js
@@ -21,8 +21,14 @@ import { GETQuestions } from './GETQuestions';
 import { GETPermissionGroups } from './GETPermissionGroups';
 import { GETOptions } from './GETOptions';
 import { GETOptionSets } from './GETOptionSets';
-import { CreateUserAccounts, RegisterUserAccounts, EditUserAccounts, GETUserAccounts } from './userAccounts';
 import {
+  CreateUserAccounts,
+  RegisterUserAccounts,
+  EditUserAccounts,
+  GETUserAccounts,
+} from './userAccounts';
+import {
+  CreateUserEntityPermissions,
   DeleteUserEntityPermissions,
   EditUserEntityPermissions,
   GETUserEntityPermissions,
@@ -71,6 +77,7 @@ const useRouteHandler = HandlerClass =>
 export default {
   authenticate: catchAsyncErrors(authenticate),
   countChanges: catchAsyncErrors(countChanges),
+  createUserEntityPermissions: useRouteHandler(CreateUserEntityPermissions),
   deleteRecord: catchAsyncErrors(deleteRecord),
   deleteUserEntityPermissions: useRouteHandler(DeleteUserEntityPermissions),
   editRecord: catchAsyncErrors(editRecord),

--- a/packages/meditrak-server/src/routes/userEntityPermissions/CreateUserEntityPermissions.js
+++ b/packages/meditrak-server/src/routes/userEntityPermissions/CreateUserEntityPermissions.js
@@ -1,0 +1,39 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
+ */
+
+import { CreateHandler } from '../CreateHandler';
+import {
+  assertAnyPermissions,
+  assertBESAdminAccess,
+  assertTupaiaAdminPanelAccess,
+} from '../../permissions';
+import { assertUserEntityPermissionUpsertPermissions } from './assertUserEntityPermissionPermissions';
+
+/**
+ * Handles POST endpoints:
+ * - /userEntityPermissions
+ */
+
+export class CreateUserEntityPermissions extends CreateHandler {
+  async assertUserHasAccess() {
+    await this.assertPermissions(
+      assertAnyPermissions(
+        [assertBESAdminAccess, assertTupaiaAdminPanelAccess],
+        'You need either BES Admin or Tupaia Admin Panel access to create user entity permissions',
+      ),
+    );
+  }
+
+  async createRecord() {
+    // Check Permissions
+    const userEntityPermissionsChecker = accessPolicy =>
+      assertUserEntityPermissionUpsertPermissions(accessPolicy, this.models, this.newRecordData);
+    await this.assertPermissions(
+      assertAnyPermissions([assertBESAdminAccess, userEntityPermissionsChecker]),
+    );
+
+    return this.insertRecord();
+  }
+}

--- a/packages/meditrak-server/src/routes/userEntityPermissions/EditUserEntityPermissions.js
+++ b/packages/meditrak-server/src/routes/userEntityPermissions/EditUserEntityPermissions.js
@@ -9,7 +9,7 @@ import {
   assertBESAdminAccess,
   assertTupaiaAdminPanelAccess,
 } from '../../permissions';
-import { assertUserEntityPermissionPermissions } from './assertUserEntityPermissionPermissions';
+import { assertUserEntityPermissionEditPermissions } from './assertUserEntityPermissionPermissions';
 
 /**
  * Handles PUT endpoints:
@@ -28,9 +28,13 @@ export class EditUserEntityPermissions extends EditHandler {
 
   async editRecord() {
     // Check Permissions
-    const userEntityPermission = await this.models.userEntityPermission.findById(this.recordId);
     const userEntityPermissionChecker = accessPolicy =>
-      assertUserEntityPermissionPermissions(accessPolicy, this.models, userEntityPermission);
+      assertUserEntityPermissionEditPermissions(
+        accessPolicy,
+        this.models,
+        this.recordId,
+        this.updatedFields,
+      );
     await this.assertPermissions(
       assertAnyPermissions([assertBESAdminAccess, userEntityPermissionChecker]),
     );

--- a/packages/meditrak-server/src/routes/userEntityPermissions/GETUserEntityPermissions.js
+++ b/packages/meditrak-server/src/routes/userEntityPermissions/GETUserEntityPermissions.js
@@ -51,10 +51,6 @@ export class GETUserEntityPermissions extends GETHandler {
     );
     const userEntityPermissions = await super.findRecords(dbConditions, options);
 
-    if (!userEntityPermissions.length) {
-      throw new Error('Your permissions do not allow access to any of the requested resources');
-    }
-
     return userEntityPermissions;
   }
 }

--- a/packages/meditrak-server/src/routes/userEntityPermissions/assertUserEntityPermissionPermissions.js
+++ b/packages/meditrak-server/src/routes/userEntityPermissions/assertUserEntityPermissionPermissions.js
@@ -39,11 +39,9 @@ export const assertUserEntityPermissionEditPermissions = async (
   await assertUserEntityPermissionUpsertPermissions(accessPolicy, models, updatedFields);
 
   // Final check to make sure we're not editing a BES admin access permission
-  // There's nothing we could edit that couldn't be abused
+  // Changing any of the pieces of data in a BES admin UEP is abusable, so completely forbid it
   const userEntityPermission = await models.userEntityPermission.findById(userEntityPermissionId);
-  const permissionGroup = await models.permissionGroup.findById(
-    userEntityPermission.permission_group_id,
-  );
+  const permissionGroup = await userEntityPermission.permissionGroup();
   if (permissionGroup.name === BES_ADMIN_PERMISSION_GROUP) {
     throw new Error('Need BES Admin access to make this change');
   }

--- a/packages/meditrak-server/src/routes/userEntityPermissions/assertUserEntityPermissionPermissions.js
+++ b/packages/meditrak-server/src/routes/userEntityPermissions/assertUserEntityPermissionPermissions.js
@@ -3,7 +3,11 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
-import { hasBESAdminAccess, TUPAIA_ADMIN_PANEL_PERMISSION_GROUP } from '../../permissions';
+import {
+  hasBESAdminAccess,
+  BES_ADMIN_PERMISSION_GROUP,
+  TUPAIA_ADMIN_PANEL_PERMISSION_GROUP,
+} from '../../permissions';
 import { getAdminPanelAllowedEntityIds } from '../utilities';
 
 export const assertUserEntityPermissionPermissions = async (
@@ -21,6 +25,52 @@ export const assertUserEntityPermissionPermissions = async (
     throw new Error('Need Admin Panel access to the country this entity is in');
   }
   return true;
+};
+
+export const assertUserEntityPermissionEditPermissions = async (
+  accessPolicy,
+  models,
+  userEntityPermissionId,
+  updatedFields,
+) => {
+  // Check we have permission to access the record we're trying to edit
+  await assertUserEntityPermissionPermissions(accessPolicy, models, userEntityPermissionId);
+  // Check we have permission for the changes
+  await assertUserEntityPermissionUpsertPermissions(accessPolicy, models, updatedFields);
+
+  // Final check to make sure we're not editing a BES admin access permission
+  // There's nothing we could edit that couldn't be abused
+  const userEntityPermission = await models.userEntityPermission.findById(userEntityPermissionId);
+  const permissionGroup = await models.permissionGroup.findById(
+    userEntityPermission.permission_group_id,
+  );
+  if (permissionGroup.name === BES_ADMIN_PERMISSION_GROUP) {
+    throw new Error('Need BES Admin access to make this change');
+  }
+
+  return true;
+};
+
+export const assertUserEntityPermissionUpsertPermissions = async (
+  accessPolicy,
+  models,
+  { permission_group_id: permissionGroupId, entity_id: entityId },
+) => {
+  // Check we're not trying to give someone:
+  // BES admin access
+  // Access to an entity we don't have admin panel access
+  if (permissionGroupId) {
+    const permissionGroup = await models.permissionGroup.findById(permissionGroupId);
+    if (permissionGroup.name === BES_ADMIN_PERMISSION_GROUP) {
+      throw new Error('Need BES Admin access to make this change');
+    }
+  }
+  if (entityId) {
+    const entity = await models.entity.findById(entityId);
+    if (!accessPolicy.allows(entity.country_code, TUPAIA_ADMIN_PANEL_PERMISSION_GROUP)) {
+      throw new Error('Need Admin Panel access to the updated entity');
+    }
+  }
 };
 
 export const createUserEntityPermissionDBFilter = async (accessPolicy, models, criteria) => {

--- a/packages/meditrak-server/src/routes/userEntityPermissions/index.js
+++ b/packages/meditrak-server/src/routes/userEntityPermissions/index.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
+export { CreateUserEntityPermissions } from './CreateUserEntityPermissions';
 export { DeleteUserEntityPermissions } from './DeleteUserEntityPermissions';
 export { EditUserEntityPermissions } from './EditUserEntityPermissions';
 export { GETUserEntityPermissions } from './GETUserEntityPermissions';

--- a/packages/meditrak-server/src/tests/routes/userEntityPermissions/CreateUserEntityPermissions.test.js
+++ b/packages/meditrak-server/src/tests/routes/userEntityPermissions/CreateUserEntityPermissions.test.js
@@ -1,0 +1,149 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
+ */
+
+import { expect } from 'chai';
+import { findOrCreateDummyRecord, findOrCreateDummyCountryEntity } from '@tupaia/database';
+import { Authenticator } from '@tupaia/auth';
+import {
+  TUPAIA_ADMIN_PANEL_PERMISSION_GROUP,
+  BES_ADMIN_PERMISSION_GROUP,
+} from '../../../permissions';
+import { TestableApp } from '../../TestableApp';
+import { prepareStubAndAuthenticate } from '../utilities/prepareStubAndAuthenticate';
+
+describe('Permissions checker for DeleteUserEntityPermissions', async () => {
+  const DEFAULT_POLICY = {
+    DL: ['Public'],
+    KI: [TUPAIA_ADMIN_PANEL_PERMISSION_GROUP, 'Admin'],
+    SB: [TUPAIA_ADMIN_PANEL_PERMISSION_GROUP, 'Royal Australasian College of Surgeons'],
+    VU: [TUPAIA_ADMIN_PANEL_PERMISSION_GROUP, 'Admin'],
+    LA: ['Admin'],
+    TO: ['Admin'],
+  };
+
+  const BES_ADMIN_POLICY = {
+    LA: [BES_ADMIN_PERMISSION_GROUP],
+  };
+
+  const app = new TestableApp();
+  const { models } = app;
+  let userAccountId;
+  let publicPermissionGroupId;
+  let BESAdminPermissionGroupId;
+  let vanuatuEntityId;
+  let laosEntityId;
+
+  before(async () => {
+    const publicPermissionGroup = await findOrCreateDummyRecord(models.permissionGroup, {
+      name: 'Public',
+    });
+    const BESAdminPermissionGroup = await findOrCreateDummyRecord(models.permissionGroup, {
+      name: BES_ADMIN_PERMISSION_GROUP,
+    });
+    publicPermissionGroupId = publicPermissionGroup.id;
+    BESAdminPermissionGroupId = BESAdminPermissionGroup.id;
+
+    const { entity: vanuatuEntity } = await findOrCreateDummyCountryEntity(models, {
+      code: 'VU',
+    });
+    const { entity: laosEntity } = await findOrCreateDummyCountryEntity(models, {
+      code: 'LA',
+    });
+    vanuatuEntityId = vanuatuEntity.id;
+    laosEntityId = laosEntity.id;
+
+    // Create test users
+    const userAccount = await findOrCreateDummyRecord(models.user, {
+      first_name: 'Clark',
+      last_name: 'Kent',
+    });
+    userAccountId = userAccount.id;
+  });
+
+  afterEach(() => {
+    Authenticator.prototype.getAccessPolicyForUser.restore();
+  });
+
+  describe('POST /userEntityPermissions', async () => {
+    describe('Insufficient permission', async () => {
+      it('Throw a permissions gate error if current user does not have BES admin or Tupaia Admin panel access anywhere', async () => {
+        const policy = {
+          DL: ['Public'],
+        };
+        await prepareStubAndAuthenticate(app, policy);
+        const { body: result } = await app.post(`userEntityPermissions`, {
+          body: {
+            user_id: userAccountId,
+            permission_group_id: publicPermissionGroupId,
+            entity_id: laosEntityId,
+          },
+        });
+
+        expect(result).to.have.keys('error');
+      });
+      it('Throw an exception when trying to create a user entity permission for an entity current user lacks permissions for', async () => {
+        await prepareStubAndAuthenticate(app, DEFAULT_POLICY);
+        const { body: result } = await app.post(`userEntityPermissions`, {
+          body: {
+            user_id: userAccountId,
+            permission_group_id: publicPermissionGroupId,
+            entity_id: laosEntityId,
+          },
+        });
+
+        expect(result).to.have.keys('error');
+      });
+      it('Throw an exception when trying to create a user entity permission with BES admin access when current user lacks BES admin access', async () => {
+        await prepareStubAndAuthenticate(app, DEFAULT_POLICY);
+        const { body: result } = await app.post(`userEntityPermissions`, {
+          body: {
+            user_id: userAccountId,
+            permission_group_id: BESAdminPermissionGroupId,
+            entity_id: vanuatuEntityId,
+          },
+        });
+
+        expect(result).to.have.keys('error');
+      });
+    });
+    describe('Sufficient permission', async () => {
+      it('Allow creation of user entity permission for entity user has permission for', async () => {
+        await prepareStubAndAuthenticate(app, DEFAULT_POLICY);
+        await app.post(`userEntityPermissions`, {
+          body: {
+            user_id: userAccountId,
+            permission_group_id: publicPermissionGroupId,
+            entity_id: laosEntityId,
+          },
+        });
+        const result = await models.userEntityPermission.find({
+          user_id: userAccountId,
+          permission_group_id: publicPermissionGroupId,
+          entity_id: laosEntityId,
+        });
+
+        expect(result).to.not.equal(null);
+      });
+
+      it('Allow creation of any user entity permission for BES admin user', async () => {
+        await prepareStubAndAuthenticate(app, BES_ADMIN_POLICY);
+        await app.post(`userEntityPermissions`, {
+          body: {
+            user_id: userAccountId,
+            permission_group_id: BESAdminPermissionGroupId,
+            entity_id: vanuatuEntityId,
+          },
+        });
+        const result = await models.userEntityPermission.find({
+          user_id: userAccountId,
+          permission_group_id: BESAdminPermissionGroupId,
+          entity_id: vanuatuEntityId,
+        });
+
+        expect(result).to.not.equal(null);
+      });
+    });
+  });
+});

--- a/packages/meditrak-server/src/tests/routes/userEntityPermissions/CreateUserEntityPermissions.test.js
+++ b/packages/meditrak-server/src/tests/routes/userEntityPermissions/CreateUserEntityPermissions.test.js
@@ -13,7 +13,7 @@ import {
 import { TestableApp } from '../../TestableApp';
 import { prepareStubAndAuthenticate } from '../utilities/prepareStubAndAuthenticate';
 
-describe('Permissions checker for DeleteUserEntityPermissions', async () => {
+describe('Permissions checker for CreateUserEntityPermissions', async () => {
   const DEFAULT_POLICY = {
     DL: ['Public'],
     KI: [TUPAIA_ADMIN_PANEL_PERMISSION_GROUP, 'Admin'],

--- a/packages/meditrak-server/src/tests/routes/userEntityPermissions/DeleteUserEntityPermissions.test.js
+++ b/packages/meditrak-server/src/tests/routes/userEntityPermissions/DeleteUserEntityPermissions.test.js
@@ -1,0 +1,111 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
+ */
+
+import { expect } from 'chai';
+import { findOrCreateDummyRecord, findOrCreateDummyCountryEntity } from '@tupaia/database';
+import { Authenticator } from '@tupaia/auth';
+import {
+  TUPAIA_ADMIN_PANEL_PERMISSION_GROUP,
+  BES_ADMIN_PERMISSION_GROUP,
+} from '../../../permissions';
+import { TestableApp } from '../../TestableApp';
+import { prepareStubAndAuthenticate } from '../utilities/prepareStubAndAuthenticate';
+
+describe('Permissions checker for DeleteUserEntityPermissions', async () => {
+  const DEFAULT_POLICY = {
+    DL: ['Public'],
+    KI: [TUPAIA_ADMIN_PANEL_PERMISSION_GROUP, 'Admin'],
+    SB: [TUPAIA_ADMIN_PANEL_PERMISSION_GROUP, 'Royal Australasian College of Surgeons'],
+    VU: [TUPAIA_ADMIN_PANEL_PERMISSION_GROUP, 'Admin'],
+    LA: ['Admin'],
+    TO: ['Admin'],
+  };
+
+  const BES_ADMIN_POLICY = {
+    LA: [BES_ADMIN_PERMISSION_GROUP],
+  };
+
+  const app = new TestableApp();
+  const { models } = app;
+  let vanuatuPublicPermission;
+  let laosPublicPermission;
+
+  before(async () => {
+    const publicPermissionGroup = await findOrCreateDummyRecord(models.permissionGroup, {
+      name: 'Public',
+    });
+
+    const { entity: vanuatuEntity } = await findOrCreateDummyCountryEntity(models, {
+      code: 'VU',
+    });
+    const { entity: laosEntity } = await findOrCreateDummyCountryEntity(models, {
+      code: 'LA',
+    });
+
+    // Create test users
+    const userAccount = await findOrCreateDummyRecord(models.user, {
+      first_name: 'Clark',
+      last_name: 'Kent',
+    });
+
+    // Give the test user some permissions
+    vanuatuPublicPermission = await findOrCreateDummyRecord(models.userEntityPermission, {
+      user_id: userAccount.id,
+      entity_id: vanuatuEntity.id,
+      permission_group_id: publicPermissionGroup.id,
+    });
+    laosPublicPermission = await findOrCreateDummyRecord(models.userEntityPermission, {
+      user_id: userAccount.id,
+      entity_id: laosEntity.id,
+      permission_group_id: publicPermissionGroup.id,
+    });
+  });
+
+  afterEach(() => {
+    Authenticator.prototype.getAccessPolicyForUser.restore();
+  });
+
+  describe('DELETE /userEntityPermissions/:id', async () => {
+    describe('Insufficient permissions', async () => {
+      it('Throw a permissions gate error if we do not have BES admin or Tupaia Admin panel access anywhere', async () => {
+        const policy = {
+          DL: ['Public'],
+        };
+        await prepareStubAndAuthenticate(app, policy);
+        const { body: result } = await app.delete(
+          `userEntityPermissions/${vanuatuPublicPermission.id}`,
+        );
+
+        expect(result).have.to.keys('error');
+      });
+      it('Throw an exception if we do not have permissions for the entity of the user entity permission', async () => {
+        await prepareStubAndAuthenticate(app, DEFAULT_POLICY);
+        const { body: result } = await app.delete(
+          `userEntityPermissions/${laosPublicPermission.id}`,
+        );
+
+        expect(result).to.have.keys('error');
+      });
+    });
+
+    describe('Sufficient permissions', async () => {
+      it('User can delete an entry they have permission for', async () => {
+        await prepareStubAndAuthenticate(app, DEFAULT_POLICY);
+        await app.delete(`userEntityPermissions/${vanuatuPublicPermission.id}`);
+        const result = await models.userEntityPermission.findById(vanuatuPublicPermission.id);
+
+        expect(result).to.equal(null);
+      });
+
+      it('BES Admin user can delete any entry', async () => {
+        await prepareStubAndAuthenticate(app, BES_ADMIN_POLICY);
+        await app.delete(`userEntityPermissions/${laosPublicPermission.id}`);
+        const result = await models.userEntityPermission.findById(laosPublicPermission.id);
+
+        expect(result).to.equal(null);
+      });
+    });
+  });
+});

--- a/packages/meditrak-server/src/tests/routes/userEntityPermissions/DeleteUserEntityPermissions.test.js
+++ b/packages/meditrak-server/src/tests/routes/userEntityPermissions/DeleteUserEntityPermissions.test.js
@@ -77,21 +77,26 @@ describe('Permissions checker for DeleteUserEntityPermissions', async () => {
         const { body: result } = await app.delete(
           `userEntityPermissions/${vanuatuPublicPermission.id}`,
         );
+        const record = await models.userEntityPermission.findById(vanuatuPublicPermission.id);
 
         expect(result).have.to.keys('error');
+        expect(record).to.not.equal(null);
       });
+
       it('Throw an exception if we do not have permissions for the entity of the user entity permission', async () => {
         await prepareStubAndAuthenticate(app, DEFAULT_POLICY);
         const { body: result } = await app.delete(
           `userEntityPermissions/${laosPublicPermission.id}`,
         );
+        const record = await models.userEntityPermission.findById(laosPublicPermission.id);
 
         expect(result).to.have.keys('error');
+        expect(record).to.not.equal(null);
       });
     });
 
     describe('Sufficient permissions', async () => {
-      it('User can delete an entry they have permission for', async () => {
+      it('Delete a user entity permission if we have admin panel access to the specific entity', async () => {
         await prepareStubAndAuthenticate(app, DEFAULT_POLICY);
         await app.delete(`userEntityPermissions/${vanuatuPublicPermission.id}`);
         const result = await models.userEntityPermission.findById(vanuatuPublicPermission.id);
@@ -99,7 +104,7 @@ describe('Permissions checker for DeleteUserEntityPermissions', async () => {
         expect(result).to.equal(null);
       });
 
-      it('BES Admin user can delete any entry', async () => {
+      it('BES Admin user can delete any user entity permission', async () => {
         await prepareStubAndAuthenticate(app, BES_ADMIN_POLICY);
         await app.delete(`userEntityPermissions/${laosPublicPermission.id}`);
         const result = await models.userEntityPermission.findById(laosPublicPermission.id);

--- a/packages/meditrak-server/src/tests/routes/userEntityPermissions/EditUserEntityPermissions.test.js
+++ b/packages/meditrak-server/src/tests/routes/userEntityPermissions/EditUserEntityPermissions.test.js
@@ -24,7 +24,7 @@ describe('Permissions checker for EditUserEntityPermissions', async () => {
   };
 
   const BES_ADMIN_POLICY = {
-    LA: [BES_ADMIN_PERMISSION_GROUP],
+    SB: [BES_ADMIN_PERMISSION_GROUP],
   };
 
   const app = new TestableApp();
@@ -32,17 +32,17 @@ describe('Permissions checker for EditUserEntityPermissions', async () => {
   let vanuatuPublicPermission;
   let kiribatiBESPermission;
   let laosPublicPermission;
-  let BESPermissionGroupId;
+  let besPermissionGroupId;
   let userAccountId2;
 
   before(async () => {
     const publicPermissionGroup = await findOrCreateDummyRecord(models.permissionGroup, {
       name: 'Public',
     });
-    const BESPermissionGroup = await findOrCreateDummyRecord(models.permissionGroup, {
+    const besPermissionGroup = await findOrCreateDummyRecord(models.permissionGroup, {
       name: BES_ADMIN_PERMISSION_GROUP,
     });
-    BESPermissionGroupId = BESPermissionGroup.id;
+    besPermissionGroupId = besPermissionGroup.id;
 
     const { entity: vanuatuEntity } = await findOrCreateDummyCountryEntity(models, {
       code: 'VU',
@@ -74,7 +74,7 @@ describe('Permissions checker for EditUserEntityPermissions', async () => {
     kiribatiBESPermission = await findOrCreateDummyRecord(models.userEntityPermission, {
       user_id: userAccount.id,
       entity_id: kiribatiEntity.id,
-      permission_group_id: BESPermissionGroup.id,
+      permission_group_id: besPermissionGroup.id,
     });
     laosPublicPermission = await findOrCreateDummyRecord(models.userEntityPermission, {
       user_id: userAccount.id,
@@ -102,7 +102,8 @@ describe('Permissions checker for EditUserEntityPermissions', async () => {
 
         expect(result).to.have.keys('error');
       });
-      it('Throw an exception when trying to edit a user entity permission the user lacks permissions for', async () => {
+
+      it('Throw an exception when editing a user entity permission when we do not have permissions for the specific entity', async () => {
         await prepareStubAndAuthenticate(app, DEFAULT_POLICY);
         const { body: result } = await app.put(`userEntityPermissions/${laosPublicPermission.id}`, {
           body: {
@@ -112,7 +113,8 @@ describe('Permissions checker for EditUserEntityPermissions', async () => {
 
         expect(result).to.have.keys('error');
       });
-      it('Throw an exception when trying to edit a user entity permission to point to an entity user lacks permission for', async () => {
+
+      it('Throw an exception when trying to edit a user entity permission to point to an entity we lack permission for', async () => {
         await prepareStubAndAuthenticate(app, DEFAULT_POLICY);
         const { body: result } = await app.put(
           `userEntityPermissions/${vanuatuPublicPermission.id}`,
@@ -125,6 +127,7 @@ describe('Permissions checker for EditUserEntityPermissions', async () => {
 
         expect(result).to.have.keys('error');
       });
+
       it('Throw an exception when trying to edit a user entity permission that contains the BES Admin permission group', async () => {
         await prepareStubAndAuthenticate(app, DEFAULT_POLICY);
         const { body: result } = await app.put(
@@ -138,13 +141,14 @@ describe('Permissions checker for EditUserEntityPermissions', async () => {
 
         expect(result).to.have.keys('error');
       });
+
       it('Throw an exception when trying to edit a user entity permission to point to BES Admin permission group', async () => {
         await prepareStubAndAuthenticate(app, DEFAULT_POLICY);
         const { body: result } = await app.put(
           `userEntityPermissions/${kiribatiBESPermission.id}`,
           {
             body: {
-              permission_group_id: BESPermissionGroupId,
+              permission_group_id: besPermissionGroupId,
             },
           },
         );
@@ -154,7 +158,7 @@ describe('Permissions checker for EditUserEntityPermissions', async () => {
     });
 
     describe('Sufficient permissions', async () => {
-      it('Edit a user entity permission the user has permissions for', async () => {
+      it('Edit a user entity permission we have access to the entity of', async () => {
         await prepareStubAndAuthenticate(app, DEFAULT_POLICY);
         await app.put(`userEntityPermissions/${vanuatuPublicPermission.id}`, {
           body: {
@@ -165,6 +169,7 @@ describe('Permissions checker for EditUserEntityPermissions', async () => {
 
         expect(result.user_id).to.equal(userAccountId2);
       });
+
       it('Edit any user entity permission as BES Admin', async () => {
         await prepareStubAndAuthenticate(app, BES_ADMIN_POLICY);
         await app.put(`userEntityPermissions/${kiribatiBESPermission.id}`, {

--- a/packages/meditrak-server/src/tests/routes/userEntityPermissions/EditUserEntityPermissions.test.js
+++ b/packages/meditrak-server/src/tests/routes/userEntityPermissions/EditUserEntityPermissions.test.js
@@ -1,0 +1,181 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
+ */
+
+import { expect } from 'chai';
+import { findOrCreateDummyRecord, findOrCreateDummyCountryEntity } from '@tupaia/database';
+import { Authenticator } from '@tupaia/auth';
+import {
+  TUPAIA_ADMIN_PANEL_PERMISSION_GROUP,
+  BES_ADMIN_PERMISSION_GROUP,
+} from '../../../permissions';
+import { TestableApp } from '../../TestableApp';
+import { prepareStubAndAuthenticate } from '../utilities/prepareStubAndAuthenticate';
+
+describe('Permissions checker for EditUserEntityPermissions', async () => {
+  const DEFAULT_POLICY = {
+    DL: ['Public'],
+    KI: [TUPAIA_ADMIN_PANEL_PERMISSION_GROUP, 'Admin'],
+    SB: [TUPAIA_ADMIN_PANEL_PERMISSION_GROUP, 'Royal Australasian College of Surgeons'],
+    VU: [TUPAIA_ADMIN_PANEL_PERMISSION_GROUP, 'Admin'],
+    LA: ['Admin'],
+    TO: ['Admin'],
+  };
+
+  const BES_ADMIN_POLICY = {
+    LA: [BES_ADMIN_PERMISSION_GROUP],
+  };
+
+  const app = new TestableApp();
+  const { models } = app;
+  let vanuatuPublicPermission;
+  let kiribatiBESPermission;
+  let laosPublicPermission;
+  let BESPermissionGroupId;
+  let userAccountId2;
+
+  before(async () => {
+    const publicPermissionGroup = await findOrCreateDummyRecord(models.permissionGroup, {
+      name: 'Public',
+    });
+    const BESPermissionGroup = await findOrCreateDummyRecord(models.permissionGroup, {
+      name: BES_ADMIN_PERMISSION_GROUP,
+    });
+    BESPermissionGroupId = BESPermissionGroup.id;
+
+    const { entity: vanuatuEntity } = await findOrCreateDummyCountryEntity(models, {
+      code: 'VU',
+    });
+    const { entity: kiribatiEntity } = await findOrCreateDummyCountryEntity(models, {
+      code: 'KI',
+    });
+    const { entity: laosEntity } = await findOrCreateDummyCountryEntity(models, {
+      code: 'LA',
+    });
+
+    // Create test users
+    const userAccount = await findOrCreateDummyRecord(models.user, {
+      first_name: 'Clark',
+      last_name: 'Kent',
+    });
+    const userAccount2 = await findOrCreateDummyRecord(models.user, {
+      first_name: 'Bruce',
+      last_name: 'Wayne',
+    });
+    userAccountId2 = userAccount2.id;
+
+    // Give the test user some permissions
+    vanuatuPublicPermission = await findOrCreateDummyRecord(models.userEntityPermission, {
+      user_id: userAccount.id,
+      entity_id: vanuatuEntity.id,
+      permission_group_id: publicPermissionGroup.id,
+    });
+    kiribatiBESPermission = await findOrCreateDummyRecord(models.userEntityPermission, {
+      user_id: userAccount.id,
+      entity_id: kiribatiEntity.id,
+      permission_group_id: BESPermissionGroup.id,
+    });
+    laosPublicPermission = await findOrCreateDummyRecord(models.userEntityPermission, {
+      user_id: userAccount.id,
+      entity_id: laosEntity.id,
+      permission_group_id: publicPermissionGroup.id,
+    });
+  });
+
+  afterEach(() => {
+    Authenticator.prototype.getAccessPolicyForUser.restore();
+  });
+
+  describe('PUT /userEntityPermissions/:id', async () => {
+    describe('Insufficient permissions', async () => {
+      it('Throw a permissions gate error if we do not have BES admin or Tupaia Admin panel access anywhere', async () => {
+        const policy = {
+          DL: ['Public'],
+        };
+        await prepareStubAndAuthenticate(app, policy);
+        const { body: result } = await app.put(`userEntityPermissions/${laosPublicPermission.id}`, {
+          body: {
+            user_id: userAccountId2,
+          },
+        });
+
+        expect(result).to.have.keys('error');
+      });
+      it('Throw an exception when trying to edit a user entity permission the user lacks permissions for', async () => {
+        await prepareStubAndAuthenticate(app, DEFAULT_POLICY);
+        const { body: result } = await app.put(`userEntityPermissions/${laosPublicPermission.id}`, {
+          body: {
+            user_id: userAccountId2,
+          },
+        });
+
+        expect(result).to.have.keys('error');
+      });
+      it('Throw an exception when trying to edit a user entity permission to point to an entity user lacks permission for', async () => {
+        await prepareStubAndAuthenticate(app, DEFAULT_POLICY);
+        const { body: result } = await app.put(
+          `userEntityPermissions/${vanuatuPublicPermission.id}`,
+          {
+            body: {
+              entity_id: laosPublicPermission.entity_id,
+            },
+          },
+        );
+
+        expect(result).to.have.keys('error');
+      });
+      it('Throw an exception when trying to edit a user entity permission that contains the BES Admin permission group', async () => {
+        await prepareStubAndAuthenticate(app, DEFAULT_POLICY);
+        const { body: result } = await app.put(
+          `userEntityPermissions/${kiribatiBESPermission.id}`,
+          {
+            body: {
+              user_id: userAccountId2,
+            },
+          },
+        );
+
+        expect(result).to.have.keys('error');
+      });
+      it('Throw an exception when trying to edit a user entity permission to point to BES Admin permission group', async () => {
+        await prepareStubAndAuthenticate(app, DEFAULT_POLICY);
+        const { body: result } = await app.put(
+          `userEntityPermissions/${kiribatiBESPermission.id}`,
+          {
+            body: {
+              permission_group_id: BESPermissionGroupId,
+            },
+          },
+        );
+
+        expect(result).to.have.keys('error');
+      });
+    });
+
+    describe('Sufficient permissions', async () => {
+      it('Edit a user entity permission the user has permissions for', async () => {
+        await prepareStubAndAuthenticate(app, DEFAULT_POLICY);
+        await app.put(`userEntityPermissions/${vanuatuPublicPermission.id}`, {
+          body: {
+            user_id: userAccountId2,
+          },
+        });
+        const result = await models.userEntityPermission.findById(vanuatuPublicPermission.id);
+
+        expect(result.user_id).to.equal(userAccountId2);
+      });
+      it('Edit any user entity permission as BES Admin', async () => {
+        await prepareStubAndAuthenticate(app, BES_ADMIN_POLICY);
+        await app.put(`userEntityPermissions/${kiribatiBESPermission.id}`, {
+          body: {
+            user_id: userAccountId2,
+          },
+        });
+        const result = await models.userEntityPermission.findById(kiribatiBESPermission.id);
+
+        expect(result.user_id).to.equal(userAccountId2);
+      });
+    });
+  });
+});

--- a/packages/meditrak-server/src/tests/routes/userEntityPermissions/GETUserEntityPermissions.test.js
+++ b/packages/meditrak-server/src/tests/routes/userEntityPermissions/GETUserEntityPermissions.test.js
@@ -24,7 +24,7 @@ describe('Permissions checker for GETUserEntityPermissions', async () => {
   };
 
   const BES_ADMIN_POLICY = {
-    LA: [BES_ADMIN_PERMISSION_GROUP],
+    SB: [BES_ADMIN_PERMISSION_GROUP],
   };
 
   const app = new TestableApp();
@@ -36,7 +36,7 @@ describe('Permissions checker for GETUserEntityPermissions', async () => {
   let filterString;
 
   before(async () => {
-    const permissionGroup = await findOrCreateDummyRecord(models.permissionGroup, {
+    const publicPermissionGroup = await findOrCreateDummyRecord(models.permissionGroup, {
       name: 'Public',
     });
 
@@ -62,17 +62,17 @@ describe('Permissions checker for GETUserEntityPermissions', async () => {
     userEntityPermission1 = await findOrCreateDummyRecord(models.userEntityPermission, {
       user_id: userAccount.id,
       entity_id: vanuatuEntity.id,
-      permission_group_id: permissionGroup.id,
+      permission_group_id: publicPermissionGroup.id,
     });
     userEntityPermission2 = await findOrCreateDummyRecord(models.userEntityPermission, {
       user_id: userAccount.id,
       entity_id: kiribatiEntity.id,
-      permission_group_id: permissionGroup.id,
+      permission_group_id: publicPermissionGroup.id,
     });
     userEntityPermission3 = await findOrCreateDummyRecord(models.userEntityPermission, {
       user_id: userAccount.id,
       entity_id: laosEntity.id,
-      permission_group_id: permissionGroup.id,
+      permission_group_id: publicPermissionGroup.id,
     });
 
     // Create a filter string so we are only requesting the test data from the endpoint
@@ -105,7 +105,7 @@ describe('Permissions checker for GETUserEntityPermissions', async () => {
       expect(result.id).to.equal(userEntityPermission2.id);
     });
 
-    it('Insufficient permissions: Throw an exception if we do not have permissions for the entity or the user entity permission', async () => {
+    it('Insufficient permissions: Throw an exception if we do not have permissions for the entity of the user entity permission', async () => {
       const policy = {
         DL: ['Public', TUPAIA_ADMIN_PANEL_PERMISSION_GROUP],
       };

--- a/packages/meditrak-server/src/tests/routes/userEntityPermissions/GETUserEntityPermissions.test.js
+++ b/packages/meditrak-server/src/tests/routes/userEntityPermissions/GETUserEntityPermissions.test.js
@@ -1,0 +1,157 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
+ */
+
+import { expect } from 'chai';
+import { findOrCreateDummyRecord, findOrCreateDummyCountryEntity } from '@tupaia/database';
+import { Authenticator } from '@tupaia/auth';
+import {
+  TUPAIA_ADMIN_PANEL_PERMISSION_GROUP,
+  BES_ADMIN_PERMISSION_GROUP,
+} from '../../../permissions';
+import { TestableApp } from '../../TestableApp';
+import { prepareStubAndAuthenticate } from '../utilities/prepareStubAndAuthenticate';
+
+describe('Permissions checker for GETUserEntityPermissions', async () => {
+  const DEFAULT_POLICY = {
+    DL: ['Public'],
+    KI: [TUPAIA_ADMIN_PANEL_PERMISSION_GROUP, 'Admin'],
+    SB: [TUPAIA_ADMIN_PANEL_PERMISSION_GROUP, 'Royal Australasian College of Surgeons'],
+    VU: [TUPAIA_ADMIN_PANEL_PERMISSION_GROUP, 'Admin'],
+    LA: ['Admin'],
+    TO: ['Admin'],
+  };
+
+  const BES_ADMIN_POLICY = {
+    LA: [BES_ADMIN_PERMISSION_GROUP],
+  };
+
+  const app = new TestableApp();
+  const { models } = app;
+  let userEntityPermission1;
+  let userEntityPermission2;
+  let userEntityPermission3;
+  let userEntityPermissionIds;
+  let filterString;
+
+  before(async () => {
+    const permissionGroup = await findOrCreateDummyRecord(models.permissionGroup, {
+      name: 'Public',
+    });
+
+    const { entity: vanuatuEntity } = await findOrCreateDummyCountryEntity(models, {
+      code: 'VU',
+    });
+
+    const { entity: kiribatiEntity } = await findOrCreateDummyCountryEntity(models, {
+      code: 'KI',
+    });
+
+    const { entity: laosEntity } = await findOrCreateDummyCountryEntity(models, {
+      code: 'LA',
+    });
+
+    // Create test users
+    const userAccount = await findOrCreateDummyRecord(models.user, {
+      first_name: 'Clark',
+      last_name: 'Kent',
+    });
+
+    // Give the test user some permissions
+    userEntityPermission1 = await findOrCreateDummyRecord(models.userEntityPermission, {
+      user_id: userAccount.id,
+      entity_id: vanuatuEntity.id,
+      permission_group_id: permissionGroup.id,
+    });
+    userEntityPermission2 = await findOrCreateDummyRecord(models.userEntityPermission, {
+      user_id: userAccount.id,
+      entity_id: kiribatiEntity.id,
+      permission_group_id: permissionGroup.id,
+    });
+    userEntityPermission3 = await findOrCreateDummyRecord(models.userEntityPermission, {
+      user_id: userAccount.id,
+      entity_id: laosEntity.id,
+      permission_group_id: permissionGroup.id,
+    });
+
+    // Create a filter string so we are only requesting the test data from the endpoint
+    userEntityPermissionIds = [
+      userEntityPermission1.id,
+      userEntityPermission2.id,
+      userEntityPermission3.id,
+    ];
+    filterString = `filter={"id":{"comparator":"in","comparisonValue":["${userEntityPermissionIds.join(
+      '","',
+    )}"]}}`;
+  });
+
+  afterEach(() => {
+    Authenticator.prototype.getAccessPolicyForUser.restore();
+  });
+
+  describe('GET /userEntityPermissions/:id', async () => {
+    it('Sufficient permissions: Return a requested user entity permission if we have access to the specific entity', async () => {
+      await prepareStubAndAuthenticate(app, DEFAULT_POLICY);
+      const { body: result } = await app.get(`userEntityPermissions/${userEntityPermission2.id}`);
+
+      expect(result.id).to.equal(userEntityPermission2.id);
+    });
+
+    it('Sufficient permissions: Return a requested user entity permission if we have BES admin access', async () => {
+      await prepareStubAndAuthenticate(app, BES_ADMIN_POLICY);
+      const { body: result } = await app.get(`userEntityPermissions/${userEntityPermission2.id}`);
+
+      expect(result.id).to.equal(userEntityPermission2.id);
+    });
+
+    it('Insufficient permissions: Throw an exception if we do not have permissions for the entity or the user entity permission', async () => {
+      const policy = {
+        DL: ['Public', TUPAIA_ADMIN_PANEL_PERMISSION_GROUP],
+      };
+      await prepareStubAndAuthenticate(app, policy);
+      const { body: result } = await app.get(`userEntityPermissions/${userEntityPermission2.id}`);
+
+      expect(result).to.have.keys('error');
+    });
+  });
+
+  describe('GET /userEntityPermissions', async () => {
+    it('Sufficient permissions: Return only the list of user entity permissions we have permissions for', async () => {
+      await prepareStubAndAuthenticate(app, DEFAULT_POLICY);
+      const { body: results } = await app.get(`userEntityPermissions?${filterString}`);
+
+      expect(results.map(r => r.id)).to.have.members([
+        userEntityPermission1.id,
+        userEntityPermission2.id,
+      ]);
+    });
+
+    it('Sufficient permissions: Return the full list of user entity permissions if we have BES Admin access', async () => {
+      await prepareStubAndAuthenticate(app, BES_ADMIN_POLICY);
+      const { body: results } = await app.get(`userEntityPermissions?${filterString}`);
+
+      expect(results.map(r => r.id)).to.have.members(userEntityPermissionIds);
+    });
+
+    it('Insufficient permissions: Throws a permissions gate error if we do not have BES admin or Tupaia Admin panel access anywhere', async () => {
+      const policy = {
+        DL: ['Public'],
+      };
+      await prepareStubAndAuthenticate(app, policy);
+      const { body: results } = await app.get(`userEntityPermissions?${filterString}`);
+
+      expect(results).have.keys('error');
+    });
+
+    it('Insufficient permissions: Return an empty array if we have permissions to no user entity permissions', async () => {
+      const policy = {
+        DL: ['Public', TUPAIA_ADMIN_PANEL_PERMISSION_GROUP],
+      };
+      await prepareStubAndAuthenticate(app, policy);
+      const { body: results } = await app.get(`userEntityPermissions?${filterString}`);
+
+      expect(results).to.be.empty;
+    });
+  });
+});


### PR DESCRIPTION
### Issue #: https://github.com/beyondessential/tupaia-backlog/issues/1132

### Changes:

- Add CreateUserEntityPermissions.js
- Add unit tests for user entity permissions CRUD handling
