### PR TITLE
2931 batch process responses

### DIFF
--- a/packages/admin-panel/src/importExport/ImportModal.js
+++ b/packages/admin-panel/src/importExport/ImportModal.js
@@ -66,9 +66,10 @@ export const ImportModalComponent = React.memo(
       setFileName(noFileMessage);
     };
 
-    const handleCancel = () => {
+    const handleClose = () => {
       setStatus(STATUS.IDLE);
       setErrorMessage(null);
+      setSuccessMessage(null);
       setIsOpen(false);
       setValues({});
       setFile(null);
@@ -93,7 +94,7 @@ export const ImportModalComponent = React.memo(
           setSuccessMessage(response.message);
           setStatus(STATUS.SUCCESS);
         } else {
-          handleDismiss();
+          handleClose();
         }
         changeSuccess();
       } catch (error) {
@@ -122,7 +123,7 @@ export const ImportModalComponent = React.memo(
     const renderButtons = useCallback(() => {
       switch (status) {
         case STATUS.SUCCESS:
-          return <Button onClick={handleDismiss}>Done</Button>;
+          return <Button onClick={handleClose}>Done</Button>;
         case STATUS.ERROR:
           return (
             <>
@@ -133,7 +134,7 @@ export const ImportModalComponent = React.memo(
         default:
           return (
             <>
-              <OutlinedButton onClick={handleCancel}>Cancel</OutlinedButton>
+              <OutlinedButton onClick={handleClose}>Cancel</OutlinedButton>
               <Button
                 type="submit"
                 disabled={!file}
@@ -145,14 +146,14 @@ export const ImportModalComponent = React.memo(
             </>
           );
       }
-    }, [status, file, handleDismiss, handleCancel, handleSubmit]);
+    }, [status, file, handleDismiss, handleClose, handleSubmit]);
 
     return (
       <>
-        <Dialog onClose={handleCancel} open={isOpen} disableBackdropClick>
+        <Dialog onClose={handleClose} open={isOpen} disableBackdropClick>
           <form>
             <DialogHeader
-              onClose={handleCancel}
+              onClose={handleClose}
               title={fileErrorMessage ? 'Error' : title}
               color={fileErrorMessage ? 'error' : 'textPrimary'}
             />

--- a/packages/admin-panel/src/importExport/ImportModal.js
+++ b/packages/admin-panel/src/importExport/ImportModal.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2018 Beyond Essential Systems Pty Ltd
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useCallback } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import ImportIcon from '@material-ui/icons/Publish';
@@ -25,7 +25,6 @@ const STATUS = {
   LOADING: 'loading',
   SUCCESS: 'success',
   ERROR: 'error',
-  DISABLED: 'disabled',
 };
 
 const noFileMessage = 'No file chosen';
@@ -42,6 +41,7 @@ export const ImportModalComponent = React.memo(
   }) => {
     const [status, setStatus] = useState(STATUS.IDLE);
     const [errorMessage, setErrorMessage] = useState(null);
+    const [successMessage, setSuccessMessage] = useState(null);
     const [isOpen, setIsOpen] = useState(false);
     const [values, setValues] = useState({});
     const [file, setFile] = useState(null);
@@ -59,6 +59,7 @@ export const ImportModalComponent = React.memo(
     const handleDismiss = () => {
       setStatus(STATUS.IDLE);
       setErrorMessage(null);
+      setSuccessMessage(null);
       // Deselect file when dismissing an error, this avoids an error when editing selected files
       // @see https://github.com/beyondessential/tupaia-backlog/issues/1211
       setFile(null);
@@ -84,12 +85,16 @@ export const ImportModalComponent = React.memo(
       const endpoint = `import/${recordType}`;
 
       try {
-        await api.upload(endpoint, recordType, file, {
+        const { body: response } = await api.upload(endpoint, recordType, file, {
           ...values,
           ...actionConfig.extraQueryParameters,
         });
-        setIsOpen(false);
-        setStatus(STATUS.SUCCESS);
+        if (response.message) {
+          setSuccessMessage(response.message);
+          setStatus(STATUS.SUCCESS);
+        } else {
+          handleDismiss();
+        }
         changeSuccess();
       } catch (error) {
         setStatus(STATUS.ERROR);
@@ -114,6 +119,34 @@ export const ImportModalComponent = React.memo(
       );
     };
 
+    const renderButtons = useCallback(() => {
+      switch (status) {
+        case STATUS.SUCCESS:
+          return <Button onClick={handleDismiss}>Done</Button>;
+        case STATUS.ERROR:
+          return (
+            <>
+              <OutlinedButton onClick={handleDismiss}>Dismiss</OutlinedButton>
+              <Button disabled>Import</Button>
+            </>
+          );
+        default:
+          return (
+            <>
+              <OutlinedButton onClick={handleCancel}>Cancel</OutlinedButton>
+              <Button
+                type="submit"
+                disabled={!file}
+                isLoading={status === STATUS.LOADING}
+                onClick={handleSubmit}
+              >
+                Import
+              </Button>
+            </>
+          );
+      }
+    }, [status, file, handleDismiss, handleCancel, handleSubmit]);
+
     return (
       <>
         <Dialog onClose={handleCancel} open={isOpen} disableBackdropClick>
@@ -127,49 +160,41 @@ export const ImportModalComponent = React.memo(
               errorMessage={fileErrorMessage}
               isLoading={status === STATUS.LOADING}
             >
-              <p>{subtitle}</p>
-              {queryParameters
-                .filter(({ visibilityCriteria }) =>
-                  checkVisibilityCriteriaAreMet(visibilityCriteria),
-                )
-                .map(queryParameter => {
-                  const { parameterKey, label, secondaryLabel } = queryParameter;
-                  return (
-                    <InputField
-                      key={parameterKey}
-                      inputKey={parameterKey}
-                      value={values[parameterKey]}
-                      {...queryParameter}
-                      onChange={handleValueChange}
-                      label={label}
-                      secondaryLabel={secondaryLabel}
-                    />
-                  );
-                })}
-              <FileUploadField
-                onChange={({ target }, newName) => {
-                  setFileName(newName);
-                  setFile(target.files[0]);
-                }}
-                name="file-upload"
-                fileName={fileName}
-              />
-            </ModalContentProvider>
-            <DialogFooter>
-              {status === STATUS.ERROR ? (
-                <OutlinedButton onClick={handleDismiss}>Dismiss</OutlinedButton>
+              {status === STATUS.SUCCESS ? (
+                <p>{successMessage}</p>
               ) : (
-                <OutlinedButton onClick={handleCancel}>Cancel</OutlinedButton>
+                <>
+                  <p>{subtitle}</p>
+                  {queryParameters
+                    .filter(({ visibilityCriteria }) =>
+                      checkVisibilityCriteriaAreMet(visibilityCriteria),
+                    )
+                    .map(queryParameter => {
+                      const { parameterKey, label, secondaryLabel } = queryParameter;
+                      return (
+                        <InputField
+                          key={parameterKey}
+                          inputKey={parameterKey}
+                          value={values[parameterKey]}
+                          {...queryParameter}
+                          onChange={handleValueChange}
+                          label={label}
+                          secondaryLabel={secondaryLabel}
+                        />
+                      );
+                    })}
+                  <FileUploadField
+                    onChange={({ target }, newName) => {
+                      setFileName(newName);
+                      setFile(target.files[0]);
+                    }}
+                    name="file-upload"
+                    fileName={fileName}
+                  />
+                </>
               )}
-              <Button
-                type="submit"
-                disabled={status === STATUS.ERROR || !file}
-                isLoading={status === STATUS.LOADING}
-                onClick={handleSubmit}
-              >
-                Import
-              </Button>
-            </DialogFooter>
+            </ModalContentProvider>
+            <DialogFooter>{renderButtons()}</DialogFooter>
           </form>
         </Dialog>
         <LightOutlinedButton startIcon={<ImportIcon />} onClick={handleOpen}>

--- a/packages/meditrak-server/src/routes/importSurveyResponses/SurveyResponseUpdateBatcher.js
+++ b/packages/meditrak-server/src/routes/importSurveyResponses/SurveyResponseUpdateBatcher.js
@@ -1,0 +1,167 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+
+import { sleep } from '@tupaia/utils';
+
+const DEFAULT_BATCH_SIZE = 100;
+const DEFAULT_COOLDOWN_TIME = 1000; // wait a second between batches to give side effects time to finish processing
+const CREATE = 'create';
+const UPDATE = 'update';
+const DELETE = 'delete';
+
+const getColumnKey = (sheetName, columnHeader) => `${sheetName}/${columnHeader}`;
+
+/**
+ * This class will hold on to all of the creates, updates, and deletes that a survey response import
+ * process wants to make, and allow running them all in batches once the whole spreadsheet is parsed
+ *
+ * The idea is that we can separate out the actual database updates from the parsing, validation,
+ * and formatting elements of the process. Those earlier parts can then run and synchronously return
+ * to the user with any validation errors.
+ *
+ * The db updates can then run in batches in the background, with "cooldown" periods between each
+ * batch, so that the database doesn't get overwhelmed with too much activity in one hit (including
+ * both the direct impact of the updates here, and the async side effects triggered by database
+ * records changing).
+ */
+export class SurveyResponseUpdateBatcher {
+  constructor(models) {
+    this.models = models;
+    // maintain a map of column keys to update details, where update details looks like
+    // { sheetName, columnHeader, type, newSurveyResponse, newDataTime, answersToUpsert, answersToDelete }
+    // n.b. all but columnHeader and type are optional
+    this.updatesByColumnKey = {};
+  }
+
+  setupColumnsForSheet(sheetName, columnHeaders) {
+    columnHeaders.forEach(columnHeader => {
+      this.updatesByColumnKey[getColumnKey(sheetName, columnHeader)] = {
+        type: UPDATE,
+        sheetName,
+        columnHeader,
+        newSurveyResponse: null, // only populated if a new survey response is to be created
+        newDataTime: null, // only populated if submission time is to be updated
+        answers: {
+          upserts: [], // populated for new or updated survey responses
+          deletes: [], // populated for existing survey responses if answers are to be deleted
+        },
+      };
+    });
+  }
+
+  createSurveyResponse(sheetName, columnHeader, newSurveyResponse) {
+    const columnKey = getColumnKey(sheetName, columnHeader);
+    this.updatesByColumnKey[columnKey].type = CREATE;
+    this.updatesByColumnKey[columnKey].newSurveyResponse = newSurveyResponse;
+  }
+
+  deleteSurveyResponse(sheetName, columnHeader) {
+    const columnKey = getColumnKey(sheetName, columnHeader);
+    this.updatesByColumnKey[columnKey].type = DELETE;
+  }
+
+  updateDataTime(sheetName, columnHeader, newDataTime) {
+    const columnKey = getColumnKey(sheetName, columnHeader);
+    this.updatesByColumnKey[columnKey].newDataTime = newDataTime;
+  }
+
+  upsertAnswer(sheetName, columnHeader, details) {
+    const columnKey = getColumnKey(sheetName, columnHeader);
+    this.updatesByColumnKey[columnKey].answers.upserts.push(details);
+  }
+
+  deleteAnswer(sheetName, columnHeader, details) {
+    const columnKey = getColumnKey(sheetName, columnHeader);
+    this.updatesByColumnKey[columnKey].answers.deletes.push(details);
+  }
+
+  async processCreateSurveyResponse(transactingModels, { newSurveyResponse, answers }) {
+    const { id: surveyResponseId } = await transactingModels.surveyResponse.create(
+      newSurveyResponse,
+    );
+    await this.processUpsertAnswers(transactingModels, surveyResponseId, answers.upserts);
+  }
+
+  async processUpdateSurveyResponse(
+    transactingModels,
+    { columnHeader: surveyResponseId, newDataTime, answers },
+  ) {
+    if (newDataTime) {
+      await transactingModels.surveyResponse.updateById(surveyResponseId, {
+        data_time: newDataTime,
+      });
+    }
+    await this.processUpsertAnswers(transactingModels, surveyResponseId, answers.upserts);
+    await this.processDeleteAnswers(transactingModels, surveyResponseId, answers.deletes);
+  }
+
+  async processDeleteSurveyResponse(transactingModels, { columnHeader: surveyResponseId }) {
+    await transactingModels.surveyResponse.deleteById(surveyResponseId);
+  }
+
+  async processUpsertAnswers(transactingModels, surveyResponseId, answers) {
+    await Promise.all(
+      answers.map(({ questionId, text, type }) =>
+        transactingModels.answer.updateOrCreate(
+          { survey_response_id: surveyResponseId, question_id: questionId },
+          { text, type },
+        ),
+      ),
+    );
+  }
+
+  async processDeleteAnswers(transactingModels, surveyResponseId, answers) {
+    await Promise.all(
+      answers.map(({ questionId }) =>
+        transactingModels.answer.delete({
+          survey_response_id: surveyResponseId,
+          question_id: questionId,
+        }),
+      ),
+    );
+  }
+
+  async processInBatches(batchSize = DEFAULT_BATCH_SIZE, cooldownTime = DEFAULT_COOLDOWN_TIME) {
+    const batches = [];
+    const columnKeys = Object.keys(this.updatesByColumnKey);
+    for (let i = 0; i < columnKeys.length; i += batchSize) {
+      batches.push(columnKeys.slice(i, i + batchSize));
+    }
+
+    const failures = [];
+    for (let batchIndex = 0; batchIndex < batches.length; batchIndex++) {
+      const batchOfUpdates = batches[batchIndex];
+      for (const columnKey of batchOfUpdates) {
+        const { type, ...details } = this.updatesByColumnKey[columnKey];
+        try {
+          // wrap each survey response in a transaction so that if any update to an individual
+          // answer etc. fails, the whole survey response is rolled back and marked as a failure
+          await this.models.wrapInTransaction(async transactingModels => {
+            switch (type) {
+              case CREATE:
+                await this.processCreateSurveyResponse(transactingModels, details);
+                break;
+              case UPDATE:
+                await this.processUpdateSurveyResponse(transactingModels, details);
+                break;
+              case DELETE:
+                await this.processDeleteSurveyResponse(transactingModels, details);
+                break;
+              default:
+                throw new Error('Missing or misconfigured update type');
+            }
+          });
+        } catch (error) {
+          const { sheetName, columnHeader } = details;
+          failures.push({ sheetName, columnHeader, error: error.message });
+        }
+      }
+
+      // wait some time between batches to give side effects time to finish processing
+      await sleep(cooldownTime);
+    }
+    return { failures };
+  }
+}

--- a/packages/meditrak-server/src/routes/importSurveyResponses/SurveyResponseUpdateBatcher.js
+++ b/packages/meditrak-server/src/routes/importSurveyResponses/SurveyResponseUpdateBatcher.js
@@ -154,8 +154,7 @@ export class SurveyResponseUpdateBatcher {
             this.processUpdate(transactingModels, update),
           );
         } catch (error) {
-          const { sheetName, type } = update;
-          failures.push({ sheetName, surveyResponseId, type, error: error.message });
+          failures.push({ ...update, error: error.message });
         }
       }
 

--- a/packages/meditrak-server/src/routes/importSurveyResponses/emailResults.js
+++ b/packages/meditrak-server/src/routes/importSurveyResponses/emailResults.js
@@ -26,10 +26,7 @@ const getFailureMessage = ({ sheetName, surveyResponseId, type, columnIndex, err
     surveyResponseId,
   )} with the error "${error}"`;
 
-export const processUpdatesAndEmail = async (models, updateBatcher, userId) => {
-  const { failures } = await updateBatcher.processInBatches();
-  const user = await models.user.findById(userId);
-
+export const emailResults = async (user, failures) => {
   // Compose message to send
   const message = `
   Hi ${user.first_name},

--- a/packages/meditrak-server/src/routes/importSurveyResponses/importSurveyResponses.js
+++ b/packages/meditrak-server/src/routes/importSurveyResponses/importSurveyResponses.js
@@ -29,7 +29,7 @@ import {
 import { assertCanImportSurveyResponses } from './assertCanImportSurveyResponses';
 import { assertAnyPermissions, assertBESAdminAccess } from '../../permissions';
 import { SurveyResponseUpdateBatcher } from './SurveyResponseUpdateBatcher';
-import { processUpdatesAndEmail } from './processUpdatesAndEmail';
+import { emailResults } from './emailResults';
 
 /**
  * Creates or updates survey responses by importing the new answers from an Excel file, and either
@@ -207,7 +207,9 @@ export async function importSurveyResponses(req, res) {
       await updateBatcher.processInSingleTransaction();
       respond(res, {});
     } else {
-      processUpdatesAndEmail(models, updateBatcher, userId);
+      const { failures } = await updateBatcher.processInBatches();
+      const user = await models.user.findById(userId);
+      emailResults(user, failures);
       respond(res, {
         message: 'Importing survey responses, you will be emailed when they have been processed',
       });

--- a/packages/meditrak-server/src/routes/importSurveyResponses/importSurveyResponses.js
+++ b/packages/meditrak-server/src/routes/importSurveyResponses/importSurveyResponses.js
@@ -19,7 +19,6 @@ import {
 } from '@tupaia/utils';
 import { getArrayQueryParameter, extractTabNameFromQuery } from '../utilities';
 import { ANSWER_TYPES } from '../../database/models/Answer';
-import { DEFAULT_DATABASE_TIMEZONE } from '../../database';
 import { constructAnswerValidator } from '../utilities/constructAnswerValidator';
 import {
   EXPORT_DATE_FORMAT,
@@ -28,6 +27,7 @@ import {
 } from '../exportSurveyResponses';
 import { assertCanImportSurveyResponses } from './assertCanImportSurveyResponses';
 import { assertAnyPermissions, assertBESAdminAccess } from '../../permissions';
+import { SurveyResponseUpdateBatcher } from './SurveyResponseUpdateBatcher';
 
 /**
  * Creates or updates survey responses by importing the new answers from an Excel file, and either
@@ -38,183 +38,172 @@ export async function importSurveyResponses(req, res) {
     if (!req.file) {
       throw new UploadError();
     }
-    const surveyNames = getArrayQueryParameter(req?.query?.surveyNames);
-    const timeZone = req?.query?.timeZone;
+    const { models, query } = req;
+    const surveyNames = getArrayQueryParameter(query.surveyNames);
+    const { timeZone, userId } = query;
     if (!timeZone) {
-      throw new Error(
-        `Timezone is required`,
-      );
+      throw new Error(`Timezone is required`);
     }
-    const { models } = req;
-    await models.wrapInTransaction(async transactingModels => {
-      const workbook = xlsx.readFile(req.file.path);
-      // Go through each sheet in the workbook and process the updated survey responses
-      const entitiesBySurveyName = await getEntitiesBySurveyName(
-        transactingModels,
-        workbook.Sheets,
-        surveyNames,
-      );
+    const config = { timeZone, userId, surveyNames };
+    const updateBatcher = new SurveyResponseUpdateBatcher(models);
+    const workbook = xlsx.readFile(req.file.path);
+    // Go through each sheet in the workbook and process the updated survey responses
+    const entitiesBySurveyName = await getEntitiesBySurveyName(
+      models,
+      workbook.Sheets,
+      surveyNames,
+    );
 
-      const importSurveyResponsePermissionsChecker = async accessPolicy => {
-        await assertCanImportSurveyResponses(accessPolicy, transactingModels, entitiesBySurveyName);
-      };
+    const importSurveyResponsePermissionsChecker = async accessPolicy => {
+      await assertCanImportSurveyResponses(accessPolicy, models, entitiesBySurveyName);
+    };
 
-      await req.assertPermissions(
-        assertAnyPermissions([assertBESAdminAccess, importSurveyResponsePermissionsChecker]),
-      );
+    await req.assertPermissions(
+      assertAnyPermissions([assertBESAdminAccess, importSurveyResponsePermissionsChecker]),
+    );
 
-      for (const surveySheets of Object.entries(workbook.Sheets)) {
-        const [tabName, sheet] = surveySheets;
-        const deletedColumnHeaders = new Set();
-        const questionIds = [];
-        const newSurveyResponseIds = {};
+    for (const surveySheets of Object.entries(workbook.Sheets)) {
+      const [tabName, sheet] = surveySheets;
+      const deletedColumnHeaders = new Set();
+      const questionIds = [];
 
-        // Create new survey responses where required
-        const { maxColumnIndex, maxRowIndex } = getMaxRowColumnIndex(sheet);
+      // extract column headers and set up update batcher
+      const { maxColumnIndex, maxRowIndex } = getMaxRowColumnIndex(sheet);
+      const responseColumnHeaders = [];
+      for (let columnIndex = 0; columnIndex <= maxColumnIndex; columnIndex++) {
+        if (!isInfoColumn(columnIndex)) {
+          responseColumnHeaders.push(getColumnHeader(sheet, columnIndex));
+        }
+        updateBatcher.setupColumnsForSheet(tabName, responseColumnHeaders);
+      }
+
+      for (let columnIndex = 0; columnIndex <= maxColumnIndex; columnIndex++) {
+        const columnHeader = getColumnHeader(sheet, columnIndex);
+        if (!isInfoColumn(columnIndex)) {
+          // A column representing a survey response
+          try {
+            if (checkIsNewSurveyResponse(columnHeader)) {
+              const surveyResponseDetails = await constructNewSurveyResponseDetails(
+                models,
+                tabName,
+                sheet,
+                columnIndex,
+                config,
+              );
+              updateBatcher.createSurveyResponse(tabName, columnHeader, surveyResponseDetails);
+            } else {
+              // Validate that every header takes id form, i.e. is an existing or deleted response
+              await hasContent(columnHeader);
+              await takesIdForm(columnHeader);
+            }
+          } catch (error) {
+            throw new ImportValidationError(
+              `Invalid survey response id ${columnHeader} causing message: ${
+                error.message
+              } at column ${columnIndex + 1} on tab ${tabName}`,
+            );
+          }
+        }
+      }
+
+      const infoValidator = new ObjectValidator(constructInfoColumnValidators(models));
+      const ignoredRowTypes = [ANSWER_TYPES.INSTRUCTION, ANSWER_TYPES.PRIMARY_ENTITY];
+      for (let rowIndex = 1; rowIndex <= maxRowIndex; rowIndex++) {
+        const excelRowNumber = rowIndex + 1; // +1 to make up for header
+        const rowType = getInfoForRow(sheet, rowIndex, 'Type');
+        if (ignoredRowTypes.includes(rowType)) {
+          continue;
+        }
+
+        // Validate every cell in rows other than the header rows
+        let answerValidator;
+        const questionId = getInfoForRow(sheet, rowIndex, 'Id');
+        if (questionId !== 'N/A') {
+          if (questionIds.includes(questionId)) {
+            throw new ImportValidationError(
+              `Question id ${questionId} is not unique`,
+              excelRowNumber,
+            );
+          }
+          questionIds.push(questionId);
+          const rowInfo = {};
+          for (const infoKey of INFO_COLUMN_HEADERS) {
+            rowInfo[infoKey] = getInfoForRow(sheet, rowIndex, infoKey);
+          }
+          await infoValidator.validate(rowInfo);
+          const question = await models.question.findById(questionId);
+          answerValidator = new ObjectValidator({}, constructAnswerValidator(models, question));
+        }
 
         for (let columnIndex = 0; columnIndex <= maxColumnIndex; columnIndex++) {
           const columnHeader = getColumnHeader(sheet, columnIndex);
-          if (!isInfoColumn(columnIndex)) {
-            // A column representing a survey response
-            try {
-              if (checkIsNewSurveyResponse(columnHeader)) {
-                if (!surveyNames) {
-                  throw new Error(
-                    'When importing new survey responses, you must specify the names of the surveys they are for',
-                  );
-                }
-                const surveyName = extractTabNameFromQuery(tabName, surveyNames);
-                const survey = await transactingModels.survey.findOne({ name: surveyName });
-                const entityCode = getInfoForColumn(sheet, columnIndex, 'Entity Code');
-                const entity = await transactingModels.entity.findOne({ code: entityCode });
-                const user = await transactingModels.user.findById(req.userId);
-                // 'Date of Data' is pulled from spreadsheet, 'Date of Survey' is current time
-                const surveyDate = getDateForColumn(sheet, columnIndex);
-                const importDate = moment();
-                const newSurveyResponse = await transactingModels.surveyResponse.create({
-                  survey_id: survey.id, // All survey responses within a sheet should be for the same survey
-                  assessor_name: `${user.first_name} ${user.last_name}`,
-                  user_id: user.id,
-                  entity_id: entity.id,
-                  start_time: importDate,
-                  end_time: importDate,
-                  data_time: stripTimezoneFromDate(surveyDate),
-                  timezone: timeZone,
-                });
-                newSurveyResponseIds[columnIndex] = newSurveyResponse.id;
-              } else {
-                // Validate that every header takes id form, i.e. is an existing or deleted response
-                await hasContent(columnHeader);
-                await takesIdForm(columnHeader);
-              }
-            } catch (error) {
-              throw new ImportValidationError(
-                `Invalid survey response id ${columnHeader} causing message: ${
-                  error.message
-                } at column ${columnIndex + 1} on tab ${tabName}`,
-              );
+          const cellValue = getCellContents(sheet, columnIndex, rowIndex);
+          // If we already deleted this survey response wholesale, no need to check specific rows
+          if (
+            columnHeader &&
+            columnIndex !== '' &&
+            !deletedColumnHeaders.has(columnHeader) &&
+            !INFO_COLUMN_HEADERS.includes(columnHeader)
+          ) {
+            if (answerValidator) {
+              const constructImportValidationError = message =>
+                new ImportValidationError(message, excelRowNumber, columnHeader, tabName);
+              await answerValidator.validate({ answer: cellValue }, constructImportValidationError);
             }
-          }
-        }
-
-        const infoValidator = new ObjectValidator(constructInfoColumnValidators(transactingModels));
-        const ignoredRowTypes = [ANSWER_TYPES.INSTRUCTION, ANSWER_TYPES.PRIMARY_ENTITY];
-        for (let rowIndex = 1; rowIndex <= maxRowIndex; rowIndex++) {
-          const excelRowNumber = rowIndex + 1; // +1 to make up for header
-          const rowType = getInfoForRow(sheet, rowIndex, 'Type');
-          if (ignoredRowTypes.includes(rowType)) {
-            continue;
-          }
-
-          // Validate every cell in rows other than the header rows
-          let answerValidator;
-          const questionId = getInfoForRow(sheet, rowIndex, 'Id');
-          if (questionId !== 'N/A') {
-            if (questionIds.includes(questionId)) {
+            if (!columnHeader || columnHeader === '') {
               throw new ImportValidationError(
-                `Question id ${questionId} is not unique`,
+                'Missing column header, should be survey response id or start with "NEW_"',
                 excelRowNumber,
               );
             }
-            questionIds.push(questionId);
-            const rowInfo = {};
-            for (const infoKey of INFO_COLUMN_HEADERS) {
-              rowInfo[infoKey] = getInfoForRow(sheet, rowIndex, infoKey);
-            }
-            await infoValidator.validate(rowInfo);
-            const question = await transactingModels.question.findById(questionId);
-            answerValidator = new ObjectValidator({}, constructAnswerValidator(models, question));
-          }
-
-          for (let columnIndex = 0; columnIndex <= maxColumnIndex; columnIndex++) {
-            const columnHeader = getColumnHeader(sheet, columnIndex);
-            const cellValue = getCellContents(sheet, columnIndex, rowIndex);
-            // If we already deleted this survey response wholesale, no need to check specific rows
-            if (
-              columnHeader &&
-              columnIndex !== '' &&
-              !deletedColumnHeaders.has(columnHeader) &&
-              !INFO_COLUMN_HEADERS.includes(columnHeader)
-            ) {
-              if (answerValidator) {
-                const constructImportValidationError = message =>
-                  new ImportValidationError(message, excelRowNumber, columnHeader, tabName);
-                await answerValidator.validate(
-                  { answer: cellValue },
-                  constructImportValidationError,
-                );
-              }
-              const surveyResponseId = checkIsNewSurveyResponse(columnHeader)
-                ? newSurveyResponseIds[columnIndex]
-                : columnHeader;
-              if (!surveyResponseId || surveyResponseId === '') {
-                throw new ImportValidationError('Missing survey response id', excelRowNumber);
-              }
-              if (questionId === 'N/A') {
-                // Info row (e.g. entity name): if no content delete the survey response wholesale
-                if (checkIsCellEmpty(cellValue)) {
-                  await transactingModels.surveyResponse.deleteById(surveyResponseId);
-                  deletedColumnHeaders.add(columnHeader);
-                } else {
-                  // Not deleting, make sure the submission date is set as defined in the spreadsheet
-                  // TODO need to only update if the date has actually changed
-                  const newSubmissionTime = getDateStringForColumn(sheet, columnIndex);
-                  await updateSubmissionTimeIfRequired(
-                    transactingModels,
-                    surveyResponseId,
-                    newSubmissionTime,
-                  );
-                }
-              } else if (checkIsCellEmpty(cellValue)) {
-                // Empty question row: delete any matching answer
-                await transactingModels.answer.delete({
-                  survey_response_id: surveyResponseId,
-                  question_id: questionId,
-                });
-              } else if (
-                rowType === ANSWER_TYPES.DATE_OF_DATA ||
-                rowType === ANSWER_TYPES.SUBMISSION_DATE
-              ) {
-                // Don't save an answer for date of data rows, instead update the date_time of the
-                // survey response. Note that this will override what is in the Date info row
-                await updateSubmissionTimeIfRequired(
-                  transactingModels,
-                  surveyResponseId,
-                  cellValue.toString(),
-                );
+            if (questionId === 'N/A') {
+              // Info row (e.g. entity name): if no content delete the survey response wholesale
+              if (checkIsCellEmpty(cellValue)) {
+                updateBatcher.deleteSurveyResponse(tabName, columnHeader);
+                deletedColumnHeaders.add(columnHeader);
               } else {
-                // Normal question row with content: update or create an answer
-                await transactingModels.answer.updateOrCreate(
-                  { survey_response_id: surveyResponseId, question_id: questionId },
-                  { text: cellValue.toString(), type: rowType },
+                // Not deleting, make sure the submission date is set as defined in the spreadsheet
+                const dataTimeInSheet = getDateStringForColumn(sheet, columnIndex);
+                const newDataTime = await getNewDataTimeIfRequired(
+                  models,
+                  columnHeader,
+                  dataTimeInSheet,
                 );
+                if (newDataTime) {
+                  updateBatcher.updateDataTime(tabName, columnHeader, newDataTime);
+                }
               }
+            } else if (checkIsCellEmpty(cellValue)) {
+              // Empty question row: delete any matching answer
+              updateBatcher.deleteAnswer(tabName, columnHeader, { questionId });
+            } else if (
+              rowType === ANSWER_TYPES.DATE_OF_DATA ||
+              rowType === ANSWER_TYPES.SUBMISSION_DATE
+            ) {
+              // Don't save an answer for date of data rows, instead update the date_time of the
+              // survey response. Note that this will override what is in the Date info row
+              const newDataTime = await getNewDataTimeIfRequired(
+                models,
+                columnHeader,
+                cellValue.toString(),
+              );
+              if (newDataTime) {
+                updateBatcher.updateDataTime(tabName, columnHeader, newDataTime);
+              }
+            } else {
+              // Normal question row with content: update or create an answer
+              updateBatcher.upsertAnswer(tabName, columnHeader, {
+                questionId,
+                text: cellValue.toString(),
+                type: rowType,
+              });
             }
           }
         }
       }
-    });
-    respond(res, { message: 'Imported survey responses' });
+    }
+    const { failures } = await updateBatcher.processInBatches();
+    respond(res, { message: 'Imported survey responses', failures });
   } catch (error) {
     if (error.respond) {
       throw error; // Already a custom error with a responder
@@ -223,6 +212,33 @@ export async function importSurveyResponses(req, res) {
     }
   }
 }
+
+const constructNewSurveyResponseDetails = async (models, tabName, sheet, columnIndex, config) => {
+  const { surveyNames, userId, timeZone } = config;
+  if (!surveyNames) {
+    throw new Error(
+      'When importing new survey responses, you must specify the names of the surveys they are for',
+    );
+  }
+  const surveyName = extractTabNameFromQuery(tabName, surveyNames);
+  const survey = await models.survey.findOne({ name: surveyName });
+  const entityCode = getInfoForColumn(sheet, columnIndex, 'Entity Code');
+  const entity = await models.entity.findOne({ code: entityCode });
+  const user = await models.user.findById(userId);
+  // 'Date of Data' is pulled from spreadsheet, 'Date of Survey' is current time
+  const surveyDate = getDateForColumn(sheet, columnIndex);
+  const importDate = moment();
+  return {
+    survey_id: survey.id, // All survey responses within a sheet should be for the same survey
+    assessor_name: `${user.first_name} ${user.last_name}`,
+    user_id: user.id,
+    entity_id: entity.id,
+    start_time: importDate,
+    end_time: importDate,
+    data_time: stripTimezoneFromDate(surveyDate),
+    timezone: timeZone,
+  };
+};
 
 /**
  * Return all the entitites of the submitted survey responses, grouped by the survey name (sheet name) that the survey responses belong to
@@ -268,9 +284,12 @@ const getMaxRowColumnIndex = sheet => {
   return { maxColumnIndex, maxRowIndex };
 };
 
-async function updateSubmissionTimeIfRequired(models, surveyResponseId, newSubmissionTimeString) {
-  const surveyResponse = await models.surveyResponse.findById(surveyResponseId);
-  if (!surveyResponse) return; // Survey response is probably deleted
+async function getNewDataTimeIfRequired(models, columnHeader, newSubmissionTimeString) {
+  if (checkIsNewSurveyResponse(columnHeader)) {
+    return null; // no need to update the data time of a survey response that is to be newly created
+  }
+  const surveyResponse = await models.surveyResponse.findById(columnHeader);
+  if (!surveyResponse) return null;
   const currentDataTime = surveyResponse.data_time;
   const isInExportFormat = moment(newSubmissionTimeString, EXPORT_DATE_FORMAT, true).isValid();
   const newDataTime = isInExportFormat
@@ -278,10 +297,9 @@ async function updateSubmissionTimeIfRequired(models, surveyResponseId, newSubmi
     : stripTimezoneFromDate(moment(newSubmissionTimeString).toDate());
 
   if (!moment(currentDataTime).isSame(newDataTime, 'minute')) {
-    await models.surveyResponse.updateById(surveyResponseId, {
-      data_time: stripTimezoneFromDate(newDataTime),
-    });
+    return stripTimezoneFromDate(newDataTime);
   }
+  return null;
 }
 
 function getDateStringForColumn(sheet, columnIndex) {

--- a/packages/meditrak-server/src/routes/importSurveyResponses/importSurveyResponses.js
+++ b/packages/meditrak-server/src/routes/importSurveyResponses/importSurveyResponses.js
@@ -230,7 +230,7 @@ const constructNewSurveyResponseDetails = async (models, tabName, sheet, columnI
   }
   const surveyName = extractTabNameFromQuery(tabName, surveyNames);
   const survey = await models.survey.findOne({ name: surveyName });
-  if (!entity) {
+  if (!survey) {
     throw new Error(`No survey named ${surveyName}`);
   }
   const entityCode = getInfoForColumn(sheet, columnIndex, 'Entity Code');

--- a/packages/meditrak-server/src/routes/importSurveyResponses/importSurveyResponses.js
+++ b/packages/meditrak-server/src/routes/importSurveyResponses/importSurveyResponses.js
@@ -84,29 +84,13 @@ export async function importSurveyResponses(req, res) {
           // A column representing a survey response
           try {
             if (checkIsNewSurveyResponse(columnHeader)) {
-              if (!surveyNames) {
-                throw new Error(
-                  'When importing new survey responses, you must specify the names of the surveys they are for',
-                );
-              }
-              const surveyName = extractTabNameFromQuery(tabName, surveyNames);
-              const survey = await models.survey.findOne({ name: surveyName });
-              const entityCode = getInfoForColumn(sheet, columnIndex, 'Entity Code');
-              const entity = await models.entity.findOne({ code: entityCode });
-              const user = await models.user.findById(userId);
-              // 'Date of Data' is pulled from spreadsheet, 'Date of Survey' is current time
-              const surveyDate = getDateForColumn(sheet, columnIndex);
-              const importDate = moment();
-              const surveyResponseDetails = {
-                survey_id: survey.id, // All survey responses within a sheet should be for the same survey
-                assessor_name: `${user.first_name} ${user.last_name}`,
-                user_id: user.id,
-                entity_id: entity.id,
-                start_time: importDate,
-                end_time: importDate,
-                data_time: stripTimezoneFromDate(surveyDate),
-                timezone: timeZone,
-              };
+              const surveyResponseDetails = await constructNewSurveyResponseDetails(
+                models,
+                tabName,
+                sheet,
+                columnIndex,
+                config,
+              );
               updateBatcher.createSurveyResponse(tabName, columnHeader, surveyResponseDetails);
             } else {
               // Validate that every header takes id form, i.e. is an existing or deleted response
@@ -263,6 +247,33 @@ ${failures.map(({ sheetName, columnHeader }) => `      - ${sheetName}, ${columnH
 
   // Send the email
   sendEmail(user.email, 'Tupaia Survey Response Import', message);
+};
+
+const constructNewSurveyResponseDetails = async (models, tabName, sheet, columnIndex, config) => {
+  const { surveyNames, userId, timeZone } = config;
+  if (!surveyNames) {
+    throw new Error(
+      'When importing new survey responses, you must specify the names of the surveys they are for',
+    );
+  }
+  const surveyName = extractTabNameFromQuery(tabName, surveyNames);
+  const survey = await models.survey.findOne({ name: surveyName });
+  const entityCode = getInfoForColumn(sheet, columnIndex, 'Entity Code');
+  const entity = await models.entity.findOne({ code: entityCode });
+  const user = await models.user.findById(userId);
+  // 'Date of Data' is pulled from spreadsheet, 'Date of Survey' is current time
+  const surveyDate = getDateForColumn(sheet, columnIndex);
+  const importDate = moment();
+  return {
+    survey_id: survey.id, // All survey responses within a sheet should be for the same survey
+    assessor_name: `${user.first_name} ${user.last_name}`,
+    user_id: user.id,
+    entity_id: entity.id,
+    start_time: importDate,
+    end_time: importDate,
+    data_time: stripTimezoneFromDate(surveyDate),
+    timezone: timeZone,
+  };
 };
 
 /**

--- a/packages/meditrak-server/src/routes/importSurveyResponses/importSurveyResponses.js
+++ b/packages/meditrak-server/src/routes/importSurveyResponses/importSurveyResponses.js
@@ -157,7 +157,7 @@ export async function importSurveyResponses(req, res) {
             if (questionId === 'N/A') {
               // Info row (e.g. entity name): if no content delete the survey response wholesale
               if (checkIsCellEmpty(cellValue)) {
-                updateBatcher.deleteSurveyResponse(tabName, surveyResponseId);
+                updateBatcher.deleteSurveyResponse(surveyResponseId);
                 deletedResponseIds.add(surveyResponseId);
               } else {
                 // Not deleting, make sure the submission date is set as defined in the spreadsheet
@@ -168,12 +168,12 @@ export async function importSurveyResponses(req, res) {
                   dataTimeInSheet,
                 );
                 if (newDataTime) {
-                  updateBatcher.updateDataTime(tabName, surveyResponseId, newDataTime);
+                  updateBatcher.updateDataTime(surveyResponseId, newDataTime);
                 }
               }
             } else if (checkIsCellEmpty(cellValue)) {
               // Empty question row: delete any matching answer
-              updateBatcher.deleteAnswer(tabName, surveyResponseId, { questionId });
+              updateBatcher.deleteAnswer(surveyResponseId, { questionId });
             } else if (
               rowType === ANSWER_TYPES.DATE_OF_DATA ||
               rowType === ANSWER_TYPES.SUBMISSION_DATE
@@ -186,11 +186,11 @@ export async function importSurveyResponses(req, res) {
                 cellValue.toString(),
               );
               if (newDataTime) {
-                updateBatcher.updateDataTime(tabName, surveyResponseId, newDataTime);
+                updateBatcher.updateDataTime(surveyResponseId, newDataTime);
               }
             } else {
               // Normal question row with content: update or create an answer
-              updateBatcher.upsertAnswer(tabName, surveyResponseId, {
+              updateBatcher.upsertAnswer(surveyResponseId, {
                 surveyResponseId,
                 questionId,
                 text: cellValue.toString(),

--- a/packages/meditrak-server/src/routes/importSurveyResponses/processUpdatesAndEmail.js
+++ b/packages/meditrak-server/src/routes/importSurveyResponses/processUpdatesAndEmail.js
@@ -1,0 +1,32 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+
+import { sendEmail } from '../../utilities';
+
+export const processUpdatesAndEmail = async (models, updateBatcher, userId) => {
+  const { failures } = await updateBatcher.processInBatches();
+  const user = await models.user.findById(userId);
+
+  // Compose message to send
+  const message = `
+  Hi ${user.first_name},
+
+  Your survey response spreadsheet has finished processing${
+    failures.length === 0 ? ', and all responses were successfully imported.' : '.'
+  }
+
+  ${
+    failures.length > 0
+      ? `
+  Unfortunately some survey responses were not able to be imported. Please try the following again:
+${failures.map(({ sheetName, columnHeader }) => `      - ${sheetName}, ${columnHeader}`).join('\n')}
+
+  Note that any responses not listed here will have been successfully imported, so can be removed for your next attempt.`
+      : ''
+  }`;
+
+  // Send the email
+  sendEmail(user.email, 'Tupaia Survey Response Import', message);
+};

--- a/packages/meditrak-server/src/routes/importSurveyResponses/processUpdatesAndEmail.js
+++ b/packages/meditrak-server/src/routes/importSurveyResponses/processUpdatesAndEmail.js
@@ -4,6 +4,21 @@
  */
 
 import { sendEmail } from '../../utilities';
+import { columnIndexToColumnCode } from '../utilities';
+import { CREATE, UPDATE, DELETE } from './SurveyResponseUpdateBatcher';
+
+const getFailureMessageForType = type => {
+  switch (type) {
+    case CREATE:
+      return 'failed to create new response';
+    case UPDATE:
+      return 'failed to update existing response';
+    case DELETE:
+      return 'failed to delete existing response';
+    default:
+      return '';
+  }
+};
 
 export const processUpdatesAndEmail = async (models, updateBatcher, userId) => {
   const { failures } = await updateBatcher.processInBatches();
@@ -21,7 +36,14 @@ export const processUpdatesAndEmail = async (models, updateBatcher, userId) => {
     failures.length > 0
       ? `
   Unfortunately some survey responses were not able to be imported. Please try the following again:
-${failures.map(({ sheetName, columnHeader }) => `      - ${sheetName}, ${columnHeader}`).join('\n')}
+${failures
+  .map(
+    ({ sheetName, surveyResponseId, type, columnIndex }) =>
+      `      - ${sheetName}, ${columnIndexToColumnCode(
+        columnIndex,
+      )}, ${surveyResponseId} (${getFailureMessageForType(type)})`,
+  )
+  .join('\n')}
 
   Note that any responses not listed here will have been successfully imported, so can be removed for your next attempt.`
       : ''

--- a/packages/meditrak-server/src/routes/importSurveyResponses/processUpdatesAndEmail.js
+++ b/packages/meditrak-server/src/routes/importSurveyResponses/processUpdatesAndEmail.js
@@ -21,7 +21,7 @@ const getUpdateTypePart = (type, surveyResponseId) => {
 };
 
 const getFailureMessage = ({ sheetName, surveyResponseId, type, columnIndex, error }) =>
-  `${sheetName}, ${columnIndexToColumnCode(columnIndex)}: Failed to ${getUpdateTypePart(
+  `${sheetName}, Column ${columnIndexToColumnCode(columnIndex)}: Failed to ${getUpdateTypePart(
     type,
     surveyResponseId,
   )} with the error "${error}"`;

--- a/packages/meditrak-server/src/routes/utilities/excel.js
+++ b/packages/meditrak-server/src/routes/utilities/excel.js
@@ -45,3 +45,15 @@ export const splitOnNewLinesOrCommas = string => {
   if (!string) return [];
   return string.includes('\n') ? splitStringOn(string, '\n') : splitStringOnComma(string);
 };
+
+export const columnIndexToColumnCode = columnIndex => {
+  let columnNumber = columnIndex + 1;
+  let code = '';
+  while (columnNumber > 0) {
+    const thisLetterInteger = (columnNumber - 1) % 26;
+    const newLetter = String.fromCharCode(thisLetterInteger + 65);
+    code = `${newLetter}${code}`;
+    columnNumber = (columnNumber - thisLetterInteger - 1) / 26;
+  }
+  return code;
+};

--- a/packages/meditrak-server/src/routes/utilities/index.js
+++ b/packages/meditrak-server/src/routes/utilities/index.js
@@ -5,13 +5,7 @@
 
 export { constructAnswerValidator } from './constructAnswerValidator';
 export { constructNewRecordValidationRules } from './constructNewRecordValidationRules';
-export {
-  extractTabNameFromQuery,
-  splitStringOn,
-  splitStringOnFirstOccurrence,
-  splitStringOnComma,
-  splitOnNewLinesOrCommas,
-} from './excel';
+export * from './excel';
 export {
   fetchCountryIdsByPermissionGroupId,
   fetchCountryCodesByPermissionGroupId,

--- a/packages/meditrak-server/src/tests/routes/importSurveyResponses/testFunctionality.js
+++ b/packages/meditrak-server/src/tests/routes/importSurveyResponses/testFunctionality.js
@@ -4,7 +4,6 @@
  */
 
 import { expect } from 'chai';
-import moment from 'moment';
 import {
   findOrCreateDummyRecord,
   findOrCreateDummyCountryEntity,

--- a/packages/meditrak-server/src/tests/routes/importSurveyResponses/testFunctionality.js
+++ b/packages/meditrak-server/src/tests/routes/importSurveyResponses/testFunctionality.js
@@ -85,7 +85,7 @@ export const testFunctionality = async () => {
     const surveyResponsesAdded = [
       {
         entityId: newResponseEntityId1,
-        date: new Date(Date.UTC(2017, 5, 28, 1, 40)), // Month is zero based in js
+        data_time: '2017-06-28 01:40:00',
         answers: {
           faccc42a44705c02a7e_test: 'Fully Operational',
           faccc42a44705c02abc_test: '1.5',
@@ -94,7 +94,7 @@ export const testFunctionality = async () => {
       },
       {
         entityId: newResponseEntityId2,
-        date: new Date(Date.UTC(2017, 5, 28, 2, 37)), // Month is zero based in js
+        data_time: '2017-06-28 02:37:00',
         answers: {
           faccc42a44705c02a7e_test: 'Fully Operational',
           faccc42a44705c02abc_test: '0.4',
@@ -264,8 +264,7 @@ export const testFunctionality = async () => {
       for (const addedResponse of surveyResponsesAdded) {
         const surveyResponse = await models.surveyResponse.findOne({
           entity_id: addedResponse.entityId,
-          // Convert date to data_time format
-          data_time: moment.utc(addedResponse.date).format('YYYY-MM-DD HH:mm:ss'),
+          data_time: addedResponse.data_time,
         });
         expect(surveyResponse, 'added survey response').to.exist;
         for (const [questionId, answerValue] of Object.entries(addedResponse.answers)) {


### PR DESCRIPTION
### Issue #:
https://github.com/beyondessential/tupaia-backlog/issues/2931

### Changes:

- If you upload a file with 100 or less survey responses, there is no behaviour change
- If you upload a file with more than 100 survey responses, it will run through the validation synchronously, but then offload the database updates to happen in batches asynchronously and email the user when done
- The admin panel will show a message in the modal indicating that the user will be emailed (see screenshot)
- The email will contain a list of any survey responses that failed during db updates (though this should be rare as the validation still happens and informs them in the admin panel)

Note that the values for batch size and cooldown time are just guesses at the moment, I'd like to do some playing around on a deployed instance and work out what values work well, but that shouldn't hold up review.

---

### Screenshots: 

In the issue: https://github.com/beyondessential/tupaia-backlog/issues/2931#issuecomment-859247050

