### PR TITLE
fix admin panel error on autocomplete

### DIFF
--- a/packages/admin-panel/src/autocomplete/Autocomplete.js
+++ b/packages/admin-panel/src/autocomplete/Autocomplete.js
@@ -72,7 +72,7 @@ const AutocompleteComponent = React.memo(
         getOptionSelected={(option, selected) =>
           option[optionLabelKey] === selected[optionLabelKey]
         }
-        getOptionLabel={option => (option ? option[optionLabelKey] : '')}
+        getOptionLabel={option => (option && option[optionLabelKey] ? option[optionLabelKey] : '')}
         loading={isLoading}
         onChange={onChangeSelection}
         onInputChange={throttle((event, newValue) => onChangeSearchTerm(newValue), 50)}


### PR DESCRIPTION
### Issue #: [2190 Sticky Region Labels Per Project](https://github.com/beyondessential/tupaia-backlog/issues/2190)

### Changes:

- Replaced `tile_sets` column with `config` in the projects table
- Updated project selectors to use config for tile sets
-  Configure Regional Labels (tooltips) based on the config

---

### Screenshots:
See issue