### PR TITLE
Fix incorrect property key in Alert Panel

### DIFF
--- a/packages/psss/src/components/AffectedSitesTab.js
+++ b/packages/psss/src/components/AffectedSitesTab.js
@@ -63,7 +63,7 @@ export const AffectedSitesTab = ({ alert }) => {
     }
 
     return weeklyData.map(weekData => {
-      const { status, period, totalCases, percentageChange, sites: siteData } = weekData;
+      const { status, period, weeklyCases, percentageChange, sites: siteData } = weekData;
 
       return (
         <AlertsOutbreaksCard key={period} variant="outlined" mb={5}>
@@ -71,7 +71,7 @@ export const AffectedSitesTab = ({ alert }) => {
             type={status}
             heading={`Week ${getWeekNumberByPeriod(period)}`}
             subheading={getDisplayDatesByPeriod(period)}
-            detailText={`Total Cases for all Sites: ${totalCases || '-'}`}
+            detailText={`Total Cases for all Sites: ${weeklyCases || '-'}`}
             percentageChange={percentageChange}
           />
           <AlertsAndOutbreaksCardBody>


### PR DESCRIPTION
### Changes:
- There's data for total cases per week but it's not showing in the Alert Panel (screenshot here: https://github.com/beyondessential/tupaia-backlog/issues/2851#issuecomment-846803816). The report returns `weeklyCases` instead of `totalCases`. So this is to fix incorrect property key in Alert Panel
- I didn't fix this in another WIP branch and wanted to fix this early because Sepi is testing the Alert Panel