### PR TITLE
Handle no baseline data differently

### DIFF
--- a/packages/web-config-server/src/apiV1/dataBuilders/generic/table/tableOfDataValues/TableOfDataValuesWithCalc.js
+++ b/packages/web-config-server/src/apiV1/dataBuilders/generic/table/tableOfDataValues/TableOfDataValuesWithCalc.js
@@ -31,8 +31,10 @@ const TRANSFORMATIONS = {
 class TableOfDataValuesWithCalcBuilder extends TableOfDataValuesBuilder {
   async build() {
     const baseLine = await this.fetchResults();
-    if (baseLine.length === 0) return { data: [] };
-    const baseLineDate = moment(baseLine[0].period, 'YYYYMMDD');
+
+    const hasBaseLineData = baseLine.length > 0;
+
+    const baseLineDate = hasBaseLineData && moment(baseLine[0].period, 'YYYYMMDD');
     this.transformConfig(baseLineDate);
     this.tableConfig = new TableConfig(this.models, this.config, baseLine);
     this.valuesByCell = getValuesByCell(this.tableConfig, baseLine);
@@ -95,7 +97,7 @@ class TableOfDataValuesWithCalcBuilder extends TableOfDataValuesBuilder {
 
     this.config.columns = this.config.columns.map(header => {
       return header.name && header.showYear
-        ? `${header.name} - ${baseLineDate.format('YYYY')}`
+        ? `${header.name}${baseLineDate ? ` - ${baseLineDate.format('YYYY')}` : ''}`
         : header;
     });
   }


### PR DESCRIPTION
### Issue #:
https://github.com/beyondessential/tupaia-backlog/issues/1751
### Changes:
Don't return `{ data: [] }` when there is no data for a matrix, it requires the keys `columns` and `rows` instead. In this case, I went with not having a different code path for no data, which could cause a bit of regression, but seems a lot cleaner to me? What do you think?

Note: the affected matrix is the only one with this dataBuilder:
![image](https://user-images.githubusercontent.com/32168886/101299108-f27c4100-3884-11eb-8185-a9a04165f5f1.png)


Screenshots on card