### PR TITLE
2182: Display loading circle when clicking retry

### DIFF
--- a/packages/web-frontend/src/reducers.js
+++ b/packages/web-frontend/src/reducers.js
@@ -469,8 +469,12 @@ function dashboard(
   action,
 ) {
   switch (action.type) {
-    case FETCH_INFO_VIEW_DATA:
-      return state;
+    case FETCH_INFO_VIEW_DATA: {
+      const { infoViewKey } = action;
+      const viewResponses = { ...state.viewResponses };
+      viewResponses[infoViewKey] = null; // Clear view prior to fetch
+      return { ...state, viewResponses };
+    }
     case FETCH_INFO_VIEW_DATA_SUCCESS: {
       const { infoViewKey, response } = action;
       const viewResponses = { ...state.viewResponses };


### PR DESCRIPTION
### Issue #: https://github.com/beyondessential/tupaia-backlog/issues/2182

### Changes:

- When fetching data, clear the view contents (when a view has no content it displays the loading circle)