### PR TITLE
2188 e2e instance data

### DIFF
--- a/packages/devops/scripts/deployment/dumpE2eDataToS3.sh
+++ b/packages/devops/scripts/deployment/dumpE2eDataToS3.sh
@@ -14,10 +14,10 @@ if [[ "$STAGE" == "e2e" ]]; then
   mkdir -p dumps
 
   echo "Dumping survey_response"
-  pg_dump -U tupaia --column-inserts --data-only --table=survey_response tupaia > dumps/survey_response.sql
+  psql -U tupaia tupaia -c "\copy survey_response to 'dumps/survey_response.csv' csv header"
 
   echo "Dumping answer"
-  pg_dump -U tupaia --column-inserts --data-only --table=answer tupaia > dumps/answer.sql
+  psql -U tupaia tupaia -c "\copy answer to 'dumps/answer.csv' csv header"
 
   echo "Compressing dumps"
   tar cfz dumps.tgz dumps/*

--- a/packages/devops/scripts/deployment/dumpE2eDataToS3.sh
+++ b/packages/devops/scripts/deployment/dumpE2eDataToS3.sh
@@ -14,10 +14,10 @@ if [[ "$STAGE" == "e2e" ]]; then
   mkdir -p dumps
 
   echo "Dumping survey_response"
-  psql -U tupaia tupaia -c "\copy survey_response to 'dumps/survey_response.csv' csv header"
+  psql -U tupaia tupaia -c "\copy survey_response to 'dumps/survey_response.csv' delimiter ',' csv header"
 
   echo "Dumping answer"
-  psql -U tupaia tupaia -c "\copy answer to 'dumps/answer.csv' csv header"
+  psql -U tupaia tupaia -c "\copy answer to 'dumps/answer.csv' delimiter ',' csv header"
 
   echo "Compressing dumps"
   tar cfz dumps.tgz dumps/*

--- a/packages/devops/scripts/deployment/dumpE2eDataToS3.sh
+++ b/packages/devops/scripts/deployment/dumpE2eDataToS3.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Run directly from a nightly cron job, so needs full setup of path etc.
+
 # Set PATH to include depencencies
 export PATH=/home/ubuntu/.local/bin:/home/ubuntu/.yarn/bin:/home/ubuntu/.config/yarn/global/node_modules/.bin:/home/ubuntu/.nvm/versions/node/v12.18.3/bin:/usr/local/bin:$PATH
 

--- a/packages/devops/scripts/deployment/dumpE2eDataToS3.sh
+++ b/packages/devops/scripts/deployment/dumpE2eDataToS3.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Set PATH to include depencencies
+export PATH=/home/ubuntu/.local/bin:/home/ubuntu/.yarn/bin:/home/ubuntu/.config/yarn/global/node_modules/.bin:/home/ubuntu/.nvm/versions/node/v12.18.3/bin:/usr/local/bin:$PATH
+
+DIR=$(dirname "$0")
+export STAGE=$(${DIR}/../utility/getEC2TagValue.sh Stage)
+
+# Set the branch based on STAGE
+if [[ "$STAGE" == "e2e" ]]; then
+  echo "Dumping E2E data from E2E baseline instance to S3"
+  mkdir -p dumps
+
+  echo "Dumping survey_response"
+  pg_dump -U tupaia --column-inserts --data-only --table=survey_response tupaia > dumps/survey_response.sql
+
+  echo "Dumping answer"
+  pg_dump -U tupaia --column-inserts --data-only --table=answer tupaia > dumps/answer.sql
+
+  echo "Compressing dumps"
+  tar cfz dumps.tgz dumps/*
+
+  echo "Pushing dumps to S3"
+  aws s3 cp dumps.tgz s3://tupaia/dumps/e2e/dumps.tgz
+
+  echo "Cleaning up"
+  rm -rf dumps*
+
+  echo "Finished dumping E2E data"
+fi
+
+
+

--- a/packages/devops/scripts/deployment/restoreE2eDataFromS3.sh
+++ b/packages/devops/scripts/deployment/restoreE2eDataFromS3.sh
@@ -16,10 +16,10 @@ echo "Clearing survey response and answer tables"
 psql -U tupaia tupaia -c "TRUNCATE TABLE survey_response CASCADE;"
 
 echo "Restoring survey responses"
-psql -U tupaia tupaia < ./dumps/survey_response.sql
+psql -U tupaia tupaia -c "\copy 'dumps/survey_response.csv' to survey_response csv header"
 
 echo "Restoring answers"
-psql -U tupaia tupaia < ./dumps/answer.sql
+psql -U tupaia tupaia -c "\copy 'dumps/answer.csv' to answer csv header"
 
 echo "Re-enabling notification triggers"
 psql -U tupaia tupaia -c "ALTER TABLE survey_response DISABLE TRIGGER survey_response_trigger;"

--- a/packages/devops/scripts/deployment/restoreE2eDataFromS3.sh
+++ b/packages/devops/scripts/deployment/restoreE2eDataFromS3.sh
@@ -16,10 +16,10 @@ echo "Clearing survey response and answer tables"
 psql -U tupaia tupaia -c "TRUNCATE TABLE survey_response CASCADE;"
 
 echo "Restoring survey responses"
-psql -U tupaia tupaia -c "\copy 'dumps/survey_response.csv' to survey_response csv header"
+psql -U tupaia tupaia -c "\copy survey_response from 'dumps/.csv' delimiter ',' csv header"
 
 echo "Restoring answers"
-psql -U tupaia tupaia -c "\copy 'dumps/answer.csv' to answer csv header"
+psql -U tupaia tupaia -c "\copy answer from 'dumps/.csv' delimiter ',' csv header"
 
 echo "Re-enabling notification triggers"
 psql -U tupaia tupaia -c "ALTER TABLE survey_response DISABLE TRIGGER survey_response_trigger;"

--- a/packages/devops/scripts/deployment/restoreE2eDataFromS3.sh
+++ b/packages/devops/scripts/deployment/restoreE2eDataFromS3.sh
@@ -12,9 +12,8 @@ echo "Disabling notification triggers"
 psql -U tupaia tupaia -c "ALTER TABLE survey_response DISABLE TRIGGER survey_response_trigger;"
 psql -U tupaia tupaia -c "ALTER TABLE answer DISABLE TRIGGER answer_trigger;"
 
-echo "Clearing survey response and data tables"
-psql -U tupaia tupaia -c "TRUNCATE TABLE answer;"
-psql -U tupaia tupaia -c "TRUNCATE TABLE survey_response;"
+echo "Clearing survey response and answer tables"
+psql -U tupaia tupaia -c "TRUNCATE TABLE survey_response CASCADE;"
 
 echo "Restoring survey responses"
 psql -U tupaia tupaia < ./dumps/survey_response.sql

--- a/packages/devops/scripts/deployment/restoreE2eDataFromS3.sh
+++ b/packages/devops/scripts/deployment/restoreE2eDataFromS3.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Set PATH to include depencencies
+export PATH=/home/ubuntu/.local/bin:/home/ubuntu/.yarn/bin:/home/ubuntu/.config/yarn/global/node_modules/.bin:/home/ubuntu/.nvm/versions/node/v12.18.3/bin:/usr/local/bin:$PATH
+
+DIR=$(dirname "$0")
+export STAGE=$(${DIR}/../utility/getEC2TagValue.sh Stage)
+
+# Set the branch based on STAGE
+if [[ "$STAGE" == *e2e ]]; then
+  echo "Restoring E2E data from S3"
+
+  echo "Pulling dumps from S3"
+  aws s3 cp s3://tupaia/dumps/e2e/dumps.tgz .
+
+  echo "Decompressing dumps"
+  tar xf dumps.tgz
+
+  echo "Restoring survey responses"
+  psql -U tupaia tupaia -c "ALTER TABLE survey_response DISABLE TRIGGER ALL;"
+  psql -U tupaia tupaia -c "TRUNCATE TABLE survey_response;"
+  psql -U tupaia tupaia < ./dumps/survey_response.sql
+  psql -U tupaia tupaia -c "ALTER TABLE survey_response ENABLE TRIGGER ALL;"
+
+  echo "Restoring answers"
+  psql -U tupaia tupaia -c "ALTER TABLE answer DISABLE TRIGGER ALL;"
+  psql -U tupaia tupaia -c "TRUNCATE TABLE answer;"
+  psql -U tupaia tupaia < ./dumps/answer.sql
+  psql -U tupaia tupaia -c "ALTER TABLE answer ENABLE TRIGGER ALL;"
+
+  echo "Cleaning up"
+  rm -rf dumps*
+
+  echo "Finished restoring E2E data"
+fi
+
+
+

--- a/packages/devops/scripts/deployment/restoreE2eDataFromS3.sh
+++ b/packages/devops/scripts/deployment/restoreE2eDataFromS3.sh
@@ -8,17 +8,23 @@ aws s3 cp s3://tupaia/dumps/e2e/dumps.tgz .
 echo "Decompressing dumps"
 tar xf dumps.tgz
 
-echo "Restoring survey responses"
-psql -U tupaia tupaia -c "ALTER TABLE survey_response DISABLE TRIGGER ALL;"
+echo "Disabling notification triggers"
+psql -U tupaia tupaia -c "ALTER TABLE survey_response DISABLE TRIGGER survey_response_trigger;"
+psql -U tupaia tupaia -c "ALTER TABLE answer DISABLE TRIGGER answer_trigger;"
+
+echo "Clearing survey response and data tables"
+psql -U tupaia tupaia -c "TRUNCATE TABLE answer;"
 psql -U tupaia tupaia -c "TRUNCATE TABLE survey_response;"
+
+echo "Restoring survey responses"
 psql -U tupaia tupaia < ./dumps/survey_response.sql
-psql -U tupaia tupaia -c "ALTER TABLE survey_response ENABLE TRIGGER ALL;"
 
 echo "Restoring answers"
-psql -U tupaia tupaia -c "ALTER TABLE answer DISABLE TRIGGER ALL;"
-psql -U tupaia tupaia -c "TRUNCATE TABLE answer;"
 psql -U tupaia tupaia < ./dumps/answer.sql
-psql -U tupaia tupaia -c "ALTER TABLE answer ENABLE TRIGGER ALL;"
+
+echo "Re-enabling notification triggers"
+psql -U tupaia tupaia -c "ALTER TABLE survey_response DISABLE TRIGGER survey_response_trigger;"
+psql -U tupaia tupaia -c "ALTER TABLE answer DISABLE TRIGGER answer_trigger;"
 
 echo "Cleaning up"
 rm -rf dumps*

--- a/packages/devops/scripts/deployment/restoreE2eDataFromS3.sh
+++ b/packages/devops/scripts/deployment/restoreE2eDataFromS3.sh
@@ -22,8 +22,8 @@ echo "Restoring answers"
 psql -U tupaia tupaia -c "\copy answer from 'dumps/answer.csv' delimiter ',' csv header"
 
 echo "Re-enabling notification triggers"
-psql -U tupaia tupaia -c "ALTER TABLE survey_response DISABLE TRIGGER survey_response_trigger;"
-psql -U tupaia tupaia -c "ALTER TABLE answer DISABLE TRIGGER answer_trigger;"
+psql -U tupaia tupaia -c "ALTER TABLE survey_response ENABLE TRIGGER survey_response_trigger;"
+psql -U tupaia tupaia -c "ALTER TABLE answer ENABLE TRIGGER answer_trigger;"
 
 echo "Cleaning up"
 rm -rf dumps*

--- a/packages/devops/scripts/deployment/restoreE2eDataFromS3.sh
+++ b/packages/devops/scripts/deployment/restoreE2eDataFromS3.sh
@@ -1,38 +1,26 @@
 #!/bin/bash
 
-# Set PATH to include depencencies
-export PATH=/home/ubuntu/.local/bin:/home/ubuntu/.yarn/bin:/home/ubuntu/.config/yarn/global/node_modules/.bin:/home/ubuntu/.nvm/versions/node/v12.18.3/bin:/usr/local/bin:$PATH
+echo "Restoring E2E data from S3"
 
-DIR=$(dirname "$0")
-export STAGE=$(${DIR}/../utility/getEC2TagValue.sh Stage)
+echo "Pulling dumps from S3"
+aws s3 cp s3://tupaia/dumps/e2e/dumps.tgz .
 
-# Set the branch based on STAGE
-if [[ "$STAGE" == *e2e ]]; then
-  echo "Restoring E2E data from S3"
+echo "Decompressing dumps"
+tar xf dumps.tgz
 
-  echo "Pulling dumps from S3"
-  aws s3 cp s3://tupaia/dumps/e2e/dumps.tgz .
+echo "Restoring survey responses"
+psql -U tupaia tupaia -c "ALTER TABLE survey_response DISABLE TRIGGER ALL;"
+psql -U tupaia tupaia -c "TRUNCATE TABLE survey_response;"
+psql -U tupaia tupaia < ./dumps/survey_response.sql
+psql -U tupaia tupaia -c "ALTER TABLE survey_response ENABLE TRIGGER ALL;"
 
-  echo "Decompressing dumps"
-  tar xf dumps.tgz
+echo "Restoring answers"
+psql -U tupaia tupaia -c "ALTER TABLE answer DISABLE TRIGGER ALL;"
+psql -U tupaia tupaia -c "TRUNCATE TABLE answer;"
+psql -U tupaia tupaia < ./dumps/answer.sql
+psql -U tupaia tupaia -c "ALTER TABLE answer ENABLE TRIGGER ALL;"
 
-  echo "Restoring survey responses"
-  psql -U tupaia tupaia -c "ALTER TABLE survey_response DISABLE TRIGGER ALL;"
-  psql -U tupaia tupaia -c "TRUNCATE TABLE survey_response;"
-  psql -U tupaia tupaia < ./dumps/survey_response.sql
-  psql -U tupaia tupaia -c "ALTER TABLE survey_response ENABLE TRIGGER ALL;"
+echo "Cleaning up"
+rm -rf dumps*
 
-  echo "Restoring answers"
-  psql -U tupaia tupaia -c "ALTER TABLE answer DISABLE TRIGGER ALL;"
-  psql -U tupaia tupaia -c "TRUNCATE TABLE answer;"
-  psql -U tupaia tupaia < ./dumps/answer.sql
-  psql -U tupaia tupaia -c "ALTER TABLE answer ENABLE TRIGGER ALL;"
-
-  echo "Cleaning up"
-  rm -rf dumps*
-
-  echo "Finished restoring E2E data"
-fi
-
-
-
+echo "Finished restoring E2E data"

--- a/packages/devops/scripts/deployment/restoreE2eDataFromS3.sh
+++ b/packages/devops/scripts/deployment/restoreE2eDataFromS3.sh
@@ -16,10 +16,10 @@ echo "Clearing survey response and answer tables"
 psql -U tupaia tupaia -c "TRUNCATE TABLE survey_response CASCADE;"
 
 echo "Restoring survey responses"
-psql -U tupaia tupaia -c "\copy survey_response from 'dumps/.csv' delimiter ',' csv header"
+psql -U tupaia tupaia -c "\copy survey_response from 'dumps/survey_response.csv' delimiter ',' csv header"
 
 echo "Restoring answers"
-psql -U tupaia tupaia -c "\copy answer from 'dumps/.csv' delimiter ',' csv header"
+psql -U tupaia tupaia -c "\copy answer from 'dumps/answer.csv' delimiter ',' csv header"
 
 echo "Re-enabling notification triggers"
 psql -U tupaia tupaia -c "ALTER TABLE survey_response DISABLE TRIGGER survey_response_trigger;"

--- a/packages/devops/scripts/deployment/startup.sh
+++ b/packages/devops/scripts/deployment/startup.sh
@@ -25,6 +25,11 @@ else
     export BRANCH="$STAGE"
 fi
 
+# If this is an E2E instance, restore E2E test data
+if [[ "$STAGE" == *e2e ]]; then
+    ${HOME_DIRECTORY}/packages/devops/scripts/deployment/restoreE2eDataFromS3.sh
+fi
+
 # Fetch the latest code
 ${HOME_DIRECTORY}/packages/devops/scripts/deployment/checkoutLatest.sh
 


### PR DESCRIPTION
### Issue #
https://github.com/beyondessential/tupaia-backlog/issues/2188

Manual steps required on release:
-[ ] Open `crontab -e` and add the following line, which will dump `survey_response` and `answer` to S3 every night at 12:30pm UTC (currently 11:30pm in Melb, 10:30pm after daylight savings):
```
30 12 * * * /home/ubuntu/tupaia/packages/devops/scripts/dumpE2eDataToS3.sh | while IFS= read -r line; do printf '\%s \%s\n' "$(date)" "$line"; done >> /home/ubuntu/logs/dump_e2e_data.txt
```
