### PR TITLE
If image already on S3, log error rather than blocking sync

### DIFF
--- a/packages/meditrak-server/src/dataAccessors/addSurveyImage.js
+++ b/packages/meditrak-server/src/dataAccessors/addSurveyImage.js
@@ -1,11 +1,16 @@
 /**
- * Tupaia MediTrak
- * Copyright (c) 2018 Beyond Essential Systems Pty Ltd
- * This uploads a surveyImage to s3
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
  */
+
+import winston from 'winston';
 import { uploadImage } from '../s3';
 
+// Upload a surveyImage to s3
 export const addSurveyImage = async (models, { id, data }) => {
-  const upload = await uploadImage(data, id);
-  return upload;
+  try {
+    await uploadImage(data, id);
+  } catch (error) {
+    winston.error(error.message);
+  }
 };


### PR DESCRIPTION
### Issue #: https://github.com/beyondessential/tupaia-backlog/issues/2094
