### PR TITLE
Permissions exports respect bes

### DIFF
--- a/packages/meditrak-server/src/routes/exportSurveyResponses/exportSurveyResponses.js
+++ b/packages/meditrak-server/src/routes/exportSurveyResponses/exportSurveyResponses.js
@@ -10,7 +10,7 @@ import { truncateString } from 'sussol-utilities';
 import { DatabaseError, addExportedDateAndOriginAtTheSheetBottom } from '@tupaia/utils';
 import { ANSWER_TYPES, NON_DATA_ELEMENT_ANSWER_TYPES } from '../../database/models/Answer';
 import { findAnswersInSurveyResponse, findQuestionsInSurvey } from '../../dataAccessors';
-import { allowNoPermissions } from '../../permissions';
+import { allowNoPermissions, hasBESAdminAccess } from '../../permissions';
 import { SurveyResponseVariablesExtractor } from '../utilities';
 
 const FILE_LOCATION = 'exports';
@@ -107,7 +107,8 @@ export async function exportSurveyResponses(req, res) {
     for (let surveyIndex = 0; surveyIndex < surveys.length; surveyIndex++) {
       const currentSurvey = surveys[surveyIndex];
       const permissionGroup = await currentSurvey.getPermissionGroup();
-      const hasSurveyAccess = accessPolicy.allows(country.code, permissionGroup.name);
+      const hasSurveyAccess =
+        hasBESAdminAccess(accessPolicy) || accessPolicy.allows(country.code, permissionGroup.name);
       if (!hasSurveyAccess) {
         const exportData = [[`You do not have export access to ${currentSurvey.name}`]];
         addDataToSheet(currentSurvey.name, exportData);

--- a/packages/meditrak-server/src/routes/exportSurveys/SurveyExporter.js
+++ b/packages/meditrak-server/src/routes/exportSurveys/SurveyExporter.js
@@ -10,6 +10,7 @@ import { findQuestionsInSurvey } from '../../dataAccessors';
 import { RowBuilder } from './RowBuilder';
 import { SurveyMetadataConfigCellBuilder } from './cellBuilders';
 import { assertCanExportSurveys } from './assertCanExportSurveys';
+import { assertAnyPermissions, assertBESAdminAccess } from '../../permissions';
 
 const FILE_TITLE = 'exports/survey_export';
 
@@ -31,7 +32,9 @@ export class SurveyExporter {
     try {
       const exportSurveysChecker = async accessPolicy =>
         assertCanExportSurveys(accessPolicy, this.models, surveys);
-      await this.assertPermissions(exportSurveysChecker);
+      await this.assertPermissions(
+        assertAnyPermissions([assertBESAdminAccess, exportSurveysChecker]),
+      );
     } catch (error) {
       permissionsError = error.message;
     }
@@ -54,7 +57,7 @@ export class SurveyExporter {
 
       const permissionsError = await this.checkPermissionsError(surveys);
 
-      //If there is permission error, export an empty excel sheet with the error message
+      // If there is permission error, export an empty excel sheet with the error message
       if (permissionsError) {
         const sheetName = 'Error';
         workbook.SheetNames.push(sheetName);

--- a/packages/meditrak-server/src/tests/routes/exportSurveys/exportSurveys.test.js
+++ b/packages/meditrak-server/src/tests/routes/exportSurveys/exportSurveys.test.js
@@ -100,7 +100,7 @@ describe('exportSurveys(): GET export/surveys, GET export/surveys/:surveyId', ()
       //json_to_sheet is called when putting exportData into excel sheet
       expect(xlsx.utils.aoa_to_sheet).to.have.been.calledOnceWithExactly([
         [
-          `Need ${adminPermissionGroup.name} access to ${vanuatuCountry.name} to export the survey ${survey1.name}`,
+          `One of the following conditions need to be satisfied:\nNeed BES Admin access\nNeed ${adminPermissionGroup.name} access to ${vanuatuCountry.name} to export the survey ${survey1.name}\n`,
         ],
       ]);
     });


### PR DESCRIPTION
### Issue #: https://github.com/beyondessential/tupaia-backlog/issues/999
https://github.com/beyondessential/tupaia-backlog/issues/998

### Changes:

- Allow BES admin permissions to override export permissions checks
- Fixup unit tests to expect the admin the new error message