### PR TITLE
Clean up timeouts after fetch resolves

### DIFF
--- a/packages/meditrak-app/app/api/TupaiaApi.js
+++ b/packages/meditrak-app/app/api/TupaiaApi.js
@@ -37,24 +37,20 @@ export class TupaiaApi {
   }
 
   async reauthenticate(loginCredentials) {
-    try {
-      const response = await this.post(
-        AUTH_API_ENDPOINT,
-        null,
-        JSON.stringify(loginCredentials),
-        CLIENT_BASIC_AUTH_HEADER,
-        false,
-      );
-      if (response.error) return response;
-      const { accessToken, refreshToken, user } = response;
-      if (!accessToken || !refreshToken || !user) {
-        return { error: 'Invalid response from auth server' };
-      }
-      this.setAuthTokens(accessToken, refreshToken);
-      return response;
-    } catch (error) {
-      throw error; // Throw error up
+    const response = await this.post(
+      AUTH_API_ENDPOINT,
+      null,
+      JSON.stringify(loginCredentials),
+      CLIENT_BASIC_AUTH_HEADER,
+      false,
+    );
+    if (response.error) return response;
+    const { accessToken, refreshToken, user } = response;
+    if (!accessToken || !refreshToken || !user) {
+      return { error: 'Invalid response from auth server' };
     }
+    this.setAuthTokens(accessToken, refreshToken);
+    return response;
   }
 
   setAuthTokens(accessToken = this.accessToken, refreshToken = this.refreshToken) {
@@ -121,7 +117,7 @@ export class TupaiaApi {
       return; // Silently swallow network errors etc, they will be picked up by the outer request
     }
     if (!response.accessToken) {
-      this.reduxStore && this.reduxStore.dispatch(logoutWithError(response.error));
+      if (this.reduxStore) this.reduxStore.dispatch(logoutWithError(response.error));
       return;
     }
     this.reduxStore.dispatch(receiveUpdatedAccessPolicy(response.user));
@@ -129,19 +125,15 @@ export class TupaiaApi {
   }
 
   async createUser(userFields) {
-    try {
-      const response = await this.post(
-        CREATE_USER_ENDPOINT,
-        null,
-        JSON.stringify(userFields),
-        CLIENT_BASIC_AUTH_HEADER,
-        false,
-      );
+    const response = await this.post(
+      CREATE_USER_ENDPOINT,
+      null,
+      JSON.stringify(userFields),
+      CLIENT_BASIC_AUTH_HEADER,
+      false,
+    );
 
-      return response;
-    } catch (error) {
-      throw error; // Throw error up
-    }
+    return response;
   }
 
   async changeUserPassword(oldPassword, newPassword, newPasswordConfirm) {
@@ -230,51 +222,43 @@ export class TupaiaApi {
       },
     };
     if (body) fetchConfig.body = body;
-    try {
-      const response = await fetchWithTimeout(queryUrl, fetchConfig);
-      // If server responded with 401, i.e. not authenticated, refresh token and try once more
-      if (
-        shouldReauthenticateIfUnauthorized &&
-        response.status === 401 &&
-        this.refreshToken !== null
-      ) {
-        try {
-          await this.refreshAccessToken();
-          return this.request(requestMethod, apiEndpoint, queryParameters, body, null, false);
-        } catch (error) {
-          throw error;
-        }
-      }
-
-      const responseJson = await response.json();
-      // If server responded with 410, i.e. old API version, log the user out and get them to update
-      if (response.status === 410 && this.reduxStore) {
-        this.reduxStore.dispatch(logoutWithError(responseJson.error));
-      }
-      // If the server responded with any other error code but failed to supply an error, add one
-      if (
-        (response.status < 200 ||
-          response.status >= 300 ||
-          (responseJson.status && (responseJson.status < 200 || responseJson.status >= 300))) &&
-        !responseJson.error
-      ) {
-        responseJson.error = responseJson.message || `Network error ${response.status}`;
-
-        analytics.trackEvent('Request failed', {
-          requestMethod,
-          apiEndpoint,
-          error: responseJson.error,
-        });
-      } else {
-        analytics.trackEvent('Request succeeded', {
-          requestMethod,
-          apiEndpoint,
-        });
-      }
-      return responseJson;
-    } catch (error) {
-      throw error;
+    const response = await fetchWithTimeout(queryUrl, fetchConfig);
+    // If server responded with 401, i.e. not authenticated, refresh token and try once more
+    if (
+      shouldReauthenticateIfUnauthorized &&
+      response.status === 401 &&
+      this.refreshToken !== null
+    ) {
+      await this.refreshAccessToken();
+      return this.request(requestMethod, apiEndpoint, queryParameters, body, null, false);
     }
+
+    const responseJson = await response.json();
+    // If server responded with 410, i.e. old API version, log the user out and get them to update
+    if (response.status === 410 && this.reduxStore) {
+      this.reduxStore.dispatch(logoutWithError(responseJson.error));
+    }
+    // If the server responded with any other error code but failed to supply an error, add one
+    if (
+      (response.status < 200 ||
+        response.status >= 300 ||
+        (responseJson.status && (responseJson.status < 200 || responseJson.status >= 300))) &&
+      !responseJson.error
+    ) {
+      responseJson.error = responseJson.message || `Network error ${response.status}`;
+
+      analytics.trackEvent('Request failed', {
+        requestMethod,
+        apiEndpoint,
+        error: responseJson.error,
+      });
+    } else {
+      analytics.trackEvent('Request succeeded', {
+        requestMethod,
+        apiEndpoint,
+      });
+    }
+    return responseJson;
   }
 }
 

--- a/packages/utils/src/__tests__/request.test.js
+++ b/packages/utils/src/__tests__/request.test.js
@@ -2,12 +2,30 @@
  * Tupaia
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
+import { fetchWithTimeout, stringifyQuery } from '../request';
 
-import { stringifyQuery } from '../request';
+jest.mock('node-fetch', () =>
+  jest.fn().mockImplementation(
+    () =>
+      new Promise(resolve => {
+        setTimeout(() => resolve('success'), 20); // mock fetch takes 20 ms to resolve
+      }),
+  ),
+);
 
 describe('request', () => {
   const BASE_URL = 'https://test-api.org';
   const ENDPOINT = 'reports';
+
+  describe('fetchWithTimeout()', () => {
+    it('resolves with request response if request is fast enough', async () => {
+      return expect(fetchWithTimeout(BASE_URL, {}, 40)).resolves.toEqual('success');
+    });
+
+    it('throws an error if request is too slow', () => {
+      return expect(fetchWithTimeout(BASE_URL, {}, 10)).rejects.toThrow(/request timed out/);
+    });
+  });
 
   describe('stringifyQuery()', () => {
     const testData = [


### PR DESCRIPTION
If you make a lot of fetches in a row, the timeouts build up and consume memory. Better to clear them as soon as the fetch resolves.

I found this because it was causing out of memory errors in my similar implementation over on Tamanu Mobile, if I ran sync super fast. There's a remote possibility that this has been contributing to our out of memory errors on web-config-server. That's a much bigger memory environment, so it's most likely not a significant factor, but great to clean it up anyway.