### PR TITLE
Allow project config of frontend exclude types 

### DIFF
--- a/packages/database/src/migrations/20210325123857-ExcludeIndividualsFromCovidSamoaFront-modifies-data.js
+++ b/packages/database/src/migrations/20210325123857-ExcludeIndividualsFromCovidSamoaFront-modifies-data.js
@@ -1,0 +1,42 @@
+'use strict';
+
+import { arrayToDbString } from '../utilities';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+const newConfig = {
+  frontendExcludedTypes: ['case', 'case_contact', 'individual'],
+};
+const projectCodes = ['covid_samoa'];
+
+exports.up = function (db) {
+  return db.runSql(`
+    update "project" 
+    set "config" = "config"::jsonb || '${JSON.stringify(newConfig)}'::jsonb
+    where "code" in (${arrayToDbString(projectCodes)});
+  `);
+};
+
+exports.down = function (db) {
+  return db.runSql(`
+    update "project" 
+    set "config" = "config"::jsonb #- '{frontend_excluded_types}'
+    where "code" in (${arrayToDbString(projectCodes)});
+  `);
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/packages/web-config-server/src/apiV1/RouteHandler.js
+++ b/packages/web-config-server/src/apiV1/RouteHandler.js
@@ -58,4 +58,6 @@ export class RouteHandler {
     this.models.project.findOne({ code: this.query.projectCode || 'explore' });
 
   fetchHierarchyId = async () => (await this.fetchProject()).entity_hierarchy_id;
+
+  fetchTypesExcludedFromWebFrontend = project => project?.config?.frontendExcludedTypes ?? this.models.entity.typesExcludedFromWebFrontend;
 }

--- a/packages/web-config-server/src/apiV1/organisationUnit.js
+++ b/packages/web-config-server/src/apiV1/organisationUnit.js
@@ -41,11 +41,12 @@ export default class extends RouteHandler {
   async getEntityAndCountryDataByCode(project) {
     const projectEntity = await project.entity();
     const country = await this.entity.countryEntity();
+    const typesExcludedFromWebFrontend = await this.fetchTypesExcludedFromWebFrontend(project);
     const countryDescendants = country
       ? await country.getDescendants(project.entity_hierarchy_id, {
           type: {
             comparator: 'not in',
-            comparisonValue: this.models.entity.typesExcludedFromWebFrontend,
+            comparisonValue: typesExcludedFromWebFrontend,
           },
         })
       : [];

--- a/packages/web-config-server/src/apiV1/organisationUnitSearch.js
+++ b/packages/web-config-server/src/apiV1/organisationUnitSearch.js
@@ -59,11 +59,12 @@ export default class extends RouteHandler {
   async getSearchResults(searchString, limit, startIndex) {
     const project = await this.fetchProject();
     const projectEntity = await project.entity();
+    const typesExcludedFromWebFrontend = await this.fetchTypesExcludedFromWebFrontend(project);
 
     const allEntities = await projectEntity.getDescendants(project.entity_hierarchy_id, {
       type: {
         comparator: 'not in',
-        comparisonValue: this.models.entity.typesExcludedFromWebFrontend,
+        comparisonValue: typesExcludedFromWebFrontend,
       },
     });
     const { matchingEntities, hasMoreResults } = await this.getMatchingEntities(


### PR DESCRIPTION
### Issue #: [2347](https://github.com/beyondessential/tupaia-backlog/issues/2347) Allow Individuals from fronent in Covid Samoa

### Changes:
- Check for project config frontendExcludedTypes else use entity default list `entity.typesExcludedFromWebFrontend` as before.
- Add migration to individual to frontendExcludedTypes for Covid Samoa