### PR TITLE
Hotfix remove geograhicalArea import contraint

### DIFF
--- a/packages/meditrak-server/src/routes/importEntities/getOrCreateParentEntity.js
+++ b/packages/meditrak-server/src/routes/importEntities/getOrCreateParentEntity.js
@@ -112,10 +112,8 @@ export async function getOrCreateParentEntity(transactingModels, entityObject, c
       parentEntity,
       transactingModels,
     );
-    if (!parentGeographicalArea)
-      throw new Error(
-        `Parent entity must have geographical area, parent entity code: ${parentCode}`,
-      );
+    if (!parentGeographicalArea) return { parentEntity };
+
     return { parentEntity, parentGeographicalArea };
   }
   // no explicit parent code provided, use either subdistrict or district as parent entity


### PR DESCRIPTION
### Issue #: [2482](https://github.com/beyondessential/tupaia-backlog/issues/2482) Issue with importing entities

- remove contraint on parents having geographicalAreas recently added for country level facilities 