### PR TITLE
2677: Added check for `session` when adjusting aggregation options

### DIFF
--- a/packages/aggregator/src/__tests__/Aggregator/Aggregator.test.js
+++ b/packages/aggregator/src/__tests__/Aggregator/Aggregator.test.js
@@ -23,6 +23,7 @@ FilterAnalytics.filterAnalytics.mockReturnValue(FILTERED_ANALYTICS);
 const { DATA_ELEMENT, DATA_GROUP } = DATA_SOURCE_TYPES;
 
 const dataBroker = createJestMockInstance('@tupaia/data-broker', 'DataBroker', {
+  context: {},
   getDataSourceTypes: () => DATA_SOURCE_TYPES,
   pull: ({ type }) => RESPONSE_BY_SOURCE_TYPE[type],
 });

--- a/packages/aggregator/src/analytics/aggregateAnalytics/adjustOptionsToAggregationList.js
+++ b/packages/aggregator/src/analytics/aggregateAnalytics/adjustOptionsToAggregationList.js
@@ -48,11 +48,11 @@ const getAdjustedOrganisationUnitsAndAggregations = async (
   aggregationList,
 ) => {
   const { hierarchy, organisationUnitCodes } = fetchOptions;
-  if (!aggregationList.some(shouldFetchDataSourceEntities)) {
+  const { session } = context;
+  // TODO: Remove this check for session when implementing https://github.com/beyondessential/tupaia-backlog/issues/2697
+  if (!aggregationList.some(shouldFetchDataSourceEntities) || !session) {
     return [organisationUnitCodes, aggregationList];
   }
-
-  const { session } = context;
 
   let adjustedOrganisationUnitCodes;
   const adjustedAggregations = [];

--- a/packages/web-config-server/src/apiV1/DataAggregatingRouteHandler.js
+++ b/packages/web-config-server/src/apiV1/DataAggregatingRouteHandler.js
@@ -15,7 +15,7 @@ import { Aggregator } from '/aggregator';
 export class DataAggregatingRouteHandler extends RouteHandler {
   constructor(req, res) {
     super(req, res);
-    this.aggregator = createAggregator(Aggregator, this.models, this);
+    this.aggregator = createAggregator(Aggregator, {}, this.models, this);
   }
 
   // Builds the list of entities data should be fetched from, using org unit descendants of the


### PR DESCRIPTION
### Issue https://github.com/beyondessential/tupaia-backlog/issues/2677:

Fairly simple hack that allows for web-config-server entity aggregation and aggregator entity aggregation logic to co-exist. Assumption is that if constructor of Aggregator doesn't provide a session in the context, then they are responsible for creating their own entity aggregation options.