### PR TITLE
2090 stop cloudwatch on startup

### DIFF
--- a/packages/devops/scripts/deployment/startup.sh
+++ b/packages/devops/scripts/deployment/startup.sh
@@ -11,6 +11,11 @@ DIR=$(dirname "$0")
 export STAGE=$(${DIR}/../utility/getEC2TagValue.sh Stage)
 echo "Starting up instance for ${STAGE}"
 
+# Turn off cloudwatch agent for all except prod and dev (can be turned on manually if needed on feature instances)
+if [[ $STAGE != "production" && $STAGE != "dev" ]]; then
+    /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -m ec2 -a stop
+fi
+
 # Set the branch based on STAGE
 if [[ $STAGE == "production" ]]; then
     export BRANCH="master"

--- a/packages/devops/scripts/deployment/startup.sh
+++ b/packages/devops/scripts/deployment/startup.sh
@@ -13,6 +13,8 @@ echo "Starting up instance for ${STAGE}"
 
 # Turn off cloudwatch agent for all except prod and dev (can be turned on manually if needed on feature instances)
 if [[ $STAGE != "production" && $STAGE != "dev" ]]; then
+    echo "Turning off cloudwatch agent for feature instance."
+    echo "To restart, run sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -m ec2 -a start"
     /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -m ec2 -a stop
 fi
 

--- a/packages/devops/scripts/deployment/startup.sh
+++ b/packages/devops/scripts/deployment/startup.sh
@@ -32,5 +32,5 @@ ${HOME_DIRECTORY}/packages/devops/scripts/deployment/configureNginx.sh
 if [[ $STAGE != "production" && $STAGE != "dev" ]]; then
     echo "Turning off cloudwatch agent for feature instance."
     echo "To restart, run sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -m ec2 -a start"
-    /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -m ec2 -a stop
+    amazon-cloudwatch-agent-ctl -m ec2 -a stop
 fi

--- a/packages/devops/scripts/deployment/startup.sh
+++ b/packages/devops/scripts/deployment/startup.sh
@@ -15,7 +15,7 @@ echo "Starting up instance for ${STAGE}"
 if [[ $STAGE != "production" && $STAGE != "dev" ]]; then
     echo "Turning off cloudwatch agent for feature instance."
     echo "To restart, run sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -m ec2 -a start"
-    amazon-cloudwatch-agent-ctl -m ec2 -a stop
+    sudo amazon-cloudwatch-agent-ctl -m ec2 -a stop
 fi
 
 # Set the branch based on STAGE

--- a/packages/devops/scripts/deployment/startup.sh
+++ b/packages/devops/scripts/deployment/startup.sh
@@ -11,6 +11,13 @@ DIR=$(dirname "$0")
 export STAGE=$(${DIR}/../utility/getEC2TagValue.sh Stage)
 echo "Starting up instance for ${STAGE}"
 
+# Turn off cloudwatch agent for all except prod and dev (can be turned on manually if needed on feature instances)
+if [[ $STAGE != "production" && $STAGE != "dev" ]]; then
+    echo "Turning off cloudwatch agent for feature instance."
+    echo "To restart, run sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -m ec2 -a start"
+    amazon-cloudwatch-agent-ctl -m ec2 -a stop
+fi
+
 # Set the branch based on STAGE
 if [[ $STAGE == "production" ]]; then
     export BRANCH="master"
@@ -27,10 +34,3 @@ ${HOME_DIRECTORY}/packages/devops/scripts/deployment/deployPackages.sh
 
 # Set nginx config and start the service running
 ${HOME_DIRECTORY}/packages/devops/scripts/deployment/configureNginx.sh
-
-# Turn off cloudwatch agent for all except prod and dev (can be turned on manually if needed on feature instances)
-if [[ $STAGE != "production" && $STAGE != "dev" ]]; then
-    echo "Turning off cloudwatch agent for feature instance."
-    echo "To restart, run sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -m ec2 -a start"
-    amazon-cloudwatch-agent-ctl -m ec2 -a stop
-fi

--- a/packages/devops/scripts/deployment/startup.sh
+++ b/packages/devops/scripts/deployment/startup.sh
@@ -11,13 +11,6 @@ DIR=$(dirname "$0")
 export STAGE=$(${DIR}/../utility/getEC2TagValue.sh Stage)
 echo "Starting up instance for ${STAGE}"
 
-# Turn off cloudwatch agent for all except prod and dev (can be turned on manually if needed on feature instances)
-if [[ $STAGE != "production" && $STAGE != "dev" ]]; then
-    echo "Turning off cloudwatch agent for feature instance."
-    echo "To restart, run sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -m ec2 -a start"
-    /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -m ec2 -a stop
-fi
-
 # Set the branch based on STAGE
 if [[ $STAGE == "production" ]]; then
     export BRANCH="master"
@@ -34,3 +27,10 @@ ${HOME_DIRECTORY}/packages/devops/scripts/deployment/deployPackages.sh
 
 # Set nginx config and start the service running
 ${HOME_DIRECTORY}/packages/devops/scripts/deployment/configureNginx.sh
+
+# Turn off cloudwatch agent for all except prod and dev (can be turned on manually if needed on feature instances)
+if [[ $STAGE != "production" && $STAGE != "dev" ]]; then
+    echo "Turning off cloudwatch agent for feature instance."
+    echo "To restart, run sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -m ec2 -a start"
+    /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -m ec2 -a stop
+fi


### PR DESCRIPTION
### Issue #: https://github.com/beyondessential/tupaia-backlog/issues/2090

### Changes:
Couldn't find a setting for cloudwatch agent to avoid turning itself on every reboot, so instead this adds a step to the startup script to turn it off for feature instances.

Note that cloudwatch agent is also on for the aggregation servers, but we rarely make extra instances of them, so I think it's okay for those rare extra instances to report their metrics.