### PR TITLE
2874: PSSS - Fix edit sentinel site data

### DIFF
--- a/packages/psss/src/containers/Panels/WeeklyReportsPanel.js
+++ b/packages/psss/src/containers/Panels/WeeklyReportsPanel.js
@@ -2,7 +2,7 @@
  * Tupaia
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
-import React, { useState, useEffect } from 'react';
+import React, { useCallback, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useParams } from 'react-router-dom';
 import { connect, useSelector } from 'react-redux';
@@ -149,6 +149,14 @@ export const WeeklyReportsPanelComponent = React.memo(
       }
     };
 
+    const handleChangeSite = useCallback(
+      siteIndex => {
+        setActiveSiteIndex(siteIndex);
+        setSitesTableStatus(TABLE_STATUSES.STATIC);
+      },
+      [setActiveSiteIndex, setSitesTableStatus],
+    );
+
     const isVerified = isFetching || unVerifiedAlerts.length === 0;
     const showSites = activeWeek !== null && siteData.length > 0;
     const selectedSite = siteData[activeSiteIndex];
@@ -197,7 +205,7 @@ export const WeeklyReportsPanelComponent = React.memo(
             <ButtonSelect
               id="active-site"
               options={siteData}
-              onChange={setActiveSiteIndex}
+              onChange={handleChangeSite}
               index={activeSiteIndex}
             />
             <SiteAddress address={selectedSite.address} contact={selectedSite.contact} />

--- a/packages/psss/src/containers/Panels/WeeklyReportsPanel.js
+++ b/packages/psss/src/containers/Panels/WeeklyReportsPanel.js
@@ -41,6 +41,8 @@ import {
 const SiteReportsSection = styled.section`
   position: relative;
   padding: 1.8rem 1.25rem;
+  pointer-events: ${props => (props.disabled ? 'none' : 'initial')};
+  opacity: ${props => (props.disabled ? '0.5' : 1)};
 
   &:after {
     display: ${props => (props.disabled ? 'block' : 'none')};
@@ -188,7 +190,10 @@ export const WeeklyReportsPanelComponent = React.memo(
           </EditableTableProvider>
         </CountryReportsSection>
         {showSites && (
-          <SiteReportsSection disabled={isSaving} data-testid="site-reports">
+          <SiteReportsSection
+            disabled={countryTableStatus === TABLE_STATUSES.EDITABLE || isSaving}
+            data-testid="site-reports"
+          >
             <ButtonSelect
               id="active-site"
               options={siteData}

--- a/packages/psss/src/containers/Tables/WeeklyReportTable/WeeklyReportTable.js
+++ b/packages/psss/src/containers/Tables/WeeklyReportTable/WeeklyReportTable.js
@@ -29,18 +29,7 @@ import { combineMutationResults, useDeleteWeeklyReport, useSaveWeeklyReport } fr
 import { TABLE_STATUSES } from '../../../constants';
 import { WeeklyReportTableHeading } from './WeeklyReportTableHeading';
 
-const GreyHeader = styled(FakeHeader)`
-  border: none;
-`;
-
 const Alert = styled(SmallAlert)`
-  margin-bottom: 1.2rem;
-`;
-
-const GreyAlert = styled(SmallAlert)`
-  background: ${props => props.theme.palette.text.secondary};
-  font-weight: 500;
-  color: white;
   margin-bottom: 1.2rem;
 `;
 
@@ -127,6 +116,8 @@ export const WeeklyReportTable = React.memo(
       week: weekNumber,
     });
     const { error, isError } = combineMutationResults([saveResults, deleteResults]);
+    const isCountryTableBeingEdited =
+      !isSiteReport && [TABLE_STATUSES.EDITABLE, TABLE_STATUSES.SAVING].includes(tableStatus);
 
     const onSubmit = async formData => {
       setTableStatus(TABLE_STATUSES.SAVING);
@@ -190,13 +181,12 @@ export const WeeklyReportTable = React.memo(
                 {error.message}
               </Alert>
             )}
-            {/*<GreyAlert severity="info" icon={<InfoIcon fontSize="inherit" />}>*/}
-            {/*Country level data has been manually edited, sentinel data will not be used.*/}
-            {/*</GreyAlert>*/}
-            {/*<GreyHeader>*/}
-            {/*  <span>SYNDROMES</span>*/}
-            {/*  <span>TOTAL CASES</span>*/}
-            {/*</GreyHeader>*/}
+            {isCountryTableBeingEdited && (
+              <Alert severity="error" variant="standard">
+                Updating aggregated data will be the source of truth. All individual Sentinel data
+                will be ignored.
+              </Alert>
+            )}
             <Table Header={TableHeader} Body={VerifiableBody} data={data} columns={columns} />
             {tableStatus === TABLE_STATUSES.EDITABLE && (
               <ActionsRow isSiteReport={isSiteReport}>


### PR DESCRIPTION
### Issue #:
* Addresses https://github.com/beyondessential/tupaia-backlog/issues/2874
* It also implements a behaviour that is included in the mockup but escaped our attention... When country level data are being edited, the sentinel data section should be disabled, and an alert should be shown (see screenshot below)

### Screenshots:
![disable_sentinel_table](https://user-images.githubusercontent.com/20692464/119607559-e33f7e80-be37-11eb-9639-9077f49696b7.JPG)
