### PR TITLE
2190 project sticky region labels

### DIFF
--- a/packages/admin-panel/src/autocomplete/Autocomplete.js
+++ b/packages/admin-panel/src/autocomplete/Autocomplete.js
@@ -72,7 +72,7 @@ const AutocompleteComponent = React.memo(
         getOptionSelected={(option, selected) =>
           option[optionLabelKey] === selected[optionLabelKey]
         }
-        getOptionLabel={option => (option ? option[optionLabelKey] : '')}
+        getOptionLabel={option => (option && option[optionLabelKey] ? option[optionLabelKey] : '')}
         loading={isLoading}
         onChange={onChangeSelection}
         onInputChange={throttle((event, newValue) => onChangeSearchTerm(newValue), 50)}

--- a/packages/admin-panel/src/pages/resources/ProjectsPage.js
+++ b/packages/admin-panel/src/pages/resources/ProjectsPage.js
@@ -51,10 +51,11 @@ const FIELDS = [
     type: 'tooltip',
   },
   {
-    Header: 'Tile Sets',
-    source: 'tile_sets',
-    secondaryLabel: 'Comma separated list (eg. osm,satellite,terrain).',
-    type: 'tooltip',
+    Header: 'Config',
+    source: 'config',
+    type: 'jsonTooltip',
+    editConfig: { type: 'jsonEditor' },
+    secondaryLabel: 'eg. { "tileSets": "osm,satellite,terrain", "permanentRegionLabels": true }',
   },
   {
     Header: 'Sort',

--- a/packages/database/src/migrations/20210224014424-AddConfigToProjects-modifies-schema.js
+++ b/packages/database/src/migrations/20210224014424-AddConfigToProjects-modifies-schema.js
@@ -1,0 +1,37 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+/**
+ *
+ *
+ * @param db
+ * @returns {{replacementParams: *, query: *}}
+ */
+exports.up = function (db) {
+  db.runSql(`ALTER TABLE project DROP COLUMN IF EXISTS tile_sets;`);
+  return db.addColumn('project', 'config', {
+    type: 'jsonb',
+    defaultValue: '{ "permanentRegionLabels": true }',
+  });
+};
+
+exports.down = function (db) {
+  return null;
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/packages/database/src/modelClasses/Project.js
+++ b/packages/database/src/modelClasses/Project.js
@@ -32,7 +32,7 @@ export class ProjectModel extends DatabaseModel {
             p.sort_order, p.user_groups,
             p.entity_id, p.image_url,
             p.logo_url, p.dashboard_group_name,
-            p.default_measure, p.tile_sets
+            p.default_measure, p.config
       from project p
         left join entity e
           on p.entity_id = e.id

--- a/packages/web-config-server/src/apiV1/projects.js
+++ b/packages/web-config-server/src/apiV1/projects.js
@@ -47,7 +47,7 @@ async function buildProjectDataForFrontend(project, req) {
     entity_ids: entityIds,
     dashboard_group_name: dashboardGroupName,
     default_measure: defaultMeasure,
-    tile_sets: tileSets,
+    config,
   } = project;
 
   const entities = await Promise.all(entityIds.map(id => req.models.entity.findById(id)));
@@ -81,7 +81,7 @@ async function buildProjectDataForFrontend(project, req) {
     homeEntityCode,
     dashboardGroupName,
     defaultMeasure,
-    tileSets,
+    config,
   };
 }
 

--- a/packages/web-frontend/src/containers/Map/AreaTooltip.js
+++ b/packages/web-frontend/src/containers/Map/AreaTooltip.js
@@ -35,13 +35,14 @@ export class AreaTooltip extends Component {
   }
 
   render() {
-    const { permanent, onMouseOver, onMouseOut, text } = this.props;
+    const { permanent, onMouseOver, onMouseOut, text, sticky } = this.props;
 
     return (
       <Tooltip
         pane="tooltipPane"
         direction="auto"
         opacity={1}
+        sticky={sticky}
         permanent={permanent}
         interactive={permanent}
         onMouseOver={onMouseOver}
@@ -60,6 +61,7 @@ export class AreaTooltip extends Component {
 
 AreaTooltip.propTypes = {
   permanent: PropTypes.bool,
+  sticky: PropTypes.bool,
   text: PropTypes.string.isRequired,
   onMouseOver: PropTypes.func,
   onMouseOut: PropTypes.func,
@@ -67,6 +69,7 @@ AreaTooltip.propTypes = {
 
 AreaTooltip.defaultProps = {
   permanent: false,
+  sticky: false,
   onMouseOver: undefined,
   onMouseOut: undefined,
 };

--- a/packages/web-frontend/src/containers/Map/ConnectedPolygon.js
+++ b/packages/web-frontend/src/containers/Map/ConnectedPolygon.js
@@ -21,6 +21,7 @@ import {
   selectAllMeasuresWithDisplayInfo,
   selectCurrentMeasureId,
   selectOrgUnitChildren,
+  selectAreRegionLabelsPermanent,
 } from '../../selectors';
 import ActivePolygon from './ActivePolygon';
 
@@ -61,7 +62,13 @@ class ConnectedPolygon extends Component {
   }
 
   getTooltip(name) {
-    const { isChildArea, hasMeasureData, orgUnitMeasureData, measureOptions } = this.props;
+    const {
+      isChildArea,
+      hasMeasureData,
+      orgUnitMeasureData,
+      measureOptions,
+      permanentLabels,
+    } = this.props;
     const hasMeasureValue = orgUnitMeasureData || orgUnitMeasureData === 0;
 
     // don't render tooltips if we have a measure loaded
@@ -72,7 +79,13 @@ class ConnectedPolygon extends Component {
       ? `${name}: ${getSingleFormattedValue(orgUnitMeasureData, measureOptions)}`
       : name;
 
-    return <AreaTooltip permanent={isChildArea && !hasMeasureValue} text={text} />;
+    return (
+      <AreaTooltip
+        permanent={permanentLabels && isChildArea && !hasMeasureValue}
+        sticky={!permanentLabels}
+        text={text}
+      />
+    );
   }
 
   render() {
@@ -138,6 +151,7 @@ ConnectedPolygon.propTypes = {
   }).isRequired,
   measureId: PropTypes.string,
   isActive: PropTypes.bool,
+  permanentLabels: PropTypes.bool,
   isChildArea: PropTypes.bool,
   onChangeOrgUnit: PropTypes.func,
   coordinates: PropTypes.arrayOf(
@@ -158,6 +172,7 @@ ConnectedPolygon.propTypes = {
 ConnectedPolygon.defaultProps = {
   measureId: '',
   isActive: false,
+  permanentLabels: true,
   isChildArea: false,
   onChangeOrgUnit: () => {},
   coordinates: undefined,
@@ -205,6 +220,7 @@ const mapStateToProps = (state, givenProps) => {
   const coordinates = orgUnit ? orgUnit.location.region : undefined;
 
   return {
+    permanentLabels: selectAreRegionLabelsPermanent(state),
     measureId,
     coordinates,
     hasShadedChildren,

--- a/packages/web-frontend/src/selectors/index.js
+++ b/packages/web-frontend/src/selectors/index.js
@@ -38,6 +38,7 @@ export {
   selectAdjustedProjectBounds,
   selectTileSets,
   selectActiveTileSet,
+  selectAreRegionLabelsPermanent,
 } from './projectSelectors';
 
 export {

--- a/packages/web-frontend/src/selectors/projectSelectors.js
+++ b/packages/web-frontend/src/selectors/projectSelectors.js
@@ -46,8 +46,8 @@ export const selectAdjustedProjectBounds = createSelector(
 export const selectTileSets = createSelector(selectCurrentProject, project => {
   let tileSetKeys = ['osm', 'satellite'];
 
-  if (project.tileSets) {
-    const customSetKeys = project.tileSets.split(',').map(item => item.trim());
+  if (project.config && project.config.tileSets) {
+    const customSetKeys = project.config.tileSets.split(',').map(item => item.trim());
     tileSetKeys = [...tileSetKeys, ...customSetKeys];
   }
 
@@ -61,4 +61,9 @@ export const selectActiveTileSet = createSelector(
   (tileSets, activeTileSetKey) => {
     return tileSets.find(tileSet => tileSet.key === activeTileSetKey);
   },
+);
+
+export const selectAreRegionLabelsPermanent = createSelector(
+  selectCurrentProject,
+  project => project.config && project.config.permanentRegionLabels,
 );

--- a/packages/web-frontend/src/tests/selectors/projectSelectors.test.js
+++ b/packages/web-frontend/src/tests/selectors/projectSelectors.test.js
@@ -183,8 +183,11 @@ describe('projectSelectors', () => {
       project: {
         projects: [
           { code: 'explore' },
-          { code: 'disaster', tileSets: 'osm,satellite,waterways,roads,ethnicity,terrain' },
-          { code: 'unfpa', tileSets: 'roads,waterways,eth, terrain' }, // testing typos in the config
+          {
+            code: 'disaster',
+            config: { tileSets: 'osm,satellite,waterways,roads,ethnicity,terrain' },
+          },
+          { code: 'unfpa', config: { tileSets: 'roads,waterways,eth, terrain' } }, // testing typos in the config
         ],
       },
       routing: {


### PR DESCRIPTION
### Issue #: [2190 Sticky Region Labels Per Project](https://github.com/beyondessential/tupaia-backlog/issues/2190)

### Changes:

- Replaced `tile_sets` column with `config` in the projects table
- Updated project selectors to use config for tile sets
-  Configure Regional Labels (tooltips) based on the config

---

### Screenshots:
See issue