### PR TITLE
PSSS: Fix event data placeholder

### DIFF
--- a/packages/psss/src/containers/Tables/FakeEventBasedDataTable.js
+++ b/packages/psss/src/containers/Tables/FakeEventBasedDataTable.js
@@ -1,0 +1,58 @@
+/*
+ * Tupaia
+ * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
+ */
+import { Table } from '@tupaia/ui-components';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { useAlerts } from '../../api';
+import { AlertMenuCell, SyndromeCell, WeekAndDateCell } from '../../components';
+import { getCurrentPeriod } from '../../utils';
+
+const columns = [
+  {
+    title: 'Syndrome',
+    key: 'syndrome',
+    align: 'left',
+    CellComponent: SyndromeCell,
+  },
+  {
+    title: 'Alert Start Date',
+    key: 'period',
+    align: 'left',
+    width: '200px',
+    CellComponent: WeekAndDateCell,
+  },
+  {
+    title: 'Cases Since Alert Began',
+    key: 'totalCases',
+    align: 'left',
+    width: '115px',
+  },
+  {
+    title: '',
+    key: 'id',
+    sortable: false,
+    CellComponent: AlertMenuCell,
+    width: '45px',
+  },
+];
+
+export const FakeEventBasedDataTable = ({ countryCode }) => {
+  const period = getCurrentPeriod();
+  const { data, isLoading, error, isFetching } = useAlerts(period, [countryCode], 'active');
+
+  return (
+    <Table
+      data={data}
+      isLoading={isLoading}
+      isFetching={!isLoading && isFetching}
+      errorMessage={error && error.message}
+      columns={columns}
+    />
+  );
+};
+
+FakeEventBasedDataTable.propTypes = {
+  countryCode: PropTypes.string.isRequired,
+};

--- a/packages/psss/src/containers/Tables/index.js
+++ b/packages/psss/src/containers/Tables/index.js
@@ -8,6 +8,7 @@ export * from './ArchiveTable';
 export * from './CountriesTable';
 export * from './CountrySummaryTable';
 export * from './CountryTable';
+export * from './FakeEventBasedDataTable';
 export * from './SiteSummaryTable';
 export * from './OutbreaksTable';
 export * from './WeeklyReportTable';

--- a/packages/psss/src/views/Tabs/EventBasedTabView.js
+++ b/packages/psss/src/views/Tabs/EventBasedTabView.js
@@ -4,8 +4,8 @@
  */
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import { Container, Main, ComingSoon } from '../../components';
-import { AlertsTable } from '../../containers/Tables';
+import { ComingSoon, Container, Main } from '../../components';
+import { FakeEventBasedDataTable } from '../../containers';
 
 export const EventBasedTabView = () => {
   const { countryCode } = useParams();
@@ -15,7 +15,7 @@ export const EventBasedTabView = () => {
       <ComingSoon text="The Event-based page will allow you to see event based data." />
       <Container>
         <Main>
-          <AlertsTable handlePanelOpen={() => {}} countryCode={countryCode} />
+          <FakeEventBasedDataTable countryCode={countryCode} />
         </Main>
       </Container>
     </div>


### PR DESCRIPTION
### Issue #:
[No issue] The **Event-based Data** placeholder broke when I refactored the alerts table. After talking with @enunan , I confirmed that the fact that we show alerts in the blurred background is a coincidence. The actual data that will be shown when we implement this feature will not be directly related to alerts.

### Screenshots:
![image](https://user-images.githubusercontent.com/20692464/119311572-954e3d80-bcb4-11eb-9501-135e3f85b65a.png)

