### PR TITLE
Hotfix: Skip mvrefresh installation if already exists

### DIFF
--- a/packages/data-api/scripts/installMvRefreshModule.sh
+++ b/packages/data-api/scripts/installMvRefreshModule.sh
@@ -1,9 +1,18 @@
 #!/bin/bash
 source .env
-git submodule update --init scripts/pg-mv-fast-refresh
-cd scripts/pg-mv-fast-refresh/
-export DB_MV_HOME="$PWD"
-(. runCreateFastRefreshModule.sh)
-cd ..
+
 export PGPASSWORD=$DB_PG_PASSWORD
-psql --set=db_user="$DB_USER" --set=mv_user="$DB_MV_USER" -h $DB_URL -d $DB_NAME -U $DB_PG_USER -f grantMvRefreshPermissions.sql
+MV_REFRESH_EXISTS=`psql -X -A -h $DB_URL -d $DB_NAME -U $DB_PG_USER -t -c "SELECT schema_name FROM information_schema.schemata WHERE schema_name = '$DB_MV_USER'"`
+
+if [ "$MV_REFRESH_EXISTS" == "$DB_MV_USER" ]; then
+    echo "Fast Refresh module already exists, skipping installation"
+else
+    git submodule update --init scripts/pg-mv-fast-refresh
+    cd scripts/pg-mv-fast-refresh/
+    export DB_MV_HOME="$PWD"
+    (. runCreateFastRefreshModule.sh)
+    cd ../..
+fi
+
+export PGPASSWORD=$DB_PG_PASSWORD
+psql --set=db_user="$DB_USER" --set=mv_user="$DB_MV_USER" -h $DB_URL -d $DB_NAME -U $DB_PG_USER -f scripts/grantMvRefreshPermissions.sql


### PR DESCRIPTION
When the script to install the mvrefresh module runs over a database with an existing install, it drops all the module functions and re-creates them.

This causes a cascading delete to the triggers on the source tables in the tupaia schema. We do not recreate those triggers when re-installing the analytics table, as we simply check if the log tables exist and skip if they do (they still exist, they are just missing their triggers). This leaves the source tables in a misconfigured state, where they will not update the log tables when they get changes.

Simplest fix I could come up with is just to check if the mvrefresh module already exists before installing, and skip the installation if it does.