### PR TITLE
1132: Add unit tests for /accessRequests endpoint

### DIFF
--- a/packages/meditrak-server/src/routes/accessRequests/EditAccessRequests.js
+++ b/packages/meditrak-server/src/routes/accessRequests/EditAccessRequests.js
@@ -10,7 +10,7 @@ import {
   assertBESAdminAccess,
   assertTupaiaAdminPanelAccess,
 } from '../../permissions';
-import { assertAccessRequestPermissions } from './assertAccessRequestPermissions';
+import { assertAccessRequestEditPermissions } from './assertAccessRequestPermissions';
 
 /**
  * Handles PUT endpoints:
@@ -31,7 +31,12 @@ export class EditAccessRequests extends EditHandler {
     // Check Permissions
     const accessRequest = await this.models.accessRequest.findById(this.recordId);
     const accessRequestChecker = accessPolicy =>
-      assertAccessRequestPermissions(accessPolicy, this.models, accessRequest);
+      assertAccessRequestEditPermissions(
+        accessPolicy,
+        this.models,
+        this.recordId,
+        this.updatedFields,
+      );
     await this.assertPermissions(
       assertAnyPermissions([assertBESAdminAccess, accessRequestChecker]),
     );

--- a/packages/meditrak-server/src/routes/accessRequests/GETAccessRequests.js
+++ b/packages/meditrak-server/src/routes/accessRequests/GETAccessRequests.js
@@ -51,10 +51,6 @@ export class GETAccessRequests extends GETHandler {
     );
     const accessRequests = await super.findRecords(dbConditions, options);
 
-    if (!accessRequests.length) {
-      throw new Error('Your permissions do not allow access to any of the requested resources');
-    }
-
     return accessRequests;
   }
 }

--- a/packages/meditrak-server/src/routes/accessRequests/assertAccessRequestPermissions.js
+++ b/packages/meditrak-server/src/routes/accessRequests/assertAccessRequestPermissions.js
@@ -3,7 +3,11 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
-import { hasBESAdminAccess, TUPAIA_ADMIN_PANEL_PERMISSION_GROUP } from '../../permissions';
+import {
+  hasBESAdminAccess,
+  BES_ADMIN_PERMISSION_GROUP,
+  TUPAIA_ADMIN_PANEL_PERMISSION_GROUP,
+} from '../../permissions';
 import { getAdminPanelAllowedEntityIds } from '../utilities';
 
 export const assertAccessRequestPermissions = async (accessPolicy, models, accessRequestId) => {
@@ -17,6 +21,50 @@ export const assertAccessRequestPermissions = async (accessPolicy, models, acces
     throw new Error('Need Admin Panel access to the country this access request is for');
   }
   return true;
+};
+
+export const assertAccessRequestEditPermissions = async (
+  accessPolicy,
+  models,
+  accessRequestId,
+  updatedFields,
+) => {
+  // Check we have basic permission to access the record we want to edit
+  await assertAccessRequestPermissions(accessPolicy, models, accessRequestId);
+  // Check we have permission for the change
+  await assertAccessRequestUpsertPermissions(accessPolicy, models, updatedFields);
+
+  // We can view access requests for BES admin access even if we don't have BES admin ourselves
+  // So this final check confirms we're not trying to approve a request for BES admin access
+  const accessRequest = await models.accessRequest.findById(accessRequestId);
+  const permissionGroup = await models.permissionGroup.findById(accessRequest.permission_group_id);
+  if (permissionGroup.name === BES_ADMIN_PERMISSION_GROUP) {
+    throw new Error('Need BES Admin access to make this change');
+  }
+
+  return true;
+};
+
+export const assertAccessRequestUpsertPermissions = async (
+  accessPolicy,
+  models,
+  { permission_group_id: permissionGroupId, entity_id: entityId },
+) => {
+  // Check we're not trying to change this access request to give someone:
+  // BES admin access
+  // Access to an entity we don't have admin panel access
+  if (permissionGroupId) {
+    const permissionGroup = await models.permissionGroup.findById(permissionGroupId);
+    if (permissionGroup.name === BES_ADMIN_PERMISSION_GROUP) {
+      throw new Error('Need BES Admin access to make this change');
+    }
+  }
+  if (entityId) {
+    const entity = await models.entity.findById(entityId);
+    if (!accessPolicy.allows(entity.country_code, TUPAIA_ADMIN_PANEL_PERMISSION_GROUP)) {
+      throw new Error('Need Admin Panel access to the updated entity');
+    }
+  }
 };
 
 export const createAccessRequestDBFilter = async (accessPolicy, models, criteria) => {

--- a/packages/meditrak-server/src/tests/routes/accessRequests/EditAccessRequests.test.js
+++ b/packages/meditrak-server/src/tests/routes/accessRequests/EditAccessRequests.test.js
@@ -1,0 +1,177 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
+ */
+
+import { expect } from 'chai';
+import { findOrCreateDummyRecord, findOrCreateDummyCountryEntity } from '@tupaia/database';
+import { Authenticator } from '@tupaia/auth';
+import {
+  TUPAIA_ADMIN_PANEL_PERMISSION_GROUP,
+  BES_ADMIN_PERMISSION_GROUP,
+} from '../../../permissions';
+import { TestableApp } from '../../TestableApp';
+import { prepareStubAndAuthenticate } from '../utilities/prepareStubAndAuthenticate';
+
+describe('Permissions checker for EditAccessRequests', async () => {
+  const DEFAULT_POLICY = {
+    DL: ['Public'],
+    KI: [TUPAIA_ADMIN_PANEL_PERMISSION_GROUP, 'Admin'],
+    SB: [TUPAIA_ADMIN_PANEL_PERMISSION_GROUP, 'Royal Australasian College of Surgeons'],
+    VU: [TUPAIA_ADMIN_PANEL_PERMISSION_GROUP, 'Admin'],
+    LA: ['Admin'],
+    TO: ['Admin'],
+  };
+
+  const BES_ADMIN_POLICY = {
+    LA: [BES_ADMIN_PERMISSION_GROUP],
+  };
+
+  const app = new TestableApp();
+  const { models } = app;
+  let vanuatuPublicRequest;
+  let laosPublicRequest;
+  let kiribatiBESRequest;
+  let laosEntityId;
+  let BESPermissionGroupId;
+
+  before(async () => {
+    const { entity: vanuatuEntity } = await findOrCreateDummyCountryEntity(models, {
+      code: 'VU',
+    });
+
+    const { entity: kiribatiEntity } = await findOrCreateDummyCountryEntity(models, {
+      code: 'KI',
+    });
+    const { entity: laosEntity } = await findOrCreateDummyCountryEntity(models, {
+      code: 'LA',
+    });
+    laosEntityId = laosEntity.id;
+
+    const publicPermissionGroup = await findOrCreateDummyRecord(models.permissionGroup, {
+      name: 'Public',
+    });
+    const BESPermissionGroup = await findOrCreateDummyRecord(models.permissionGroup, {
+      name: BES_ADMIN_PERMISSION_GROUP,
+    });
+    BESPermissionGroupId = BESPermissionGroup.id;
+
+    vanuatuPublicRequest = await findOrCreateDummyRecord(models.accessRequest, {
+      entity_id: vanuatuEntity.id,
+      permission_group_id: publicPermissionGroup.id,
+      approved: null,
+      processed_by: null,
+    });
+    laosPublicRequest = await findOrCreateDummyRecord(models.accessRequest, {
+      entity_id: laosEntity.id,
+      permission_group_id: publicPermissionGroup.id,
+      approved: null,
+      processed_by: null,
+    });
+    kiribatiBESRequest = await findOrCreateDummyRecord(models.accessRequest, {
+      entity_id: kiribatiEntity.id,
+      permission_group_id: BESPermissionGroup.id,
+      approved: null,
+      processed_by: null,
+    });
+  });
+
+  afterEach(() => {
+    Authenticator.prototype.getAccessPolicyForUser.restore();
+  });
+
+  describe('PUT /accessRequests/:id', async () => {
+    describe('Insufficient permissions', async () => {
+      it('Throw a permissions gate error if current user does not have BES admin or Tupaia Admin panel access anywhere', async () => {
+        const policy = {
+          DL: ['Public'],
+        };
+        await prepareStubAndAuthenticate(app, policy);
+        const { body: result } = await app.put(`accessRequests/${vanuatuPublicRequest.id}`, {
+          body: { approved: true },
+        });
+
+        expect(result).to.have.keys('error');
+      });
+      it('Throw an exception when trying to edit an access request user lacks permissions for', async () => {
+        await prepareStubAndAuthenticate(app, DEFAULT_POLICY);
+        const { body: result } = await app.put(`accessRequests/${laosPublicRequest.id}`, {
+          body: { approved: true },
+        });
+
+        expect(result).to.have.keys('error');
+      });
+      it('Throw an exception when trying to edit an access request to point to an entity user lacks permission for', async () => {
+        await prepareStubAndAuthenticate(app, DEFAULT_POLICY);
+        const { body: result } = await app.put(`accessRequests/${vanuatuPublicRequest.id}`, {
+          body: {
+            approved: true,
+            entity_id: laosEntityId,
+          },
+        });
+
+        expect(result).to.have.keys('error');
+      });
+      it('Throw an exception when trying to approve a BES Admin request as a non BES Admin user', async () => {
+        await prepareStubAndAuthenticate(app, DEFAULT_POLICY);
+        const { body: result } = await app.put(`accessRequests/${kiribatiBESRequest.id}`, {
+          body: {
+            approved: true,
+          },
+        });
+
+        expect(result).to.have.keys('error');
+      });
+      it('Throw an exception when trying to edit an access request to point to BES Admin permission group', async () => {
+        await prepareStubAndAuthenticate(app, DEFAULT_POLICY);
+        const { body: result } = await app.put(`accessRequests/${vanuatuPublicRequest.id}`, {
+          body: {
+            approved: true,
+            permission_group_id: BESPermissionGroupId,
+          },
+        });
+
+        expect(result).to.have.keys('error');
+      });
+    });
+
+    describe('Sufficient permissions', async () => {
+      it('Edit an access request user has permissions for', async () => {
+        await prepareStubAndAuthenticate(app, DEFAULT_POLICY);
+        await app.put(`accessRequests/${vanuatuPublicRequest.id}`, {
+          body: { approved: true },
+        });
+        const result = await models.accessRequest.findById(vanuatuPublicRequest.id);
+
+        expect(result.approved).to.true;
+      });
+      it('Edit any access request as BES Admin', async () => {
+        await prepareStubAndAuthenticate(app, BES_ADMIN_POLICY);
+        await app.put(`accessRequests/${kiribatiBESRequest.id}`, {
+          body: { approved: true },
+        });
+        const result = await models.accessRequest.findById(kiribatiBESRequest.id);
+
+        expect(result.approved).to.true;
+      });
+    });
+
+    describe('Restricted actions', async () => {
+      it('Throw an exception when trying to edit an access request that has already been processed', async () => {
+        // Exactly the same as the sufficient permissions check
+        // Most of the time, this is still approved from the previous check
+        // But redoing it here allows this unit test to run in isolation
+        await prepareStubAndAuthenticate(app, DEFAULT_POLICY);
+        await app.put(`accessRequests/${vanuatuPublicRequest.id}`, {
+          body: { approved: true },
+        });
+        // Attempt to approve a second time, this time it should fail
+        const { body: result } = await app.put(`accessRequests/${vanuatuPublicRequest.id}`, {
+          body: { approved: true },
+        });
+
+        expect(result).to.have.keys('error');
+      });
+    });
+  });
+});

--- a/packages/meditrak-server/src/tests/routes/accessRequests/GETAccessRequests.test.js
+++ b/packages/meditrak-server/src/tests/routes/accessRequests/GETAccessRequests.test.js
@@ -1,0 +1,133 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
+ */
+
+import { expect } from 'chai';
+import { findOrCreateDummyRecord, findOrCreateDummyCountryEntity } from '@tupaia/database';
+import { Authenticator } from '@tupaia/auth';
+import {
+  TUPAIA_ADMIN_PANEL_PERMISSION_GROUP,
+  BES_ADMIN_PERMISSION_GROUP,
+} from '../../../permissions';
+import { TestableApp } from '../../TestableApp';
+import { prepareStubAndAuthenticate } from '../utilities/prepareStubAndAuthenticate';
+
+describe('Permissions checker for GETAccessRequests', async () => {
+  const DEFAULT_POLICY = {
+    DL: ['Public'],
+    KI: [TUPAIA_ADMIN_PANEL_PERMISSION_GROUP, 'Admin'],
+    SB: [TUPAIA_ADMIN_PANEL_PERMISSION_GROUP, 'Royal Australasian College of Surgeons'],
+    VU: [TUPAIA_ADMIN_PANEL_PERMISSION_GROUP, 'Admin'],
+    LA: ['Admin'],
+    TO: ['Admin'],
+  };
+
+  const BES_ADMIN_POLICY = {
+    LA: [BES_ADMIN_PERMISSION_GROUP],
+  };
+
+  const app = new TestableApp();
+  const { models } = app;
+  let accessRequest1;
+  let accessRequest2;
+  let accessRequest3;
+  let accessRequestIds;
+  let filterString;
+
+  before(async () => {
+    const { entity: vanuatuEntity } = await findOrCreateDummyCountryEntity(models, {
+      code: 'VU',
+    });
+
+    const { entity: kiribatiEntity } = await findOrCreateDummyCountryEntity(models, {
+      code: 'KI',
+    });
+
+    const { entity: laosEntity } = await findOrCreateDummyCountryEntity(models, {
+      code: 'LA',
+    });
+
+    accessRequest1 = await findOrCreateDummyRecord(models.accessRequest, {
+      entity_id: vanuatuEntity.id,
+    });
+    accessRequest2 = await findOrCreateDummyRecord(models.accessRequest, {
+      entity_id: kiribatiEntity.id,
+    });
+    accessRequest3 = await findOrCreateDummyRecord(models.accessRequest, {
+      entity_id: laosEntity.id,
+    });
+
+    // Create a filter string so we are only requesting the test data from the endpoint
+    accessRequestIds = [accessRequest1.id, accessRequest2.id, accessRequest3.id];
+    filterString = `filter={"id":{"comparator":"in","comparisonValue":["${accessRequestIds.join(
+      '","',
+    )}"]}}`;
+  });
+
+  afterEach(() => {
+    Authenticator.prototype.getAccessPolicyForUser.restore();
+  });
+
+  describe('GET /accessRequests/:id', async () => {
+    it('Sufficient permissions: Return a requested access request if users have admin panel access to the entity the access request is for', async () => {
+      await prepareStubAndAuthenticate(app, DEFAULT_POLICY);
+      const { body: result } = await app.get(`accessRequests/${accessRequest1.id}`);
+
+      expect(result.id).to.equal(accessRequest1.id);
+    });
+
+    it('Sufficient permissions: Return a requested access request if users have BES admin access', async () => {
+      await prepareStubAndAuthenticate(app, BES_ADMIN_POLICY);
+      const { body: result } = await app.get(`accessRequests/${accessRequest1.id}`);
+
+      expect(result.id).to.equal(accessRequest1.id);
+    });
+
+    it('Insufficient permissions: Throw an exception if users do not have access to entity of the access request', async () => {
+      const policy = {
+        DL: ['Public', TUPAIA_ADMIN_PANEL_PERMISSION_GROUP],
+      };
+      await prepareStubAndAuthenticate(app, policy);
+      const { body: result } = await app.get(`accessRequests/${accessRequest1.id}`);
+
+      expect(result).to.have.keys('error');
+    });
+  });
+
+  describe('GET /accessRequests', async () => {
+    it('Sufficient permissions: Return only the list of entries we have permissions for', async () => {
+      await prepareStubAndAuthenticate(app, DEFAULT_POLICY);
+      const { body: results } = await app.get(`accessRequests?${filterString}`);
+
+      expect(results.map(r => r.id)).to.have.members([accessRequest1.id, accessRequest2.id]);
+    });
+
+    it('Sufficient permissions: Return the full list of access requests if we have BES Admin access', async () => {
+      await prepareStubAndAuthenticate(app, BES_ADMIN_POLICY);
+      const { body: results } = await app.get(`accessRequests?${filterString}`);
+
+      expect(results.map(r => r.id)).to.have.members(accessRequestIds);
+    });
+
+    it('Insufficient permissions: Throws a permissions gate error if we do not have BES admin or Tupaia Admin panel access anywhere', async () => {
+      const policy = {
+        DL: ['Public'],
+      };
+      await prepareStubAndAuthenticate(app, policy);
+      const { body: results } = await app.get(`accessRequests?${filterString}`);
+
+      expect(results).have.keys('error');
+    });
+
+    it('Insufficient permissions: Return an empty array if we have permissions to no access requests', async () => {
+      const policy = {
+        DL: ['Public', TUPAIA_ADMIN_PANEL_PERMISSION_GROUP],
+      };
+      await prepareStubAndAuthenticate(app, policy);
+      const { body: results } = await app.get(`accessRequests?${filterString}`);
+
+      expect(results).to.be.empty;
+    });
+  });
+});

--- a/packages/meditrak-server/src/tests/routes/accessRequests/GETAccessRequests.test.js
+++ b/packages/meditrak-server/src/tests/routes/accessRequests/GETAccessRequests.test.js
@@ -24,7 +24,7 @@ describe('Permissions checker for GETAccessRequests', async () => {
   };
 
   const BES_ADMIN_POLICY = {
-    LA: [BES_ADMIN_PERMISSION_GROUP],
+    SB: [BES_ADMIN_PERMISSION_GROUP],
   };
 
   const app = new TestableApp();
@@ -70,21 +70,21 @@ describe('Permissions checker for GETAccessRequests', async () => {
   });
 
   describe('GET /accessRequests/:id', async () => {
-    it('Sufficient permissions: Return a requested access request if users have admin panel access to the entity the access request is for', async () => {
+    it('Sufficient permissions: Return a requested access request if we have admin panel access to the entity the access request is for', async () => {
       await prepareStubAndAuthenticate(app, DEFAULT_POLICY);
       const { body: result } = await app.get(`accessRequests/${accessRequest1.id}`);
 
       expect(result.id).to.equal(accessRequest1.id);
     });
 
-    it('Sufficient permissions: Return a requested access request if users have BES admin access', async () => {
+    it('Sufficient permissions: Return a requested access request if we have BES admin access', async () => {
       await prepareStubAndAuthenticate(app, BES_ADMIN_POLICY);
       const { body: result } = await app.get(`accessRequests/${accessRequest1.id}`);
 
       expect(result.id).to.equal(accessRequest1.id);
     });
 
-    it('Insufficient permissions: Throw an exception if users do not have access to entity of the access request', async () => {
+    it('Insufficient permissions: Throw an exception if we do not have access to entity of the access request', async () => {
       const policy = {
         DL: ['Public', TUPAIA_ADMIN_PANEL_PERMISSION_GROUP],
       };
@@ -117,7 +117,7 @@ describe('Permissions checker for GETAccessRequests', async () => {
       await prepareStubAndAuthenticate(app, policy);
       const { body: results } = await app.get(`accessRequests?${filterString}`);
 
-      expect(results).have.keys('error');
+      expect(results).to.have.keys('error');
     });
 
     it('Insufficient permissions: Return an empty array if we have permissions to no access requests', async () => {


### PR DESCRIPTION
### Issue #: https://github.com/beyondessential/tupaia-backlog/issues/1132

### Changes: 

- Update add additional checks to prevent a user from self elevating their permissions
- Add unit tests for GET and Edit handlers
