### PR TITLE
PSSS: Minor UI fixes

### DIFF
--- a/packages/psss/src/api/queries/useCountrySitesWeeklyReport.js
+++ b/packages/psss/src/api/queries/useCountrySitesWeeklyReport.js
@@ -23,7 +23,6 @@ export const useCountrySitesWeeklyReport = (countryCode, period) => {
 
   return {
     ...query,
-    reportCount: report.length,
     data,
   };
 };

--- a/packages/psss/src/api/queries/useSitesSingleWeeklyReport.js
+++ b/packages/psss/src/api/queries/useSitesSingleWeeklyReport.js
@@ -29,7 +29,6 @@ export const useSitesSingleWeeklyReport = (countryCode, period, pageQueryKey) =>
 
   return {
     ...query,
-    reportCount: report.length,
     data,
   };
 };

--- a/packages/psss/src/containers/ProfileButton.js
+++ b/packages/psss/src/containers/ProfileButton.js
@@ -10,7 +10,8 @@ import { getCurrentUser, logout } from '../store';
 
 const ProfileLinksComponent = ({ onLogout }) => (
   <>
-    <ProfileButtonItem to="/profile">Edit Profile</ProfileButtonItem>
+    {/* Removed for MVP @see https://github.com/beyondessential/tupaia-backlog/issues/1117*/}
+    {/*<ProfileButtonItem to="/profile">Edit Profile</ProfileButtonItem>*/}
     <ProfileButtonItem button onClick={onLogout}>
       Logout
     </ProfileButtonItem>

--- a/packages/psss/src/containers/Tables/AlertsTable.js
+++ b/packages/psss/src/containers/Tables/AlertsTable.js
@@ -77,6 +77,7 @@ const AlertsTableComponent = React.memo(({ countryCodes, period }) => {
       isLoading={isLoading}
       isFetching={!isLoading && isFetching}
       errorMessage={error && error.message}
+      noDataMessage="No active alerts found"
       columns={columns}
       onRowClick={handleRowClick}
     />

--- a/packages/psss/src/containers/Tables/ArchiveTable.js
+++ b/packages/psss/src/containers/Tables/ArchiveTable.js
@@ -85,6 +85,7 @@ export const ArchiveTableComponent = React.memo(({ countryCodes, period }) => {
       isLoading={isLoading}
       isFetching={!isLoading && isFetching}
       errorMessage={error && error.message}
+      noDataMessage="No archived alerts found"
       columns={columns}
     />
   );

--- a/packages/psss/src/containers/Tables/SiteSummaryTable.js
+++ b/packages/psss/src/containers/Tables/SiteSummaryTable.js
@@ -84,27 +84,26 @@ export const SiteSummaryTableComponent = React.memo(({ rowData, handleOpen }) =>
   const { countryCode } = useParams();
   const { period, Sites: totalSites = '', 'Sites Reported': sitesReported = '' } = rowData;
   const { isLoading, isFetching, error, data } = useCountrySitesWeeklyReport(countryCode, period);
-  const isDataLoading = !isLoading && !isFetching;
 
   return (
     <>
-      {isDataLoading && (
-        <TableWrapper>
-          <FakeHeader>
-            <div>{`${sitesReported}/${totalSites} Sentinel Sites Reported`}</div>
-            <Link component="button" onClick={() => handleOpen(period)} underline="always">
-              Review and Confirm Now
-            </Link>
-          </FakeHeader>
-          <Table
-            errorMessage={error}
-            columns={siteWeekColumns}
-            data={data}
-            Header={false}
-            Body={CondensedTableBody}
-          />
-        </TableWrapper>
-      )}
+      <TableWrapper>
+        <FakeHeader>
+          <div>{`${sitesReported}/${totalSites} Sentinel Sites Reported`}</div>
+          <Link component="button" onClick={() => handleOpen(period)} underline="always">
+            Review and Confirm Now
+          </Link>
+        </FakeHeader>
+        <Table
+          isLoading={isLoading}
+          isFetching={!isLoading && isFetching}
+          errorMessage={error?.message}
+          columns={siteWeekColumns}
+          data={data}
+          Header={false}
+          Body={CondensedTableBody}
+        />
+      </TableWrapper>
       <TableFooter>
         <Text>Verify data to submit Weekly report to Regional</Text>
         <Button onClick={() => handleOpen(period)}>Review and Confirm Now</Button>

--- a/packages/psss/src/containers/Tables/SiteSummaryTable.js
+++ b/packages/psss/src/containers/Tables/SiteSummaryTable.js
@@ -82,16 +82,13 @@ const Link = styled(MuiLink)`
 
 export const SiteSummaryTableComponent = React.memo(({ rowData, handleOpen }) => {
   const { countryCode } = useParams();
-  const { period, Sites: totalSites = 0, 'Sites Reported': sitesReported = 0 } = rowData;
-  const { isLoading, isFetching, error, reportCount, data } = useCountrySitesWeeklyReport(
-    countryCode,
-    period,
-  );
-  const showSites = !isLoading && !isFetching && reportCount > 0;
+  const { period, Sites: totalSites = '', 'Sites Reported': sitesReported = '' } = rowData;
+  const { isLoading, isFetching, error, data } = useCountrySitesWeeklyReport(countryCode, period);
+  const isDataLoading = !isLoading && !isFetching;
 
   return (
     <>
-      {showSites && (
+      {isDataLoading && (
         <TableWrapper>
           <FakeHeader>
             <div>{`${sitesReported}/${totalSites} Sentinel Sites Reported`}</div>

--- a/packages/ui-components/src/components/Table/Table.js
+++ b/packages/ui-components/src/components/Table/Table.js
@@ -48,7 +48,7 @@ export const Table = React.memo(
       <TableMessageProvider
         errorMessage={errorMessage}
         isLoading={isLoading}
-        isData={data.length > 0}
+        hasData={data.length > 0}
         noDataMessage={noDataMessage}
         colSpan={columns.length}
       >

--- a/packages/ui-components/src/components/Table/TableMessageProvider.js
+++ b/packages/ui-components/src/components/Table/TableMessageProvider.js
@@ -17,10 +17,10 @@ const ErrorAlert = styled(SmallAlert)`
   margin-bottom: 0.75rem;
 `;
 
-const getMessage = ({ isLoading, errorMessage, isData, noDataMessage }) => {
+const getMessage = ({ isLoading, errorMessage, hasData, noDataMessage }) => {
   if (isLoading) return 'Loading...';
   if (errorMessage) return errorMessage;
-  if (isData === 0) return noDataMessage;
+  if (!hasData) return noDataMessage;
   return null;
 };
 
@@ -28,8 +28,8 @@ const getMessage = ({ isLoading, errorMessage, isData, noDataMessage }) => {
  * Checks if there is a status message for the table and if so returns it instead of the table body
  */
 export const TableMessageProvider = React.memo(
-  ({ isLoading, errorMessage, isData, noDataMessage, colSpan, children }) => {
-    const message = getMessage({ errorMessage, isLoading, isData, noDataMessage });
+  ({ isLoading, errorMessage, hasData, noDataMessage, colSpan, children }) => {
+    const message = getMessage({ errorMessage, isLoading, hasData, noDataMessage });
     if (message) {
       return (
         <MuiTableBody>
@@ -53,9 +53,9 @@ export const TableMessageProvider = React.memo(
 );
 
 TableMessageProvider.propTypes = {
-  isData: PropTypes.bool.isRequired,
+  hasData: PropTypes.bool.isRequired,
   colSpan: PropTypes.number.isRequired,
-  children: PropTypes.any.isRequired,
+  children: PropTypes.node.isRequired,
   noDataMessage: PropTypes.string,
   isLoading: PropTypes.bool,
   errorMessage: PropTypes.string,


### PR DESCRIPTION
### Issue #:
Addresses a few existing UI issues

### Changes

1. In a past commit I enabled the "Edit Profile" button, thinking that this was all that was left to implement https://github.com/beyondessential/tupaia-backlog/issues/1117. It seems that there is also back-end work that needs to be done. Since this was a nice-to-have for Phase 2, I'm reverting this change until the back-end is built (in a future phase)
2. The current UI was a bit inconsistent when displaying the sentinel site summary in the Weekly Report page:
   * If there was at least one report submitted in the selected week, all sites were shown. Empty data are shown as `-`
   * If there were no reports submitted, then **no** site was shown.

   This PR changes this behaviour by always showing the sentinel site summary:

   ![no_sentinel_site_data](https://user-images.githubusercontent.com/20692464/119455043-8e8afd80-bd7c-11eb-914b-14d77bc5115f.JPG)

   I discussed with @tcaiger and it seems that this was the intended behaviour in the first place.

3. The existing UI didn't handle loading/error info correctly in the sentinel site summary. This is fixed now:
   ![loading_screen](https://user-images.githubusercontent.com/20692464/119455127-a4002780-bd7c-11eb-9407-8e808209ed79.JPG)

   ![error_screen](https://user-images.githubusercontent.com/20692464/119455138-a793ae80-bd7c-11eb-9696-5f7a165d102f.JPG)
4. There was no provision for an "empty data" message in case no alerts were found. This is now fixed:
   ![no_active_alerts](https://user-images.githubusercontent.com/20692464/119457368-f3dfee00-bd7e-11eb-9bdd-c608c1cecedf.JPG)
   ![no_archived_alerts](https://user-images.githubusercontent.com/20692464/119457372-f5111b00-bd7e-11eb-9951-a47acf2b165e.JPG)


