### PR TITLE
2714: Improve performance of 'PSSS_Total_Sites_Reported' indicator

### DIFF
--- a/packages/data-api/scripts/createAnalyticsTableIndexes.sql
+++ b/packages/data-api/scripts/createAnalyticsTableIndexes.sql
@@ -10,7 +10,7 @@ begin
   RAISE NOTICE 'Created [data_element, entity, date] index, took %', clock_timestamp() - tStartTime;
   
   tStartTime := clock_timestamp();
-  CREATE INDEX IF NOT EXISTS analytics_data_element_entity_data_group_event_date_idx ON public.analytics(data_element_code, entity_code, data_group_code, event_id, date desc);
-  RAISE NOTICE 'Created [data_element, entity, data_group, event, date] index, took %', clock_timestamp() - tStartTime;
+  CREATE INDEX IF NOT EXISTS analytics_data_group_entity_event_date_idx ON public.analytics(data_group_code, entity_code, event_id, date desc);
+  RAISE NOTICE 'Created [data_group, entity, event, date] index, took %', clock_timestamp() - tStartTime;
 
 end $$;


### PR DESCRIPTION
### Issue https://github.com/beyondessential/tupaia-backlog/issues/2714:

Altered events index on analytics table to perform well even if no data element code is specified

Arguably I should have created a migration to change this index on the existing analytics table, however that would require creating a mechanism for performing migrations as a user other than the tupaia user and that seemed rather out of scope (the analytics table is owned by the mvrefresh user)

- [ ] PR Task: Drop old index and create new one