### PR TITLE
2746 legend too far down

### DIFF
--- a/packages/lesmis/src/views/MapView.js
+++ b/packages/lesmis/src/views/MapView.js
@@ -24,7 +24,7 @@ const Container = styled.div`
   z-index: 1; // make sure the map is under the site menus & search
   display: flex;
   height: calc(100vh - 219px);
-  min-height: 600px;
+  min-height: 350px; // below which the map is basically unusable
 `;
 
 const Main = styled.div`


### PR DESCRIPTION
### Issue #: 
https://github.com/beyondessential/tupaia-backlog/issues/2746

### Changes:
I didn't entirely remove the min height because below a certain point it seems better to have the legend disappear than to have the map become unusable

See issue for what it looks like at 350px