### PR TITLE
only load user page urls when no project is being loaded

### DIFF
--- a/packages/web-frontend/src/historyNavigation/utils.js
+++ b/packages/web-frontend/src/historyNavigation/utils.js
@@ -29,9 +29,10 @@ import {
 
 export const createLocation = params => {
   const { userPage } = params;
-  if (userPage) {
-    // Userpage locations are created by the backend,
-    // this is good enough for here
+
+  // Userpage urls are hanlded differently to project pages (eg. reset-password and verify-email)
+  // Assumption - Only load the user page url if there is no project being loaded
+  if (userPage && !params.PROJECT) {
     return { pathname: `/${userPage}`, search: '' };
   }
 


### PR DESCRIPTION
### Issue #: [2402](https://github.com/beyondessential/tupaia-backlog/issues/2402) Fix user page urls

This is a hotfix but I think it needs to be tested before being released so I have made it from the dev branch and not the release branch.

### Changes:

- Fix user page urls

---
