### PR TITLE
Bump meditrak version to 1.11.112

### DIFF
--- a/packages/meditrak-app/ios/TupaiaMediTrak/Info.plist
+++ b/packages/meditrak-app/ios/TupaiaMediTrak/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.10.111</string>
+	<string>1.11.112</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>111</string>
+	<string>112</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/packages/meditrak-app/package.json
+++ b/packages/meditrak-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/meditrak-app",
-  "version": "1.10.111",
+  "version": "1.11.112",
   "private": true,
   "description": "Android and iOS app for surveying medical facilities",
   "repository": {


### PR DESCRIPTION
The timezone changes from https://github.com/beyondessential/tupaia-backlog/issues/1149 are big enough to warrant a version bump