### PR TITLE
Add Covid 19 Samoa overlays to covid 19 Samoa project

### DIFF
--- a/packages/database/src/migrations/20210413043932-AddExploreOverlayToCovidSamoaProject-modifies-data.js
+++ b/packages/database/src/migrations/20210413043932-AddExploreOverlayToCovidSamoaProject-modifies-data.js
@@ -1,0 +1,48 @@
+'use strict';
+
+import { codeToId, insertObject, generateId } from '../utilities';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+const overlayIDs = ['Samoa_COVID_Isolation_Beds', 'Samoa_COVID_ICU_Beds'];
+
+const mapOverLayGroupId = async db => {
+  return codeToId(db, 'map_overlay_group', 'COVID19_Samoa');
+};
+
+exports.up = async function (db) {
+  for (const id of overlayIDs) {
+    await insertObject(db, 'map_overlay_group_relation', {
+      id: generateId(),
+      map_overlay_group_id: await mapOverLayGroupId(db),
+      child_id: id,
+      child_type: 'mapOverlay',
+    });
+  }
+};
+
+exports.down = async function (db) {
+  for (const id of overlayIDs) {
+    await db.runSql(`
+      delete from "map_overlay_group_relation" 
+      where "child_id" = '${id}'
+      and "map_overlay_group_id" = '${await mapOverLayGroupId(db)}';
+    `);
+  }
+};
+
+exports._meta = {
+  version: 1,
+};


### PR DESCRIPTION
### Issue #: [2576](https://app.zenhub.com/workspaces/active-sprints-5eea9d3de8519e0019186490/issues/beyondessential/tupaia-backlog/2576)

### Changes:

- Create migration to add overlays to dashboard group

### Manual step:
- Will need to add the two overlays to 'covid_samoa' via admin panel (keep in explore):
  - Samoa_COVID_ICU_Beds
  - Samoa_COVID_Isolation_Beds

### Screenshots:
