### PR TITLE
Use http/2 protocol on all requests

### DIFF
--- a/packages/devops/configs/servers.conf
+++ b/packages/devops/configs/servers.conf
@@ -5,8 +5,8 @@ server {
 }
 server {
 
-  listen       443 ssl;
-  listen       [::]:443 ssl;
+  listen       443 ssl http2;
+  listen       [::]:443 ssl http2;
   server_name  ~^.*admin\.tupaia\.org$;
   root         /home/ubuntu/tupaia/packages/admin-panel/served_build/;
 
@@ -41,8 +41,8 @@ server {
 }
 server {
 
-  listen       443 ssl;
-  listen       [::]:443 ssl;
+  listen       443 ssl http2;
+  listen       [::]:443 ssl http2;
   server_name  ~^.*psss\.tupaia\.org$;
   root         /home/ubuntu/tupaia/packages/psss/served_build/;
 
@@ -77,8 +77,8 @@ server {
 }
 server {
 
-  listen       443 ssl;
-  listen       [::]:443 ssl;
+  listen       443 ssl http2;
+  listen       [::]:443 ssl http2;
   server_name  ~^.*api\.tupaia\.org$;
   root         /usr/share/nginx/html;
 
@@ -121,8 +121,8 @@ server {
 }
 server {
 
-  listen       443 ssl;
-  listen       [::]:443 ssl;
+  listen       443 ssl http2;
+  listen       [::]:443 ssl http2;
   server_name  ~^.*mobile\.tupaia\.org$;
   root         /home/ubuntu/tupaia/packages/web-frontend/builds/mobile;
 
@@ -157,8 +157,8 @@ server {
 }
 server {
 
-  listen       443 ssl;
-  listen       [::]:443 ssl;
+  listen       443 ssl http2;
+  listen       [::]:443 ssl http2;
   server_name  ~^.*export\.tupaia\.org$;
   root         /home/ubuntu/tupaia/packages/web-frontend/builds/exporter;
 
@@ -193,8 +193,8 @@ server {
 }
 server {
 
-  listen       443 ssl;
-  listen       [::]:443 ssl;
+  listen       443 ssl http2;
+  listen       [::]:443 ssl http2;
   server_name  ~^.*config\.tupaia\.org$;
   root         /usr/share/nginx/html;
 
@@ -237,8 +237,8 @@ server {
 }
 server {
 
-  listen       443 ssl;
-  listen       [::]:443 ssl;
+  listen       443 ssl http2;
+  listen       [::]:443 ssl http2;
   server_name  tupaia.org www.tupaia.org ~^(?<subdomain>((?!^www).)+)\.tupaia\.org$;
   root         /home/ubuntu/tupaia/packages/web-frontend/builds/desktop;
   set $mobile_rewrite do_not_perform;


### PR DESCRIPTION
### Issue #: https://github.com/beyondessential/tupaia-backlog/issues/1542

We have been using http/1.1 by default. According to https://developers.google.com/web/tools/chrome-devtools/network/reference?utm_source=devtools#timing-explanation 

> There are already six TCP connections open for this origin, which is the limit. Applies to HTTP/1.0 and HTTP/1.1 only.

This moves us to http/2

Will need to be manually applied - there is no CI/CD set up for nginx settings.