### PR TITLE
Reduce cache memory footprint

### DIFF
--- a/packages/database/src/modelClasses/Entity.js
+++ b/packages/database/src/modelClasses/Entity.js
@@ -359,7 +359,7 @@ export class EntityModel extends DatabaseModel {
       ancestorsOrDescendants === ENTITY_RELATION_TYPE.ANCESTORS
         ? ['ancestor_id', 'descendant_id']
         : ['descendant_id', 'ancestor_id'];
-    return this.runCachedFunction(cacheKey, async () => {
+    const relationData = await this.runCachedFunction(cacheKey, async () => {
       const relations = await this.find(
         {
           ...criteria,
@@ -373,6 +373,7 @@ export class EntityModel extends DatabaseModel {
       );
       return Promise.all(relations.map(async r => r.getData()));
     });
+    return Promise.all(relationData.map(async r => this.generateInstance(r)));
   }
 
   getDhisLevel(type) {

--- a/packages/database/src/modelClasses/Entity.js
+++ b/packages/database/src/modelClasses/Entity.js
@@ -359,8 +359,8 @@ export class EntityModel extends DatabaseModel {
       ancestorsOrDescendants === ENTITY_RELATION_TYPE.ANCESTORS
         ? ['ancestor_id', 'descendant_id']
         : ['descendant_id', 'ancestor_id'];
-    return this.runCachedFunction(cacheKey, async () =>
-      this.find(
+    return this.runCachedFunction(cacheKey, async () => {
+      const relations = await this.find(
         {
           ...criteria,
           [filterByEntityId]: entityId,
@@ -370,8 +370,9 @@ export class EntityModel extends DatabaseModel {
           joinCondition: ['entity.id', joinTablesOn],
           sort: ['generational_distance ASC'],
         },
-      ),
-    );
+      );
+      return Promise.all(relations.map(async r => r.getData()));
+    });
   }
 
   getDhisLevel(type) {


### PR DESCRIPTION
### Issue #: https://github.com/beyondessential/tupaia-backlog/issues/2196

Rather than storing the overhead of the models etc. in the cache, we should just store the data, and construct the model instances again when we need them.

This was revealed when testing redis, because the models are a circular structure (each model references the other models, which then reference the original and around it goes), which can't be serialised to JSON and stored in redis. Seems it's not just a benefit in making the cache serialisable, but also means we save about 65% less memory in the cache for the Laos entity hierarchy alone.

See https://docs.google.com/spreadsheets/d/1KoewibyIxEJjpcjataeKi5svspPi41gbcG0LUtwIHZk/edit#gid=1369222111 for memory usage data (second tab)

