### PR TITLE
2240 hotfix survey submit

### DIFF
--- a/packages/meditrak-server/src/routes/importSurveyResponses/assertCanImportSurveyResponses.js
+++ b/packages/meditrak-server/src/routes/importSurveyResponses/assertCanImportSurveyResponses.js
@@ -61,10 +61,12 @@ export const assertCanImportSurveyResponses = async (
 const getEntityCodeFromSurveyResponseChange = async (models, surveyResponse) => {
   // If we're creating a new entity we don't have a currently valid entity_code
   // So instead, check our permissions against the new entity's parent
-  const newEntity = surveyResponse.entities_created.find(e => e.id === surveyResponse.entity_id);
-  if (newEntity) {
-    const parentEntity = await models.entity.findById(newEntity.parent_id);
-    return parentEntity.code;
+  if (surveyResponse.entities_created) {
+    const newEntity = surveyResponse.entities_created.find(e => e.id === surveyResponse.entity_id);
+    if (newEntity) {
+      const parentEntity = await models.entity.findById(newEntity.parent_id);
+      return parentEntity.code;
+    }
   }
 
   // There are three valid ways to refer to the entity in a batch change:

--- a/packages/meditrak-server/src/routes/importSurveyResponses/assertCanImportSurveyResponses.js
+++ b/packages/meditrak-server/src/routes/importSurveyResponses/assertCanImportSurveyResponses.js
@@ -59,6 +59,14 @@ export const assertCanImportSurveyResponses = async (
 };
 
 const getEntityCodeFromSurveyResponseChange = async (models, surveyResponse) => {
+  // If we're creating a new entity we don't have a currently valid entity_code
+  // So instead, check our permissions against the new entity's parent
+  const newEntity = surveyResponse.entities_created.find(e => e.id === surveyResponse.entity_id);
+  if (newEntity) {
+    const parentEntity = await models.entity.findById(newEntity.parent_id);
+    return parentEntity.code;
+  }
+
   // There are three valid ways to refer to the entity in a batch change:
   // entity_code, entity_id, clinic_id
   if (surveyResponse.entity_code) {


### PR DESCRIPTION
### Issue #: https://github.com/beyondessential/tupaia-backlog/issues/2240

### Changes:

- When submitting a survey against a new entity, run the permissions check against the parent entity of the newly created entity
