### PR TITLE
Fix to display Pitcairn

### DIFF
--- a/packages/psss/src/utils/countries.js
+++ b/packages/psss/src/utils/countries.js
@@ -5,8 +5,24 @@
 
 import { getName } from 'country-list';
 
-const circleFlagsUrl = 'https://hatscripts.github.io/circle-flags/flags';
 // eg. https://hatscripts.github.io/circle-flags/flags/as.svg
-export const countryFlagImage = countryCode => `${circleFlagsUrl}/${countryCode.toLowerCase()}.svg`;
+const circleFlagsUrl = 'https://hatscripts.github.io/circle-flags/flags';
 
-export const getCountryName = countryCode => getName(countryCode) || '';
+export const countryFlagImage = countryCode => {
+  // Temporary fix for Pitcairn until the country code in the database is updated
+  // @see https://github.com/beyondessential/tupaia-backlog/issues/1782
+  if (countryCode === 'PI') {
+    return `${circleFlagsUrl}/pn.svg`;
+  }
+
+  return `${circleFlagsUrl}/${countryCode.toLowerCase()}.svg`;
+};
+
+export const getCountryName = countryCode => {
+  // Temporary fix for Pitcairn until the country code in the database is updated
+  // @see https://github.com/beyondessential/tupaia-backlog/issues/1782
+  if (countryCode === 'PI') {
+    return getName('PN') || '';
+  }
+  return getName(countryCode) || '';
+};


### PR DESCRIPTION
### Issue #: relates to test card [665](https://app.zenhub.com/workspaces/sprint-board-5eea9d3de8519e0019186490/issues/beyondessential/tupaia-backlog/665)

### Changes:

Pitcairn is not showing up properly in psss because the country code in the database is not the expected standard country code. This is a temporary fix to display the country name and country flag correctly and there is a [new card](https://github.com/beyondessential/tupaia-backlog/issues/1782) in the backlog for fixing the underlying issue.

---

### Screenshots:
