### PR TITLE
fix-ui-components-build

### DIFF
--- a/packages/ui-components/src/index.js
+++ b/packages/ui-components/src/index.js
@@ -15,7 +15,6 @@ export * from './components/Dialog';
 export * from './components/HomeButton';
 export * from './components/IconButton';
 export * from './components/BarMeter';
-export * from './components/Map';
 export * from './components/NavBar';
 export * from './components/ProfileButton';
 export * from './components/Tabs';


### PR DESCRIPTION
### Issue #: No Issue

Map components were split out into to their own bundle but the map directory was never removed from the main ui-components bundle. 

### Changes:

- Remove map components from main bundle.

---
