### PR TITLE
1601 indicators support intemediary values

### DIFF
--- a/packages/indicators/src/__tests__/builders/buildArithmetic/buildArithmetic.test.ts
+++ b/packages/indicators/src/__tests__/builders/buildArithmetic/buildArithmetic.test.ts
@@ -20,9 +20,9 @@ describe('buildArithmetic', () => {
       ['formula is not a string', { formula: {}, aggregation: {} }, /Error .*formula.* string/],
       ['undefined aggregation', { formula: 'A + B' }, /Error .*aggregation.* empty/],
       [
-        'aggregation is not an object',
-        { formula: 'A + B', aggregation: 'MOST_RECENT' },
-        /Error .*aggregation.* object/,
+        'wrong aggregation type',
+        { formula: 'A + B', aggregation: ['MOST_RECENT'] },
+        /must be one of string \| object/i,
       ],
       [
         'a data element referenced in the formula has no defined aggregation',
@@ -48,12 +48,17 @@ describe('buildArithmetic', () => {
     );
   });
 
-  it('resolves for valid config', async () => {
-    const config = {
-      formula: '2 * A + B',
-      aggregation: { A: 'MOST_RECENT', B: ['SUM', 'MOST_RECENT'] },
-    };
-    return expect(buildArithmetic({ aggregator, config, fetchOptions: {} })).toResolve();
+  describe('resolves for valid config', () => {
+    const formula = '2 * A + B';
+    const testData = [
+      ['string aggregation', 'MOST_RECENT'],
+      ['object aggregation', { A: 'MOST_RECENT', B: ['SUM', 'MOST_RECENT'] }],
+    ];
+
+    it.each(testData)('%s', (_, aggregation) => {
+      const config = { formula, aggregation };
+      return expect(buildArithmetic({ aggregator, config, fetchOptions: {} })).toResolve();
+    });
   });
 
   it('calls `aggregator.fetchAnalytics` with `fetchOptions`', async () => {

--- a/packages/indicators/src/__tests__/builders/helpers/helpers.test.ts
+++ b/packages/indicators/src/__tests__/builders/helpers/helpers.test.ts
@@ -9,7 +9,7 @@ import {
   groupKeysByValueJson,
   validateConfig,
 } from '../../../builders/helpers';
-import { Aggregation } from '../../../types';
+import { Aggregation, AggregationSpecs } from '../../../types';
 import { createAggregator } from '../stubs';
 import { ANALYTIC_RESPONSE_CONFIG } from './helpers.fixtures';
 
@@ -26,45 +26,56 @@ describe('helpers', () => {
       countMale: [assertIsNotNegative],
     };
 
-    it('should resolve for empty validators', () =>
+    it('resolves for empty config', () => expect(validateConfig(undefined, {})).toResolve());
+
+    it('resolves for empty validators', () =>
       expect(validateConfig({ random: 'string' })).toResolve());
 
-    it('should throw if a field is invalid', async () =>
+    it('throws if a field is invalid', async () =>
       expect(validateConfig({ countFemale: -1, countMale: 2 }, configValidators)).toBeRejectedWith(
         "Error in field 'countFemale': Must be >= 0",
       ));
 
-    it('should resolve if all fields are valid', () =>
+    it('resolves if all fields are valid', () =>
       expect(validateConfig({ countFemale: 1, countMale: 2 }, configValidators)).toResolve());
   });
 
   describe('getAggregationsByCode()', () => {
-    const testData: [string, Record<string, string | string[]>, Record<string, Aggregation[]>][] = [
-      [
-        'string values',
-        { BCD01: 'FINAL_EACH_WEEK', BCD02: 'FINAL_EACH_WEEK' },
-        { BCD01: [{ type: 'FINAL_EACH_WEEK' }], BCD02: [{ type: 'FINAL_EACH_WEEK' }] },
-      ],
-      [
-        'array values',
-        { BCD01: ['FINAL_EACH_WEEK', 'SUM'], BCD02: ['FINAL_EACH_WEEK', 'COUNT'] },
-        {
-          BCD01: [{ type: 'FINAL_EACH_WEEK' }, { type: 'SUM' }],
-          BCD02: [{ type: 'FINAL_EACH_WEEK' }, { type: 'COUNT' }],
-        },
-      ],
-      [
-        'mixed values',
-        { BCD01: ['FINAL_EACH_WEEK', 'SUM'], BCD02: ['FINAL_EACH_WEEK'] },
-        {
-          BCD01: [{ type: 'FINAL_EACH_WEEK' }, { type: 'SUM' }],
-          BCD02: [{ type: 'FINAL_EACH_WEEK' }],
-        },
-      ],
-    ];
+    it('string', () => {
+      expect(getAggregationsByCode('SUM', 'BCD01 + BCD02')).toStrictEqual({
+        BCD01: [{ type: 'SUM' }],
+        BCD02: [{ type: 'SUM' }],
+      });
+    });
 
-    it.each(testData)('%s', (_, aggregationsByCode, expected) => {
-      expect(getAggregationsByCode(aggregationsByCode)).toStrictEqual(expected);
+    describe('object', () => {
+      const testData: [string, AggregationSpecs, Record<string, Aggregation[]>][] = [
+        [
+          'string values',
+          { BCD01: 'FINAL_EACH_WEEK', BCD02: 'FINAL_EACH_WEEK' },
+          { BCD01: [{ type: 'FINAL_EACH_WEEK' }], BCD02: [{ type: 'FINAL_EACH_WEEK' }] },
+        ],
+        [
+          'array values',
+          { BCD01: ['FINAL_EACH_WEEK', 'SUM'], BCD02: ['FINAL_EACH_WEEK', 'COUNT'] },
+          {
+            BCD01: [{ type: 'FINAL_EACH_WEEK' }, { type: 'SUM' }],
+            BCD02: [{ type: 'FINAL_EACH_WEEK' }, { type: 'COUNT' }],
+          },
+        ],
+        [
+          'mixed values',
+          { BCD01: ['FINAL_EACH_WEEK', 'SUM'], BCD02: ['FINAL_EACH_WEEK'] },
+          {
+            BCD01: [{ type: 'FINAL_EACH_WEEK' }, { type: 'SUM' }],
+            BCD02: [{ type: 'FINAL_EACH_WEEK' }],
+          },
+        ],
+      ];
+
+      it.each(testData)('%s', (_, aggregationsByCode, expected) => {
+        expect(getAggregationsByCode(aggregationsByCode)).toStrictEqual(expected);
+      });
     });
   });
 

--- a/packages/indicators/src/builders/helpers.ts
+++ b/packages/indicators/src/builders/helpers.ts
@@ -3,6 +3,7 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
+import { getVariables } from '@beyondessential/arithmetic';
 import groupBy from 'lodash.groupby';
 
 import { Aggregator } from '@tupaia/aggregator';
@@ -23,14 +24,20 @@ export const validateConfig = async <T extends Record<string, unknown>>(
   return config as T;
 };
 
-export const getAggregationsByCode = (aggregationSpecs: AggregationSpecs) =>
-  Object.fromEntries(
-    Object.entries(aggregationSpecs).map(([code, descriptor]) => {
+export const getAggregationsByCode = (aggregationSpecs: AggregationSpecs, formula?: string) => {
+  const aggregationObject =
+    typeof aggregationSpecs === 'string'
+      ? Object.fromEntries(getVariables(formula).map(code => [code, aggregationSpecs]))
+      : aggregationSpecs;
+
+  return Object.fromEntries(
+    Object.entries(aggregationObject).map(([code, descriptor]) => {
       const descriptorArray = Array.isArray(descriptor) ? descriptor : [descriptor];
       const aggregations = descriptorArray.map(aggregationType => ({ type: aggregationType }));
       return [code, aggregations];
     }),
   );
+};
 
 export const groupKeysByValueJson = (object: Record<string, unknown>) =>
   groupBy(Object.keys(object), code => JSON.stringify(object[code]));

--- a/packages/indicators/src/types.ts
+++ b/packages/indicators/src/types.ts
@@ -63,6 +63,6 @@ export interface Aggregation {
 /**
  * Used to define the aggregation(s) that should be used for each data element in an indicator.
  */
-export type AggregationSpecs = Readonly<Record<string, string | string[]>>;
+export type AggregationSpecs = string | Readonly<Record<string, string | string[]>>;
 
 export type FetchOptions = Readonly<Record<string, unknown>>;

--- a/packages/utils/src/__tests__/validation/validatorFunctions.test.js
+++ b/packages/utils/src/__tests__/validation/validatorFunctions.test.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
-import { allValuesAreNumbers } from '../../validation';
+import { allValuesAreNumbers, constructIsOneOfType } from '../../validation';
 
 describe('validatorFunctions', () => {
   describe('allValuesAreNumbers', () => {
@@ -23,6 +23,59 @@ describe('validatorFunctions', () => {
 
     it('passes if given an empty object', () => {
       expect(() => allValuesAreNumbers({})).not.toThrowError();
+    });
+  });
+
+  describe('constructIsOneOfType', () => {
+    it('throws if types are not an array', () => {
+      expect(() => constructIsOneOfType('string')).toThrow('expects an array');
+    });
+
+    it('throws if types are an empty array ', () => {
+      expect(() => constructIsOneOfType([])).toThrow('expects at least one type');
+    });
+
+    describe('single type - passes', () => {
+      const testData = [
+        ['array', [1, 2]],
+        ['object', { alpha: 1 }],
+        ['number', 1],
+        ['string', '1'],
+        ['boolean', false],
+      ];
+
+      it.each(testData)('%s', (type, value) => {
+        const validator = constructIsOneOfType([type]);
+        expect(() => validator(value)).not.toThrow();
+      });
+    });
+
+    describe('single type - fails', () => {
+      const testData = [
+        ['array', { alpha: 1 }],
+        ['object', [1, 2]],
+        ['number', '1'],
+        ['string', 1],
+        ['boolean', 'true'],
+      ];
+
+      it.each(testData)('%s', (type, value) => {
+        const validator = constructIsOneOfType([type]);
+        expect(() => validator(value)).toThrow(`Must be one of ${type}`);
+      });
+    });
+
+    it('multiple types - passes', () => {
+      const validator = constructIsOneOfType(['string', 'number', 'array']);
+      expect(() => validator(1)).not.toThrow();
+      expect(() => validator([1])).not.toThrow();
+    });
+
+    it('multiple types - fails', () => {
+      const validator = constructIsOneOfType(['string', 'number', 'array']);
+      const errorMessage = 'Must be one of string | number | array';
+      expect(() => validator({ alpha: 1 })).toThrow(errorMessage);
+      expect(() => validator(false)).toThrow(errorMessage);
     });
   });
 });

--- a/packages/utils/src/validation/validatorFunctions.js
+++ b/packages/utils/src/validation/validatorFunctions.js
@@ -76,13 +76,12 @@ export const isEmail = value => {
   }
 };
 
+// Conditional taken from https://github.com/bttmly/is-pojo/blob/master/lib/index.js
+const isPojo = value =>
+  value !== null && typeof value === 'object' && Object.getPrototypeOf(value) === Object.prototype;
+
 export const isPlainObject = value => {
-  // Conditional taken from https://github.com/bttmly/is-pojo/blob/master/lib/index.js
-  const isPojo =
-    value !== null &&
-    typeof value === 'object' &&
-    Object.getPrototypeOf(value) === Object.prototype;
-  if (!isPojo) {
+  if (!isPojo(value)) {
     throw new Error('Not a plain javascript object');
   }
 };
@@ -124,6 +123,37 @@ export const constructIsOneOf = options => value => {
   if (!options.includes(value)) {
     throw new ValidationError(`${value} is not an accepted value`);
   }
+};
+
+const checkIsOfType = (value, type) => {
+  switch (type) {
+    case 'array':
+      return Array.isArray(value);
+    case 'object':
+      return isPojo(value);
+    case 'number':
+    case 'string':
+    case 'boolean':
+      // eslint-disable-next-line valid-typeof
+      return typeof value === type;
+    default:
+      throw new Error(`Non supported type: ${type}`);
+  }
+};
+
+export const constructIsOneOfType = types => {
+  if (!Array.isArray(types)) {
+    throw new Error('constructIsOneOfType expects an array of types');
+  }
+  if (types.length === 0) {
+    throw new Error('constructIsOneOfType expects at least one type');
+  }
+
+  return value => {
+    if (!types.some(type => checkIsOfType(value, type))) {
+      throw new Error(`Must be one of ${types.join(' | ')}`);
+    }
+  };
 };
 
 export const constructRecordExistsWithCode = model => async value => {


### PR DESCRIPTION
### Issue #:
[No issue]

This adds support for single strings to be specified as an indicator's `aggregation`, eg

```json
{
  "formula": "MRDT_POS_CONSULT_WEEKLY / SSWT1001",
  "aggregation": "FINAL_EACH_WEEK"
}
```

is equivalent to
```json
{
  "formula": "MRDT_POS_CONSULT_WEEKLY / SSWT1001",
  "aggregation": { "MRDT_POS_CONSULT_WEEKLY": "FINAL_EACH_WEEK", "SSWT1001": "FINAL_EACH_WEEK" }
}
```

