### PR TITLE
1740: Hotfix unable to export survey responses via the admin panel

### DIFF
--- a/packages/admin-panel/src/importExport/ExportButton.js
+++ b/packages/admin-panel/src/importExport/ExportButton.js
@@ -27,11 +27,11 @@ const processFileName = (unprocessedFileName, rowData) => {
 export const ExportButton = ({ actionConfig, row }) => (
   <IconButton
     onClick={async () => {
-      const { exportEndpoint, rowIdQueryParameter, fileName } = actionConfig;
+      const { exportEndpoint, rowIdQueryParameter, extraQueryParameters, fileName } = actionConfig;
       const queryParameters = buildExportQueryParameters(rowIdQueryParameter, row);
       const endpoint = `export/${exportEndpoint}${!queryParameters && row.id ? `/${row.id}` : ''}`;
       const processedFileName = processFileName(fileName, row);
-      await api.download(endpoint, queryParameters, processedFileName);
+      await api.download(endpoint, { queryParameters, ...extraQueryParameters }, processedFileName);
     }}
   >
     <ExportIcon />

--- a/packages/admin-panel/src/pages/resources/SurveyResponsesPage.js
+++ b/packages/admin-panel/src/pages/resources/SurveyResponsesPage.js
@@ -6,6 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
+import { getTimeZone } from '../../utilities';
 import { ResourcePage } from './ResourcePage';
 import { SurveyResponsesExportModal } from '../../importExport';
 
@@ -65,6 +66,9 @@ export const SURVEY_RESPONSE_COLUMNS = [
     actionConfig: {
       exportEndpoint: 'surveyResponse',
       fileName: 'Survey Response',
+      extraQueryParameters: {
+        timeZone: getTimeZone(),
+      },
     },
   },
 ];

--- a/packages/admin-panel/src/pages/resources/SurveyResponsesPage.js
+++ b/packages/admin-panel/src/pages/resources/SurveyResponsesPage.js
@@ -6,7 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
-import { getTimeZone } from '../../utilities';
+import { getBrowserTimeZone } from '@tupaia/utils';
 import { ResourcePage } from './ResourcePage';
 import { SurveyResponsesExportModal } from '../../importExport';
 
@@ -67,7 +67,7 @@ export const SURVEY_RESPONSE_COLUMNS = [
       exportEndpoint: 'surveyResponse',
       fileName: 'Survey Response',
       extraQueryParameters: {
-        timeZone: getTimeZone(),
+        timeZone: getBrowserTimeZone(),
       },
     },
   },

--- a/packages/admin-panel/src/utilities/index.js
+++ b/packages/admin-panel/src/utilities/index.js
@@ -8,4 +8,5 @@ export { createNestedReducer } from './createNestedReducer';
 export { convertSearchTermToFilter } from './convertSearchTermToFilter';
 export { makeSubstitutionsInString } from './makeSubstitutionsInString';
 export { usePortalWithCallback } from './usePortalWithCallback';
+export { getTimeZone } from './getTimeZone';
 export * from './pretty';

--- a/packages/admin-panel/src/utilities/index.js
+++ b/packages/admin-panel/src/utilities/index.js
@@ -8,5 +8,4 @@ export { createNestedReducer } from './createNestedReducer';
 export { convertSearchTermToFilter } from './convertSearchTermToFilter';
 export { makeSubstitutionsInString } from './makeSubstitutionsInString';
 export { usePortalWithCallback } from './usePortalWithCallback';
-export { getTimeZone } from './getTimeZone';
 export * from './pretty';

--- a/packages/meditrak-server/src/routes/exportSurveyResponses.js
+++ b/packages/meditrak-server/src/routes/exportSurveyResponses.js
@@ -68,7 +68,7 @@ export async function exportSurveyResponses(req, res) {
     latest = false,
     startDate,
     endDate,
-    timeZone = 'Australia/Melbourne',
+    timeZone = 'UTC',
     viewId,
     easyReadingMode = false,
   } = req.query;

--- a/packages/meditrak-server/src/routes/exportSurveyResponses.js
+++ b/packages/meditrak-server/src/routes/exportSurveyResponses.js
@@ -68,7 +68,7 @@ export async function exportSurveyResponses(req, res) {
     latest = false,
     startDate,
     endDate,
-    timeZone,
+    timeZone = 'Australia/Melbourne',
     viewId,
     easyReadingMode = false,
   } = req.query;

--- a/packages/utils/src/getBrowserTimeZone.js
+++ b/packages/utils/src/getBrowserTimeZone.js
@@ -1,13 +1,13 @@
 /**
- * Tupaia Config Server
- * Copyright (c) 2020 Beyond Essential Systems Pty Ltd
+ * Tupaia
+ * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
-export function getTimeZone() {
+export const getBrowserTimeZone = () => {
   try {
     return Intl.DateTimeFormat().resolvedOptions().timeZone;
   } catch (e) {
     // Time zone not supported in this browser.
     return 'Australia/Melbourne';
   }
-}
+};

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -23,3 +23,4 @@ export * from './validation';
 export { WorkBookParser } from './WorkBookParser';
 export { checkValueSatisfiesCondition } from './checkValueSatisfiesCondition';
 export { addExportedDateAndOriginAtTheSheetBottom } from './addExportDateAndOriginInExcelExportData';
+export { getBrowserTimeZone } from './getBrowserTimeZone';

--- a/packages/web-frontend/src/containers/EnlargedDialog/EnlargedDialog.js
+++ b/packages/web-frontend/src/containers/EnlargedDialog/EnlargedDialog.js
@@ -10,7 +10,6 @@ import moment from 'moment';
 import styled from 'styled-components';
 import Dialog from '@material-ui/core/Dialog';
 
-import { getBrowserTimeZone } from '@tupaia/utils';
 import { exportToPng, exportToExcel } from '../../utils/exports';
 import {
   attemptDrillDown,
@@ -20,7 +19,7 @@ import {
 import { DrillDownOverlay } from '../DrillDownOverlay';
 import { EnlargedDialogContent } from './EnlargedDialogContent';
 import { getIsMatrix, getIsDataDownload, VIEW_CONTENT_SHAPE } from '../../components/View';
-import { isMobile, sleep, stringToFilename } from '../../utils';
+import { isMobile, sleep, stringToFilename, getBrowserTimeZone } from '../../utils';
 import { DIALOG_Z_INDEX } from '../../styles';
 import {
   selectCurrentInfoViewKey,

--- a/packages/web-frontend/src/containers/EnlargedDialog/EnlargedDialog.js
+++ b/packages/web-frontend/src/containers/EnlargedDialog/EnlargedDialog.js
@@ -10,6 +10,7 @@ import moment from 'moment';
 import styled from 'styled-components';
 import Dialog from '@material-ui/core/Dialog';
 
+import { getBrowserTimeZone } from '@tupaia/utils';
 import { exportToPng, exportToExcel } from '../../utils/exports';
 import {
   attemptDrillDown,
@@ -19,7 +20,7 @@ import {
 import { DrillDownOverlay } from '../DrillDownOverlay';
 import { EnlargedDialogContent } from './EnlargedDialogContent';
 import { getIsMatrix, getIsDataDownload, VIEW_CONTENT_SHAPE } from '../../components/View';
-import { getTimeZone, isMobile, sleep, stringToFilename } from '../../utils';
+import { isMobile, sleep, stringToFilename } from '../../utils';
 import { DIALOG_Z_INDEX } from '../../styles';
 import {
   selectCurrentInfoViewKey,
@@ -99,7 +100,7 @@ const EnlargedDialogComponent = ({
           organisationUnitName,
           startDate,
           endDate,
-          timeZone: getTimeZone(),
+          timeZone: getBrowserTimeZone(),
           filename,
         });
       } else {

--- a/packages/web-frontend/src/sagas.js
+++ b/packages/web-frontend/src/sagas.js
@@ -7,6 +7,7 @@
 
 import queryString from 'query-string';
 import { call, delay, put, select, take, takeEvery, takeLatest } from 'redux-saga/effects';
+import { getBrowserTimeZone } from '@tupaia/utils';
 import request from './utils/request';
 import {
   ATTEMPT_CHANGE_PASSWORD,
@@ -130,7 +131,7 @@ import {
   selectOrgUnitCountry,
   selectProjectByCode,
 } from './selectors';
-import { formatDateForApi, isMobile, processMeasureInfo, getTimeZone } from './utils';
+import { formatDateForApi, isMobile, processMeasureInfo } from './utils';
 import { getDefaultDates } from './utils/periodGranularities';
 import { fetchProjectData } from './projects/sagas';
 import { clearLocation } from './historyNavigation/historyNavigation';
@@ -724,7 +725,7 @@ function* fetchViewData(parameters, errorHandler) {
     isExpanded,
     startDate: formatDateForApi(startDate),
     endDate: formatDateForApi(endDate),
-    timeZone: getTimeZone(),
+    timeZone: getBrowserTimeZone(),
     ...extraUrlParameters,
   };
   const requestResourceUrl = `view?${queryString.stringify(urlParameters)}`;

--- a/packages/web-frontend/src/sagas.js
+++ b/packages/web-frontend/src/sagas.js
@@ -7,7 +7,6 @@
 
 import queryString from 'query-string';
 import { call, delay, put, select, take, takeEvery, takeLatest } from 'redux-saga/effects';
-import { getBrowserTimeZone } from '@tupaia/utils';
 import request from './utils/request';
 import {
   ATTEMPT_CHANGE_PASSWORD,
@@ -131,7 +130,7 @@ import {
   selectOrgUnitCountry,
   selectProjectByCode,
 } from './selectors';
-import { formatDateForApi, isMobile, processMeasureInfo } from './utils';
+import { formatDateForApi, isMobile, processMeasureInfo, getBrowserTimeZone } from './utils';
 import { getDefaultDates } from './utils/periodGranularities';
 import { fetchProjectData } from './projects/sagas';
 import { clearLocation } from './historyNavigation/historyNavigation';

--- a/packages/web-frontend/src/utils/getBrowserTimeZone.js
+++ b/packages/web-frontend/src/utils/getBrowserTimeZone.js
@@ -1,0 +1,13 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
+ */
+
+export const getBrowserTimeZone = () => {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone;
+  } catch (e) {
+    // Time zone not supported in this browser.
+    return 'Australia/Melbourne';
+  }
+};

--- a/packages/web-frontend/src/utils/index.js
+++ b/packages/web-frontend/src/utils/index.js
@@ -27,7 +27,6 @@ export {
 } from './measures';
 export { default as ga, gaEvent, gaPageView, gaMiddleware } from './ga';
 export { formatDateForApi } from './formatDateForApi';
-export { getTimeZone } from './getTimeZone';
 export { formatDataValue } from './formatters';
 export { findByKey } from './collection';
 export { areStringsEqual, stringToFilename } from './string';

--- a/packages/web-frontend/src/utils/index.js
+++ b/packages/web-frontend/src/utils/index.js
@@ -27,6 +27,7 @@ export {
 } from './measures';
 export { default as ga, gaEvent, gaPageView, gaMiddleware } from './ga';
 export { formatDateForApi } from './formatDateForApi';
+export { getBrowserTimeZone } from './getBrowserTimeZone';
 export { formatDataValue } from './formatters';
 export { findByKey } from './collection';
 export { areStringsEqual, stringToFilename } from './string';


### PR DESCRIPTION
### Issue: https://github.com/beyondessential/tupaia-backlog/issues/1740

### Changes:

- `timeZone` (from browser) query parameter was added into the export survey response meditrak-server endpoint for this ticket (https://github.com/beyondessential/tupaia/pull/1627). It was only done for web-frontend. We should also do it for admin-panel. So this PR is just for sending through timeZone from Admin-Panel when exporting. A default timeZone to fall back was also added to in the endpoint
