### PR TITLE
2663 async issues psss (2)

### DIFF
--- a/packages/meditrak-server/src/dataAccessors/updateOrCreateSurveyResponse.js
+++ b/packages/meditrak-server/src/dataAccessors/updateOrCreateSurveyResponse.js
@@ -4,7 +4,7 @@
  */
 
 import momentTimezone from 'moment-timezone';
-import { DatabaseError, UploadError, stripTimezoneFromDate } from '@tupaia/utils';
+import { DatabaseError, UploadError, stripTimezoneFromDate, reformatDateStringWithoutTz, ValidationError } from '@tupaia/utils';
 import { uploadImage } from '../s3';
 import { BUCKET_PATH, getImageFilePath } from '../s3/constants';
 import { DEFAULT_DATABASE_TIMEZONE, getEntityIdFromClinicId } from '../database';
@@ -66,19 +66,7 @@ export async function updateOrCreateSurveyResponse(models, surveyResponseObject)
     }
 
     // Ensure data_time is populated, supporting legacy versions of MediTrak
-    const {
-      data_time: suppliedDataTime,
-      submission_time: submissionTime, // v1.7.87 to v1.9.110 (inclusive) uses submission_time
-      end_time: endTime, // prior to v1.7.87 fall back to end_time
-      timezone = DEFAULT_DATABASE_TIMEZONE, // if no timezone provided, use db default
-    } = surveyResponseObject;
-    const dataTime = suppliedDataTime || submissionTime || endTime;
-
-    // Convert to the original timezone, then strip timezone suffix, so it ends up in db as it
-    // appeared to the original survey submitter
-    surveyResponseProperties.data_time = stripTimezoneFromDate(
-      momentTimezone(dataTime).tz(timezone).format(),
-    );
+    surveyResponseProperties.data_time = getDataTime(surveyResponseObject);
 
     surveyResponse = await models.surveyResponse.updateOrCreate(
       {
@@ -134,3 +122,49 @@ const createEntities = async (models, entitiesCreated, surveyId) => {
     ),
   );
 };
+
+/**
+ * @param surveyResponseObject
+ * @return {string}
+ * @throws ValidationError
+ */
+const getDataTime = surveyResponseObject => {
+  const {
+    data_time: suppliedDataTime,
+    submission_time: submissionTime, // v1.7.87 to v1.9.110 (inclusive) uses submission_time
+    end_time: endTime, // prior to v1.7.87 fall back to end_time
+    timezone: suppliedTimezone,
+  } = surveyResponseObject;
+
+  if (suppliedDataTime) {
+
+    if (suppliedTimezone) {
+      // Timezone specified, strip it
+      return stripTimezoneFromDate(
+        momentTimezone(suppliedDataTime, suppliedTimezone).format(),
+      );
+    }
+
+    // No timezone specified. We are submitting the data_time explicitly without a tz.
+    //
+    // If the input is in a known format like ISO8601 without tz, we can use this directly, we just
+    // reformat it into our specific format without tz.
+    const reformattedDataTime = reformatDateStringWithoutTz(suppliedDataTime);
+    if (reformattedDataTime) {
+      return reformattedDataTime;
+    } else {
+      throw new ValidationError(`Unable to parse data_time ${suppliedDataTime} against known formats without timezone. Either use a known format or specify a timezone.`);
+    }
+  }
+
+  // Fallback for older versions
+  const dataTime = submissionTime || endTime;
+
+  const timezone = suppliedTimezone || DEFAULT_DATABASE_TIMEZONE; // if no timezone provided, use db default
+
+  // Convert to the original timezone, then strip timezone suffix, so it ends up in db as it
+  // appeared to the original survey submitter
+  return stripTimezoneFromDate(
+    momentTimezone(dataTime).tz(timezone).format(),
+  );
+}

--- a/packages/meditrak-server/src/dataAccessors/updateOrCreateSurveyResponse.js
+++ b/packages/meditrak-server/src/dataAccessors/updateOrCreateSurveyResponse.js
@@ -141,7 +141,7 @@ const getDataTime = surveyResponseObject => {
     if (suppliedTimezone) {
       // Timezone specified, strip it
       return stripTimezoneFromDate(
-        momentTimezone(suppliedDataTime, suppliedTimezone).format(),
+        momentTimezone(suppliedDataTime).tz(suppliedTimezone).format(),
       );
     }
 

--- a/packages/meditrak-server/src/routes/importSurveyResponses/importSurveyResponses.js
+++ b/packages/meditrak-server/src/routes/importSurveyResponses/importSurveyResponses.js
@@ -39,7 +39,12 @@ export async function importSurveyResponses(req, res) {
       throw new UploadError();
     }
     const surveyNames = getArrayQueryParameter(req?.query?.surveyNames);
-    const timeZone = req?.query?.timeZone || DEFAULT_DATABASE_TIMEZONE;
+    const timeZone = req?.query?.timeZone;
+    if (!timeZone) {
+      throw new Error(
+        `Timezone is required`,
+      );
+    }
     const { models } = req;
     await models.wrapInTransaction(async transactingModels => {
       const workbook = xlsx.readFile(req.file.path);

--- a/packages/meditrak-server/src/routes/postChanges.js
+++ b/packages/meditrak-server/src/routes/postChanges.js
@@ -28,6 +28,7 @@ import {
   translateUserEmailToIdAndAssessorName,
   translateQuestionCodeToId,
 } from './utilities';
+import { AnalyticsRefresher } from '@tupaia/database';
 
 // Action constants
 const SUBMIT_SURVEY_RESPONSE = 'SubmitSurveyResponse';
@@ -44,13 +45,13 @@ export async function postChanges(req, res) {
   const changes = req.body;
   const { models } = req;
   const translatedChanges = [];
-  for (const { action, payload } of changes) {
+  for (const { action, payload, ...rest } of changes) {
     if (!ACTION_HANDLERS[action]) {
       throw new ValidationError(`${action} is not a supported change action`);
     }
     const translatedPayload = await PAYLOAD_TRANSLATORS[action](models, payload);
     await PAYLOAD_VALIDATORS[action](models, translatedPayload);
-    translatedChanges.push({ action, translatedPayload });
+    translatedChanges.push({ action, translatedPayload, ...rest });
   }
 
   // Check permissions for survey responses
@@ -64,8 +65,17 @@ export async function postChanges(req, res) {
     assertAnyPermissions([assertBESAdminAccess, surveyResponsePermissionsChecker]),
   );
 
-  for (const { action, translatedPayload } of translatedChanges) {
+  for (const { action, translatedPayload, ...rest } of translatedChanges) {
     await ACTION_HANDLERS[action](models, translatedPayload);
+
+    if (action === SUBMIT_SURVEY_RESPONSE) {
+      const { waitForAnalyticsRebuild } = rest;
+      if (waitForAnalyticsRebuild) {
+        const { database } = models;
+        await AnalyticsRefresher.executeRefresh(database);
+      }
+
+    }
   }
 
   // Reset the cache for the current users rewards.

--- a/packages/meditrak-server/src/routes/surveyResponses/DeleteSurveyResponses.js
+++ b/packages/meditrak-server/src/routes/surveyResponses/DeleteSurveyResponses.js
@@ -11,6 +11,7 @@ import {
   assertTupaiaAdminPanelAccess,
 } from '../../permissions';
 import { assertSurveyResponsePermissions } from './assertSurveyResponsePermissions';
+import { AnalyticsRefresher } from '@tupaia/database';
 
 /**
  * Handles DELETE endpoints:
@@ -31,5 +32,14 @@ export class DeleteSurveyResponses extends DeleteHandler {
         assertAllPermissions([assertTupaiaAdminPanelAccess, surveyResponsePermissionChecker]),
       ]),
     );
+  }
+
+  async deleteRecord() {
+    await super.deleteRecord();
+
+    if (this.req.query.waitForAnalyticsRebuild === 'true') {
+      const { database } = this.models;
+      await AnalyticsRefresher.executeRefresh(database);
+    }
   }
 }

--- a/packages/meditrak-server/src/tests/routes/importSurveyResponses/testPermissions.js
+++ b/packages/meditrak-server/src/tests/routes/importSurveyResponses/testPermissions.js
@@ -34,7 +34,7 @@ export const testPermissions = async () => {
   const importFile = (filename, surveyNames) => {
     const surveyNamesParam = surveyNames.map(s => `surveyNames=${s}`).join('&');
     return app
-      .post(`import/surveyResponses?${surveyNamesParam}`)
+      .post(`import/surveyResponses?${surveyNamesParam}&timeZone=Australia%2FMelbourne`)
       .attach('surveyResponses', `${TEST_DATA_FOLDER}/surveyResponses/${filename}`);
   };
 

--- a/packages/psss-server/src/connections/ApiConnection.ts
+++ b/packages/psss-server/src/connections/ApiConnection.ts
@@ -32,8 +32,8 @@ export class ApiConnection {
     return this.request('PUT', endpoint, queryParameters, body);
   }
 
-  delete(endpoint: string) {
-    return this.request('DELETE', endpoint);
+  delete(endpoint: string, queryParameters: QueryParameters) {
+    return this.request('DELETE', endpoint, queryParameters);
   }
 
   async request(

--- a/packages/psss-server/src/connections/MeditrakConnection.ts
+++ b/packages/psss-server/src/connections/MeditrakConnection.ts
@@ -84,6 +84,7 @@ export class MeditrakConnection extends ApiConnection {
     return this.post(`changes`, {}, [
       {
         action: 'SubmitSurveyResponse',
+        waitForAnalyticsRebuild: true,
         payload: {
           id: surveyResponse.id,
           data_time: surveyResponse.data_time,
@@ -118,6 +119,7 @@ export class MeditrakConnection extends ApiConnection {
     return this.post(`changes`, {}, [
       {
         action: 'SubmitSurveyResponse',
+        waitForAnalyticsRebuild: true,
         payload: {
           id: generateId(),
           data_time: stripTimezoneFromDate(new Date(endDate).toISOString()),

--- a/packages/psss-server/src/connections/MeditrakConnection.ts
+++ b/packages/psss-server/src/connections/MeditrakConnection.ts
@@ -135,6 +135,6 @@ export class MeditrakConnection extends ApiConnection {
   }
 
   async deleteSurveyResponse(surveyResponse: SurveyResponseObject) {
-    return this.delete(`surveyResponses/${surveyResponse.id}`);
+    return this.delete(`surveyResponses/${surveyResponse.id}`, { waitForAnalyticsRebuild: 'true' });
   }
 }

--- a/packages/psss/src/api/mutations.js
+++ b/packages/psss/src/api/mutations.js
@@ -14,6 +14,7 @@ export const useConfirmWeeklyReport = (countryCode, period) =>
       }),
     {
       onSuccess: () => {
+        // Same as useSaveWeeklyReport, we need to invalidate all weekly data
         queryCache.invalidateQueries(`confirmedWeeklyReport/${countryCode}`);
         // regional (multi-country) level
         queryCache.invalidateQueries('confirmedWeeklyReport', { exact: true });
@@ -31,7 +32,9 @@ export const useSaveWeeklyReport = ({ countryCode, siteCode = '', week }) =>
     {
       onSuccess: () => {
         queryCache.invalidateQueries(`weeklyReport/${countryCode}/${siteCode}`);
-        queryCache.invalidateQueries(`weeklyReport/${countryCode}`, { exact: true });
+        // Even though we only changed one week of data, we need to re-fetch the complete list because
+        // the data for a specific week is dependant on previous weeks, even across pages.
+        queryCache.invalidateQueries(`weeklyReport/${countryCode}`);
       },
     },
   );
@@ -44,6 +47,7 @@ export const useDeleteWeeklyReport = ({ countryCode, week }) =>
       }),
     {
       onSuccess: () => {
+        // Same as useSaveWeeklyReport, we need to invalidate all weekly data
         queryCache.invalidateQueries(`weeklyReport/${countryCode}`);
       },
     },

--- a/packages/psss/src/api/mutations.js
+++ b/packages/psss/src/api/mutations.js
@@ -31,7 +31,7 @@ export const useSaveWeeklyReport = ({ countryCode, siteCode = '', week }) =>
       }),
     {
       onSuccess: () => {
-        queryCache.invalidateQueries(`weeklyReport/${countryCode}/${siteCode}`);
+        queryCache.invalidateQueries(`weeklyReport/${countryCode}/sites`);
         // Even though we only changed one week of data, we need to re-fetch the complete list because
         // the data for a specific week is dependant on previous weeks, even across pages.
         queryCache.invalidateQueries(`weeklyReport/${countryCode}`);

--- a/packages/psss/src/api/queries/useSingleWeeklyReport.js
+++ b/packages/psss/src/api/queries/useSingleWeeklyReport.js
@@ -30,6 +30,8 @@ const useCachedQuery = (endpoint, period, queryKey) => {
     },
     {
       initialData: () => {
+        // If we have a page of data, and we open a detail for a specific week, we don't want
+        // to re-fetch the data for that week, so we get the specific week data from the cache
         const cachedQuery = queryCache.getQueryData([endpoint, queryKey]);
         const results = cachedQuery?.data?.results;
 

--- a/packages/psss/src/containers/Panels/WeeklyReportsPanel.js
+++ b/packages/psss/src/containers/Panels/WeeklyReportsPanel.js
@@ -114,7 +114,11 @@ export const WeeklyReportsPanelComponent = React.memo(
       unVerifiedAlerts,
       error: countryWeekError,
     } = useSingleWeeklyReport(countryCode, activeWeek, verifiedStatuses, pageQueryKey);
-    const { data: siteData } = useSitesSingleWeeklyReport(
+
+    const {
+      isFetching: isSiteDataFetching,
+      data: siteData
+    } = useSitesSingleWeeklyReport(
       countryCode,
       activeWeek,
       verifiedStatuses,
@@ -197,6 +201,7 @@ export const WeeklyReportsPanelComponent = React.memo(
               >
                 <WeeklyReportTable
                   data={selectedSite.syndromes}
+                  isFetching={isSiteDataFetching}
                   isSiteReport
                   siteCode={selectedSite.code}
                   weekNumber={activeWeek}

--- a/packages/utils/src/__tests__/stripTimezoneFromDate.test.js
+++ b/packages/utils/src/__tests__/stripTimezoneFromDate.test.js
@@ -1,0 +1,38 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
+ */
+
+import { stripTimezoneFromDate, reformatDateStringWithoutTz } from '../stripTimezoneFromDate';
+
+describe('stripTimezoneFromDate', () => {
+  it('Should return the same dateTime if no timezone specified', async () => {
+    expect(stripTimezoneFromDate('2021-01-01 02:03:04')).toBe('2021-01-01T02:03:04.000');
+    expect(stripTimezoneFromDate('2021-01-01 00:00:00')).toBe('2021-01-01T00:00:00.000');
+    expect(stripTimezoneFromDate('2021-01-01')).toBe('2021-01-01T00:00:00.000');
+  });
+
+  it('Should strip the timezone if it is specified', async () => {
+    expect(stripTimezoneFromDate('2021-01-01 02:03:04+05')).toBe('2021-01-01T02:03:04.000');
+    expect(stripTimezoneFromDate('2021-01-01 02:03:04Z')).toBe('2021-01-01T02:03:04.000');
+  });
+});
+
+describe('reformatDateStringWithoutTz', () => {
+  it('Should reformat', async () => {
+    expect(reformatDateStringWithoutTz('2021-01-01 02:03:04')).toBe('2021-01-01T02:03:04.000');
+    expect(reformatDateStringWithoutTz('2021-01-01T00:00:00')).toBe('2021-01-01T00:00:00.000');
+  });
+
+  it('Should return null if a timezone is specified', async () => {
+    expect(reformatDateStringWithoutTz('2021-01-01 02:03:04+05')).toBe(null);
+    expect(reformatDateStringWithoutTz('2021-01-01T02:03:04+05')).toBe(null);
+    expect(reformatDateStringWithoutTz('2021-01-01 02:03:04Z')).toBe(null);
+    expect(reformatDateStringWithoutTz('2021-01-01T02:03:04Z')).toBe(null);
+  });
+
+  it('Should return null if an unknown format is used', async () => {
+    expect(reformatDateStringWithoutTz('1 Jan 2021')).toBe(null);
+    expect(reformatDateStringWithoutTz('2021-01-01')).toBe(null);
+  });
+});

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -3,6 +3,8 @@
  * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
  */
 
+import { reformatDateStringWithoutTz } from './stripTimezoneFromDate';
+
 export * from './array';
 export { AsyncTaskQueue } from './AsyncTaskQueue';
 export * from './compare';
@@ -33,7 +35,7 @@ export { WorkBookParser } from './WorkBookParser';
 export { checkValueSatisfiesCondition } from './checkValueSatisfiesCondition';
 export { addExportedDateAndOriginAtTheSheetBottom } from './addExportDateAndOriginInExcelExportData';
 export { getBrowserTimeZone } from './getBrowserTimeZone';
-export { stripTimezoneFromDate } from './stripTimezoneFromDate';
+export { stripTimezoneFromDate, reformatDateStringWithoutTz } from './stripTimezoneFromDate';
 export { VALUE_TYPES, formatDataValueByType } from './formatDataValueByType';
 export { createClassExtendingProxy } from './proxy';
 export { fetchPatiently } from './fetchPatiently';

--- a/packages/utils/src/stripTimezoneFromDate.js
+++ b/packages/utils/src/stripTimezoneFromDate.js
@@ -11,3 +11,25 @@ const ISO_DATE_FORMAT_WITHOUT_TZ = 'YYYY-MM-DDTHH:mm:ss.SSS';
 export function stripTimezoneFromDate(date) {
   return moment.parseZone(date).format(ISO_DATE_FORMAT_WITHOUT_TZ);
 }
+
+const KNOWN_FORMATS_WITHOUT_TZ = [
+  'YYYY-MM-DD HH:mm:ss',
+  'YYYY-MM-DD HH:mm:ss.SSS',
+  'YYYY-MM-DDTHH:mm:ss',
+  'YYYY-MM-DDTHH:mm:ss.SSS',
+]
+
+/**
+ * Given a date string e.g. "2021-01-01 00:00:00", return in our format i.e. 2021-01-01T00:00.000
+ * @param date string
+ * @return string|null if unable to parse format
+ */
+export function reformatDateStringWithoutTz(date) {
+  for (const format of KNOWN_FORMATS_WITHOUT_TZ) {
+    const parsed = moment(date, format, true);
+    if (parsed.isValid()) {
+      return parsed.format(ISO_DATE_FORMAT_WITHOUT_TZ);
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
### Changes:

See each commit for changes, summary:
- Add opt-in flag for survey response submissions that blocks the response and waits for analytics table rebuild
- Allow submit survey responses with a data_time without a tz
- Fix frontend query cache invalidation to properly refetch data after mutation

---

### Screenshots:
https://github.com/beyondessential/tupaia-backlog/issues/2663#issuecomment-841042918
