### PR TITLE
2100: Use data_time field in analytics table

### DIFF
--- a/packages/data-api/scripts/createAnalyticsMaterializedView.sql
+++ b/packages/data-api/scripts/createAnalyticsMaterializedView.sql
@@ -1,4 +1,4 @@
-do $$ 
+do $$
 declare
   tStartTime TIMESTAMP;
   source_table TEXT;
@@ -12,11 +12,11 @@ declare
       survey_response.id as event_id,
       answer.text as value,
       question.type as type,
-      date_trunc(''day'', survey_response.submission_time) as "day_period",
-      date_trunc(''week'', survey_response.submission_time) as "week_period",
-      date_trunc(''month'', survey_response.submission_time) as "month_period",
-      date_trunc(''year'', survey_response.submission_time) as "year_period",
-      survey_response.submission_time as "date"
+      date_trunc(''day'', survey_response.data_time) as "day_period",
+      date_trunc(''week'', survey_response.data_time) as "week_period",
+      date_trunc(''month'', survey_response.data_time) as "month_period",
+      date_trunc(''year'', survey_response.data_time) as "year_period",
+      survey_response.data_time as "date"
     FROM
       survey_response
     INNER JOIN
@@ -27,19 +27,19 @@ declare
       survey ON survey.id = survey_response.survey_id
     INNER JOIN
       question ON question.id = answer.question_id
-    INNER JOIN 
+    INNER JOIN
       data_source ON data_source.id = question.data_source_id
     WHERE data_source.service_type = ''tupaia''';
 
-begin 
+begin
   RAISE NOTICE 'Creating Materialized View Logs...';
 
   FOREACH source_table IN ARRAY source_tables_array LOOP
     IF (SELECT NOT EXISTS (
-      SELECT FROM pg_tables 
+      SELECT FROM pg_tables
       WHERE schemaname = 'public'
       AND tablename   = 'log$_' || source_table
-    )) 
+    ))
     THEN
       EXECUTE 'DROP TRIGGER IF EXISTS ' || source_table || '_trigger' || ' ON ' || source_table;
       tStartTime := clock_timestamp();
@@ -54,7 +54,7 @@ begin
 
   RAISE NOTICE 'Creating analytics materialized view...';
   IF (SELECT NOT EXISTS (
-    SELECT FROM pg_tables 
+    SELECT FROM pg_tables
     WHERE schemaname = 'public'
     AND tablename   = 'analytics'
   ))

--- a/packages/data-api/src/TupaiaDataApi.js
+++ b/packages/data-api/src/TupaiaDataApi.js
@@ -6,7 +6,7 @@
 import groupBy from 'lodash.groupby';
 
 import moment from 'moment';
-import { getSortByKey, momentToDateString, utcMoment } from '@tupaia/utils';
+import { getSortByKey, momentToDateString } from '@tupaia/utils';
 import { fetchData } from './fetchData';
 import { SqlQuery } from './SqlQuery';
 import { sanitizeDataValue } from './utils';

--- a/packages/data-api/src/TupaiaDataApi.js
+++ b/packages/data-api/src/TupaiaDataApi.js
@@ -35,13 +35,8 @@ export class TupaiaDataApi {
           {},
         );
         return {
-<<<<<<< HEAD
           event: eventId,
-          eventDate: utcMoment(date).format(EVENT_DATE_FORMAT),
-=======
-          event: surveyResponseId,
           eventDate: moment(date).format(EVENT_DATE_FORMAT),
->>>>>>> origin/dev
           orgUnit: entityCode,
           orgUnitName: entityName,
           dataValues,

--- a/packages/data-api/src/__tests__/TupaiaDataApi.fixtures.js
+++ b/packages/data-api/src/__tests__/TupaiaDataApi.fixtures.js
@@ -130,13 +130,10 @@ export const CROP_RESPONSE_AUCKLAND_2020 = {
   id: generateTestId(),
   surveyCode: CROP_SURVEY.code,
   entityCode: auckland.code,
-<<<<<<< HEAD
-  submission_time: '2020-11-21T09:00:00Z',
-  answers: { [CROP_2.code]: '55' },
-=======
   data_time: '2020-11-21T09:00:00',
-  answers: { CROP_2: '55' },
->>>>>>> origin/dev
+  answers: {
+    [CROP_2.code]: '55',
+  },
 };
 
 export const CROP_RESPONSE_WELLINGTON_2019 = {

--- a/packages/data-api/src/__tests__/TupaiaDataApi.fixtures.js
+++ b/packages/data-api/src/__tests__/TupaiaDataApi.fixtures.js
@@ -151,7 +151,7 @@ export const KITTY_RESPONSE_WELLINGTON_MORNING_20210104W1 = {
   id: generateTestId(),
   surveyCode: KITTY_SURVEY.code,
   entityCode: wellington.code,
-  submission_time: '2021-01-04T09:00:00Z',
+  data_time: '2021-01-04T09:00:00Z',
   answers: {
     [KITTY_1.code]: '18.4',
     [KITTY_2.code]: '50',
@@ -162,7 +162,7 @@ export const KITTY_RESPONSE_WELLINGTON_MIDDAY_20210104W1 = {
   id: generateTestId(),
   surveyCode: KITTY_SURVEY.code,
   entityCode: wellington.code,
-  submission_time: '2021-01-04T09:01:00Z',
+  data_time: '2021-01-04T09:01:00Z',
   answers: {
     [KITTY_1.code]: '12.4',
     [KITTY_2.code]: '60',
@@ -173,7 +173,7 @@ export const KITTY_RESPONSE_WELLINGTON_NIGHT_20210104W1 = {
   id: generateTestId(),
   surveyCode: KITTY_SURVEY.code,
   entityCode: wellington.code,
-  submission_time: '2021-01-04T09:02:00Z',
+  data_time: '2021-01-04T09:02:00Z',
   answers: {
     [KITTY_1.code]: '14.4',
     [KITTY_2.code]: '62',
@@ -184,7 +184,7 @@ export const KITTY_RESPONSE_WELLINGTON_MORNING_20210105W1 = {
   id: generateTestId(),
   surveyCode: KITTY_SURVEY.code,
   entityCode: wellington.code,
-  submission_time: '2021-01-05T09:00:00Z',
+  data_time: '2021-01-05T09:00:00Z',
   answers: {
     [KITTY_1.code]: '17.4',
     [KITTY_2.code]: '52',
@@ -195,7 +195,7 @@ export const KITTY_RESPONSE_WELLINGTON_NIGHT_20210105W1 = {
   id: generateTestId(),
   surveyCode: KITTY_SURVEY.code,
   entityCode: wellington.code,
-  submission_time: '2021-01-05T09:02:00Z',
+  data_time: '2021-01-05T09:02:00Z',
   answers: {
     [KITTY_1.code]: '19.4',
     [KITTY_2.code]: '40',
@@ -206,7 +206,7 @@ export const KITTY_RESPONSE_WELLINGTON_MORNING_20210113W2 = {
   id: generateTestId(),
   surveyCode: KITTY_SURVEY.code,
   entityCode: wellington.code,
-  submission_time: '2021-01-13T09:00:00Z',
+  data_time: '2021-01-13T09:00:00Z',
   answers: {
     [KITTY_1.code]: '23.4',
     [KITTY_2.code]: '6',
@@ -217,7 +217,7 @@ export const KITTY_RESPONSE_WELLINGTON_MORNING_20210115W2 = {
   id: generateTestId(),
   surveyCode: KITTY_SURVEY.code,
   entityCode: wellington.code,
-  submission_time: '2021-01-15T09:00:00Z',
+  data_time: '2021-01-15T09:00:00Z',
   answers: {
     [KITTY_1.code]: '13.4',
     [KITTY_2.code]: '67',
@@ -228,7 +228,7 @@ export const KITTY_RESPONSE_WELLINGTON_MORNING_20210205W5 = {
   id: generateTestId(),
   surveyCode: KITTY_SURVEY.code,
   entityCode: wellington.code,
-  submission_time: '2021-02-05T09:00:00Z',
+  data_time: '2021-02-05T09:00:00Z',
   answers: {
     [KITTY_1.code]: '16.4',
     [KITTY_2.code]: '87',
@@ -239,7 +239,7 @@ export const KITTY_RESPONSE_WELLINGTON_MORNING_20210219W7 = {
   id: generateTestId(),
   surveyCode: KITTY_SURVEY.code,
   entityCode: wellington.code,
-  submission_time: '2021-02-19T09:00:00Z',
+  data_time: '2021-02-19T09:00:00Z',
   answers: {
     [KITTY_1.code]: '17.4',
     [KITTY_2.code]: '47',
@@ -250,7 +250,7 @@ export const KITTY_RESPONSE_WELLINGTON_MORNING_20220606W23 = {
   id: generateTestId(),
   surveyCode: KITTY_SURVEY.code,
   entityCode: wellington.code,
-  submission_time: '2022-06-06T09:00:00Z',
+  data_time: '2022-06-06T09:00:00Z',
   answers: {
     [KITTY_1.code]: '8.4',
     [KITTY_2.code]: '187',
@@ -261,7 +261,7 @@ export const KITTY_RESPONSE_WELLINGTON_MORNING_20220608W23 = {
   id: generateTestId(),
   surveyCode: KITTY_SURVEY.code,
   entityCode: wellington.code,
-  submission_time: '2022-06-08T09:00:00Z',
+  data_time: '2022-06-08T09:00:00Z',
   answers: {
     [KITTY_1.code]: '19.4',
     [KITTY_2.code]: '36',
@@ -272,7 +272,7 @@ export const KITTY_RESPONSE_AUCKLAND_MORNING_20210608W23 = {
   id: generateTestId(),
   surveyCode: KITTY_SURVEY.code,
   entityCode: auckland.code,
-  submission_time: '2021-06-08T09:00:00Z',
+  data_time: '2021-06-08T09:00:00Z',
   answers: {
     [KITTY_1.code]: '15.4',
     [KITTY_2.code]: '63',
@@ -283,7 +283,7 @@ export const KITTY_RESPONSE_AUCKLAND_MORNING_20220608W23 = {
   id: generateTestId(),
   surveyCode: KITTY_SURVEY.code,
   entityCode: auckland.code,
-  submission_time: '2022-06-08T09:00:00Z',
+  data_time: '2022-06-08T09:00:00Z',
   answers: {
     [KITTY_1.code]: '12.4',
     [KITTY_2.code]: '360',

--- a/packages/data-api/src/fetchData.js
+++ b/packages/data-api/src/fetchData.js
@@ -2,11 +2,10 @@
  * Tupaia
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
-import { utcMoment, stripTimezoneFromDate } from '@tupaia/utils';
+import { utcMoment } from '@tupaia/utils';
 
 import { SqlQuery } from './SqlQuery';
 
-<<<<<<< HEAD
 const AGGREGATIONS = {
   FINAL_EACH_DAY: {
     periodColumns: ['day_period'],
@@ -80,59 +79,18 @@ const getA1GroupByClause = firstAggregation => {
     ? `GROUP BY ${COMMON_FIELDS.concat(firstAggregation.periodColumns).join(', ')}`
     : '';
 };
-=======
-const generateBaseSqlQuery = ({ dataElementCodes, organisationUnitCodes, startDate, endDate }) => {
-  const sqlQuery = new SqlQuery(
-    `
-    SELECT
-      survey_response.id as "surveyResponseId",
-      survey_response.data_time as "date",
-      entity.code as "entityCode",
-      entity.name as "entityName",
-      question.code as "dataElementCode",
-      question.type as "type",
-      answer.text as "value"
-    FROM
-      survey_response
-    JOIN
-      answer ON answer.survey_response_id = survey_response.id
-    JOIN
-      entity ON entity.id = survey_response.entity_id
-    JOIN
-      question ON question.id = answer.question_id
-    JOIN
-      survey ON survey.id = survey_response.survey_id
-    WHERE
-      question.code IN ${SqlQuery.parameteriseArray(dataElementCodes)}
-    AND
-      entity.code IN ${SqlQuery.parameteriseArray(organisationUnitCodes)}
-  `,
-    [...dataElementCodes, ...organisationUnitCodes],
-  );
->>>>>>> origin/dev
 
 const getA2WhereClause = (firstAggregation, startDate, endDate, paramsArray) => {
   const whereClauses = COMMON_FIELDS.concat(firstAggregation.periodColumns).map(
     field => `${field} = a1.${field}`,
   );
   if (startDate) {
-<<<<<<< HEAD
     whereClauses.push('date >= ?');
     paramsArray.push(startDate);
   }
   if (endDate) {
     whereClauses.push('date <= ?');
     paramsArray.push(endDate);
-=======
-    sqlQuery.addClause(`AND survey_response.data_time >= ?`, [
-      stripTimezoneFromDate(utcMoment(startDate).startOf('day').toISOString()),
-    ]);
-  }
-  if (endDate) {
-    sqlQuery.addClause(`AND survey_response.data_time <= ?`, [
-      stripTimezoneFromDate(utcMoment(endDate).endOf('day').toISOString()),
-    ]);
->>>>>>> origin/dev
   }
   return `WHERE ${whereClauses.join('\n      AND ')}`;
 };
@@ -166,7 +124,7 @@ const generateBaseSqlQuery = ({
   const paramsArray = [];
   const sqlQuery = new SqlQuery(
     `
-    SELECT 
+    SELECT
       date AS "date",
       entity_code AS "entityCode",
       entity_name AS "entityName",
@@ -194,11 +152,7 @@ const generateBaseSqlQuery = ({
     paramsArray,
   );
 
-<<<<<<< HEAD
   sqlQuery.addOrderByClause('date');
-=======
-  sqlQuery.orderBy('survey_response.data_time');
->>>>>>> origin/dev
 
   return sqlQuery;
 };

--- a/packages/data-api/src/fetchData.js
+++ b/packages/data-api/src/fetchData.js
@@ -2,7 +2,7 @@
  * Tupaia
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
-import { utcMoment } from '@tupaia/utils';
+import { utcMoment, stripTimezoneFromDate } from '@tupaia/utils';
 
 import { SqlQuery } from './SqlQuery';
 
@@ -117,9 +117,11 @@ const generateBaseSqlQuery = ({
   aggregations,
 }) => {
   const adjustedStartDate = startDate
-    ? utcMoment(startDate).startOf('day').toISOString()
+    ? stripTimezoneFromDate(utcMoment(startDate).startOf('day').toISOString())
     : undefined;
-  const adjustedEndDate = endDate ? utcMoment(endDate).endOf('day').toISOString() : undefined;
+  const adjustedEndDate = endDate
+    ? stripTimezoneFromDate(utcMoment(endDate).endOf('day').toISOString())
+    : undefined;
   const firstAggregation = AGGREGATIONS[aggregations?.[0]?.type] || AGGREGATIONS.DEFAULT;
   const paramsArray = [];
   const sqlQuery = new SqlQuery(

--- a/packages/indicators/src/__tests__/__integration/fixtures/helpers.ts
+++ b/packages/indicators/src/__tests__/__integration/fixtures/helpers.ts
@@ -5,7 +5,7 @@
 
 import { arrayToAnalytics } from '@tupaia/data-broker';
 
-// surveyCode, entityCode, submissionTime, answers
+// surveyCode, entityCode, data_time, answers
 export type ArraySurveyResponse = [string, string, string, Record<string, string>];
 
 export const arrayToSurveyResponse = (arrayResponse: ArraySurveyResponse) => {

--- a/packages/meditrak-server/src/database/models/SurveyResponse.js
+++ b/packages/meditrak-server/src/database/models/SurveyResponse.js
@@ -6,11 +6,7 @@
 import momentTimezone from 'moment-timezone';
 import moment from 'moment';
 
-<<<<<<< HEAD
 import { MaterializedViewLogDatabaseModel, DatabaseType, TYPES } from '@tupaia/database';
-=======
-import { DatabaseModel, DatabaseType, TYPES } from '@tupaia/database';
->>>>>>> origin/dev
 
 class SurveyResponseType extends DatabaseType {
   static databaseType = TYPES.SURVEY_RESPONSE;


### PR DESCRIPTION
### Issue #:

https://github.com/beyondessential/tupaia-backlog/issues/2100

`dev` now includes the new `data_time` field! For ease of reviewing, I created [2101-merge-dev-with-conflicts](2101-merge-dev-with-conflicts) as a helper branch. This is the same as [2101-analytics-table-materialized-view](https://github.com/beyondessential/tupaia/tree/2101-analytics-table-materialized-view), plus a simple [commit](https://github.com/beyondessential/tupaia/commit/808170035145a7d4de2286e81eb0a12a6aaa1e10) that merges `dev`. There is no conflict resolution in that commit, in an effort to expose them in this PR.

