### PR TITLE
Fix countDisasterAffectedFacilitiesByStatus query params

### DIFF
--- a/packages/web-config-server/src/apiV1/dataBuilders/modules/disaster/countDisasterAffectedFacilitiesByStatus.js
+++ b/packages/web-config-server/src/apiV1/dataBuilders/modules/disaster/countDisasterAffectedFacilitiesByStatus.js
@@ -20,6 +20,7 @@ export const countDisasterAffectedFacilitiesByStatus = async (
   const facilities = await entity.getDescendantsOfType(hierarchyId, models.entity.types.FACILITY);
   const options = await dhisApi.getOptionSetOptions({ code: optionSetCode });
   const { results } = await aggregator.fetchAnalytics([AFFECTED_STATUS_DATA_ELEMENT_CODE], {
+    ...query,
     dataServices,
     period,
   });


### PR DESCRIPTION
### Issue #: [2503](https://github.com/beyondessential/tupaia-backlog/issues/2503)

### Changes:
- add missing query params to fetch analytics in countDisasterAffectedFacilitiesByStatus