### PR TITLE
Show value if it is singled in chart tooltip

### DIFF
--- a/packages/web-frontend/src/components/View/ChartWrapper/Tooltip.js
+++ b/packages/web-frontend/src/components/View/ChartWrapper/Tooltip.js
@@ -97,10 +97,7 @@ const SingleValueTooltip = ({ valueType, payload, periodGranularity, labelType }
 function Tooltip(props) {
   const filteredPayload = props.payload.filter(({ value }) => value !== undefined);
   if (props.active && filteredPayload.length >= 1) {
-    if (props.chartType) {
-      return <MultiValueTooltip {...props} payload={filteredPayload} />;
-    }
-    if (filteredPayload.length === 1 && !props.presentationOptions) {
+    if (props.payload.length === 1 && !props.presentationOptions) {
       return <SingleValueTooltip {...props} payload={filteredPayload} />;
     }
     return <MultiValueTooltip {...props} payload={filteredPayload} />;

--- a/packages/web-frontend/src/components/View/ChartWrapper/Tooltip.js
+++ b/packages/web-frontend/src/components/View/ChartWrapper/Tooltip.js
@@ -97,6 +97,9 @@ const SingleValueTooltip = ({ valueType, payload, periodGranularity, labelType }
 function Tooltip(props) {
   const filteredPayload = props.payload.filter(({ value }) => value !== undefined);
   if (props.active && filteredPayload.length >= 1) {
+    if (props.chartType) {
+      return <MultiValueTooltip {...props} payload={filteredPayload} />;
+    }
     if (filteredPayload.length === 1 && !props.presentationOptions) {
       return <SingleValueTooltip {...props} payload={filteredPayload} />;
     }


### PR DESCRIPTION
### Issue #:
[1660 - Values on hover wrong for UNFPA visuals Q2 2020 onwards](https://github.com/beyondessential/tupaia-backlog/issues/1660)
### Changes:
If dashboard is a chart, always performs `.MultiValueTooltip()`. `.SingleValueTooltip()` couldn't show single value in chart's tooltip properly.
