### PR TITLE
Migration to update Raw Data Download reports survey codes CD to  DIA

### DIFF
--- a/packages/database/src/migrations/20201126075832-ChangeRawDataDownloadSurveyCodeFromCDtoDIA-modifies-data.js
+++ b/packages/database/src/migrations/20201126075832-ChangeRawDataDownloadSurveyCodeFromCDtoDIA-modifies-data.js
@@ -1,0 +1,45 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+const reportIds = `'Raw_Data_CK_Surveys',
+                  'Raw_Data_DL_Surveys',
+                  'Raw_Data_VU_Surveys',
+                  'Raw_Data_TL_Surveys',
+                  'Raw_Data_KI_Surveys',
+                  'Raw_Data_TK_Surveys',
+                  'Raw_Data_SB_Surveys',
+                  'Raw_Data_VE_Surveys',
+                  'Raw_Data_TO_Surveys'`;
+
+exports.up = function(db) {
+  return db.runSql(`
+    update "dashboardReport" 
+    set "dataBuilderConfig" = jsonb_set("dataBuilderConfig", '{surveys,2,code}', '"DIA"') 
+    where id in (${reportIds});
+  `);
+};
+
+exports.down = function(db) {
+  return db.runSql(`
+    update "dashboardReport" 
+    set "dataBuilderConfig" = jsonb_set("dataBuilderConfig", '{surveys,2,code}', '"CD"') 
+    where id in (${reportIds});
+  `);
+};
+
+exports._meta = {
+  "version": 1
+};


### PR DESCRIPTION
### Issue #: https://github.com/beyondessential/tupaia-backlog/issues/1470 

### Changes: 
- Migration to update Raw Data Download reports survey code for "Childhood Diarrhoea" from 'CD' to "DIA"
- updated 'Raw_Data_CK_Surveys',
                  'Raw_Data_DL_Surveys',
                  'Raw_Data_VU_Surveys',
                  'Raw_Data_TL_Surveys',
                  'Raw_Data_KI_Surveys',
                  'Raw_Data_TK_Surveys',
                  'Raw_Data_SB_Surveys',
                  'Raw_Data_VE_Surveys',
                  'Raw_Data_TO_Surveys'

-Raw_Data_Core_Surveys is handled by https://github.com/beyondessential/tupaia/pull/1702

### Screenshots:
