### PR TITLE
Fix DLI spelling

### DIFF
--- a/packages/psss/src/api/FakeApi.js
+++ b/packages/psss/src/api/FakeApi.js
@@ -104,7 +104,7 @@ export const FakeAPI = {
       this.makeSyndrome('dia', 'Diarrhoea (DIA)'),
       this.makeSyndrome('ili', 'Influenza-like Illness (ILI)'),
       this.makeSyndrome('pf', 'Prolonged Fever (PF)'),
-      this.makeSyndrome('dil', 'Dengue-like Illness (DIL)'),
+      this.makeSyndrome('dli', 'Dengue-like Illness (DLI)'),
     ];
   },
 
@@ -227,13 +227,13 @@ export const FakeAPI = {
       id: faker.random.uuid(),
       name: faker.address.country(),
       countryCode: faker.address.countryCode().toLowerCase(),
-      syndrome: faker.random.arrayElement(['AFR', 'DIA', 'ILI', 'PF', 'DIL']),
+      syndrome: faker.random.arrayElement(['AFR', 'DIA', 'ILI', 'PF', 'DLI']),
       syndromeDisplayName: faker.random.arrayElement([
         'Acute Fever and Rash (AFR)',
         'Diarrhoea (DIA)',
         'Influenza-like Illness (ILI)',
         'Prolonged Fever (PF)',
-        'Dengue-like Illness (DIL)',
+        'Dengue-like Illness (DLI)',
       ]),
       weekNumber: faker.random.number({
         min: 1,

--- a/packages/psss/src/containers/Modals/CreateOutbreakModal.js
+++ b/packages/psss/src/containers/Modals/CreateOutbreakModal.js
@@ -47,7 +47,7 @@ const options = [
   { label: 'Diarrhoea (DIA)', value: 'dia' },
   { label: 'Influenza-like Illness (ILI)', value: 'ili' },
   { label: 'Prolonged Fever (AFR)', value: 'pf' },
-  { label: 'Dengue-like Illness (DIL)', value: 'dil' },
+  { label: 'Dengue-like Illness (DLI)', value: 'dli' },
 ];
 
 const TickIcon = styled(CheckCircle)`

--- a/packages/psss/src/containers/Tables/CountriesTable.js
+++ b/packages/psss/src/containers/Tables/CountriesTable.js
@@ -56,9 +56,9 @@ const countriesTableColumns = [
     CellComponent: AlertCell,
   },
   {
-    title: 'DIL',
-    key: 'DIL',
-    accessor: createTotalCasesAccessor('dil'),
+    title: 'DLI',
+    key: 'DLI',
+    accessor: createTotalCasesAccessor('dli'),
     CellComponent: AlertCell,
   },
 ];

--- a/packages/psss/src/containers/Tables/CountrySummaryTable.js
+++ b/packages/psss/src/containers/Tables/CountrySummaryTable.js
@@ -54,9 +54,9 @@ const countrySummaryTableColumns = [
     CellComponent: AlertCell,
   },
   {
-    title: 'DIL',
-    key: 'DIL',
-    accessor: createTotalCasesAccessor('dil'),
+    title: 'DLI',
+    key: 'DLI',
+    accessor: createTotalCasesAccessor('dli'),
     CellComponent: AlertCell,
   },
 ];

--- a/packages/psss/src/containers/Tables/CountryTable.js
+++ b/packages/psss/src/containers/Tables/CountryTable.js
@@ -125,9 +125,9 @@ const countryColumns = [
     CellComponent: AlertCell,
   },
   {
-    title: 'DIL',
-    key: 'DIL',
-    accessor: createTotalCasesAccessor('dil'),
+    title: 'DLI',
+    key: 'DLI',
+    accessor: createTotalCasesAccessor('dli'),
     CellComponent: AlertCell,
   },
   {

--- a/packages/psss/src/containers/Tables/SiteSummaryTable.js
+++ b/packages/psss/src/containers/Tables/SiteSummaryTable.js
@@ -60,9 +60,9 @@ const siteWeekColumns = [
     CellComponent: AlertCell,
   },
   {
-    title: 'DIL',
-    key: 'DIL',
-    accessor: createTotalCasesAccessor('dil'),
+    title: 'DLI',
+    key: 'DLI',
+    accessor: createTotalCasesAccessor('dli'),
     CellComponent: AlertCell,
   },
   {

--- a/packages/psss/src/containers/__tests__/fixtures/country.fixtures.json
+++ b/packages/psss/src/containers/__tests__/fixtures/country.fixtures.json
@@ -36,8 +36,8 @@
         "isAlert": false
       },
       {
-        "id": "dil",
-        "title": "Dengue-like Illness (DIL)",
+        "id": "dli",
+        "title": "Dengue-like Illness (DLI)",
         "percentageChange": -8,
         "totalCases": 607,
         "isAlert": false
@@ -78,8 +78,8 @@
         "totalCases": 689
       },
       {
-        "id": "dil",
-        "title": "Dengue-like Illness (DIL)",
+        "id": "dli",
+        "title": "Dengue-like Illness (DLI)",
         "percentageChange": 1,
         "totalCases": 367
       }
@@ -119,8 +119,8 @@
         "totalCases": 844
       },
       {
-        "id": "dil",
-        "title": "Dengue-like Illness (DIL)",
+        "id": "dli",
+        "title": "Dengue-like Illness (DLI)",
         "percentageChange": -4,
         "totalCases": 324
       }
@@ -160,8 +160,8 @@
         "totalCases": 13
       },
       {
-        "id": "dil",
-        "title": "Dengue-like Illness (DIL)",
+        "id": "dli",
+        "title": "Dengue-like Illness (DLI)",
         "percentageChange": 3,
         "totalCases": 851
       }
@@ -201,8 +201,8 @@
         "totalCases": 834
       },
       {
-        "id": "dil",
-        "title": "Dengue-like Illness (DIL)",
+        "id": "dli",
+        "title": "Dengue-like Illness (DLI)",
         "percentageChange": 6,
         "totalCases": 423
       }
@@ -242,8 +242,8 @@
         "totalCases": 41
       },
       {
-        "id": "dil",
-        "title": "Dengue-like Illness (DIL)",
+        "id": "dli",
+        "title": "Dengue-like Illness (DLI)",
         "percentageChange": 5,
         "totalCases": 645
       }
@@ -283,8 +283,8 @@
         "totalCases": 141
       },
       {
-        "id": "dil",
-        "title": "Dengue-like Illness (DIL)",
+        "id": "dli",
+        "title": "Dengue-like Illness (DLI)",
         "percentageChange": 8,
         "totalCases": 589
       }
@@ -324,8 +324,8 @@
         "totalCases": 402
       },
       {
-        "id": "dil",
-        "title": "Dengue-like Illness (DIL)",
+        "id": "dli",
+        "title": "Dengue-like Illness (DLI)",
         "percentageChange": -5,
         "totalCases": 321
       }
@@ -365,8 +365,8 @@
         "totalCases": 35
       },
       {
-        "id": "dil",
-        "title": "Dengue-like Illness (DIL)",
+        "id": "dli",
+        "title": "Dengue-like Illness (DLI)",
         "percentageChange": -6,
         "totalCases": 610
       }
@@ -406,8 +406,8 @@
         "totalCases": 377
       },
       {
-        "id": "dil",
-        "title": "Dengue-like Illness (DIL)",
+        "id": "dli",
+        "title": "Dengue-like Illness (DLI)",
         "percentageChange": 3,
         "totalCases": 707
       }

--- a/packages/psss/src/containers/__tests__/fixtures/sites.fixtures.json
+++ b/packages/psss/src/containers/__tests__/fixtures/sites.fixtures.json
@@ -39,8 +39,8 @@
         "totalCases": 910
       },
       {
-        "id": "dil",
-        "title": "Dengue-like Illness (DIL)",
+        "id": "dli",
+        "title": "Dengue-like Illness (DLI)",
         "percentageChange": 4,
         "totalCases": 371
       }
@@ -86,8 +86,8 @@
         "totalCases": 284
       },
       {
-        "id": "dil",
-        "title": "Dengue-like Illness (DIL)",
+        "id": "dli",
+        "title": "Dengue-like Illness (DLI)",
         "percentageChange": -6,
         "totalCases": 866
       }
@@ -133,8 +133,8 @@
         "totalCases": 934
       },
       {
-        "id": "dil",
-        "title": "Dengue-like Illness (DIL)",
+        "id": "dli",
+        "title": "Dengue-like Illness (DLI)",
         "percentageChange": -15,
         "totalCases": 726
       }
@@ -180,8 +180,8 @@
         "totalCases": 793
       },
       {
-        "id": "dil",
-        "title": "Dengue-like Illness (DIL)",
+        "id": "dli",
+        "title": "Dengue-like Illness (DLI)",
         "percentageChange": 5,
         "totalCases": 94
       }
@@ -227,8 +227,8 @@
         "totalCases": 780
       },
       {
-        "id": "dil",
-        "title": "Dengue-like Illness (DIL)",
+        "id": "dli",
+        "title": "Dengue-like Illness (DLI)",
         "percentageChange": 2,
         "totalCases": 23
       }
@@ -274,8 +274,8 @@
         "totalCases": 577
       },
       {
-        "id": "dil",
-        "title": "Dengue-like Illness (DIL)",
+        "id": "dli",
+        "title": "Dengue-like Illness (DLI)",
         "percentageChange": -12,
         "totalCases": 923
       }

--- a/packages/psss/src/containers/__tests__/weeklyReportsPanel.test.js
+++ b/packages/psss/src/containers/__tests__/weeklyReportsPanel.test.js
@@ -36,7 +36,7 @@ const defaultState = {
         dia: false,
         ili: null,
         pf: null,
-        dil: null,
+        dli: null,
       },
     },
   },


### PR DESCRIPTION
The acronym for Dengue Like Illness was spelt incorrectly everywhere it was used so just fixing that.