### PR TITLE
revert constants to lesmis project

### DIFF
--- a/packages/lesmis-server/src/constants.ts
+++ b/packages/lesmis-server/src/constants.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  *
  */
+
 export const LESMIS_PERMISSION_GROUP = 'LESMIS Public';
-// @Todo: Set back to lesmis
-export const LESMIS_PROJECT_NAME = 'fanafana';
-export const LESMIS_COUNTRY_ENTITY_CODE = 'TO';
+export const LESMIS_PROJECT_NAME = 'laos_schools';
+export const LESMIS_COUNTRY_ENTITY_CODE = 'LA';

--- a/packages/lesmis/src/constants/constants.js
+++ b/packages/lesmis/src/constants/constants.js
@@ -5,9 +5,8 @@
  */
 
 // Project Data Constants
-// @Todo: Set back to lesmis
-export const PROJECT_CODE = 'fanafana';
-export const COUNTRY_CODE = 'TO';
+export const PROJECT_CODE = 'laos_schools';
+export const COUNTRY_CODE = 'LA';
 
 // Date Constants
 export const SINGLE_YEAR_GRANULARITY = 'one_year_at_a_time';


### PR DESCRIPTION
### Issue #: [2680](https://github.com/beyondessential/tupaia-backlog/issues/2680) revert constants to lesmis project

While testing the 2680 issue, the lesmis app was pointed at the `fanfana` project. That ticket is now testing passed so we need to revert the lesmis app to point to the lesmis project data.