### PR TITLE
1336: Support deriving PSSS Total Sites indicator from number of reporting sites

### DIFF
--- a/packages/aggregator/src/Aggregator.js
+++ b/packages/aggregator/src/Aggregator.js
@@ -91,9 +91,16 @@ export class Aggregator {
       return [];
     }
     const dataSourceSpec = { code, type: this.dataSourceTypes.DATA_GROUP };
-    const events = await this.dataBroker.pull(dataSourceSpec, fetchOptions);
 
-    return this.processEvents(events, aggregationOptions);
+    const [adjustedFetchOptions, adjustedAggregationOptions] = await adjustOptionsToAggregationList(
+      this.context,
+      fetchOptions,
+      aggregationOptions,
+    );
+
+    const events = await this.dataBroker.pull(dataSourceSpec, adjustedFetchOptions);
+
+    return this.processEvents(events, adjustedAggregationOptions);
   }
 
   async fetchDataElements(codes, fetchOptions) {

--- a/packages/aggregator/src/analytics/aggregateAnalytics/adjustOptionsToAggregationList.js
+++ b/packages/aggregator/src/analytics/aggregateAnalytics/adjustOptionsToAggregationList.js
@@ -116,7 +116,9 @@ const getAdjustedOrganisationUnitsAndAggregations = async (
 export const adjustOptionsToAggregationList = async (context, fetchOptions, aggregationOptions) => {
   const { aggregations: aggregationList = [] } = aggregationOptions;
   if (aggregationList.length === 0) {
-    return [fetchOptions, aggregationOptions];
+    // Trim off any pre-existing aggregations from fetch options
+    const { aggregations, ...restOfFetchOptions } = fetchOptions;
+    return [restOfFetchOptions, aggregationOptions];
   }
 
   const { startDate, endDate } = getAdjustedDateRange(fetchOptions, aggregationList);

--- a/packages/database/src/migrations/20210419225536-UpdatePSSSTotalSitesReportToUseSiteData-modifies-data.js
+++ b/packages/database/src/migrations/20210419225536-UpdatePSSSTotalSitesReportToUseSiteData-modifies-data.js
@@ -22,10 +22,17 @@ const oldConfig = {
 };
 
 const newConfig = {
-  formula: `firstExistingValue(PSSS_Sites_Reported, PSSS_Site_Reported)`,
+  formula: `firstExistingValue(PSSS_Sites_Reported, PSSS_Site_Weekly_Survey_Completed, PSSS_Site_Daily_Survey_Completed)`,
   aggregation: {
     PSSS_Sites_Reported: 'FINAL_EACH_WEEK',
-    PSSS_Site_Reported: [
+    PSSS_Site_Weekly_Survey_Completed: [
+      'FINAL_EACH_WEEK',
+      {
+        type: 'SUM_PER_PERIOD_PER_ORG_GROUP',
+        config: { dataSourceEntityType: 'facility', aggregationEntityType: 'country' },
+      },
+    ],
+    PSSS_Site_Daily_Survey_Completed: [
       'FINAL_EACH_WEEK',
       {
         type: 'SUM_PER_PERIOD_PER_ORG_GROUP',
@@ -35,16 +42,26 @@ const newConfig = {
   },
   defaultValues: {
     PSSS_Sites_Reported: 'undefined',
-    PSSS_Site_Reported: 'undefined',
+    PSSS_Site_Weekly_Survey_Completed: 'undefined',
+    PSSS_Site_Daily_Survey_Completed: 'undefined',
   },
 };
 
-const PSSS_SITE_REPORTED = {
-  code: 'PSSS_Site_Reported',
+const PSSS_SITE_REPORTED_WEEKLY = {
+  code: 'PSSS_Site_Weekly_Survey_Completed',
   builder: 'eventCheckConditions',
   config: {
     formula: 'true',
     programCode: 'PSSS_WSR',
+  },
+};
+
+const PSSS_SITE_REPORTED_DAILY = {
+  code: 'PSSS_Site_Daily_Survey_Completed',
+  builder: 'eventCheckConditions',
+  config: {
+    formula: 'true',
+    programCode: 'PSSS_DSR',
   },
 };
 
@@ -81,13 +98,15 @@ const updateIndicator = async (db, code, config) => {
 };
 
 exports.up = async function (db) {
-  await insertIndicator(db, PSSS_SITE_REPORTED);
+  await insertIndicator(db, PSSS_SITE_REPORTED_WEEKLY);
+  await insertIndicator(db, PSSS_SITE_REPORTED_DAILY);
   await updateIndicator(db, 'PSSS_Total_Sites_Reported', newConfig);
 };
 
 exports.down = async function (db) {
   await updateIndicator(db, 'PSSS_Total_Sites_Reported', oldConfig);
-  await deleteIndicator(db, PSSS_SITE_REPORTED);
+  await deleteIndicator(db, PSSS_SITE_REPORTED_DAILY);
+  await deleteIndicator(db, PSSS_SITE_REPORTED_WEEKLY);
 };
 
 exports._meta = {

--- a/packages/database/src/migrations/20210419225536-UpdatePSSSTotalSitesReportToUseSiteData-modifies-data.js
+++ b/packages/database/src/migrations/20210419225536-UpdatePSSSTotalSitesReportToUseSiteData-modifies-data.js
@@ -1,0 +1,95 @@
+'use strict';
+
+import { generateId, insertObject } from '../utilities';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+const oldConfig = {
+  formula: 'PSSS_Sites_Reported',
+  aggregation: 'FINAL_EACH_WEEK',
+};
+
+const newConfig = {
+  formula: `firstExistingValue(PSSS_Sites_Reported, PSSS_Site_Reported)`,
+  aggregation: {
+    PSSS_Sites_Reported: 'FINAL_EACH_WEEK',
+    PSSS_Site_Reported: [
+      'FINAL_EACH_WEEK',
+      {
+        type: 'SUM_PER_PERIOD_PER_ORG_GROUP',
+        config: { dataSourceEntityType: 'facility', aggregationEntityType: 'country' },
+      },
+    ],
+  },
+  defaultValues: {
+    PSSS_Sites_Reported: 'undefined',
+    PSSS_Site_Reported: 'undefined',
+  },
+};
+
+const PSSS_SITE_REPORTED = {
+  code: 'PSSS_Site_Reported',
+  builder: 'eventCheckConditions',
+  config: {
+    formula: 'true',
+    programCode: 'PSSS_WSR',
+  },
+};
+
+const insertIndicator = async (db, indicator) => {
+  const { code } = indicator;
+
+  await insertObject(db, 'data_source', {
+    id: generateId(),
+    code,
+    type: 'dataElement',
+    service_type: 'indicator',
+  });
+  await insertObject(db, 'indicator', { id: generateId(), ...indicator });
+};
+
+const deleteIndicator = async (db, indicator) => {
+  const { code } = indicator;
+  await db.runSql(
+    `DELETE FROM data_source WHERE code = '${code}';
+    DELETE FROM indicator WHERE code = '${code}';
+  `,
+  );
+};
+
+const updateIndicator = async (db, code, config) => {
+  return db.runSql(`
+    UPDATE
+      "indicator"
+    SET
+      "config" = '${JSON.stringify(config)}'
+    WHERE
+    "code" = '${code}';
+  `);
+};
+
+exports.up = async function (db) {
+  await insertIndicator(db, PSSS_SITE_REPORTED);
+  await updateIndicator(db, 'PSSS_Total_Sites_Reported', newConfig);
+};
+
+exports.down = async function (db) {
+  await updateIndicator(db, 'PSSS_Total_Sites_Reported', oldConfig);
+  await deleteIndicator(db, PSSS_SITE_REPORTED);
+};
+
+exports._meta = {
+  version: 1,
+};


### PR DESCRIPTION
### Issue https://github.com/beyondessential/tupaia-backlog/issues/1336:

Added 2 new indicators to determine if a site has completed a Weekly Survey or a Daily Survey for a given week

Updated Total Cases indicator to preferentially use: 
- National recorded answer for Sites Reported
- Number of Sites that submitted a weekly survey
- Number of sites that completed a daily survey

Note: After adding these indicators the performance of PSSS has dropped substantially! (~15 seconds to load the Weekly Report in my local). Subsequent work must be done to improve performance but that's out of the scope for this PR.