### PR TITLE
Hotfix: Check latest code before running scripts

### DIFF
--- a/packages/database/src/runPostMigration.js
+++ b/packages/database/src/runPostMigration.js
@@ -86,6 +86,12 @@ export const runPostMigration = async driver => {
     ),
   );
 
+  // Refresh analytics in case they've been impacted by migrations
+  const start = Date.now();
+  await driver.runSql(`SELECT mv$refreshMaterializedView('analytics', 'public', true);`);
+  const end = Date.now();
+  console.log(`Analytics refresh took: ${end - start}ms`);
+
   driver.close(err => {
     if (tablesWithoutNotifier.length > 0) {
       console.log(`Created change notification triggers for ${tablesWithoutNotifier.join(', ')}`);

--- a/packages/devops/scripts/deployment/startup.sh
+++ b/packages/devops/scripts/deployment/startup.sh
@@ -25,13 +25,13 @@ else
     export BRANCH="$STAGE"
 fi
 
+# Fetch the latest code
+${HOME_DIRECTORY}/packages/devops/scripts/deployment/checkoutLatest.sh
+
 # If this is an E2E instance, restore E2E test data
 if [[ "$STAGE" == *e2e ]]; then
     ${HOME_DIRECTORY}/packages/devops/scripts/deployment/restoreE2eDataFromS3.sh
 fi
-
-# Fetch the latest code
-${HOME_DIRECTORY}/packages/devops/scripts/deployment/checkoutLatest.sh
 
 # Deploy each package based on the stage, including injecting environment variables from parameter
 # store into the .env file


### PR DESCRIPTION
We should be able to  load the `restoreE2eDataFromS3` script from the deployed branch and not always from production