### PR TITLE
2230: Allow import data service entity when importing entities in Admin Panel

### DIFF
--- a/packages/meditrak-server/src/routes/importEntities/extractEntitiesByCountryName.js
+++ b/packages/meditrak-server/src/routes/importEntities/extractEntitiesByCountryName.js
@@ -35,12 +35,15 @@ const geojsonParser = filePath => {
 
 const processXlsxRow = (row, { countryName }) => {
   const entity = { ...row, country_name: countryName };
-  const { geojson, attributes } = row;
+  const { geojson, attributes, data_service_entity: dataServiceEntity } = row;
   if (geojson) {
     entity.geojson = JSON.parse(geojson);
   }
   if (attributes) {
     entity.attributes = convertCellToJson(attributes);
+  }
+  if (dataServiceEntity) {
+    entity.data_service_entity = convertCellToJson(dataServiceEntity);
   }
 
   return entity;

--- a/packages/meditrak-server/src/routes/importEntities/getEntityObjectValidator.js
+++ b/packages/meditrak-server/src/routes/importEntities/getEntityObjectValidator.js
@@ -26,6 +26,7 @@ const constructEntityFieldValidators = models => ({
     },
   ],
   attributes: [constructIsEmptyOr(isPlainObject)],
+  data_service_entity: [constructIsEmptyOr(isPlainObject)],
 });
 
 const constructSpecificEntityTypeValidators = (entityType, models) => {

--- a/packages/meditrak-server/src/routes/importEntities/updateCountryEntities.js
+++ b/packages/meditrak-server/src/routes/importEntities/updateCountryEntities.js
@@ -64,6 +64,7 @@ export async function updateCountryEntities(transactingModels, countryName, enti
       longitude,
       latitude,
       geojson,
+      data_service_entity: dataServiceEntity,
       type_name: typeName,
       screen_bounds: screenBounds,
       category_code: categoryCode,
@@ -105,6 +106,17 @@ export async function updateCountryEntities(transactingModels, countryName, enti
         newFacility.category_code = defaultTypeDetails.categoryCode;
       }
       await newFacility.save();
+    }
+    if (dataServiceEntity) {
+      const dataServiceEntityToUpsert = {
+        entity_code: code,
+        config: dataServiceEntity,
+      };
+
+      await transactingModels.dataServiceEntity.updateOrCreate(
+        { entity_code: code },
+        dataServiceEntityToUpsert,
+      );
     }
     await transactingModels.entity.updateOrCreate(
       { code },


### PR DESCRIPTION
### Issue: https://github.com/beyondessential/tupaia-backlog/issues/2230

### Changes:

- Allow import data service entity when importing entities in Admin Panel