### PR TITLE
2301: Allow disable syncing subdistrict and district when importing facilities

### DIFF
--- a/packages/meditrak-server/src/routes/importEntities/getEntityMetadata.js
+++ b/packages/meditrak-server/src/routes/importEntities/getEntityMetadata.js
@@ -1,0 +1,21 @@
+
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+
+export const getEntityMetadata = async (transactingModels, defaultMetadata, code, pushToDhis) => {
+  const newDefaultMetadata = {
+    ...defaultMetadata,
+  };
+
+  // Only assign push = false, by default all entities will be pushed to dhis
+  if (!pushToDhis) {
+    newDefaultMetadata.dhis.push = pushToDhis;
+  }
+
+  const entity = await transactingModels.entity.findOne({ code });
+  return entity && entity.metadata
+    ? entity.metadata // we don't want to override the metadata if the entity already exists
+    : newDefaultMetadata;
+};

--- a/packages/meditrak-server/src/routes/importEntities/getOrCreateParentEntity.js
+++ b/packages/meditrak-server/src/routes/importEntities/getOrCreateParentEntity.js
@@ -3,6 +3,8 @@
  * Copyright (c) 2019 Beyond Essential Systems Pty Ltd
  */
 
+import { getEntityMetadata } from './getEntityMetadata';
+
 function getGeographicalAreaCode(name, country, district) {
   return `${district ? district.code : country.code}_${name.replace("'", '')}`;
 }
@@ -29,7 +31,12 @@ async function getGeographicalAreaFromEntity(entity, models) {
   return null;
 }
 
-export async function getOrCreateParentEntity(transactingModels, entityObject, country) {
+export async function getOrCreateParentEntity(
+  transactingModels,
+  entityObject,
+  country,
+  pushToDhis,
+) {
   const {
     district: districtName,
     district_osm_id: districtOsmId,
@@ -56,6 +63,16 @@ export async function getOrCreateParentEntity(transactingModels, entityObject, c
       level_name: 'District',
     };
     district = await transactingModels.geographicalArea.findOrCreate(districtObject);
+    const defaultMetadata = {
+      dhis: { isDataRegional: true },
+      openStreetMaps: { id: districtOsmId },
+    };
+    const districtEntityMetadata = await getEntityMetadata(
+      transactingModels,
+      defaultMetadata,
+      code,
+      pushToDhis,
+    );
     districtEntity = await transactingModels.entity.updateOrCreate(
       {
         code,
@@ -65,10 +82,7 @@ export async function getOrCreateParentEntity(transactingModels, entityObject, c
         type: transactingModels.entity.types.DISTRICT,
         parent_id: countryEntity.id,
         country_code: country.code,
-        metadata: {
-          dhis: { isDataRegional: true },
-          openStreetMaps: { id: districtOsmId },
-        },
+        metadata: districtEntityMetadata,
       },
     );
   }
@@ -81,15 +95,22 @@ export async function getOrCreateParentEntity(transactingModels, entityObject, c
       level_code: 'sub_district',
       level_name: 'Sub District',
     };
+    const defaultMetadata = {
+      dhis: { isDataRegional: true },
+      openStreetMaps: { id: subDistrictOsmId },
+    };
+    const subDistrictEntityMetadata = await getEntityMetadata(
+      transactingModels,
+      defaultMetadata,
+      code,
+      pushToDhis,
+    );
     const subDistrictEntityObject = {
       name: subDistrictName,
       type: transactingModels.entity.types.SUB_DISTRICT,
       parent_id: countryEntity.id,
       country_code: country.code,
-      metadata: {
-        dhis: { isDataRegional: true },
-        openStreetMaps: { id: subDistrictOsmId },
-      },
+      metadata: subDistrictEntityMetadata,
     };
     // If a district is also being added, use as the parent of the sub_district
     if (district.id) {

--- a/packages/meditrak-server/src/routes/importEntities/updateCountryEntities.js
+++ b/packages/meditrak-server/src/routes/importEntities/updateCountryEntities.js
@@ -6,6 +6,7 @@
 import { ImportValidationError, getCountryCode } from '@tupaia/utils';
 import { getEntityObjectValidator } from './getEntityObjectValidator';
 import { getOrCreateParentEntity } from './getOrCreateParentEntity';
+import { getEntityMetadata } from './getEntityMetadata';
 
 const DEFAULT_TYPE_NAMES = {
   1: 'Hospital',
@@ -27,23 +28,12 @@ function getDefaultTypeDetails(type) {
   return { categoryCode, typeName };
 }
 
-const getEntityMetadata = async (transactingModels, code, pushToDhis) => {
-  const defaultMetadata = {
-    dhis: { isDataRegional: true },
-  };
-  
-  // Only assign push = false, by default all entities will be pushed to dhis
-  if (!pushToDhis) {
-    defaultMetadata.dhis.push = pushToDhis;
-  }
-
-  const entity = await transactingModels.entity.findOne({ code });
-  return entity && entity.metadata
-      ? entity.metadata // we don't want to override the metadata if the entity already exists
-      : defaultMetadata;
-}
-
-export async function updateCountryEntities(transactingModels, countryName, entityObjects, pushToDhis = true) {
+export async function updateCountryEntities(
+  transactingModels,
+  countryName,
+  entityObjects,
+  pushToDhis = true,
+) {
   const countryCode = getCountryCode(countryName, entityObjects);
   const country = await transactingModels.country.findOrCreate(
     { name: countryName },
@@ -52,8 +42,16 @@ export async function updateCountryEntities(transactingModels, countryName, enti
   const { id: worldId } = await transactingModels.entity.findOne({
     type: transactingModels.entity.types.WORLD,
   });
-  
-  const countryEntityMetadata = await getEntityMetadata(transactingModels, countryCode, pushToDhis);
+  const defaultMetadata = {
+    dhis: { isDataRegional: true },
+  };
+  const countryEntityMetadata = await getEntityMetadata(
+    transactingModels,
+    defaultMetadata,
+    countryCode,
+    pushToDhis,
+  );
+
   await transactingModels.entity.findOrCreate(
     { code: countryCode },
     {
@@ -100,6 +98,7 @@ export async function updateCountryEntities(transactingModels, countryName, enti
       transactingModels,
       entityObject,
       country,
+      pushToDhis,
     );
     if (entityType === transactingModels.entity.types.FACILITY) {
       const defaultTypeDetails = getDefaultTypeDetails(facilityType);
@@ -135,7 +134,12 @@ export async function updateCountryEntities(transactingModels, countryName, enti
       );
     }
 
-    const entityMetadata = await getEntityMetadata(transactingModels, code, pushToDhis);
+    const entityMetadata = await getEntityMetadata(
+      transactingModels,
+      defaultMetadata,
+      code,
+      pushToDhis,
+    );
     await transactingModels.entity.updateOrCreate(
       { code },
       {


### PR DESCRIPTION
### Issue: https://github.com/beyondessential/tupaia-backlog/issues/2301

### Changes:

- Allow disable syncing subdistrict and district when importing facilities. Addressing the bug found here: https://github.com/beyondessential/tupaia-backlog/issues/2301#issuecomment-799054228
