### PR TITLE
Allow a deployment to be "protected" from lambda

### DIFF
--- a/packages/devops/scripts/lambda/createOrRestoreDeployment.py
+++ b/packages/devops/scripts/lambda/createOrRestoreDeployment.py
@@ -51,6 +51,12 @@ def get_instances(filters):
 
 async def restore_instance(account_ids, instance):
     print('Restoring instance {}'.format(instance['InstanceId']))
+    # Check it's not protected
+    protected = get_tag(instance, 'Protected')
+    name = get_tag(instance, 'Name')
+    if protected == 'true':
+        raise Exception('The instance ' + name + ' is protected and cannot be wiped and restored')
+
     # Get snapshot to restore volume from
     restore_code = get_tag(instance, 'RestoreFrom')
     snapshot_id = get_latest_snapshot_id(account_ids, restore_code)

--- a/packages/devops/scripts/lambda/deleteDeployment.py
+++ b/packages/devops/scripts/lambda/deleteDeployment.py
@@ -66,6 +66,11 @@ def lambda_handler(event, context):
     if not instance:
       raise Exception('No matching instance found')
 
+    # Check it's not protected
+    protected = get_tag(instance, 'Protected')
+    if protected == 'true':
+        raise Exception('The instance ' + event['InstanceName'] + ' is protected and cannot be deleted')
+
     # Get tagged details of instance
     stage = get_tag(instance, 'Stage')
     domain = get_tag(instance, 'DomainName')


### PR DESCRIPTION
@tcaiger had the idea that we should make sure no one can accidentally delete production using lambda. I've attached the "Protected": "true" tags to the three key production EC2 instances, and already deployed the code in this PR to lambda