### PR TITLE
Added 'served_build/*' to lesmis .gitignore

### DIFF
--- a/packages/lesmis/.gitignore
+++ b/packages/lesmis/.gitignore
@@ -1,0 +1,1 @@
+served_build/*


### PR DESCRIPTION
Build gets generated here on deployment instances so worth ignoring for when deving directly on a feature instance