### PR TITLE
Override default join for GETSurveys to use left outer

### DIFF
--- a/packages/meditrak-server/src/routes/GETHandler/GETHandler.js
+++ b/packages/meditrak-server/src/routes/GETHandler/GETHandler.js
@@ -67,6 +67,7 @@ export class GETHandler extends CRUDHandler {
       columnNames,
       this.recordType,
       this.customJoinConditions,
+      this.defaultJoinType,
     );
 
     const { limit, page } = this.getPaginationParameters();

--- a/packages/meditrak-server/src/routes/GETHandler/helpers.js
+++ b/packages/meditrak-server/src/routes/GETHandler/helpers.js
@@ -83,7 +83,7 @@ export const getQueryOptionsForColumns = (
   columnNames,
   baseRecordType,
   customJoinConditions = {},
-  defaultJoinType = null,
+  joinType = null,
 ) => {
   if (columnNames.some(c => c.startsWith('_'))) {
     throw new ValidationError(
@@ -104,7 +104,7 @@ export const getQueryOptionsForColumns = (
           `${recordType}.id`,
           getForeignKeyColumnName(recordType),
         ];
-        multiJoin.push({ joinWith: recordType, joinCondition, joinType: defaultJoinType });
+        multiJoin.push({ joinWith: recordType, joinCondition, joinType });
         recordTypesInQuery.add(recordType);
       }
     });

--- a/packages/meditrak-server/src/routes/GETHandler/helpers.js
+++ b/packages/meditrak-server/src/routes/GETHandler/helpers.js
@@ -83,6 +83,7 @@ export const getQueryOptionsForColumns = (
   columnNames,
   baseRecordType,
   customJoinConditions = {},
+  defaultJoinType = null,
 ) => {
   if (columnNames.some(c => c.startsWith('_'))) {
     throw new ValidationError(
@@ -103,7 +104,7 @@ export const getQueryOptionsForColumns = (
           `${recordType}.id`,
           getForeignKeyColumnName(recordType),
         ];
-        multiJoin.push({ joinWith: recordType, joinCondition });
+        multiJoin.push({ joinWith: recordType, joinCondition, joinType: defaultJoinType });
         recordTypesInQuery.add(recordType);
       }
     });

--- a/packages/meditrak-server/src/routes/surveys/GETSurveys.js
+++ b/packages/meditrak-server/src/routes/surveys/GETSurveys.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
+import { JOIN_TYPES } from '@tupaia/database';
 import { GETHandler } from '../GETHandler';
 import {
   assertSurveyGetPermissions,
@@ -20,6 +21,8 @@ import { assertAnyPermissions, assertBESAdminAccess } from '../../permissions';
 
 export class GETSurveys extends GETHandler {
   permissionsFilteredInternally = true;
+
+  defaultJoinType = JOIN_TYPES.LEFT_OUTER;
 
   async findSingleRecord(surveyId, options) {
     const survey = await super.findSingleRecord(surveyId, options);


### PR DESCRIPTION
### Issue #: https://github.com/beyondessential/tupaia-backlog/issues/1130

### Changes:
- Add ability to define default joins for GETHandlers, override on GETSurveys to match behaviour on dev
