### PR TITLE
2263: Make sure entity updates are not pushed to Laos DHIS

### DIFF
--- a/packages/database/src/migrations/20210222124639-UpdateLaosEntitiesPushMetadata-modifies-data.js
+++ b/packages/database/src/migrations/20210222124639-UpdateLaosEntitiesPushMetadata-modifies-data.js
@@ -1,0 +1,62 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = async function (db) {
+  await db.runSql(`
+    -- We want to drop the entity trigger because we just want to add push: false to Laos entities, no actual data is changed, this shouldn't trigger any change listener (eg: for pushing)
+    DROP TRIGGER IF EXISTS entity_trigger
+    ON entity;
+
+    -- Add push = false to Laos entities
+    UPDATE entity
+    SET metadata = jsonb_set(metadata, '{dhis,push}', 'false')
+    WHERE country_code = 'LA'
+    AND metadata->'dhis' IS NOT NULL;
+
+    -- Also change the metadata in data column if dhis_sync_log to reflect the same push = false
+    UPDATE dhis_sync_log
+    SET data = jsonb_set(data::jsonb, '{metadata,dhis,push}', 'false')::text
+    WHERE record_type = 'entity'
+    AND record_id IN (SELECT id FROM entity WHERE country_code = 'LA' AND metadata->'dhis' IS NOT NULL);
+  `);
+};
+
+exports.down = async function (db) {
+  await db.runSql(`
+    DROP TRIGGER IF EXISTS entity_trigger
+    ON entity;
+
+    UPDATE entity
+    SET metadata = metadata #- '{dhis,push}'
+    WHERE country_code = 'LA'
+    AND metadata->'dhis'->'push' IS NOT NULL;
+
+    UPDATE dhis_sync_log
+    SET data = (data::jsonb #- '{metadata,dhis,push}')::text
+    WHERE record_type = 'entity'
+    AND record_id IN (SELECT id FROM entity WHERE country_code = 'LA' AND metadata->'dhis'->'push' IS NOT NULL);
+
+    -- Recreate triggers
+    CREATE TRIGGER entity_trigger
+    AFTER INSERT OR UPDATE or DELETE
+    ON entity
+    FOR EACH ROW EXECUTE PROCEDURE notification();
+  `);
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/packages/database/src/migrations/20210222124639-UpdateLaosEntitiesPushMetadata-modifies-data.js
+++ b/packages/database/src/migrations/20210222124639-UpdateLaosEntitiesPushMetadata-modifies-data.js
@@ -14,6 +14,13 @@ exports.setup = function (options, seedLink) {
   seed = seedLink;
 };
 
+const NEW_METADATA = {
+  dhis: {
+    push: false,
+    isDataRegional: true,
+  },
+};
+
 exports.up = async function (db) {
   await db.runSql(`
     -- We want to drop the entity trigger because we just want to add push: false to Laos entities, no actual data is changed, this shouldn't trigger any change listener (eg: for pushing)
@@ -22,32 +29,14 @@ exports.up = async function (db) {
 
     -- Add push = false to Laos entities
     UPDATE entity
-    SET metadata = jsonb_set(metadata, '{dhis,push}', 'false')
-    WHERE country_code = 'LA'
-    AND metadata->'dhis' IS NOT NULL;
+    SET metadata = '${JSON.stringify(NEW_METADATA)}'
+    WHERE country_code = 'LA';
 
     -- Also change the metadata in data column if dhis_sync_log to reflect the same push = false
     UPDATE dhis_sync_log
-    SET data = jsonb_set(data::jsonb, '{metadata,dhis,push}', 'false')::text
+    SET data = jsonb_set(data::jsonb, '{metadata}', '${JSON.stringify(NEW_METADATA)}')::text
     WHERE record_type = 'entity'
-    AND record_id IN (SELECT id FROM entity WHERE country_code = 'LA' AND metadata->'dhis' IS NOT NULL);
-  `);
-};
-
-exports.down = async function (db) {
-  await db.runSql(`
-    DROP TRIGGER IF EXISTS entity_trigger
-    ON entity;
-
-    UPDATE entity
-    SET metadata = metadata #- '{dhis,push}'
-    WHERE country_code = 'LA'
-    AND metadata->'dhis'->'push' IS NOT NULL;
-
-    UPDATE dhis_sync_log
-    SET data = (data::jsonb #- '{metadata,dhis,push}')::text
-    WHERE record_type = 'entity'
-    AND record_id IN (SELECT id FROM entity WHERE country_code = 'LA' AND metadata->'dhis'->'push' IS NOT NULL);
+    AND record_id IN (SELECT id FROM entity WHERE country_code = 'LA');
 
     -- Recreate triggers
     CREATE TRIGGER entity_trigger
@@ -55,6 +44,10 @@ exports.down = async function (db) {
     ON entity
     FOR EACH ROW EXECUTE PROCEDURE notification();
   `);
+};
+
+exports.down = function (db) {
+  return null;
 };
 
 exports._meta = {

--- a/packages/database/src/migrations/20210222204800-UpdateEntityDhisIdToTrackEntityInstanceId-modifies-data.js
+++ b/packages/database/src/migrations/20210222204800-UpdateEntityDhisIdToTrackEntityInstanceId-modifies-data.js
@@ -1,0 +1,66 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = async function (db) {
+  await db.runSql(`
+    -- We want to drop the entity trigger because we just want to change the id key -> trackedEntityId, no actual data is changed, this shouldn't trigger any change listener (eg: for pushing)
+    DROP TRIGGER IF EXISTS entity_trigger
+    ON entity;
+
+    -- Change dhis.id to dhis.trackedEntityId in metadata column of entity for clarity
+    UPDATE entity e 
+    SET metadata = jsonb_set(metadata, '{dhis}', metadata->'dhis' || jsonb_build_object('trackedEntityId', metadata->'dhis'->'id') #- '{id}')
+    WHERE metadata->'dhis'->'id' IS NOT NULL;
+
+    --Also change the metadata in data column if dhis_sync_log to reflect the same dhis.trackedEntityId
+    UPDATE dhis_sync_log
+    SET data = jsonb_set(data::jsonb, '{metadata,dhis}', data::jsonb->'metadata'->'dhis' || jsonb_build_object('trackedEntityId', data::jsonb->'metadata'->'dhis'->'id') #- '{id}')::text
+    WHERE record_type = 'entity' 
+    AND data::jsonb->'metadata'->'dhis'->'id' IS NOT NULL;
+
+    -- Recreate triggers
+    CREATE TRIGGER entity_trigger
+      AFTER INSERT OR UPDATE or DELETE
+      ON entity
+      FOR EACH ROW EXECUTE PROCEDURE notification();
+  `);
+};
+
+exports.down = async function (db) {
+  await db.runSql(`
+    DROP TRIGGER IF EXISTS entity_trigger
+    ON entity;
+
+    UPDATE entity e 
+    SET metadata = jsonb_set(metadata, '{dhis}', metadata->'dhis' || jsonb_build_object('id', metadata->'dhis'->'trackedEntityId') #- '{trackedEntityId}')
+    WHERE metadata->'dhis'->'trackedEntityId' IS NOT NULL;
+
+    UPDATE dhis_sync_log
+    SET data = jsonb_set(data::jsonb, '{metadata,dhis}', data::jsonb->'metadata'->'dhis' || jsonb_build_object('id', data::jsonb->'metadata'->'dhis'->'trackedEntityId') #- '{trackedEntityId}')::text
+    WHERE record_type = 'entity' 
+    AND data::jsonb->'metadata'->'dhis'->'trackedEntityId' IS NOT NULL;
+
+    -- Recreate triggers
+    CREATE TRIGGER entity_trigger
+    AFTER INSERT OR UPDATE or DELETE
+    ON entity
+    FOR EACH ROW EXECUTE PROCEDURE notification();
+  `);
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/packages/database/src/modelClasses/Entity.js
+++ b/packages/database/src/modelClasses/Entity.js
@@ -126,7 +126,7 @@ export class EntityType extends DatabaseType {
     return !!this.getDhisTrackedEntityId();
   }
 
-  allowsPush() {
+  allowsPushingToDhis() {
     const { dhis = {} } = this.metadata || {};
     const { push = true } = dhis; // by default push = true, if an entity shouldn't be pushed to DHIS2, set it to false
     return push;

--- a/packages/database/src/modelClasses/Entity.js
+++ b/packages/database/src/modelClasses/Entity.js
@@ -107,23 +107,29 @@ export class EntityType extends DatabaseType {
     return !this.isOrganisationUnit();
   }
 
-  getDhisId() {
-    return this.metadata && this.metadata.dhis && this.metadata.dhis.id;
+  getDhisTrackedEntityId() {
+    return this.metadata && this.metadata.dhis && this.metadata.dhis.trackedEntityId;
   }
 
-  async setDhisId(dhisId) {
+  async setDhisTrackedEntityId(trackedEntityId) {
     if (!this.metadata) {
       this.metadata = {};
     }
     if (!this.metadata.dhis) {
       this.metadata.dhis = {};
     }
-    this.metadata.dhis.id = dhisId;
+    this.metadata.dhis.trackedEntityId = trackedEntityId;
     return this.save();
   }
 
-  hasDhisId() {
-    return !!this.getDhisId();
+  hasDhisTrackedEntityId() {
+    return !!this.getDhisTrackedEntityId();
+  }
+
+  allowsPush() {
+    const { dhis = {} } = this.metadata || {};
+    const { push = true } = dhis; // by default push = true, if an entity shouldn't be pushed to DHIS2, set it to false
+    return push;
   }
 
   async countryEntity() {

--- a/packages/meditrak-server/src/dhis/DhisChangeValidator.js
+++ b/packages/meditrak-server/src/dhis/DhisChangeValidator.js
@@ -110,9 +110,17 @@ export class DhisChangeValidator extends ChangeValidator {
     return this.queryValidSurveyResponseIds(surveyResponseIds);
   };
 
+  getValidEntityUpdates = async updateChanges => {
+    const entityIds = this.getIdsFromChangesForModel(updateChanges, this.models.entity);
+    if (entityIds.length === 0) return [];
+
+    const entities = await this.models.entity.findManyById(entityIds);
+    return entities.filter(e => e.allowsPush()).map(e => e.id);
+  };
+
   getValidUpdates = async changes => {
     const updateChanges = this.getUpdateChanges(changes);
-    const validEntityIds = this.getIdsFromChangesForModel(updateChanges, this.models.entity); // all entity updates are valid
+    const validEntityIds = await this.getValidEntityUpdates(updateChanges);
     const validAnswerIds = await this.getValidAnswerUpdates(updateChanges);
     const validSurveyResponseIds = await this.getValidSurveyResponseUpdates(updateChanges);
     return this.filterChangesWithMatchingIds(changes, [

--- a/packages/meditrak-server/src/dhis/DhisChangeValidator.js
+++ b/packages/meditrak-server/src/dhis/DhisChangeValidator.js
@@ -115,7 +115,7 @@ export class DhisChangeValidator extends ChangeValidator {
     if (entityIds.length === 0) return [];
 
     const entities = await this.models.entity.findManyById(entityIds);
-    return entities.filter(e => e.allowsPush()).map(e => e.id);
+    return entities.filter(e => e.allowsPushingToDhis()).map(e => e.id);
   };
 
   getValidUpdates = async changes => {

--- a/packages/meditrak-server/src/dhis/pushers/data/event/EventBuilder.js
+++ b/packages/meditrak-server/src/dhis/pushers/data/event/EventBuilder.js
@@ -65,7 +65,7 @@ export class EventBuilder {
   }
 
   async enrollTrackedEntityAndGetTrackerEventFields(entity, programCode) {
-    const trackedEntityId = entity.getDhisId();
+    const trackedEntityId = entity.getDhisTrackedEntityId();
     const program = await this.fetchProgram(programCode);
     if (!program) {
       throw new Error(`Program ${programCode} was not found on DHIS2`);

--- a/packages/meditrak-server/src/dhis/pushers/entity/TrackedEntityPusher.js
+++ b/packages/meditrak-server/src/dhis/pushers/entity/TrackedEntityPusher.js
@@ -24,9 +24,9 @@ export class TrackedEntityPusher extends EntityPusher {
     const record = await this.buildRecord(entity);
     const diagnostics = await this.api.updateRecord(TRACKED_ENTITY_INSTANCE, record);
 
-    if (!entity.hasDhisId()) {
-      const dhisId = diagnostics.references[0];
-      await entity.setDhisId(dhisId);
+    if (!entity.hasDhisTrackedEntityId()) {
+      const trackedEntityId = diagnostics.references[0];
+      await entity.setDhisTrackedEntityId(trackedEntityId);
     }
 
     const data = await entity.getData();
@@ -38,8 +38,9 @@ export class TrackedEntityPusher extends EntityPusher {
    */
   async delete() {
     const entityData = await this.fetchDataFromSyncLog();
-    const dhisId = entityData.metadata && entityData.metadata.dhis && entityData.metadata.dhis.id;
-    const diagnostics = await this.api.deleteRecordById(TRACKED_ENTITY_INSTANCE, dhisId);
+    const trackedEntityId =
+      entityData.metadata && entityData.metadata.dhis && entityData.metadata.dhis.trackedEntityId;
+    const diagnostics = await this.api.deleteRecordById(TRACKED_ENTITY_INSTANCE, trackedEntityId);
 
     return diagnostics;
   }
@@ -55,8 +56,8 @@ export class TrackedEntityPusher extends EntityPusher {
       orgUnit,
       attributes,
     };
-    if (entity.hasDhisId()) {
-      record.id = entity.getDhisId();
+    if (entity.hasDhisTrackedEntityId()) {
+      record.id = entity.getDhisTrackedEntityId();
     }
 
     return record;

--- a/packages/meditrak-server/src/routes/importEntities/updateCountryEntities.js
+++ b/packages/meditrak-server/src/routes/importEntities/updateCountryEntities.js
@@ -118,6 +118,14 @@ export async function updateCountryEntities(transactingModels, countryName, enti
         dataServiceEntityToUpsert,
       );
     }
+    const entity = await transactingModels.entity.findOne({ code });
+    const metadata =
+      entity && entity.metadata
+        ? entity.metadata // we don't want to override the metadata if the entity already exists
+        : {
+            dhis: { isDataRegional: true },
+          };
+
     await transactingModels.entity.updateOrCreate(
       { code },
       {
@@ -126,9 +134,7 @@ export async function updateCountryEntities(transactingModels, countryName, enti
         type: entityType,
         country_code: country.code,
         image_url: imageUrl,
-        metadata: {
-          dhis: { isDataRegional: true },
-        },
+        metadata,
         attributes,
       },
     );

--- a/packages/meditrak-server/src/tests/dhis/EventBuilder.fixtures.js
+++ b/packages/meditrak-server/src/tests/dhis/EventBuilder.fixtures.js
@@ -19,7 +19,7 @@ export const ENTITIES = {
     type: 'case',
     metadata: {
       dhis: {
-        id: 'trackedEntity_dhisId',
+        trackedEntityId: 'trackedEntity_dhisId',
       },
     },
   },

--- a/packages/meditrak-server/src/tests/dhis/pushers/entity/TrackedEntityPusher.test.js
+++ b/packages/meditrak-server/src/tests/dhis/pushers/entity/TrackedEntityPusher.test.js
@@ -13,7 +13,7 @@ import { createDhisApiStub, createEntityStub, createModelsStub } from './helpers
 
 const { TRACKED_ENTITY_INSTANCE } = DHIS2_RESOURCE_TYPES;
 
-const DHIS_ID = 'dhisId';
+const DHIS_TRACKED_ENTITY_ID = 'dhisTrackedEntityId';
 const ENTITY_ID = 'entityId';
 const ENTITY_NAME = 'entityName';
 const ENTITY_CODE = 'entityCode';
@@ -27,7 +27,7 @@ const DEFAULT_DHIS_API_STUB_PROPS = {
   entityType: { id: ENTITY_TYPE_ID, displayName: 'Type' },
   organisationUnit: { id: ORGANISATION_UNIT_ID, code: ORGANISATION_UNIT_CODE },
   updateRecord: {
-    references: [DHIS_ID],
+    references: [DHIS_TRACKED_ENTITY_ID],
     wasSuccessful: true,
   },
   deleteRecordById: {
@@ -45,7 +45,7 @@ const getExistingEntity = () =>
     closestOrgUnit: getClosestOrgUnit(),
     type: 'type',
     metadata: {
-      dhis: { id: DHIS_ID },
+      dhis: { trackedEntityId: DHIS_TRACKED_ENTITY_ID },
     },
   });
 const getChange = () => ({ type: 'update', record_id: ENTITY_ID });
@@ -86,7 +86,9 @@ describe('TrackedEntityPusher', () => {
           orgUnit: ORGANISATION_UNIT_ID,
           attributes: [],
         });
-        expect(entity.setDhisId).to.always.have.been.calledWith(DHIS_ID);
+        expect(entity.setDhisTrackedEntityId).to.always.have.been.calledWith(
+          DHIS_TRACKED_ENTITY_ID,
+        );
         expect(result).to.equal(true);
       });
 
@@ -98,12 +100,12 @@ describe('TrackedEntityPusher', () => {
 
         const result = await pusher.push();
         expect(dhisApiStub.updateRecord).to.have.been.calledOnceWith(TRACKED_ENTITY_INSTANCE, {
-          id: DHIS_ID,
+          id: DHIS_TRACKED_ENTITY_ID,
           trackedEntityType: ENTITY_TYPE_ID,
           orgUnit: ORGANISATION_UNIT_ID,
           attributes: [],
         });
-        expect(entity.setDhisId).to.have.callCount(0);
+        expect(entity.setDhisTrackedEntityId).to.have.callCount(0);
         expect(result).to.equal(true);
       });
 
@@ -159,7 +161,7 @@ describe('TrackedEntityPusher', () => {
         const result = await pusher.push();
         expect(dhisApiStub.deleteRecordById).to.have.been.calledOnceWith(
           TRACKED_ENTITY_INSTANCE,
-          DHIS_ID,
+          DHIS_TRACKED_ENTITY_ID,
         );
         expect(result).to.equal(true);
       });

--- a/packages/meditrak-server/src/tests/dhis/pushers/entity/helpers.js
+++ b/packages/meditrak-server/src/tests/dhis/pushers/entity/helpers.js
@@ -12,9 +12,9 @@ const { ORGANISATION_UNIT, TRACKED_ENTITY_ATTRIBUTE, TRACKED_ENTITY_TYPE } = DHI
 
 export const createEntityStub = (
   id,
-  { code, metadata, name, closestOrgUnit, setDhisId, type } = {},
+  { code, metadata, name, closestOrgUnit, setDhisTrackedEntityId, type } = {},
 ) => {
-  const dhisId = metadata && metadata.dhis && metadata.dhis.id;
+  const trackedEntityId = metadata && metadata.dhis && metadata.dhis.trackedEntityId;
 
   return {
     id,
@@ -23,9 +23,9 @@ export const createEntityStub = (
     name,
     type,
     fetchNearestOrgUnitAncestor: () => closestOrgUnit,
-    getDhisId: () => dhisId,
-    hasDhisId: () => !!dhisId,
-    setDhisId: setDhisId || sinon.stub().returnsArg(0),
+    getDhisTrackedEntityId: () => trackedEntityId,
+    hasDhisTrackedEntityId: () => !!trackedEntityId,
+    setDhisTrackedEntityId: setDhisTrackedEntityId || sinon.stub().returnsArg(0),
     getData: () => ({ id, code, metadata, name, type }),
   };
 };


### PR DESCRIPTION
### Issue: https://github.com/beyondessential/tupaia-backlog/issues/2263

### Changes:

- Added push flag to metadata column of entity to prevent pushing to DHIS2
- Changed dhis.id to dhis.trackedEntityId for clarity