### PR TITLE
[Hot fix] Prevent multiple concurrent analytics refreshes

### DIFF
--- a/packages/database/src/analytics/AnalyticsRefresher.js
+++ b/packages/database/src/analytics/AnalyticsRefresher.js
@@ -8,9 +8,10 @@ import winston from 'winston';
 const REFRESH_DEBOUNCE_TIME = 1000; // wait 1 second after changes before refreshing, to avoid double-up
 
 export class AnalyticsRefresher {
-  constructor(database, models) {
+  constructor(database, models, refreshDebounceTime = REFRESH_DEBOUNCE_TIME) {
     this.database = database;
     this.models = models;
+    this.refreshDebounceTime = refreshDebounceTime;
     this.scheduledRefreshTimeout = null;
     this.scheduledRefreshPromise = null;
     this.scheduledRefreshPromiseResolve = null;
@@ -52,7 +53,7 @@ export class AnalyticsRefresher {
     // schedule the rebuild to happen after an adequate period of debouncing
     this.scheduledRefreshTimeout = setTimeout(() => {
       this.activeRefreshPromise = this.refreshAnalytics();
-    }, REFRESH_DEBOUNCE_TIME);
+    }, this.refreshDebounceTime);
     return this.scheduledRefreshPromise;
   }
 

--- a/packages/database/src/tests/analytics/AnalyticsRefresher.test.js
+++ b/packages/database/src/tests/analytics/AnalyticsRefresher.test.js
@@ -4,6 +4,8 @@
  */
 
 import { expect } from 'chai';
+import sinon from 'sinon';
+import { sleep } from '@tupaia/utils';
 import {
   getTestDatabase,
   getTestModels,
@@ -30,10 +32,12 @@ const matchingFields = [
   'date',
 ];
 
+const REFRESH_DEBOUNCE_TIME = 100; // short debounce time so tests run more quickly
+
 describe('AnalyticsRefresher', () => {
   const database = getTestDatabase();
   const models = getTestModels();
-  const analyticsRefresher = new AnalyticsRefresher(database, models);
+  const analyticsRefresher = new AnalyticsRefresher(database, models, REFRESH_DEBOUNCE_TIME);
 
   const assertAnalyticsMatch = async expectedAnalytics => {
     await models.database.waitForAllChangeHandlers();
@@ -188,5 +192,99 @@ describe('AnalyticsRefresher', () => {
       return analytic;
     });
     await assertAnalyticsMatch(updatedAnalytics);
+  });
+
+  it('debounces analytics table refreshes that are started at the same time', async () => {
+    sinon.stub(AnalyticsRefresher, 'executeRefresh');
+
+    // call several times in a row
+    analyticsRefresher.scheduleAnalyticsRefresh();
+    analyticsRefresher.scheduleAnalyticsRefresh();
+    analyticsRefresher.scheduleAnalyticsRefresh();
+    await analyticsRefresher.scheduleAnalyticsRefresh(); // await final call
+
+    expect(AnalyticsRefresher.executeRefresh).to.have.been.calledOnce; // should have debounced
+
+    AnalyticsRefresher.executeRefresh.restore();
+  });
+
+  it('debounces analytics table refreshes that are started within a second of another one each other', async () => {
+    sinon.stub(AnalyticsRefresher, 'executeRefresh');
+
+    // call several times with half the debounce time between each
+    analyticsRefresher.scheduleAnalyticsRefresh();
+    await sleep(REFRESH_DEBOUNCE_TIME / 2);
+    analyticsRefresher.scheduleAnalyticsRefresh();
+    await sleep(REFRESH_DEBOUNCE_TIME / 2);
+    analyticsRefresher.scheduleAnalyticsRefresh();
+    await sleep(REFRESH_DEBOUNCE_TIME / 2);
+    await analyticsRefresher.scheduleAnalyticsRefresh(); // await final call
+
+    expect(AnalyticsRefresher.executeRefresh).to.have.been.calledOnce; // should have debounced
+
+    AnalyticsRefresher.executeRefresh.restore();
+  });
+
+  it('only runs one refresh at a time', async () => {
+    let resolveOnRefreshStart;
+    let isRefreshRunning = false;
+    let refreshNumber = 0;
+    sinon.stub(AnalyticsRefresher, 'executeRefresh').callsFake(async () => {
+      if (resolveOnRefreshStart) {
+        resolveOnRefreshStart();
+      }
+      expect(isRefreshRunning).to.equal(false);
+      isRefreshRunning = true;
+      refreshNumber++;
+      // sleep for longer than the debounce time so that we're still refreshing when the next one
+      // should be triggered
+      await sleep(REFRESH_DEBOUNCE_TIME + 200);
+      isRefreshRunning = false;
+    });
+
+    // start a refresh
+    analyticsRefresher.scheduleAnalyticsRefresh();
+    const refreshOneStarted = new Promise(resolve => {
+      resolveOnRefreshStart = resolve;
+    });
+
+    // after refresh one has started but not yet completed, schedule another analytics refresh
+    await refreshOneStarted;
+    expect(isRefreshRunning).to.equal(true);
+    expect(refreshNumber).to.equal(1);
+    analyticsRefresher.scheduleAnalyticsRefresh();
+    const refreshTwoStarted = new Promise(resolve => {
+      resolveOnRefreshStart = resolve;
+    });
+
+    // wait for longer than the debounce time, so the just scheduled refresh would want to start,
+    // but should still be running the first refresh
+    await sleep(REFRESH_DEBOUNCE_TIME + 10);
+    expect(isRefreshRunning).to.equal(true);
+    expect(refreshNumber).to.equal(1);
+
+    // after refresh two has started but not yet completed, schedule another few analytics refresh
+    // these should debounce and result in one more refresh
+    await refreshTwoStarted;
+    expect(isRefreshRunning).to.equal(true);
+    expect(refreshNumber).to.equal(2);
+    analyticsRefresher.scheduleAnalyticsRefresh();
+    analyticsRefresher.scheduleAnalyticsRefresh();
+    analyticsRefresher.scheduleAnalyticsRefresh();
+    const finalRefreshPromise = analyticsRefresher.scheduleAnalyticsRefresh();
+
+    // wait for longer than the debounce time, so the just scheduled refresh would want to start,
+    // but should still be running the second refresh
+    await sleep(REFRESH_DEBOUNCE_TIME + 10);
+    expect(isRefreshRunning).to.equal(true);
+    expect(refreshNumber).to.equal(2);
+
+    // wait for final refresh to complete, then check a total of three were called
+    await finalRefreshPromise;
+    expect(isRefreshRunning).to.equal(false);
+    expect(refreshNumber).to.equal(3);
+    expect(AnalyticsRefresher.executeRefresh).to.have.been.calledThrice;
+
+    AnalyticsRefresher.executeRefresh.restore();
   });
 });

--- a/packages/database/src/tests/analytics/AnalyticsRefresher.test.js
+++ b/packages/database/src/tests/analytics/AnalyticsRefresher.test.js
@@ -233,7 +233,7 @@ describe('AnalyticsRefresher', () => {
       if (resolveOnRefreshStart) {
         resolveOnRefreshStart();
       }
-      expect(isRefreshRunning).to.equal(false);
+      expect(isRefreshRunning).to.equal(false); // assert against concurrent refreshes
       isRefreshRunning = true;
       refreshNumber++;
       // sleep for longer than the debounce time so that we're still refreshing when the next one


### PR DESCRIPTION
I've listed this as a hot fix as it'd be great to get it into production to help make Juliana's job importing heaps of EMIS data easier, though we do still need to test it on its own deployment and see whether it will actually help with that