### PR TITLE
Add style for tooltip's transparent background

### DIFF
--- a/packages/web-frontend/src/styles/index.js
+++ b/packages/web-frontend/src/styles/index.js
@@ -465,6 +465,8 @@ export const VIEW_STYLES = {
       },
   tooltip: {
     color: fullWhite,
+    background: 'rgba(0, 0, 0, 0.7)',
+    padding: '15px 10px 15px 5px',
   },
   legend: {
     color: fullWhite,


### PR DESCRIPTION
### Issue #:
[1365 - hover text difficult to read](https://github.com/beyondessential/tupaia-backlog/issues/1365)
### Changes:

- Add style for tooltip's transparent background
