### PR TITLE
Add psss stubs

### DIFF
--- a/packages/psss/src/components/ComingSoon.js
+++ b/packages/psss/src/components/ComingSoon.js
@@ -34,9 +34,9 @@ const StyledAlert = styled(SmallAlert)`
   z-index: 10;
 
   &.MuiAlert-filledWarning {
-    background-color: #fee2e2;
-    color: #d13333;
-    border: 1px solid rgba(209, 51, 51, 0.15);
+    background-color: white;
+    color: #333;
+    border: 1px solid #ccc;
   }
 `;
 

--- a/packages/psss/src/components/ComingSoon.js
+++ b/packages/psss/src/components/ComingSoon.js
@@ -1,0 +1,58 @@
+/*
+ * Tupaia
+ * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
+ */
+import React from 'react';
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+import { SmallAlert } from '@tupaia/ui-components';
+
+const Container = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 999;
+  backdrop-filter: blur(2px);
+  background: rgba(0, 0, 0, 0.3);
+`;
+
+const Heading = styled.p`
+  font-size: 16px;
+  font-weight: 600;
+  margin-bottom: 5px;
+  margin-top: 0;
+`;
+
+const StyledAlert = styled(SmallAlert)`
+  position: absolute;
+  max-width: 350px;
+  top: 35%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 10;
+
+  &.MuiAlert-filledWarning {
+    background-color: #fee2e2;
+    color: #d13333;
+    border: 1px solid rgba(209, 51, 51, 0.15);
+  }
+`;
+
+export const ComingSoon = ({ text }) => (
+  <Container>
+    <StyledAlert severity="warning">
+      <Heading>Under Construction</Heading>
+      {text}
+    </StyledAlert>
+  </Container>
+);
+
+ComingSoon.propTypes = {
+  text: PropTypes.string,
+};
+
+ComingSoon.defaultProps = {
+  text: null,
+};

--- a/packages/psss/src/components/Layout.js
+++ b/packages/psss/src/components/Layout.js
@@ -13,6 +13,7 @@ const desktopWidth = '768px';
  * Wrapping container
  */
 export const Container = styled(MuiContainer)`
+  position: relative;
   display: grid;
   grid-template-columns: 2fr 1fr;
   grid-gap: 40px;

--- a/packages/psss/src/components/Layout.js
+++ b/packages/psss/src/components/Layout.js
@@ -13,7 +13,6 @@ const desktopWidth = '768px';
  * Wrapping container
  */
 export const Container = styled(MuiContainer)`
-  position: relative;
   display: grid;
   grid-template-columns: 2fr 1fr;
   grid-gap: 40px;

--- a/packages/psss/src/components/index.js
+++ b/packages/psss/src/components/index.js
@@ -15,3 +15,4 @@ export * from './ActivityTab';
 export * from './FetchLoader';
 export * from './Modal';
 export * from './AffectedSitesTab';
+export * from './ComingSoon';

--- a/packages/psss/src/containers/Modals/ExportModal.js
+++ b/packages/psss/src/containers/Modals/ExportModal.js
@@ -20,7 +20,7 @@ import {
 import CheckCircle from '@material-ui/icons/CheckCircle';
 import Typography from '@material-ui/core/Typography';
 import { useForm, Controller } from 'react-hook-form';
-import { FlexSpaceBetween } from '../../components/Layout';
+import { FlexSpaceBetween, ComingSoon } from '../../components';
 import { connectApi } from '../../api';
 
 // Todo replace with data from api
@@ -134,6 +134,7 @@ export const ExportModalComponent = ({ renderCustomFields, isOpen, handleClose, 
 
   return (
     <Dialog onClose={handleClose} open={isOpen}>
+      <ComingSoon text="The Modal dialog will enable you to export report data." />
       <form onSubmit={handleSubmit(handleConfirm)} noValidate>
         <DialogHeader onClose={handleClose} title="Export Weekly Case Data" />
         <LoadingContainer isLoading={status === STATUS.LOADING}>

--- a/packages/psss/src/containers/Panels/WeeklyReportsPanel.js
+++ b/packages/psss/src/containers/Panels/WeeklyReportsPanel.js
@@ -27,6 +27,7 @@ import {
   DrawerHeader,
   PercentageChangeCell,
   AlertCreatedModal,
+  ComingSoon,
 } from '../../components';
 import {
   getSitesForWeek,
@@ -190,6 +191,7 @@ export const WeeklyReportsPanelComponent = React.memo(
           </EditableTableProvider>
         </GreySection>
         <MainSection disabled={isSaving} data-testid="site-reports">
+          <ComingSoon text="The Sentinel Case data section will allow you to explore sentinel site data." />
           <ButtonSelect
             id="active-site"
             options={sitesData}

--- a/packages/psss/src/views/CountriesReportsView.js
+++ b/packages/psss/src/views/CountriesReportsView.js
@@ -14,7 +14,15 @@ import {
   WarningCloud,
   Virus,
 } from '@tupaia/ui-components';
-import { DateToolbar, Container, Main, Sidebar, Header, HeaderTitle } from '../components';
+import {
+  DateToolbar,
+  Container,
+  Main,
+  Sidebar,
+  Header,
+  HeaderTitle,
+  ComingSoon,
+} from '../components';
 import { CountriesTable, WeeklyReportsExportModal } from '../containers';
 
 const StyledCardContent = styled(CardContent)`
@@ -63,9 +71,10 @@ export const CountriesReportsView = () => (
             <CircleMeter value={11} total={22} />
           </StyledCardContent>
         </Card>
-        <Card variant="outlined">
-          <DataCardTabs data={tabData} />
-        </Card>
+        {/* Temporarily removed for MVP release. Please do not delete */}
+        {/*<Card variant="outlined">*/}
+        {/*  <DataCardTabs data={tabData} />*/}
+        {/*</Card>*/}
       </Sidebar>
     </Container>
   </>

--- a/packages/psss/src/views/CountriesReportsView.js
+++ b/packages/psss/src/views/CountriesReportsView.js
@@ -14,15 +14,7 @@ import {
   WarningCloud,
   Virus,
 } from '@tupaia/ui-components';
-import {
-  DateToolbar,
-  Container,
-  Main,
-  Sidebar,
-  Header,
-  HeaderTitle,
-  ComingSoon,
-} from '../components';
+import { DateToolbar, Container, Main, Sidebar, Header, HeaderTitle } from '../components';
 import { CountriesTable, WeeklyReportsExportModal } from '../containers';
 
 const StyledCardContent = styled(CardContent)`

--- a/packages/psss/src/views/Tabs/AlertsTabView.js
+++ b/packages/psss/src/views/Tabs/AlertsTabView.js
@@ -8,7 +8,7 @@ import styled from 'styled-components';
 import Typography from '@material-ui/core/Typography';
 import { CalendarToday } from '@material-ui/icons';
 import { CardContent, CardHeader, Card } from '@tupaia/ui-components';
-import { Container, Main, Sidebar } from '../../components';
+import { Container, Main, Sidebar, ComingSoon } from '../../components';
 import { AlertsTable, AlertsPanel } from '../../containers';
 
 const DateSubtitle = styled(Typography)`
@@ -31,25 +31,27 @@ export const AlertsTabView = React.memo(() => {
 
   return (
     <Container>
+      <ComingSoon text="The Alerts page will show Syndromes that have reached alert level." />
       <Main>
         <AlertsTable handlePanelOpen={handlePanelOpen} countryCode={countryCode} />
         <AlertsPanel isOpen={isPanelOpen} handleClose={handlePanelClose} />
       </Main>
-      <Sidebar>
-        <Card variant="outlined">
-          <CardHeader
-            color="primary"
-            title="Current Week"
-            label={<CalendarToday color="primary" />}
-          />
-          <CardContent>
-            <Typography variant="h4">Week 10</Typography>
-            <DateSubtitle variant="subtitle2" gutterBottom>
-              Feb 25, 2020 - Mar 1, 2020
-            </DateSubtitle>
-          </CardContent>
-        </Card>
-      </Sidebar>
+      {/* Temporarily removed for MVP release. Please do not delete */}
+      {/*<Sidebar>*/}
+      {/*  <Card variant="outlined">*/}
+      {/*    <CardHeader*/}
+      {/*      color="primary"*/}
+      {/*      title="Current Week"*/}
+      {/*      label={<CalendarToday color="primary" />}*/}
+      {/*    />*/}
+      {/*    <CardContent>*/}
+      {/*      <Typography variant="h4">Week 10</Typography>*/}
+      {/*      <DateSubtitle variant="subtitle2" gutterBottom>*/}
+      {/*        Feb 25, 2020 - Mar 1, 2020*/}
+      {/*      </DateSubtitle>*/}
+      {/*    </CardContent>*/}
+      {/*  </Card>*/}
+      {/*</Sidebar>*/}
     </Container>
   );
 });

--- a/packages/psss/src/views/Tabs/AlertsTabView.js
+++ b/packages/psss/src/views/Tabs/AlertsTabView.js
@@ -30,28 +30,30 @@ export const AlertsTabView = React.memo(() => {
   }, [setIsPanelOpen]);
 
   return (
-    <Container>
+    <div style={{ position: 'relative' }}>
       <ComingSoon text="The Alerts page will show Syndromes that have reached alert level." />
-      <Main>
-        <AlertsTable handlePanelOpen={handlePanelOpen} countryCode={countryCode} />
-        <AlertsPanel isOpen={isPanelOpen} handleClose={handlePanelClose} />
-      </Main>
-      {/* Temporarily removed for MVP release. Please do not delete */}
-      {/*<Sidebar>*/}
-      {/*  <Card variant="outlined">*/}
-      {/*    <CardHeader*/}
-      {/*      color="primary"*/}
-      {/*      title="Current Week"*/}
-      {/*      label={<CalendarToday color="primary" />}*/}
-      {/*    />*/}
-      {/*    <CardContent>*/}
-      {/*      <Typography variant="h4">Week 10</Typography>*/}
-      {/*      <DateSubtitle variant="subtitle2" gutterBottom>*/}
-      {/*        Feb 25, 2020 - Mar 1, 2020*/}
-      {/*      </DateSubtitle>*/}
-      {/*    </CardContent>*/}
-      {/*  </Card>*/}
-      {/*</Sidebar>*/}
-    </Container>
+      <Container>
+        <Main>
+          <AlertsTable handlePanelOpen={handlePanelOpen} countryCode={countryCode} />
+          <AlertsPanel isOpen={isPanelOpen} handleClose={handlePanelClose} />
+        </Main>
+        {/* Temporarily removed for MVP release. Please do not delete */}
+        {/*<Sidebar>*/}
+        {/*  <Card variant="outlined">*/}
+        {/*    <CardHeader*/}
+        {/*      color="primary"*/}
+        {/*      title="Current Week"*/}
+        {/*      label={<CalendarToday color="primary" />}*/}
+        {/*    />*/}
+        {/*    <CardContent>*/}
+        {/*      <Typography variant="h4">Week 10</Typography>*/}
+        {/*      <DateSubtitle variant="subtitle2" gutterBottom>*/}
+        {/*        Feb 25, 2020 - Mar 1, 2020*/}
+        {/*      </DateSubtitle>*/}
+        {/*    </CardContent>*/}
+        {/*  </Card>*/}
+        {/*</Sidebar>*/}
+      </Container>
+    </div>
   );
 });

--- a/packages/psss/src/views/Tabs/ArchiveTabView.js
+++ b/packages/psss/src/views/Tabs/ArchiveTabView.js
@@ -12,11 +12,13 @@ export const ArchiveTabView = () => {
   const { countryCode } = useParams();
 
   return (
-    <MuiContainer style={{ position: 'relative ' }}>
+    <div style={{ position: 'relative' }}>
       <ComingSoon text="The Archive page will show archived Alerts and Outbreaks." />
-      <Main>
-        <ArchiveTable countryCode={countryCode} />
-      </Main>
-    </MuiContainer>
+      <MuiContainer style={{ position: 'relative ' }}>
+        <Main>
+          <ArchiveTable countryCode={countryCode} />
+        </Main>
+      </MuiContainer>
+    </div>
   );
 };

--- a/packages/psss/src/views/Tabs/ArchiveTabView.js
+++ b/packages/psss/src/views/Tabs/ArchiveTabView.js
@@ -5,14 +5,15 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
 import MuiContainer from '@material-ui/core/Container';
-import { Main } from '../../components';
+import { ComingSoon, Container, Main } from '../../components';
 import { ArchiveTable } from '../../containers';
 
 export const ArchiveTabView = () => {
   const { countryCode } = useParams();
 
   return (
-    <MuiContainer>
+    <MuiContainer style={{ position: 'relative ' }}>
+      <ComingSoon text="The Archive page will show archived Alerts and Outbreaks." />
       <Main>
         <ArchiveTable countryCode={countryCode} />
       </Main>

--- a/packages/psss/src/views/Tabs/EventBasedTabView.js
+++ b/packages/psss/src/views/Tabs/EventBasedTabView.js
@@ -11,11 +11,13 @@ export const EventBasedTabView = () => {
   const { countryCode } = useParams();
 
   return (
-    <Container>
+    <div style={{ position: 'relative' }}>
       <ComingSoon text="The Event-based page will allow you to see event based data." />
-      <Main>
-        <AlertsTable handlePanelOpen={() => {}} countryCode={countryCode} />
-      </Main>
-    </Container>
+      <Container>
+        <Main>
+          <AlertsTable handlePanelOpen={() => {}} countryCode={countryCode} />
+        </Main>
+      </Container>
+    </div>
   );
 };

--- a/packages/psss/src/views/Tabs/EventBasedTabView.js
+++ b/packages/psss/src/views/Tabs/EventBasedTabView.js
@@ -3,49 +3,19 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 import React from 'react';
-import styled from 'styled-components';
-import Typography from '@material-ui/core/Typography';
-import { Container, Main } from '../../components';
+import { useParams } from 'react-router-dom';
+import { Container, Main, ComingSoon } from '../../components';
+import { AlertsTable } from '../../containers/Tables';
 
-const Section = styled.section`
-  background: white;
-  border: 2px dashed black;
-  height: 600px;
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-`;
+export const EventBasedTabView = () => {
+  const { countryCode } = useParams();
 
-export const SidebarPlaceholder = styled.aside`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  margin-top: -85px;
-  align-items: center;
-  background: white;
-  border-radius: 3px;
-  border: 1px solid #dedee0;
-  height: 600px;
-`;
-
-export const EventBasedTabView = () => (
-  <Container>
-    <Main>
-      <Section>
-        <Typography variant="h2" gutterBottom>
-          Event Based View
-        </Typography>
-      </Section>
-    </Main>
-    <SidebarPlaceholder>
-      <Typography variant="h2" gutterBottom>
-        Sidebar
-      </Typography>
-      <Typography variant="body1" gutterBottom>
-        Event Based Country View
-      </Typography>
-    </SidebarPlaceholder>
-  </Container>
-);
+  return (
+    <Container>
+      <ComingSoon text="The Event-based page will allow you to see event based data." />
+      <Main>
+        <AlertsTable handlePanelOpen={() => {}} countryCode={countryCode} />
+      </Main>
+    </Container>
+  );
+};

--- a/packages/psss/src/views/Tabs/OutbreaksTabView.js
+++ b/packages/psss/src/views/Tabs/OutbreaksTabView.js
@@ -13,12 +13,14 @@ export const OutbreaksTabView = () => {
   const { countryCode } = useParams();
 
   return (
-    <MuiContainer style={{ position: 'relative ' }}>
+    <div style={{ position: 'relative' }}>
       <ComingSoon text="The Outbreaks page will show archived Alerts and Outbreaks." />
-      <Main>
-        <OutbreaksTable handlePanelOpen={() => setIsPanelOpen(true)} countryCode={countryCode} />
-        <OutbreaksPanel isOpen={isPanelOpen} handleClose={() => setIsPanelOpen(false)} />
-      </Main>
-    </MuiContainer>
+      <MuiContainer style={{ position: 'relative ' }}>
+        <Main>
+          <OutbreaksTable handlePanelOpen={() => setIsPanelOpen(true)} countryCode={countryCode} />
+          <OutbreaksPanel isOpen={isPanelOpen} handleClose={() => setIsPanelOpen(false)} />
+        </Main>
+      </MuiContainer>
+    </div>
   );
 };

--- a/packages/psss/src/views/Tabs/OutbreaksTabView.js
+++ b/packages/psss/src/views/Tabs/OutbreaksTabView.js
@@ -5,7 +5,7 @@
 import React, { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import MuiContainer from '@material-ui/core/Container';
-import { Main } from '../../components';
+import { ComingSoon, Main } from '../../components';
 import { OutbreaksTable, OutbreaksPanel } from '../../containers';
 
 export const OutbreaksTabView = () => {
@@ -13,7 +13,8 @@ export const OutbreaksTabView = () => {
   const { countryCode } = useParams();
 
   return (
-    <MuiContainer>
+    <MuiContainer style={{ position: 'relative ' }}>
+      <ComingSoon text="The Outbreaks page will show archived Alerts and Outbreaks." />
       <Main>
         <OutbreaksTable handlePanelOpen={() => setIsPanelOpen(true)} countryCode={countryCode} />
         <OutbreaksPanel isOpen={isPanelOpen} handleClose={() => setIsPanelOpen(false)} />

--- a/packages/psss/src/views/Tabs/WeeklyCasesTabView.js
+++ b/packages/psss/src/views/Tabs/WeeklyCasesTabView.js
@@ -115,9 +115,10 @@ export const WeeklyCasesTabViewComponent = React.memo(
               <BarMeter value={22} total={30} legend="Sites reported" />
             </CardFooter>
           </Card>
-          <Card variant="outlined">
-            <DataCardTabs data={tabData} />
-          </Card>
+          {/* Temporarily removed for MVP release. Please do not delete */}
+          {/*<Card variant="outlined">*/}
+          {/*  <DataCardTabs data={tabData} />*/}
+          {/*</Card>*/}
         </Sidebar>
       </Container>
     );


### PR DESCRIPTION
### Issue #: [1576 PSSS stubs for coming soon features](https://github.com/beyondessential/tupaia-backlog/issues/1576)

### Changes:

- Add coming soon message to export modals, alerts and outbreaks pages events based data page, sentinel case data
- Comment out the alerts summary cards from the sidebar. I initially added the coming soon message to them but it looked too messy.

---

### Screenshots:
See [the issue](https://github.com/beyondessential/tupaia-backlog/issues/1576) for screenshots