### PR TITLE
Add Covid Samoa Quarantine site by flight report (#1891)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ dump.sql
 .idea
 dockercfg
 packages/.vscode/settings.json
+**/testRequests/*.http

--- a/packages/database/src/migrations/20201117224102-DeleteUNFPAStaffTrainedLines-modifies-data.js
+++ b/packages/database/src/migrations/20201117224102-DeleteUNFPAStaffTrainedLines-modifies-data.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const { arrayToDbString } = require('../utilities/migration');
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+const DASHBOARD_GROUP_CODES = ['UNFPA_Project'];
+
+const REPORT_IDS = [
+  'UNFPA_Region_Facilities_Offering_Services_At_Least_1_Family_Planning',
+  'UNFPA_Region_Facilities_Offering_Services_At_Least_1_Delivery',
+  'UNFPA_Region_Facilities_Offering_Services_At_Least_1_Delivery_SGBV',
+];
+
+const deleteReport = async (db, reportId) => {
+  await db.runSql(`
+    DELETE FROM "dashboardReport" WHERE id = '${reportId}';
+    UPDATE
+      "dashboardGroup"
+    SET
+      "dashboardReports" = array_remove("dashboardReports", '${reportId}')
+    WHERE
+      "code" in (${arrayToDbString(DASHBOARD_GROUP_CODES)});
+  `);
+};
+
+exports.up = async function (db) {
+  for (let i = 0; i < REPORT_IDS.length; i++) {
+    await deleteReport(db, REPORT_IDS[i]);
+  }
+};
+
+exports.down = function (db) {};
+
+exports._meta = {
+  version: 1,
+};

--- a/packages/database/src/migrations/20201117224832-AddUNFPAStaffTrainedMatrix-modifies-data.js
+++ b/packages/database/src/migrations/20201117224832-AddUNFPAStaffTrainedMatrix-modifies-data.js
@@ -1,0 +1,146 @@
+'use strict';
+
+import { insertObject, arrayToDbString } from '../utilities/migration';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+const dataElementToName = {
+  RHS4UNFPA809: 'Family Planning',
+  RHS3UNFPA5410: 'Delivery',
+  RHS2UNFPA292: 'SGBV Services',
+  $dataDate: 'Data Collection Date',
+};
+
+const countryCodeToName = {
+  FJ: 'Fiji',
+  FM: 'FSM',
+  KI: 'Kiribati',
+  MH: 'Marshall Islands',
+  WS: 'Samoa',
+  SB: 'Solomon Islands',
+  TO: 'Tonga',
+  VU: 'Vanuatu',
+};
+
+const countryCodeToDate = {
+  FJ: 'Q3 2019',
+  FM: 'Q4 2018',
+  KI: 'Q3 2019',
+  MH: 'Q4 2018',
+  WS: 'Q4 2018',
+  SB: 'N/A',
+  TO: 'Q3 2019',
+  VU: 'N/A',
+};
+
+const DASHBOARD_GROUP_CODES = ['UNFPA_Project'];
+
+const REPORT_ID = 'UNFPA_Region_Facilities_offering_services_At_Least_1_Matrix';
+
+const buildDataDateCell = (countryCode, key) => {
+  return {
+    key,
+    operator: 'STATIC',
+    value: countryCodeToDate[countryCode],
+    noDataValue: 'N/A',
+    dataElement: 'RHS1UNFPA03',
+    filter: {
+      organisationUnit: countryCode,
+    },
+  };
+};
+
+const buildCell = (dataElement, countryCode) => {
+  const key = `${countryCodeToName[countryCode]}_${dataElementToName[dataElement].replace(
+    / /g,
+    '_',
+  )}`;
+
+  if (dataElement === '$dataDate') return buildDataDateCell(countryCode, key);
+
+  return {
+    key,
+    operator: 'FRACTION_AND_PERCENTAGE',
+    operands: [
+      {
+        aggregationType: 'COUNT',
+        dataValues: [dataElement],
+        aggregationConfig: {
+          countCondition: { operator: '>', value: 0 },
+        },
+      },
+      { aggregationType: 'COUNT', dataValues: ['RHS1UNFPA03'] },
+    ],
+    filter: {
+      organisationUnit: countryCode,
+    },
+  };
+};
+
+const DATA_BUILDER_CONFIG = {
+  rows: Object.values(dataElementToName),
+  cells: Object.keys(dataElementToName).map(dataElement =>
+    Object.keys(countryCodeToName).map(countryCode => buildCell(dataElement, countryCode)),
+  ),
+  columns: Object.values(countryCodeToName),
+  entityAggregation: {
+    aggregationType: 'REPLACE_ORG_UNIT_WITH_ORG_GROUP',
+    dataSourceEntityType: 'facility',
+    aggregationEntityType: 'country',
+  },
+};
+
+const VIEW_JSON = {
+  name: '% of facilities with at least 1 staff member trained in SRH service provision',
+  type: 'matrix',
+  placeholder: '/static/media/PEHSMatrixPlaceholder.png',
+};
+
+const REPORT = {
+  id: REPORT_ID,
+  dataBuilder: 'tableOfCalculatedValues',
+  dataBuilderConfig: DATA_BUILDER_CONFIG,
+  viewJson: VIEW_JSON,
+};
+
+exports.up = async function (db) {
+  await insertObject(db, 'dashboardReport', REPORT);
+
+  return db.runSql(`
+    UPDATE
+      "dashboardGroup"
+    SET
+      "dashboardReports" = "dashboardReports" || '{ ${REPORT.id} }'
+    WHERE
+      "code" IN (${arrayToDbString(DASHBOARD_GROUP_CODES)});
+  `);
+};
+
+exports.down = function (db) {
+  return db.runSql(`
+    DELETE FROM "dashboardReport" WHERE id = '${REPORT.id}';
+
+    UPDATE
+      "dashboardGroup"
+    SET
+      "dashboardReports" = array_remove("dashboardReports", '${REPORT.id}')
+    WHERE
+    "code" IN (${arrayToDbString(DASHBOARD_GROUP_CODES)});
+  `);
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/packages/database/src/migrations/20201123014943-IntegrateInconsistentAnswersForHotelNames-modifies-data.js
+++ b/packages/database/src/migrations/20201123014943-IntegrateInconsistentAnswersForHotelNames-modifies-data.js
@@ -1,0 +1,89 @@
+'use strict';
+
+import { updateValues } from '../utilities';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+const convertData = [
+  { incorrectNames: ['9'], correctName: 'HQ - Matautu Uta' },
+  { incorrectNames: ['Dave Eco Lodge', 'Dave Parker Eco Lodge'], correctName: "Dave's Eco Lodge" },
+  {
+    incorrectNames: ['Home - Lotopa mamoga 2', 'Home - Lotopa mamoga 3'],
+    correctName: 'Home - Lotopa mamoga',
+  },
+  { incorrectNames: ['home - avele'], correctName: 'Home - Avele' },
+  { incorrectNames: ['Home - Ululoloa'], correctName: 'Home - Ululoloa Riverside' },
+  { incorrectNames: ['Home - Vailima'], correctName: 'Home - Vailima Australian High Commission' },
+  { incorrectNames: ['Home - Vaivase'], correctName: 'Home - Vaivase uta' },
+  { incorrectNames: ['Insel'], correctName: 'Insel Hotel' },
+  { incorrectNames: ['Karls Getaway'], correctName: "Karl's Getaway" },
+  {
+    incorrectNames: ['lynns getaway', 'Lynns Getaway'],
+    correctName: "Lynn's Getaway",
+  },
+  { incorrectNames: ['Pasifika Inn'], correctName: 'Pasefika Inn' },
+  { incorrectNames: ['Samoa Tradition'], correctName: 'Samoa Traditional Resort' },
+  { incorrectNames: ['sheraton'], correctName: 'Sheraton' },
+  { incorrectNames: ['Shrine of the Three Hearts'], correctName: 'Shrine of Three Hearts' },
+  { incorrectNames: ['Talanoa Fale'], correctName: 'Talanoa Fales' },
+  { incorrectNames: ['Travellers Point'], correctName: "Traveller's Point" },
+  { incorrectNames: ['Vaea'], correctName: 'Vaea Hotel' },
+  { incorrectNames: ['vaiala beach fales'], correctName: 'Vaiala Beach Fales' },
+  { incorrectNames: ['Vaiala Beach Fale'], correctName: 'Vaiala Beach Fales' },
+  { incorrectNames: ['Vaivase Accomadation'], correctName: 'Vaivase Accommodation' },
+];
+
+function checkHotelName(answer) {
+  for (const { incorrectNames, correctName } of convertData) {
+    if (incorrectNames.includes(answer.text)) return { id: answer.id, text: correctName };
+  }
+  return null;
+}
+
+const surveyId = '5f62bcbe61f76a2603093a3f'; // SC1QMIA
+
+exports.up = async function (db) {
+  // trim all site names
+  await db.runSql(`
+    update answer 
+    set "text" = TRIM(text) 
+    where id in (
+      select a.id from answer a 
+      join question q on a.question_id = q.id 
+      join survey_response sr on sr.id = a.survey_response_id and sr.survey_id = '${surveyId}'
+      where q.text = 'Quarantine Site');
+  `);
+
+  const { rows: answers } = await db.runSql(`
+    select a.id, a."text" from answer a 
+    join question q on a.question_id = q.id
+    join survey_response sr on sr.id = a.survey_response_id 
+        and sr.survey_id = '${surveyId}' 
+    where q.text = 'Quarantine Site'
+  `);
+  const trimAnswers = answers.map(a => ({ ...a, text: a.text.trim() }));
+  for (const answer of trimAnswers) {
+    const newAnswer = checkHotelName(answer);
+    if (newAnswer) await updateValues(db, 'answer', { text: newAnswer.text }, { id: newAnswer.id });
+  }
+};
+
+exports.down = function (db) {
+  return null;
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/packages/database/src/migrations/20201204224102-DeleteUNFPAStaffTrainedLinesCountry-modifies-data.js
+++ b/packages/database/src/migrations/20201204224102-DeleteUNFPAStaffTrainedLinesCountry-modifies-data.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const { arrayToDbString } = require('../utilities/migration');
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+const DASHBOARD_GROUP_CODES = ['UNFPA_Project'];
+
+const REPORT_IDS = ['UNFPA_Percentage_Of_Facilities_At_Least_1_Staff_Trained_SRH_Services'];
+
+const deleteReport = async (db, reportId) => {
+  await db.runSql(`
+    DELETE FROM "dashboardReport" WHERE id = '${reportId}';
+    UPDATE
+      "dashboardGroup"
+    SET
+      "dashboardReports" = array_remove("dashboardReports", '${reportId}')
+    WHERE
+      "code" in (${arrayToDbString(DASHBOARD_GROUP_CODES)});
+  `);
+};
+
+exports.up = async function (db) {
+  for (let i = 0; i < REPORT_IDS.length; i++) {
+    await deleteReport(db, REPORT_IDS[i]);
+  }
+};
+
+exports.down = function (db) {};
+
+exports._meta = {
+  version: 1,
+};

--- a/packages/database/src/migrations/20201204224832-AddUNFPAStaffTrainedMatrixCountry-modifies-data.js
+++ b/packages/database/src/migrations/20201204224832-AddUNFPAStaffTrainedMatrixCountry-modifies-data.js
@@ -1,0 +1,158 @@
+'use strict';
+
+import { insertObject, arrayToDbString } from '../utilities/migration';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+const dataElementToName = {
+  RHS4UNFPA809: 'Family Planning',
+  RHS3UNFPA5410: 'Delivery',
+  RHS2UNFPA292: 'SGBV Services',
+  $dataDate: 'Data Collection Date',
+};
+
+const countryCodeToName = {
+  FJ: 'Fiji',
+  FM: 'FSM',
+  KI: 'Kiribati',
+  MH: 'Marshall Islands',
+  WS: 'Samoa',
+  SB: 'Solomon Islands',
+  TO: 'Tonga',
+  VU: 'Vanuatu',
+};
+
+const countryCodeToDate = {
+  FJ: 'Q3 2019',
+  FM: 'Q4 2018',
+  KI: 'Q3 2019',
+  MH: 'Q4 2018',
+  WS: 'Q4 2018',
+  SB: 'N/A',
+  TO: 'Q3 2019',
+  VU: 'N/A',
+};
+
+const BASE_REPORT_ID = 'UNFPA_Country_Facilities_offering_services_At_Least_1_Matrix';
+
+const buildDataDateCell = (countryCode, key) => {
+  return {
+    key,
+    operator: 'STATIC',
+    value: countryCodeToDate[countryCode],
+    noDataValue: 'N/A',
+    dataElement: 'RHS1UNFPA03',
+    filter: {
+      organisationUnit: countryCode,
+    },
+  };
+};
+
+const buildCell = (dataElement, countryCode) => {
+  const key = `${countryCodeToName[countryCode]}_${dataElementToName[dataElement].replace(
+    / /g,
+    '_',
+  )}`;
+  if (dataElement === '$dataDate') return buildDataDateCell(countryCode, key);
+
+  return {
+    key,
+    operator: 'FRACTION_AND_PERCENTAGE',
+    operands: [
+      {
+        aggregationType: 'COUNT',
+        dataValues: [dataElement],
+        aggregationConfig: {
+          countCondition: { operator: '>', value: 0 },
+        },
+      },
+      { aggregationType: 'COUNT', dataValues: ['RHS1UNFPA03'] },
+    ],
+    filter: {
+      organisationUnit: countryCode,
+    },
+  };
+};
+
+const buildDataBuilderConfig = countryCode => ({
+  rows: Object.values(dataElementToName),
+  cells: Object.keys(dataElementToName).map(dataElement => [buildCell(dataElement, countryCode)]),
+  columns: [countryCode],
+  entityAggregation: {
+    aggregationType: 'REPLACE_ORG_UNIT_WITH_ORG_GROUP',
+    dataSourceEntityType: 'facility',
+    aggregationEntityType: 'country',
+  },
+});
+
+const VIEW_JSON = {
+  name: '% of facilities with at least 1 staff member trained in SRH service provision',
+  type: 'matrix',
+  placeholder: '/static/media/PEHSMatrixPlaceholder.png',
+};
+
+const buildReport = countryCode => ({
+  id: `${BASE_REPORT_ID}_${countryCode}`,
+  dataBuilder: 'tableOfCalculatedValues',
+  dataBuilderConfig: buildDataBuilderConfig(countryCode),
+  viewJson: VIEW_JSON,
+});
+
+const addReport = async (db, countryCode) => {
+  const DASHBOARD_GROUP_CODES = [`${countryCode}_Unfpa_Country`];
+  const report = buildReport(countryCode);
+
+  await insertObject(db, 'dashboardReport', report);
+  return db.runSql(`
+     UPDATE
+      "dashboardGroup"
+    SET
+       "dashboardReports" = "dashboardReports" || '{ ${report.id} }'
+    WHERE
+      "code" IN (${arrayToDbString(DASHBOARD_GROUP_CODES)});
+  `);
+};
+
+const deleteReport = async (db, countryCode) => {
+  const DASHBOARD_GROUP_CODES = [`${countryCode}_Unfpa_Country`];
+  const reportId = `${BASE_REPORT_ID}_${countryCode}`;
+
+  return db.runSql(`
+    DELETE FROM "dashboardReport" WHERE id = '${reportId}';
+
+    UPDATE
+      "dashboardGroup"
+    SET
+      "dashboardReports" = array_remove("dashboardReports", '${reportId}')
+    WHERE
+    "code" IN (${arrayToDbString(DASHBOARD_GROUP_CODES)});
+  `);
+};
+
+exports.up = async function (db) {
+  for (const countryCode of Object.keys(countryCodeToName)) {
+    await addReport(db, countryCode);
+  }
+};
+
+exports.down = async function (db) {
+  for (const countryCode of Object.keys(countryCodeToName)) {
+    await deleteReport(db, countryCode);
+  }
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/packages/database/src/migrations/20210114131303-AddCovidSamoaQuarantineSiteByFlight-modifies-data.js
+++ b/packages/database/src/migrations/20210114131303-AddCovidSamoaQuarantineSiteByFlight-modifies-data.js
@@ -1,0 +1,59 @@
+'use strict';
+
+import {
+  insertObject,
+  addReportToGroups,
+  deleteReport,
+  removeReportFromGroups,
+} from '../utilities';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+const dashboardReport = {
+  id: 'Samoa_Covid_Quarantine_Site_By_Flight',
+  dataBuilder: 'valueAndPercentageByDataValueByFlightDate',
+  dataBuilderConfig: {
+    programCode: 'SC1QMIA',
+    rows: '$allValues',
+    cells: [['QMIA002']],
+    entityAggregation: { dataSourceEntityType: 'case' },
+  },
+  viewJson: {
+    name: 'Quarantine sites by flight (COVID-19)',
+    type: 'matrix',
+    placeholder: '/static/media/PEHSMatrixPlaceholder.png',
+  },
+  dataServices: [],
+};
+
+exports.up = async function (db) {
+  await insertObject(db, 'dashboardReport', dashboardReport);
+
+  await addReportToGroups(db, dashboardReport.id, ['WS_Covid_Samoa_Country']);
+
+  return null;
+};
+
+exports.down = async function (db) {
+  await deleteReport(db, dashboardReport.id);
+
+  await removeReportFromGroups(db, dashboardReport.id, ['WS_Covid_Samoa_Country']);
+
+  return null;
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/packages/devops/scripts/deployment/startup.sh
+++ b/packages/devops/scripts/deployment/startup.sh
@@ -11,6 +11,13 @@ DIR=$(dirname "$0")
 export STAGE=$(${DIR}/../utility/getEC2TagValue.sh Stage)
 echo "Starting up instance for ${STAGE}"
 
+# Turn off cloudwatch agent for all except prod and dev (can be turned on manually if needed on feature instances)
+if [[ $STAGE != "production" && $STAGE != "dev" ]]; then
+    echo "Turning off cloudwatch agent for feature instance."
+    echo "To restart, run sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -m ec2 -a start"
+    sudo amazon-cloudwatch-agent-ctl -m ec2 -a stop
+fi
+
 # Set the branch based on STAGE
 if [[ $STAGE == "production" ]]; then
     export BRANCH="master"

--- a/packages/expression-parser/src/expression-parser/ExpressionParser.js
+++ b/packages/expression-parser/src/expression-parser/ExpressionParser.js
@@ -28,6 +28,7 @@ export class ExpressionParser {
     this.parser = this.math.parser();
     this.customFunctions = this.getCustomFunctions();
     this.math.import(this.customFunctions);
+    this.validExpressionCache = new Set();
   }
 
   /**
@@ -48,6 +49,10 @@ export class ExpressionParser {
    * @param {*} expression
    */
   validate(expression) {
+    if (this.validExpressionCache.has(expression)) {
+      return;
+    }
+
     const nodeTree = this.math.parse(expression);
     nodeTree.traverse(node => {
       if (node.isOperatorNode && node.op === '*' && node.implicit) {
@@ -56,6 +61,7 @@ export class ExpressionParser {
         );
       }
     });
+    this.validExpressionCache.add(expression);
   }
 
   /**

--- a/packages/meditrak-app/ios/TupaiaMediTrak/Info.plist
+++ b/packages/meditrak-app/ios/TupaiaMediTrak/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.9.109</string>
+	<string>1.9.110</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>109</string>
+	<string>110</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/packages/meditrak-app/package.json
+++ b/packages/meditrak-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/meditrak-app",
-  "version": "1.9.109",
+  "version": "1.9.110",
   "private": true,
   "description": "Android and iOS app for surveying medical facilities",
   "repository": {

--- a/packages/psss/src/components/EditableTable.js
+++ b/packages/psss/src/components/EditableTable.js
@@ -6,7 +6,7 @@ import React, { createContext, useContext } from 'react';
 import { useFormContext } from 'react-hook-form';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { TextField } from '@tupaia/ui-components';
+import { Tooltip, TextField } from '@tupaia/ui-components';
 import { TABLE_STATUSES } from '../constants';
 
 const EditableTextField = styled(TextField)`
@@ -42,6 +42,16 @@ const ReadOnlyTextField = styled(EditableTextField)`
   }
 `;
 
+const ErrorTooltip = styled(Tooltip)`
+  & .MuiTooltip-tooltip {
+    background: ${props => props.theme.palette.error.main};
+
+    .MuiTooltip-arrow {
+      color: ${props => props.theme.palette.error.main};
+    }
+  }
+`;
+
 export const EditableTableContext = createContext({});
 
 export const EditableCell = React.memo(({ id, columnKey, ...props }) => {
@@ -52,16 +62,22 @@ export const EditableCell = React.memo(({ id, columnKey, ...props }) => {
 
   if (editable) {
     return (
-      <EditableTextField
-        id={id}
-        name={id}
-        defaultValue={defaultValue}
-        inputProps={{ 'aria-label': columnKey }}
-        error={!!errors[id]}
-        inputRef={register({
-          required: 'Required',
-        })}
-      />
+      <ErrorTooltip title={errors[id] ? errors[id].message : ''} placement="left" open>
+        <EditableTextField
+          id={id}
+          name={id}
+          defaultValue={defaultValue}
+          inputProps={{ 'aria-label': columnKey }}
+          error={!!errors[id]}
+          inputRef={register({
+            required: 'Required',
+            pattern: {
+              value: /^\d+$/,
+              message: 'Invalid character',
+            },
+          })}
+        />
+      </ErrorTooltip>
     );
   }
 

--- a/packages/psss/src/containers/Panels/WeeklyReportsPanel.js
+++ b/packages/psss/src/containers/Panels/WeeklyReportsPanel.js
@@ -119,6 +119,7 @@ export const WeeklyReportsPanelComponent = React.memo(
       syndromes: countrySyndromesData,
       reportStatus,
       unVerifiedAlerts,
+      error: countryWeekError,
     } = useSingleWeeklyReport(countryCode, activeWeek, verifiedStatuses, pageQueryKey);
 
     const [confirmReport, { isLoading: isConfirming, reset, error }] = useConfirmWeeklyReport(
@@ -173,6 +174,7 @@ export const WeeklyReportsPanelComponent = React.memo(
           >
             <CountryReportTable
               data={countrySyndromesData}
+              fetchError={countryWeekError && countryWeekError.message}
               isFetching={isLoading || isFetching}
               sitesReported={countryWeekData['Sites Reported']}
               totalSites={countryWeekData.Sites}

--- a/packages/psss/src/containers/Tables/CountryReportTable.js
+++ b/packages/psss/src/containers/Tables/CountryReportTable.js
@@ -129,7 +129,7 @@ const ErrorTooltip = styled(Tooltip)`
 `;
 
 export const CountryReportTable = React.memo(
-  ({ isFetching, data, sitesReported, totalSites, weekNumber }) => {
+  ({ isFetching, data, fetchError, sitesReported, totalSites, weekNumber }) => {
     const { tableStatus, setTableStatus } = useContext(EditableTableContext);
     const { countryCode } = useParams();
 
@@ -168,6 +168,7 @@ export const CountryReportTable = React.memo(
       <LoadingContainer
         isLoading={isFetching || tableStatus === TABLE_STATUSES.SAVING}
         heading={isFetching ? 'Loading data' : 'Saving Data'}
+        errorMessage={fetchError}
       >
         <FormProvider {...methods}>
           <form onSubmit={handleSubmit(onSubmit)}>
@@ -260,6 +261,7 @@ export const CountryReportTable = React.memo(
 CountryReportTable.propTypes = {
   isFetching: PropTypes.bool,
   data: PropTypes.array.isRequired,
+  fetchError: PropTypes.string,
   sitesReported: PropTypes.number.isRequired,
   weekNumber: PropTypes.string.isRequired,
   totalSites: PropTypes.number.isRequired,
@@ -267,4 +269,5 @@ CountryReportTable.propTypes = {
 
 CountryReportTable.defaultProps = {
   isFetching: false,
+  fetchError: null,
 };

--- a/packages/psss/src/containers/Tables/CountryReportTable.js
+++ b/packages/psss/src/containers/Tables/CountryReportTable.js
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import { useForm, FormProvider } from 'react-hook-form';
 import { useParams } from 'react-router-dom';
 import Typography from '@material-ui/core/Typography';
-import MuiLink from '@material-ui/core/Link';
+import { Tooltip } from '@tupaia/ui-components';
 import styled from 'styled-components';
 import {
   LoadingContainer,
@@ -118,6 +118,16 @@ const columns = [
   },
 ];
 
+const ErrorTooltip = styled(Tooltip)`
+  & .MuiTooltip-tooltip {
+    background: ${props => props.theme.palette.error.main};
+
+    .MuiTooltip-arrow {
+      color: ${props => props.theme.palette.error.main};
+    }
+  }
+`;
+
 export const CountryReportTable = React.memo(
   ({ isFetching, data, sitesReported, totalSites, weekNumber }) => {
     const { tableStatus, setTableStatus } = useContext(EditableTableContext);
@@ -165,23 +175,43 @@ export const CountryReportTable = React.memo(
               {tableStatus === TABLE_STATUSES.EDITABLE ? (
                 <FormRow>
                   <ReportedSites variant="h6">Reported Sites:</ReportedSites>
-                  <StyledTextField
-                    defaultValue={sitesReported}
-                    error={!!methods.errors.sitesReported}
-                    name="sitesReported"
-                    inputRef={methods.register({
-                      required: 'Required',
-                    })}
-                  />
+                  <ErrorTooltip
+                    title={methods.errors.sitesReported ? methods.errors.sitesReported.message : ''}
+                    placement="left"
+                    open
+                  >
+                    <StyledTextField
+                      defaultValue={sitesReported}
+                      error={!!methods.errors.sitesReported}
+                      name="sitesReported"
+                      inputRef={methods.register({
+                        required: 'Required',
+                        pattern: {
+                          value: /^\d+$/,
+                          message: 'Invalid character',
+                        },
+                      })}
+                    />
+                  </ErrorTooltip>
                   <ReportedSites variant="h5"> / Total Sites: </ReportedSites>
-                  <StyledTextField
-                    defaultValue={totalSites}
-                    error={!!methods.errors.totalSites}
-                    name="totalSites"
-                    inputRef={methods.register({
-                      required: 'Required',
-                    })}
-                  />
+                  <ErrorTooltip
+                    title={methods.errors.totalSites ? methods.errors.totalSites.message : ''}
+                    placement="left"
+                    open
+                  >
+                    <StyledTextField
+                      defaultValue={totalSites}
+                      error={!!methods.errors.totalSites}
+                      name="totalSites"
+                      inputRef={methods.register({
+                        required: 'Required',
+                        pattern: {
+                          value: /^\d+$/,
+                          message: 'Invalid character',
+                        },
+                      })}
+                    />
+                  </ErrorTooltip>
                 </FormRow>
               ) : (
                 <Typography variant="h5">

--- a/packages/report-server/src/reportBuilder/transform/aliases/keyValueByFieldAliases.ts
+++ b/packages/report-server/src/reportBuilder/transform/aliases/keyValueByFieldAliases.ts
@@ -3,31 +3,37 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
-import { buildTransform } from '..';
+import { Row } from '../../types';
 
-export const keyValueByDataElementName = () =>
-  buildTransform([
-    {
-      transform: 'select',
-      '$row.dataElement': '$row.value',
-      '...': ['period', 'organisationUnit'],
-    },
-  ]);
+/**
+ * { period: '20200101', organisationUnit: 'TO', dataElement: 'CH01', value: 7 }
+ *  => { period: '20200101', organisationUnit: 'TO', CH01: 7 }
+ */
+export const keyValueByDataElementName = () => (rows: Row[]) => {
+  return rows.map(row => {
+    const { dataElement, value, ...restOfRow } = row;
+    return { [dataElement as string]: value, ...restOfRow };
+  });
+};
 
-export const keyValueByOrgUnit = () =>
-  buildTransform([
-    {
-      transform: 'select',
-      '$row.organisationUnit': '$row.value',
-      '...': ['period', 'dataElement'],
-    },
-  ]);
+/**
+ * { period: '20200101', organisationUnit: 'TO', dataElement: 'CH01', value: 7 }
+ *  => { period: '20200101', TO: 7, dataElement: 'CH01' }
+ */
+export const keyValueByOrgUnit = () => (rows: Row[]) => {
+  return rows.map(row => {
+    const { organisationUnit, value, ...restOfRow } = row;
+    return { [organisationUnit as string]: value, ...restOfRow };
+  });
+};
 
-export const keyValueByPeriod = () =>
-  buildTransform([
-    {
-      transform: 'select',
-      '$row.period': '$row.value',
-      '...': ['dataElement', 'organisationUnit'],
-    },
-  ]);
+/**
+ * { period: '20200101', organisationUnit: 'TO', dataElement: 'CH01', value: 7 }
+ *  => { 20200101: 7, organisationUnit: 'TO', dataElement: 'CH01' }
+ */
+export const keyValueByPeriod = () => (rows: Row[]) => {
+  return rows.map(row => {
+    const { period, value, ...restOfRow } = row;
+    return { [period as string]: value, ...restOfRow };
+  });
+};

--- a/packages/report-server/src/reportBuilder/transform/transform.ts
+++ b/packages/report-server/src/reportBuilder/transform/transform.ts
@@ -8,6 +8,7 @@ import { transformBuilders } from './functions';
 import { aliases } from './aliases';
 
 type TransformParams = {
+  name: string;
   apply: (rows: Row[]) => Row[];
 };
 
@@ -28,6 +29,7 @@ const buildParams = (params: unknown): TransformParams => {
     }
 
     return {
+      name: params,
       apply: aliases[params as keyof typeof aliases](),
     };
   }
@@ -48,6 +50,7 @@ const buildParams = (params: unknown): TransformParams => {
   }
 
   return {
+    name: transformStep,
     apply: transformBuilders[transformStep as keyof typeof transformBuilders](
       restOfTransformParams,
     ),

--- a/packages/ui-components/src/components/LoadingContainer.js
+++ b/packages/ui-components/src/components/LoadingContainer.js
@@ -7,6 +7,7 @@ import styled from 'styled-components';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import Typography from '@material-ui/core/Typography';
 import PropTypes from 'prop-types';
+import { SmallAlert } from './Alert';
 
 const Container = styled.div`
   position: relative;
@@ -41,10 +42,32 @@ const LoadingText = styled(Typography)`
   color: ${props => props.theme.palette.text.secondary};
 `;
 
+const ErrorAlert = styled(SmallAlert)`
+  position: absolute;
+  top: 30%;
+  width: 90%;
+  font-weight: 500;
+  border: 1px solid rgba(209, 51, 51, 0.2);
+  justify-content: center;
+`;
+
 /**
  * Adds a loader around the children
  */
-export const LoadingContainer = ({ isLoading, heading, text, children }) => {
+export const LoadingContainer = ({ isLoading, heading, text, children, errorMessage }) => {
+  if (errorMessage) {
+    return (
+      <Container>
+        {children}
+        <LoadingScreen>
+          <ErrorAlert severity="error" variant="standard">
+            {errorMessage}
+          </ErrorAlert>
+        </LoadingScreen>
+      </Container>
+    );
+  }
+
   if (isLoading) {
     return (
       <Container>

--- a/packages/ui-components/src/components/Table/TableMessageProvider.js
+++ b/packages/ui-components/src/components/Table/TableMessageProvider.js
@@ -7,9 +7,14 @@ import MuiTableBody from '@material-ui/core/TableBody';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { TableCell, StyledTableRow } from './TableRow';
+import { SmallAlert } from '../Alert';
 
-const ErrorSpan = styled.span`
-  color: ${props => props.theme.palette.warning.main};
+const ErrorAlert = styled(SmallAlert)`
+  font-weight: 500;
+  border: 1px solid rgba(209, 51, 51, 0.2);
+  justify-content: center;
+  margin-top: 0.75rem;
+  margin-bottom: 0.75rem;
 `;
 
 const getMessage = ({ isLoading, errorMessage, isData, noDataMessage }) => {
@@ -30,7 +35,13 @@ export const TableMessageProvider = React.memo(
         <MuiTableBody>
           <StyledTableRow>
             <TableCell colSpan={colSpan} align="center">
-              {errorMessage ? <ErrorSpan>{errorMessage}</ErrorSpan> : message}
+              {errorMessage ? (
+                <ErrorAlert severity="error" variant="standard">
+                  {errorMessage}
+                </ErrorAlert>
+              ) : (
+                message
+              )}
             </TableCell>
           </StyledTableRow>
         </MuiTableBody>

--- a/packages/ui-components/stories/tables/table.stories.js
+++ b/packages/ui-components/stories/tables/table.stories.js
@@ -6,7 +6,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import * as COLORS from '../story-utils/theme/colors';
-import { Table } from '../../src';
+import { Table, LoadingContainer } from '../../src';
 import { useTableData } from '../../helpers/useTableData';
 
 export default {
@@ -53,6 +53,25 @@ export const SimpleTable = () => {
           console.log('click on row...');
         }}
       />
+    </Container>
+  );
+};
+
+export const ErroredTable = () => {
+  const { loading, data } = useTableData();
+
+  return (
+    <Container>
+      <LoadingContainer errorMessage="Network Error. Please try again">
+        <Table
+          columns={columns}
+          data={data}
+          loading={loading}
+          onRowClick={() => {
+            console.log('click on row...');
+          }}
+        />
+      </LoadingContainer>
     </Container>
   );
 };

--- a/packages/web-config-server/src/apiV1/dataBuilders/helpers/divideValues.js
+++ b/packages/web-config-server/src/apiV1/dataBuilders/helpers/divideValues.js
@@ -17,3 +17,8 @@ export const divideValues = (numerator, denominator, fractionType = 'percentage'
 
   return modifierFunc(numerator / denominator);
 };
+
+export const fractionAndPercentage = (numerator, divisor) =>
+  (numerator || numerator === 0) && divisor
+    ? `${numerator} / ${divisor} = ${Math.round(divideValues(numerator, divisor) * 100)}%`
+    : NO_DATA_AVAILABLE;

--- a/packages/web-frontend/src/historyNavigation/historyMiddleware.js
+++ b/packages/web-frontend/src/historyNavigation/historyMiddleware.js
@@ -47,7 +47,7 @@ export const historyMiddleware = store => next => action => {
       dispatchLocationUpdate(store, URL_COMPONENTS.ORG_UNIT, action.organisationUnitCode);
       break;
     case SET_DASHBOARD_GROUP:
-      dispatchLocationUpdate(store, URL_COMPONENTS.DASHBOARD, action.name);
+      dispatchLocationUpdate(store, URL_COMPONENTS.DASHBOARD, encodeURIComponent(action.name));
       break;
     case GO_HOME:
       // Completely clear location, explore project will be set in a saga.

--- a/packages/web-frontend/src/sagas.js
+++ b/packages/web-frontend/src/sagas.js
@@ -192,9 +192,6 @@ function* handleUserPage(userPage, initialComponents) {
   }
 }
 
-const userHasAccessToProject = (projects, currentProject) =>
-  projects.filter(p => p.hasAccess).find(p => p.code === currentProject);
-
 const URL_REFRESH_COMPONENTS = {
   [URL_COMPONENTS.PROJECT]: setProject,
   [URL_COMPONENTS.ORG_UNIT]: setOrgUnit,
@@ -1108,8 +1105,10 @@ function* watchLogoutSuccess() {
 function* fetchLoginData(action) {
   if (action.loginType === LOGIN_TYPES.MANUAL) {
     const { routing: location } = yield select();
-    const { PROJECT } = decodeLocation(location);
-    const overlay = PROJECT === 'explore' ? LANDING : null;
+    const { PROJECT, ORG_UNIT } = decodeLocation(location);
+
+    const overlay = PROJECT === 'explore' && ORG_UNIT === 'explore' ? LANDING : null;
+
     yield put(setOverlayComponent(overlay));
     yield call(fetchProjectData);
     yield call(handleLocationChange, {

--- a/packages/web-frontend/src/selectors/dashboardSelectors.js
+++ b/packages/web-frontend/src/selectors/dashboardSelectors.js
@@ -13,7 +13,10 @@ import { selectLocation } from './utils';
 
 export const selectCurrentDashboardGroupCodeFromLocation = createSelector(
   [selectLocation],
-  location => getLocationComponentValue(location, URL_COMPONENTS.DASHBOARD),
+  location => {
+    const dashboardSegment = getLocationComponentValue(location, URL_COMPONENTS.DASHBOARD);
+    return dashboardSegment && decodeURIComponent(dashboardSegment);
+  },
 );
 
 export const selectCurrentExpandedViewId = createSelector([selectLocation], location =>


### PR DESCRIPTION
* Add ValueAndPercentageByDataValueByFlightDate
ValueAndPercentageByAgeByFlightDate extends above
migration for samoa covid health conditions report

* refactor getPassengersPerAgeRange
remove duplicate code
add getPassengersPerDataValue test

* Add Covid Samoa Individual Sex Matrix
Modify getPassengersPerDataValue to specify compare value
add getPassengersPerDataValue test specified value

* add Covid Samoa Clearance Documents report

* Add Covid Samoa Quarantine site by flight report
allow $allValues row config valueAndPercentageByDataValueByFlightDate

* Assign correct hotel names to make them consistent (#1674)

* Add migration

* Remove duplicated hotel name

* Update answers when needed

* Limit data update to specific survey

* trim all sites

* format update trim query

Co-authored-by: nick <nickw@ourcomunity.com.au>
Co-authored-by: Biao Li <31789355+billli0@users.noreply.github.com>

### Issue #:

### Changes:

- Example

---

### Screenshots:
