### PR TITLE
2678: Analytics table refresh is broken after running migrations if Tupaia User has Super User privileges

### DIFF
--- a/packages/database/src/analytics/AnalyticsRefresher.js
+++ b/packages/database/src/analytics/AnalyticsRefresher.js
@@ -3,6 +3,8 @@
  * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
  */
 
+import winston from 'winston';
+
 const REFRESH_DEBOUNCE_TIME = 1000; // wait 1 second after changes before refreshing, to avoid double-up
 
 export class AnalyticsRefresher {
@@ -57,6 +59,13 @@ export class AnalyticsRefresher {
   };
 
   static async executeRefresh(database) {
-    await database.executeSql(`SELECT mv$refreshMaterializedView('analytics', 'public', true);`);
+    try {
+      const start = Date.now();
+      await database.executeSql(`SELECT mv$refreshMaterializedView('analytics', 'public', true);`);
+      const end = Date.now();
+      winston.info(`Analytics table refresh took: ${end - start}ms`);
+    } catch (error) {
+      winston.error(`Analytics table refresh failed: ${error.message}`);
+    }
   }
 }

--- a/packages/database/src/runPostMigration.js
+++ b/packages/database/src/runPostMigration.js
@@ -17,6 +17,7 @@ const EXCLUDED_TABLES_FROM_TRIGGER_CREATION = [
   'ancestor_descendant_relation',
   'psss_session',
   'lesmis_session',
+  'analytics',
 ];
 
 // tables that should only have records created and deleted, and will throw an error if an update is
@@ -35,6 +36,7 @@ const getSelectForTablesWithoutTriggers = triggerSuffix => `
     AND privileges.privilege_type = 'TRIGGER'
     AND t.table_schema = 'public'
     AND t.table_type != 'VIEW'
+    AND t.table_name NOT LIKE 'log$_%'
 `;
 
 export const runPostMigration = async driver => {


### PR DESCRIPTION
### Issue https://github.com/beyondessential/tupaia-backlog/issues/2678:

Added logic to prevent installing the notificationt trigger on the analytics and log tables
