### PR TITLE
Remove the all data options from the year selectors

### DIFF
--- a/packages/lesmis/src/api/queries/utils.js
+++ b/packages/lesmis/src/api/queries/utils.js
@@ -4,7 +4,7 @@
  *
  */
 import { formatDateForApi, roundStartEndDates } from '@tupaia/ui-components/lib/chart';
-import { ALL_DATES_VALUE, MIN_DATA_YEAR, SINGLE_YEAR_GRANULARITY } from '../../constants';
+import { MIN_DATA_YEAR, SINGLE_YEAR_GRANULARITY } from '../../constants';
 
 /**
  *
@@ -13,8 +13,8 @@ import { ALL_DATES_VALUE, MIN_DATA_YEAR, SINGLE_YEAR_GRANULARITY } from '../../c
  */
 export const yearToApiDates = year => {
   const currentYear = new Date().getFullYear().toString();
-  const startYear = !year || year === ALL_DATES_VALUE ? MIN_DATA_YEAR : year;
-  const endYear = !year || year === ALL_DATES_VALUE ? currentYear : year;
+  const startYear = !year ? MIN_DATA_YEAR : year;
+  const endYear = !year ? currentYear : year;
   const { startDate, endDate } = roundStartEndDates(SINGLE_YEAR_GRANULARITY, startYear, endYear);
   return { startDate: formatDateForApi(startDate), endDate: formatDateForApi(endDate) };
 };

--- a/packages/lesmis/src/api/queries/utils.js
+++ b/packages/lesmis/src/api/queries/utils.js
@@ -13,8 +13,8 @@ import { MIN_DATA_YEAR, SINGLE_YEAR_GRANULARITY } from '../../constants';
  */
 export const yearToApiDates = year => {
   const currentYear = new Date().getFullYear().toString();
-  const startYear = !year ? MIN_DATA_YEAR : year;
-  const endYear = !year ? currentYear : year;
+  const startYear = year || MIN_DATA_YEAR;
+  const endYear = year || currentYear;
   const { startDate, endDate } = roundStartEndDates(SINGLE_YEAR_GRANULARITY, startYear, endYear);
   return { startDate: formatDateForApi(startDate), endDate: formatDateForApi(endDate) };
 };

--- a/packages/lesmis/src/components/YearSelector.js
+++ b/packages/lesmis/src/components/YearSelector.js
@@ -7,15 +7,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Select } from '@tupaia/ui-components';
-import { MIN_DATA_YEAR, ALL_DATES_VALUE } from '../constants';
+import { MIN_DATA_YEAR } from '../constants';
 
 const getYearOptions = () => {
-  const years = [
-    {
-      label: 'All Data',
-      value: ALL_DATES_VALUE,
-    },
-  ];
+  const years = [];
 
   const startYear = parseInt(MIN_DATA_YEAR);
   let year = new Date().getFullYear();

--- a/packages/lesmis/src/constants/constants.js
+++ b/packages/lesmis/src/constants/constants.js
@@ -13,7 +13,7 @@ export const DEFAULT_DASHBOARD_GROUP = 'Students / Schools';
 export const SINGLE_YEAR_GRANULARITY = 'one_year_at_a_time';
 export const MIN_DATA_DATE = '20150101';
 export const MIN_DATA_YEAR = '2015';
-export const ALL_DATES_VALUE = 'all';
+export const DEFAULT_DATA_YEAR = '2020';
 
 // Layout Constants
 export const NAVBAR_HEIGHT = '70px';

--- a/packages/lesmis/src/views/DashboardReportTabView.js
+++ b/packages/lesmis/src/views/DashboardReportTabView.js
@@ -20,7 +20,7 @@ import {
   TabPanel,
   YearSelector,
 } from '../components';
-import { DEFAULT_DASHBOARD_GROUP, ALL_DATES_VALUE } from '../constants';
+import { DEFAULT_DASHBOARD_GROUP, DEFAULT_DATA_YEAR } from '../constants';
 
 const DashboardSection = styled(FlexCenter)`
   min-height: 31rem;
@@ -37,7 +37,7 @@ const setDefaultDashboard = (data, setSelectedDashboard) => {
 };
 
 export const DashboardReportTabView = ({ entityCode, TabSelector }) => {
-  const [selectedYear, setSelectedYear] = useState(ALL_DATES_VALUE);
+  const [selectedYear, setSelectedYear] = useState(DEFAULT_DATA_YEAR);
   const [selectedDashboard, setSelectedDashboard] = useState(DEFAULT_DASHBOARD_GROUP);
   const { data, isLoading, isError, error } = useDashboardData(entityCode);
 

--- a/packages/lesmis/src/views/MapView.js
+++ b/packages/lesmis/src/views/MapView.js
@@ -16,7 +16,7 @@ import {
 } from '@tupaia/ui-components/lib/map';
 import { YearSelector, MapOverlaysPanel } from '../components';
 import { useMapOverlayReportData, useMapOverlaysData } from '../api';
-import { ALL_DATES_VALUE, TILE_SETS } from '../constants';
+import { TILE_SETS, DEFAULT_DATA_YEAR } from '../constants';
 import { useUrlParams } from '../utils';
 
 const Container = styled.div`
@@ -71,7 +71,7 @@ const getDefaultTileSet = () => {
 
 export const MapView = () => {
   const { entityCode } = useUrlParams();
-  const [selectedYear, setSelectedYear] = useState(ALL_DATES_VALUE);
+  const [selectedYear, setSelectedYear] = useState(DEFAULT_DATA_YEAR);
   const [activeTileSetKey, setActiveTileSetKey] = useState(getDefaultTileSet());
 
   const { data: overlaysData, isLoading: isLoadingOverlays } = useMapOverlaysData({ entityCode });


### PR DESCRIPTION
### Issue #: No issue

### Changes:

- remove the all data option from dashboard and map overlay year selector
- set 2020 as the default year

