### PR TITLE
Add ValueAndPercentageByDataValueByFlightDate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ dump.sql
 /snapshots.js
 .idea
 dockercfg
+packages/.vscode/settings.json

--- a/packages/database/src/migrations/20210110220114-AddCovidSamoaDemoIndivQuarhealthCond-modifies-data.js
+++ b/packages/database/src/migrations/20210110220114-AddCovidSamoaDemoIndivQuarhealthCond-modifies-data.js
@@ -1,0 +1,83 @@
+'use strict';
+
+import {
+  generateId,
+  insertObject,
+  addReportToGroups,
+  deleteReport,
+  removeReportFromGroups,
+} from '../utilities';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+const dashboardReport = {
+  id: 'Samoa_Covid_Demo_Health_Cons_Per_Flight',
+  dataBuilder: 'valueAndPercentageByDataValueByFlightDate',
+  dataBuilderConfig: {
+    programCode: 'SC1QMIA',
+    rows: [
+      'Chronic lung disease',
+      'Diabetes mellitus',
+      'Cardiovascular disease',
+      'Chronic renal disease',
+      'Recent measles infection',
+      'Malignancy',
+      'Immunosuppressed',
+      'Current / recent smoker',
+      'Pregnant',
+      'Other',
+    ],
+    cells: [
+      // 'QMIA028', Flight
+      ['QMIA031'],
+      ['QMIA032'],
+      ['QMIA033'],
+      ['QMIA034'],
+      ['QMIA035'],
+      ['QMIA036'],
+      ['QMIA037'],
+      ['QMIA038'],
+      ['QMIA039'],
+      ['QMIA040'],
+    ],
+    entityAggregation: { dataSourceEntityType: 'case' },
+  },
+  viewJson: {
+    name: 'Demographics of individuals in quarantine: Health Conditions (COVID-19)',
+    type: 'matrix',
+    placeholder: '/static/media/PEHSMatrixPlaceholder.png',
+  },
+  dataServices: [],
+};
+
+exports.up = async function (db) {
+  await insertObject(db, 'dashboardReport', dashboardReport);
+
+  await addReportToGroups(db, dashboardReport.id, ['WS_Covid_Samoa_Country']);
+
+  return null;
+};
+
+exports.down = async function (db) {
+  await deleteReport(db, dashboardReport.id);
+
+  await removeReportFromGroups(db, dashboardReport.id, ['WS_Covid_Samoa_Country']);
+
+  return null;
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/packages/database/src/utilities/migration.js
+++ b/packages/database/src/utilities/migration.js
@@ -209,7 +209,7 @@ export function addReportToGroups(db, reportId, groupCodes) {
 }
 
 // Remove a dashboard report from a dashboard group
-function removeReportFromGroups(db, reportId, groupCodes) {
+export function removeReportFromGroups(db, reportId, groupCodes) {
   return db.runSql(`
     UPDATE
       "dashboardGroup"
@@ -221,7 +221,7 @@ function removeReportFromGroups(db, reportId, groupCodes) {
 }
 
 // Delete a report
-function deleteReport(db, reportId) {
+export function deleteReport(db, reportId) {
   return db.runSql(`
     DELETE FROM
       "dashboardReport"

--- a/packages/web-config-server/src/apiV1/dataBuilders/modules/covid-samoa/flight/flightAgeRanges.js
+++ b/packages/web-config-server/src/apiV1/dataBuilders/modules/covid-samoa/flight/flightAgeRanges.js
@@ -33,40 +33,29 @@ export const getTotalNumPassengers = (flight) => {
  * @param {Flight} flight
  * @returns {*}
  */
-export const getPassengersPerAgeRange = (flight) => {
-  const ageRangeData = {};
-
-  for (const ageRange of getAgeRanges()) {
-    const numPassengersInThisAgeRange = flight.events
-      .filter(event => event.dataValues[PASSENGER_AGE] >= ageRange.min && event.dataValues[PASSENGER_AGE] <= ageRange.max)
+export const getPassengersPerDataValue = (flight, dataValues, comparator = dataValue => event => event.dataValues[dataValue] && event.dataValues[dataValue] === 'Yes') => {
+  const dataValueCounts = {};
+  for (const dataValue of dataValues) {
+    const numPassengers = flight.events
+      .filter(comparator(dataValue))
       .length;
 
-    ageRangeData[ageRange.key] = {
-      numPassengersInThisAgeRange,
-      percentageOfTotalPassengers: numPassengersInThisAgeRange / getTotalNumPassengers(flight),
+      dataValueCounts[(dataValue.key || dataValue)] = {
+      numPassengers,
+      percentageOfTotalPassengers: numPassengers / getTotalNumPassengers(flight),
     };
   }
 
-  return ageRangeData;
+  return dataValueCounts;
 }
 
 /**
  * @param {Flight} flight
  * @returns {*}
  */
-export const getPassengersPerDataValue = (flight, dataValues) => {
-  const dataValueCounts = {};
-  for (const dataValue of dataValues) {
-    const numPassengersWithDataValue = flight.events
-      .filter(event => event.dataValues[dataValue] && event.dataValues[dataValue] === 'Yes')
-      .length;
-
-      dataValueCounts[dataValue] = {
-      numPassengersWithDataValue,
-      percentageOfTotalPassengers: numPassengersWithDataValue / getTotalNumPassengers(flight),
-    };
-  }
-
-  return dataValueCounts;
+export const getPassengersPerAgeRange = (flight) => {
+  const dataValues = getAgeRanges();
+  const comparator = ageRange => event =>  event.dataValues[PASSENGER_AGE] >= ageRange.min && event.dataValues[PASSENGER_AGE] <= ageRange.max;
+  return getPassengersPerDataValue(flight, dataValues, comparator);
 }
 

--- a/packages/web-config-server/src/apiV1/dataBuilders/modules/covid-samoa/flight/flightAgeRanges.js
+++ b/packages/web-config-server/src/apiV1/dataBuilders/modules/covid-samoa/flight/flightAgeRanges.js
@@ -50,3 +50,23 @@ export const getPassengersPerAgeRange = (flight) => {
   return ageRangeData;
 }
 
+/**
+ * @param {Flight} flight
+ * @returns {*}
+ */
+export const getPassengersPerDataValue = (flight, dataValues) => {
+  const dataValueCounts = {};
+  for (const dataValue of dataValues) {
+    const numPassengersWithDataValue = flight.events
+      .filter(event => event.dataValues[dataValue] && event.dataValues[dataValue] === 'Yes')
+      .length;
+
+      dataValueCounts[dataValue] = {
+      numPassengersWithDataValue,
+      percentageOfTotalPassengers: numPassengersWithDataValue / getTotalNumPassengers(flight),
+    };
+  }
+
+  return dataValueCounts;
+}
+

--- a/packages/web-config-server/src/apiV1/dataBuilders/modules/covid-samoa/index.js
+++ b/packages/web-config-server/src/apiV1/dataBuilders/modules/covid-samoa/index.js
@@ -1,1 +1,2 @@
 export { valueAndPercentageByAgeByFlightDate } from './valueAndPercentageByAgeByFlightDate';
+export { valueAndPercentageByDataValueByFlightDate } from './valueAndPercentageByDataValueByFlightDate';

--- a/packages/web-config-server/src/apiV1/dataBuilders/modules/covid-samoa/valueAndPercentageByAgeByFlightDate.js
+++ b/packages/web-config-server/src/apiV1/dataBuilders/modules/covid-samoa/valueAndPercentageByAgeByFlightDate.js
@@ -30,9 +30,9 @@ export class ValueAndPercentageByAgeByFlightDate extends ValueAndPercentageByDat
           const passengersForThisAgeRange = getPassengersPerAgeRange(flight)[ageRange.key];
 
           row[column.key] = {
-            value: passengersForThisAgeRange.numPassengersInThisAgeRange,
+            value: passengersForThisAgeRange.numPassengers,
             metadata: {
-              numerator: passengersForThisAgeRange.numPassengersInThisAgeRange,
+              numerator: passengersForThisAgeRange.numPassengers,
               denominator: getTotalNumPassengers(flight),
             }
           };

--- a/packages/web-config-server/src/apiV1/dataBuilders/modules/covid-samoa/valueAndPercentageByAgeByFlightDate.js
+++ b/packages/web-config-server/src/apiV1/dataBuilders/modules/covid-samoa/valueAndPercentageByAgeByFlightDate.js
@@ -2,8 +2,7 @@
  * Tupaia Config Server
  * Copyright (c) 2019 Beyond Essential Systems Pty Ltd
  */
-import moment from 'moment';
-import { DataBuilder } from '/apiV1/dataBuilders/DataBuilder';
+import { ValueAndPercentageByDataValueByFlightDate } from './valueAndPercentageByDataValueByFlightDate';
 import {
   Flight,
   FLIGHT_DATE,
@@ -13,39 +12,9 @@ import {
   getAgeRanges,
 } from './flight';
 
-class ValueAndPercentageByAgeByFlightDate extends DataBuilder {
-  async build() {
-    const dataElementCodes = [FLIGHT_DATE, PASSENGER_AGE];
+export class ValueAndPercentageByAgeByFlightDate extends ValueAndPercentageByDataValueByFlightDate {
 
-    const events = await this.fetchEvents({ useDeprecatedApi: false, dataElementCodes });
-
-    const flights = Flight.fromEvents(events);
-
-    const columns = this.getColumns(flights);
-
-    const rows = this.getRows(flights, columns);
-
-    return {
-      columns,
-      rows,
-    }
-  }
-
-  getColumns = (flights) => {
-    const columns = [];
-
-    flights.sort((a, b) => a.date < b.date ? -1 : 1);
-
-    for (const flight of flights) {
-      const formattedDate = moment(flight.date).format('MMM D') + ' Flight';
-      columns.push({
-        key: flight.key,
-        title: `Number (%): ${formattedDate}`,
-      });
-    }
-
-    return columns;
-  }
+  getDataElementCodes = () => [FLIGHT_DATE, PASSENGER_AGE]; 
 
   getRows = (flights, columns) => {
     const rows = getAgeRanges()
@@ -72,14 +41,7 @@ class ValueAndPercentageByAgeByFlightDate extends DataBuilder {
         return row;
       });
 
-    const totalsRow = {
-      dataElement: 'Total',
-    };
-    for (const column of columns) {
-      const flight = Flight.getFlightByKey(flights, column.key);
-      totalsRow[column.key] = getTotalNumPassengers(flight);
-    }
-    rows.push(totalsRow);
+      rows.push(this.getTotalsRow(flights, columns));
 
     return rows;
   }

--- a/packages/web-config-server/src/apiV1/dataBuilders/modules/covid-samoa/valueAndPercentageByDataValueByFlightDate.js
+++ b/packages/web-config-server/src/apiV1/dataBuilders/modules/covid-samoa/valueAndPercentageByDataValueByFlightDate.js
@@ -64,9 +64,9 @@ export class ValueAndPercentageByDataValueByFlightDate extends DataBuilder {
           const passengersForThisDataKey = getPassengersPerDataValue(flight, cells)[dataKey];
           
           row[column.key] = {
-            value:  passengersForThisDataKey.numPassengersWithDataValue,
+            value:  passengersForThisDataKey.numPassengers,
             metadata: {
-              numerator: passengersForThisDataKey.numPassengersWithDataValue,
+              numerator: passengersForThisDataKey.numPassengers,
               denominator: getTotalNumPassengers(flight),
             }
           };

--- a/packages/web-config-server/src/apiV1/dataBuilders/modules/covid-samoa/valueAndPercentageByDataValueByFlightDate.js
+++ b/packages/web-config-server/src/apiV1/dataBuilders/modules/covid-samoa/valueAndPercentageByDataValueByFlightDate.js
@@ -1,0 +1,107 @@
+/**
+ * Tupaia Config Server
+ * Copyright (c) 2019 Beyond Essential Systems Pty Ltd
+ */
+import moment from 'moment';
+import { DataBuilder } from '/apiV1/dataBuilders/DataBuilder';
+import {
+  Flight,
+  getTotalNumPassengers,
+  getPassengersPerDataValue,
+  FLIGHT_DATE,
+} from './flight';
+
+export class ValueAndPercentageByDataValueByFlightDate extends DataBuilder {
+  async build() {  
+    const dataElementCodes = this.getDataElementCodes();
+
+    const events = await this.fetchEvents({ useDeprecatedApi: false, dataElementCodes });
+
+    const flights = Flight.fromEvents(events);
+
+    const columns = this.getColumns(flights);
+
+    const rows = this.getRows(flights, columns);
+
+    return {
+      columns,
+      rows,
+    }
+  }
+
+  getDataElementCodes = () => {
+    const { cells } = this.config;  
+    return [FLIGHT_DATE, ...cells.flat(Infinity)];
+  }
+
+  getColumns = (flights) => {
+    const columns = [];
+
+    flights.sort((a, b) => a.date < b.date ? -1 : 1);
+
+    for (const flight of flights) {
+      const formattedDate = moment(flight.date).format('MMM D') + ' Flight';
+      columns.push({
+        key: flight.key,
+        title: `Number (%): ${formattedDate}`,
+      });
+    }
+
+    return columns;
+  }
+
+  getRows = (flights, columns) => {
+    const { rows: rowHeaders, cells } = this.config;
+    const rows = rowHeaders
+      .map((rowHeader, rowIndex) => {
+        const row = {
+          dataElement: `${rowHeader}`,
+          valueType: 'numberAndPercentage',
+        };
+        const dataKey = cells[rowIndex];
+        for (const column of columns) {
+          const flight = Flight.getFlightByKey(flights, column.key);
+          const passengersForThisDataKey = getPassengersPerDataValue(flight, cells)[dataKey];
+          
+          row[column.key] = {
+            value:  passengersForThisDataKey.numPassengersWithDataValue,
+            metadata: {
+              numerator: passengersForThisDataKey.numPassengersWithDataValue,
+              denominator: getTotalNumPassengers(flight),
+            }
+          };
+        }
+        
+        return row;
+      });
+
+    rows.push(this.getTotalsRow(flights, columns));
+
+    return rows;
+  }
+
+  getTotalsRow = (flights, columns) => {
+    const totalsRow = {
+      dataElement: 'Total',
+    };
+    for (const column of columns) {
+      const flight = Flight.getFlightByKey(flights, column.key);
+      totalsRow[column.key] = getTotalNumPassengers(flight);
+    }
+    return totalsRow;
+  }
+}
+
+export const valueAndPercentageByDataValueByFlightDate = async ({ models, dataBuilderConfig, query, entity }, aggregator, dhisApi) => {
+  const builder = new ValueAndPercentageByDataValueByFlightDate(
+    models,
+    aggregator,
+    dhisApi,
+    dataBuilderConfig,
+    query,
+    entity,
+    dataBuilderConfig.aggregationType,
+  );
+  return builder.build();
+}
+

--- a/packages/web-config-server/src/tests/apiV1/dataBuilders/modules/covid-samoa/flight/flightAgeRanges.test.js
+++ b/packages/web-config-server/src/tests/apiV1/dataBuilders/modules/covid-samoa/flight/flightAgeRanges.test.js
@@ -6,6 +6,7 @@
 import { expect } from 'chai';
 import {
   Flight,
+  getPassengersPerDataValue,
   getPassengersPerAgeRange,
   getTotalNumPassengers,
 } from '../../../../../../apiV1/dataBuilders/modules/covid-samoa/flight';
@@ -30,8 +31,8 @@ describe('flightAgeRanges', () => {
 
     const passengersPerAgeRange = getPassengersPerAgeRange(flight);
 
-    expect(passengersPerAgeRange['0_4'].numPassengersInThisAgeRange).to.equal(2);
-    expect(passengersPerAgeRange['40_44'].numPassengersInThisAgeRange).to.equal(1);
+    expect(passengersPerAgeRange['0_4'].numPassengers).to.equal(2);
+    expect(passengersPerAgeRange['40_44'].numPassengers).to.equal(1);
   });
 
   it('skips events that do not have an age, or are outside of the age brackets', () => {
@@ -53,6 +54,32 @@ describe('flightAgeRanges', () => {
 
     const passengersPerAgeRange = getPassengersPerAgeRange(flight);
 
-    expect(passengersPerAgeRange['0_4'].numPassengersInThisAgeRange).to.equal(1);
+    expect(passengersPerAgeRange['0_4'].numPassengers).to.equal(1);
+  });
+
+  it('can count passengers per data_value', () => {
+    const flight = new Flight();
+
+    flight.events = [
+      {
+        dataValues: { QMIA031: 'Yes' },
+      },
+      {
+        dataValues: { QMIA031: 'Yes' },
+      },
+      {
+        dataValues: { QMIA031: 'No', QMIA032: 'Yes' },
+      },
+    ];
+
+    const dataValues = ['QMIA031', 'QMIA032', 'QMIA033'];
+
+    expect(getTotalNumPassengers(flight)).to.equal(3);
+
+    const passengersPerAgeRange = getPassengersPerDataValue(flight, dataValues);
+
+    expect(passengersPerAgeRange['QMIA031'].numPassengers).to.equal(2);
+    expect(passengersPerAgeRange['QMIA032'].numPassengers).to.equal(1);
+    expect(passengersPerAgeRange['QMIA033'].numPassengers).to.equal(0);
   });
 });


### PR DESCRIPTION
### Issue: [#1441 - Covid Samoa Demographics of individuals in quarantine: Health Conditions](https://github.com/beyondessential/tupaia-backlog/issues/1441)

### Changes:
- Generalise databuilder `ValueAndPercentageByAgeByFlightDate` as `ValueAndPercentageByDataValueByFlightDate` and extend the latter class by the former. 
- Create migration to add Covid Samoa Demographics of individuals in quarantine: Health Conditions report
- export migration delete utilities
- add getPassengersPerDataValue test