### PR TITLE
1221 Allow buildInternalDependencies to build only deps of a specific package

### DIFF
--- a/scripts/bash/backendStartDev.sh
+++ b/scripts/bash/backendStartDev.sh
@@ -55,5 +55,5 @@ else
     # add the watch flags to the server start process, as well as a 1 second delay to debounce the
     # many restarts that otherwise happen during the initial build of internal dependencies
     start_server="${start_server} --delay 1 ${watch_flags}"
-    yarn concurrently "${DIR}/buildInternalDependencies.sh --watch --withTypes" "eval ${start_server}"
+    yarn concurrently "${DIR}/buildInternalDependencies.sh --watch --packagePath ." "eval ${start_server}"
 fi

--- a/scripts/bash/backendStartDev.sh
+++ b/scripts/bash/backendStartDev.sh
@@ -49,7 +49,7 @@ if [[ ${skip_internal} == true ]]; then
     eval ${start_server}
 else
     echo "Internal dependencies are under watch for hot reload (use --skip-internal or -s for faster startup times)"
-    for PACKAGE in $(${DIR}/getInternalDependencies.sh ${PWD}); do
+    for PACKAGE in $(${DIR}/getInternalDependencies.sh .); do
         watch_flags="${watch_flags} --watch ../${PACKAGE}/dist"
     done
     # add the watch flags to the server start process, as well as a 1 second delay to debounce the

--- a/scripts/bash/backendStartDev.sh
+++ b/scripts/bash/backendStartDev.sh
@@ -49,7 +49,7 @@ if [[ ${skip_internal} == true ]]; then
     eval ${start_server}
 else
     echo "Internal dependencies are under watch for hot reload (use --skip-internal or -s for faster startup times)"
-    for PACKAGE in $(${DIR}/getInternalDependencies.sh); do
+    for PACKAGE in $(${DIR}/getInternalDependencies.sh ${PWD}); do
         watch_flags="${watch_flags} --watch ../${PACKAGE}/dist"
     done
     # add the watch flags to the server start process, as well as a 1 second delay to debounce the

--- a/scripts/bash/buildInternalDependencies.sh
+++ b/scripts/bash/buildInternalDependencies.sh
@@ -10,6 +10,7 @@ OUT_DIR="dist"
 
 watch=false
 with_types=false
+package_json_path=false
 while [ "$1" != "" ]; do
     case $1 in
     --watch)
@@ -19,6 +20,10 @@ while [ "$1" != "" ]; do
     --withTypes)
         shift
         with_types=true
+        ;;
+    -p | --packageJsonPath)
+        shift
+        package_json_path=$1
         shift
         ;;
     -h | --help)
@@ -38,15 +43,17 @@ done
 build_commands=()
 delete_command="rm -rf"
 
+
+
 # Build dependencies
-for PACKAGE in $(${DIR}/getInternalDependencies.sh); do
+for PACKAGE in $(${DIR}/getInternalDependencies.sh ${package_json_path}); do
     delete_command="${delete_command} packages/${PACKAGE}/${OUT_DIR}"
     build_commands+=("\"yarn workspace @tupaia/${PACKAGE} build $build_args\"")
 done
 
 # Build types
 if [ $with_types == "true" ]; then
-    for PACKAGE in $(${DIR}/getTypedInternalDependencies.sh); do
+    for PACKAGE in $(${DIR}/getTypedInternalDependencies.sh ${package_json_path}); do
         build_commands+=("\"yarn workspace @tupaia/${PACKAGE} build:ts $build_ts_args\"")
     done
 fi

--- a/scripts/bash/buildInternalDependencies.sh
+++ b/scripts/bash/buildInternalDependencies.sh
@@ -10,7 +10,7 @@ OUT_DIR="dist"
 
 watch=false
 with_types=false
-package_path=false
+package_path=""
 while [ "$1" != "" ]; do
     case $1 in
     --watch)

--- a/scripts/bash/buildInternalDependencies.sh
+++ b/scripts/bash/buildInternalDependencies.sh
@@ -10,7 +10,7 @@ OUT_DIR="dist"
 
 watch=false
 with_types=false
-package_json_path=false
+package_path=false
 while [ "$1" != "" ]; do
     case $1 in
     --watch)
@@ -21,9 +21,9 @@ while [ "$1" != "" ]; do
         shift
         with_types=true
         ;;
-    -p | --packageJsonPath)
+    -p | --packagePath)
         shift
-        package_json_path=$1
+        package_path=$1
         shift
         ;;
     -h | --help)
@@ -46,14 +46,14 @@ delete_command="rm -rf"
 
 
 # Build dependencies
-for PACKAGE in $(${DIR}/getInternalDependencies.sh ${package_json_path}); do
+for PACKAGE in $(${DIR}/getInternalDependencies.sh ${package_path}); do
     delete_command="${delete_command} packages/${PACKAGE}/${OUT_DIR}"
     build_commands+=("\"yarn workspace @tupaia/${PACKAGE} build $build_args\"")
 done
 
 # Build types
 if [ $with_types == "true" ]; then
-    for PACKAGE in $(${DIR}/getTypedInternalDependencies.sh ${package_json_path}); do
+    for PACKAGE in $(${DIR}/getTypedInternalDependencies.sh); do
         build_commands+=("\"yarn workspace @tupaia/${PACKAGE} build:ts $build_ts_args\"")
     done
 fi

--- a/scripts/bash/getInternalDependencies.sh
+++ b/scripts/bash/getInternalDependencies.sh
@@ -1,16 +1,67 @@
 #!/bin/bash
 
-package_json_path=$1
+DIR=$(dirname "$0")
+package_path=$1
+
+# pop the package_path off, and interpret the rest as dependencies that have been checked earlier
+# in the recursion
+shift
+dependencies_already_visited=($@)
 
 # if no package.json entrypoint is specified, just return all internal dependencies
-if [ -z ${package_json_path} ]; then
+if [ -z ${package_path} ]; then
   echo "access-policy" "aggregator" "auth" "database" "data-api" "data-broker" "dhis-api" "expression-parser"  "indicators" "utils" "ui-components" "weather-api" "server-boilerplate"
   exit 0
 fi
 
 # we are getting internal dependencies for a specific package.json
+internal_dependencies=($(grep -o '@tupaia/[^"]*": "[0-9\.]*"' "${PWD}/${package_path}/package.json" | cut -d / -f 2 | cut -d \" -f 1))
+if [ ${#internal_dependencies[@]} -eq 0 ]; then
+  exit 0 # no internal dependencies of this package, early return
+fi
+
+# remove any dependencies already recursed this dependency earlier in the tree
+for dependency in "${dependencies_already_visited[@]}"; do
+  for i in "${!internal_dependencies[@]}"; do
+    if [[ ${internal_dependencies[i]} = $dependency ]]; then
+      unset 'internal_dependencies[i]'
+    fi
+  done
+done
+for i in "${!internal_dependencies[@]}"; do
+    array_without_gaps+=( "${internal_dependencies[i]}" )
+done
+internal_dependencies=("${array_without_gaps[@]}")
+unset array_without_gaps
+
 # recursively build up an array of all internal dependencies this package depends on
-internal_dependencies=$(grep -o '@tupaia/[^"]*": "[0-9\.]*"' "${PWD}/${package_json_path}" | cut -d / -f 2 | cut -d \" -f 1)
-echo $internal_dependencies
+for dependency in ${internal_dependencies[@]}; do
+
+  nested_dependencies=($(${DIR}/getInternalDependencies.sh "${package_path}/../${dependency}" ${dependencies_already_visited[@]} ${internal_dependencies[@]} ))
+  if [ ${#nested_dependencies[@]} -eq 0 ]; then
+    continue
+  fi
+
+  # add nested deps to internal dependencies
+  internal_dependencies=("${internal_dependencies[@]}" "${nested_dependencies[@]}")
+done
+
+# remove any duplicates
+deduplicated_union=()
+for i in "${!internal_dependencies[@]}"; do
+  for j in "${!internal_dependencies[@]}"; do
+    if [[ i -ne j ]] && [[ ${internal_dependencies[i]} = ${internal_dependencies[j]} ]]; then
+      unset 'internal_dependencies[i]'
+    fi
+  done
+done
+for i in "${!internal_dependencies[@]}"; do
+    array_without_gaps+=( "${internal_dependencies[i]}" )
+done
+internal_dependencies=("${array_without_gaps[@]}")
+unset array_without_gaps
+
+# echo out result for calling script to pick up
+echo ${internal_dependencies[@]}
 exit 0
 

--- a/scripts/bash/getInternalDependencies.sh
+++ b/scripts/bash/getInternalDependencies.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-DIR=$(dirname "$0")
 package_json_path=$1
 
 # if no package.json entrypoint is specified, just return all internal dependencies
@@ -11,7 +10,7 @@ fi
 
 # we are getting internal dependencies for a specific package.json
 # recursively build up an array of all internal dependencies this package depends on
-internal_dependencies=$(grep -o '@tupaia/[^"]*": "[0-9\.]*"' "${DIR}/${package_json_path}" | cut -d / -f 2 | cut -d \" -f 1)
+internal_dependencies=$(grep -o '@tupaia/[^"]*": "[0-9\.]*"' "${PWD}/${package_json_path}" | cut -d / -f 2 | cut -d \" -f 1)
 echo $internal_dependencies
 exit 0
 

--- a/scripts/bash/getInternalDependencies.sh
+++ b/scripts/bash/getInternalDependencies.sh
@@ -1,2 +1,17 @@
 #!/bin/bash
-echo "access-policy" "aggregator" "auth" "database" "data-api" "data-broker" "dhis-api" "expression-parser"  "indicators" "utils" "ui-components" "weather-api" "server-boilerplate"
+
+DIR=$(dirname "$0")
+package_json_path=$1
+
+# if no package.json entrypoint is specified, just return all internal dependencies
+if [ -z ${package_json_path} ]; then
+  echo "access-policy" "aggregator" "auth" "database" "data-api" "data-broker" "dhis-api" "expression-parser"  "indicators" "utils" "ui-components" "weather-api" "server-boilerplate"
+  exit 0
+fi
+
+# we are getting internal dependencies for a specific package.json
+# recursively build up an array of all internal dependencies this package depends on
+internal_dependencies=$(grep -o '@tupaia/[^"]*": "[0-9\.]*"' "${DIR}/${package_json_path}" | cut -d / -f 2 | cut -d \" -f 1)
+echo $internal_dependencies
+exit 0
+


### PR DESCRIPTION
### Issue #: 
https://github.com/beyondessential/tupaia-backlog/issues/1221

### Changes:
buildInternalDependencies now optionally takes in --packageJsonPath to indicate the package.json of the package to build internal dependencies of