### PR TITLE
If a lesmis school image fails to load, default to mini-map

### DIFF
--- a/packages/lesmis/src/views/DashboardView.js
+++ b/packages/lesmis/src/views/DashboardView.js
@@ -179,9 +179,13 @@ const VerticalDivider = styled(MuiDivider)`
 `;
 
 const PhotoOrMap = ({ vitals }) => {
+  const [validImage, setValidImage] = useState(true);
   if (vitals.isLoading) return null;
 
-  if (vitals.Photo) return <img src={vitals.Photo} alt="place" width="720px" />;
+  if (vitals.Photo && validImage)
+    return (
+      <img src={vitals.Photo} alt="place" width="720px" onError={() => setValidImage(false)} />
+    );
 
   return <MiniMap entityCode={vitals.code} />;
 };


### PR DESCRIPTION
### Issue #: https://github.com/beyondessential/tupaia-backlog/issues/2774

### Changes:

- Add a `validImage` state to `PhotoOrMap` component
- If image fails to load, invalidate the image