### PR TITLE
Use lastPerPeriodPerOrgUnit aggregation in PSSS Reports

### DIFF
--- a/packages/database/src/migrations/20201209001056-ChangePSSSReportsToUseLastPerPeriodPerOrgUnit-modifies-data.js
+++ b/packages/database/src/migrations/20201209001056-ChangePSSSReportsToUseLastPerPeriodPerOrgUnit-modifies-data.js
@@ -1,0 +1,39 @@
+'use strict';
+
+import { arrayToDbString } from '../utilities';
+
+var dbm;
+var type;
+var seed;
+
+const REPORT_CODES = ['PSSS_Weekly_Cases', 'PSSS_Weekly_Report', 'PSSS_Confirmed_Weekly_Report'];
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = async function (db) {
+  return db.runSql(`
+      UPDATE report
+      SET config = jsonb_set(config, '{transform,2}', '"lastValuePerPeriodPerOrgUnit"')
+      WHERE code IN (${arrayToDbString(REPORT_CODES)})
+  `);
+};
+
+exports.down = function (db) {
+  return db.runSql(`
+      UPDATE report
+      SET config = jsonb_set(config, '{transform,2}', '"firstValuePerPeriodPerOrgUnit"')
+      WHERE code IN (${arrayToDbString(REPORT_CODES)})
+  `);
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/packages/report-server/src/reportBuilder/transform/aliases/aggregateAliases.ts
+++ b/packages/report-server/src/reportBuilder/transform/aliases/aggregateAliases.ts
@@ -27,3 +27,13 @@ export const firstValuePerPeriodPerOrgUnit = () =>
       '...': 'first',
     },
   ]);
+
+export const lastValuePerPeriodPerOrgUnit = () =>
+  buildTransform([
+    {
+      transform: 'aggregate',
+      organisationUnit: 'group',
+      period: 'group',
+      '...': 'last',
+    },
+  ]);

--- a/packages/report-server/src/reportBuilder/transform/aliases/index.ts
+++ b/packages/report-server/src/reportBuilder/transform/aliases/index.ts
@@ -8,7 +8,11 @@ import {
   keyValueByOrgUnit,
   keyValueByPeriod,
 } from './keyValueByFieldAliases';
-import { mostRecentValuePerOrgUnit, firstValuePerPeriodPerOrgUnit } from './aggregateAliases';
+import {
+  mostRecentValuePerOrgUnit,
+  firstValuePerPeriodPerOrgUnit,
+  lastValuePerPeriodPerOrgUnit,
+} from './aggregateAliases';
 import { convertPeriodToWeek } from './periodConversionAliases';
 
 export const aliases = {
@@ -17,5 +21,6 @@ export const aliases = {
   keyValueByPeriod,
   mostRecentValuePerOrgUnit,
   firstValuePerPeriodPerOrgUnit,
+  lastValuePerPeriodPerOrgUnit,
   convertPeriodToWeek,
 };


### PR DESCRIPTION
### Issue https://github.com/beyondessential/tupaia-backlog/issues/1634#issuecomment-741268716:

Was previously fetching the earliest submitted response, now fetches the latest one