### PR TITLE
Import Survey Responses relative to browser timezone

### DIFF
--- a/packages/admin-panel/src/pages/resources/SurveyResponsesPage.js
+++ b/packages/admin-panel/src/pages/resources/SurveyResponsesPage.js
@@ -136,6 +136,9 @@ const IMPORT_CONFIG = {
   title: 'Import Survey Responses',
   actionConfig: {
     importEndpoint: 'surveyResponses',
+    extraQueryParameters: {
+      timeZone: getBrowserTimeZone(),
+    },
   },
   queryParameters: [
     {

--- a/packages/meditrak-server/src/dataAccessors/updateOrCreateSurveyResponse.js
+++ b/packages/meditrak-server/src/dataAccessors/updateOrCreateSurveyResponse.js
@@ -7,7 +7,7 @@ import momentTimezone from 'moment-timezone';
 import { DatabaseError, UploadError, stripTimezoneFromDate } from '@tupaia/utils';
 import { uploadImage } from '../s3';
 import { BUCKET_PATH, getImageFilePath } from '../s3/constants';
-import { getEntityIdFromClinicId } from '../database/utilities';
+import { DEFAULT_DATABASE_TIMEZONE, getEntityIdFromClinicId } from '../database';
 
 async function saveAnswer(models, answer, surveyResponseId) {
   const answerDocument = {
@@ -70,7 +70,7 @@ export async function updateOrCreateSurveyResponse(models, surveyResponseObject)
       data_time: suppliedDataTime,
       submission_time: submissionTime, // v1.7.87 to v1.9.110 (inclusive) uses submission_time
       end_time: endTime, // prior to v1.7.87 fall back to end_time
-      timezone = 'Pacific/Auckland', // if no timezone provided, use db default
+      timezone = DEFAULT_DATABASE_TIMEZONE, // if no timezone provided, use db default
     } = surveyResponseObject;
     const dataTime = suppliedDataTime || submissionTime || endTime;
 

--- a/packages/meditrak-server/src/database/constants.js
+++ b/packages/meditrak-server/src/database/constants.js
@@ -1,0 +1,6 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+
+export const DEFAULT_DATABASE_TIMEZONE = 'Pacific/Auckland';

--- a/packages/meditrak-server/src/database/index.js
+++ b/packages/meditrak-server/src/database/index.js
@@ -6,3 +6,4 @@
 export { SyncQueue } from './SyncQueue';
 export { createMeditrakSyncQueue } from './createMeditrakSyncQueue';
 export * from './utilities';
+export * from './constants';

--- a/packages/meditrak-server/src/routes/importSurveyResponses/importSurveyResponses.js
+++ b/packages/meditrak-server/src/routes/importSurveyResponses/importSurveyResponses.js
@@ -83,14 +83,16 @@ export async function importSurveyResponses(req, res) {
                 const entityCode = getInfoForColumn(sheet, columnIndex, 'Entity Code');
                 const entity = await transactingModels.entity.findOne({ code: entityCode });
                 const user = await transactingModels.user.findById(req.userId);
+                // Pull data_time from spreadsheet, set end_time to current time
                 const surveyDate = getDateForColumn(sheet, columnIndex, timeZone);
+                const importDate = moment();
                 const newSurveyResponse = await transactingModels.surveyResponse.create({
                   survey_id: survey.id, // All survey responses within a sheet should be for the same survey
                   assessor_name: `${user.first_name} ${user.last_name}`,
                   user_id: user.id,
                   entity_id: entity.id,
-                  start_time: surveyDate,
-                  end_time: surveyDate,
+                  start_time: importDate,
+                  end_time: importDate,
                   data_time: stripTimezoneFromDate(surveyDate),
                   timezone: timeZone,
                 });

--- a/packages/meditrak-server/src/routes/importSurveyResponses/importSurveyResponses.js
+++ b/packages/meditrak-server/src/routes/importSurveyResponses/importSurveyResponses.js
@@ -83,8 +83,8 @@ export async function importSurveyResponses(req, res) {
                 const entityCode = getInfoForColumn(sheet, columnIndex, 'Entity Code');
                 const entity = await transactingModels.entity.findOne({ code: entityCode });
                 const user = await transactingModels.user.findById(req.userId);
-                // Pull data_time from spreadsheet, set end_time to current time
-                const surveyDate = getDateForColumn(sheet, columnIndex, timeZone);
+                // 'Date of Data' is pulled from spreadsheet, 'Date of Survey' is current time
+                const surveyDate = getDateForColumn(sheet, columnIndex);
                 const importDate = moment();
                 const newSurveyResponse = await transactingModels.surveyResponse.create({
                   survey_id: survey.id, // All survey responses within a sheet should be for the same survey
@@ -283,9 +283,9 @@ function getDateStringForColumn(sheet, columnIndex) {
   return getInfoForColumn(sheet, columnIndex, 'Date');
 }
 
-function getDateForColumn(sheet, columnIndex, timeZone) {
+function getDateForColumn(sheet, columnIndex) {
   const dateString = getDateStringForColumn(sheet, columnIndex);
-  return moment.tz(dateString, EXPORT_DATE_FORMAT, timeZone).toDate();
+  return moment.utc(dateString, EXPORT_DATE_FORMAT).toDate();
 }
 
 function checkIsCellEmpty(cellValue) {

--- a/packages/meditrak-server/src/tests/routes/importSurveyResponses/testFunctionality.js
+++ b/packages/meditrak-server/src/tests/routes/importSurveyResponses/testFunctionality.js
@@ -4,6 +4,7 @@
  */
 
 import { expect } from 'chai';
+import moment from 'moment';
 import {
   findOrCreateDummyRecord,
   findOrCreateDummyCountryEntity,
@@ -263,7 +264,8 @@ export const testFunctionality = async () => {
       for (const addedResponse of surveyResponsesAdded) {
         const surveyResponse = await models.surveyResponse.findOne({
           entity_id: addedResponse.entityId,
-          end_time: addedResponse.date,
+          // Convert date to data_time format
+          data_time: moment.utc(addedResponse.date).format('YYYY-MM-DD HH:mm:ss'),
         });
         expect(surveyResponse, 'added survey response').to.exist;
         for (const [questionId, answerValue] of Object.entries(addedResponse.answers)) {

--- a/packages/meditrak-server/src/tests/routes/importSurveyResponses/testFunctionality.js
+++ b/packages/meditrak-server/src/tests/routes/importSurveyResponses/testFunctionality.js
@@ -33,7 +33,9 @@ export const testFunctionality = async () => {
 
   const importFile = (filename, surveyNames = []) =>
     app
-      .post(`import/surveyResponses?${surveyNames.map(s => `surveyNames=${s}`).join('&')}`)
+      .post(
+        `import/surveyResponses?${surveyNames.map(s => `surveyNames=${s}`).join('&')}&timeZone=UTC`,
+      )
       .attach('surveyResponses', `${TEST_DATA_FOLDER}/surveyResponses/${filename}`);
 
   const deletedSurveyResponseId = '1125f5e462d7a74a5a2_test';


### PR DESCRIPTION
### Issue #:
https://github.com/beyondessential/tupaia-backlog/issues/1149
https://github.com/beyondessential/tupaia-backlog/issues/717

### Changes:

- Add browser timezone to REST request when importing survey responses
- Create survey responses relative to the given timezone
- Set an imported survey responses start and end time to current time