### PR TITLE
Use correct sign when comparing expiry time

### DIFF
--- a/packages/psss-server/src/models/PsssSession.ts
+++ b/packages/psss-server/src/models/PsssSession.ts
@@ -59,7 +59,7 @@ export class PsssSessionType extends DatabaseType {
   }
 
   isAccessTokenExpired() {
-    return this.access_token_expiry >= Date.now();
+    return this.access_token_expiry <= Date.now();
   }
 
   async getAuthHeader() {


### PR DESCRIPTION
### Issue #: https://github.com/beyondessential/tupaia-backlog/issues/1762
