### PR TITLE
2936: Improve PSSS performance for countries with many sites

### DIFF
--- a/packages/aggregator/src/connections/EntityConnection.js
+++ b/packages/aggregator/src/connections/EntityConnection.js
@@ -13,6 +13,22 @@ export class EntityConnection extends ApiConnection {
   constructor(session) {
     const { getAuthHeader } = session;
     super({ getAuthHeader });
+
+    session.aggregatorEntityConnectionCache = session.aggregatorEntityConnectionCache || {};
+    this.cache = session.aggregatorEntityConnectionCache;
+  }
+
+  // functionArguments should receive the 'arguments' object
+  getCacheKey = (url, query) => `${url}:${JSON.stringify(query)}`;
+
+  runCachedFetch(url, query) {
+    const cacheKey = this.getCacheKey(url, query);
+    if (this.cache[cacheKey]) {
+      return this.cache[cacheKey];
+    }
+
+    this.cache[cacheKey] = this.get(url, query); // may be async, in which case we cache the promise to be awaited
+    return this.cache[cacheKey];
   }
 
   async getDataSourceEntities(
@@ -21,7 +37,7 @@ export class EntityConnection extends ApiConnection {
     dataSourceEntityType,
     dataSourceEntityFilter = {}, // TODO: Add support for dataSourceEntityFilter https://github.com/beyondessential/tupaia-backlog/issues/2660
   ) {
-    return this.get(`hierarchy/${hierarchyName}/relatives`, {
+    return this.runCachedFetch(`hierarchy/${hierarchyName}/relatives`, {
       entities: entityCodes.join(','),
       descendant_filter: `type:${dataSourceEntityType}`,
       field: 'code',
@@ -47,12 +63,12 @@ export class EntityConnection extends ApiConnection {
       query.ancestor_filter = `type:${aggregationEntityType}`;
     }
 
-    const response = await this.get(`hierarchy/${hierarchyName}/relationships`, query);
-
-    const formattedRelationships = {};
-    Object.entries(response).forEach(([descendant, ancestor]) => {
-      formattedRelationships[descendant] = { code: ancestor };
+    return this.runCachedFetch(`hierarchy/${hierarchyName}/relationships`, query).then(response => {
+      const formattedRelationships = {};
+      Object.entries(response).forEach(([descendant, ancestor]) => {
+        formattedRelationships[descendant] = { code: ancestor };
+      });
+      return [Object.keys(formattedRelationships), formattedRelationships];
     });
-    return [Object.keys(formattedRelationships), formattedRelationships];
   }
 }

--- a/packages/database/src/modelClasses/Entity.js
+++ b/packages/database/src/modelClasses/Entity.js
@@ -166,31 +166,15 @@ export class EntityType extends DatabaseType {
   }
 
   async getAncestors(hierarchyId, criteria) {
-    return this.model.getRelationsOfEntity(ENTITY_RELATION_TYPE.ANCESTORS, this.id, {
-      entity_hierarchy_id: hierarchyId,
-      ...criteria,
-    });
+    return this.model.getAncestorsOfEntities(hierarchyId, [this.id], criteria);
   }
 
   async getDescendants(hierarchyId, criteria) {
-    return this.model.getRelationsOfEntity(ENTITY_RELATION_TYPE.DESCENDANTS, this.id, {
-      entity_hierarchy_id: hierarchyId,
-      ...criteria,
-    });
+    return this.model.getDescendantsOfEntities(hierarchyId, [this.id], criteria);
   }
 
   async getRelatives(hierarchyId, criteria) {
-    // getAncestors() comes sorted closest -> furthest, we want furthest -> closest
-    const ancestors = (await this.getAncestors(hierarchyId, criteria)).slice().reverse();
-
-    const self = await this.model.find({
-      ...criteria,
-      id: this.id, // Find an entity that matches the criteria AND this entity
-    });
-
-    const descendants = await this.getDescendants(hierarchyId, criteria);
-
-    return [...ancestors, ...self, ...descendants];
+    return this.model.getRelativesOfEntities(hierarchyId, [this.id], criteria);
   }
 
   async getAncestorOfType(hierarchyId, entityType) {
@@ -277,12 +261,12 @@ export class EntityType extends DatabaseType {
   async getChildrenViaHierarchy(hierarchyId) {
     return this.database.executeSql(
       `
-        SELECT entity.*
-        FROM entity
-        INNER JOIN entity_relation on entity.id = entity_relation.child_id
-        WHERE entity_relation.parent_id = ?
-        AND entity_relation.entity_hierarchy_id = ?;
-      `,
+          SELECT entity.*
+          FROM entity
+          INNER JOIN entity_relation on entity.id = entity_relation.child_id
+          WHERE entity_relation.parent_id = ?
+          AND entity_relation.entity_hierarchy_id = ?;
+        `,
       [this.id, hierarchyId],
     );
   }
@@ -334,12 +318,12 @@ export class EntityModel extends MaterializedViewLogDatabaseModel {
   async updatePointCoordinatesFormatted(code, point) {
     return this.database.executeSql(
       `
-        UPDATE "entity"
-        SET
-          point = ST_GeomFromGeoJSON(?),
-          bounds = ST_Expand(ST_Envelope(ST_GeomFromGeoJSON(?)::geometry), 1)
-        WHERE code = ?;
-      `,
+          UPDATE "entity"
+          SET
+            point = ST_GeomFromGeoJSON(?),
+            bounds = ST_Expand(ST_Envelope(ST_GeomFromGeoJSON(?)::geometry), 1)
+          WHERE code = ?;
+        `,
       [point, point, code],
     );
   }
@@ -347,10 +331,10 @@ export class EntityModel extends MaterializedViewLogDatabaseModel {
   async updateBoundsCoordinates(code, bounds) {
     return this.database.executeSql(
       `
-        UPDATE "entity"
-        SET "bounds" = ?
-        WHERE "code" = ?;
-      `,
+          UPDATE "entity"
+          SET "bounds" = ?
+          WHERE "code" = ?;
+        `,
       [bounds, code],
     );
   }
@@ -369,10 +353,10 @@ export class EntityModel extends MaterializedViewLogDatabaseModel {
 
     return this.database.executeSql(
       `
-        UPDATE "entity"
-        SET "region" = ST_GeomFromGeoJSON(?) ${boundsString}
-        WHERE "code" = ?;
-      `,
+          UPDATE "entity"
+          SET "region" = ST_GeomFromGeoJSON(?) ${boundsString}
+          WHERE "code" = ?;
+        `,
       shouldSetBounds ? [geojson, geojson, code] : [geojson, code],
     );
   }
@@ -394,22 +378,22 @@ export class EntityModel extends MaterializedViewLogDatabaseModel {
         descendantCodes,
         batchOfDescendantCodes => [
           `
-          SELECT descendant.code as descendant_code, ancestor.code as ancestor_code, ancestor.name as ancestor_name
-          FROM
-            ancestor_descendant_relation
-          JOIN
-            entity as ancestor on ancestor.id = ancestor_descendant_relation.ancestor_id
-          JOIN
-            entity as descendant ON descendant.id = ancestor_descendant_relation.descendant_id
-          WHERE
-            descendant.code IN (${batchOfDescendantCodes.map(() => '?').join(',')})
-          AND
-            ancestor_descendant_relation.entity_hierarchy_id = ?
-          AND
-            ancestor.type = ?
-          ORDER BY
-            generational_distance ASC
-        `,
+            SELECT descendant.code as descendant_code, ancestor.code as ancestor_code, ancestor.name as ancestor_name
+            FROM
+              ancestor_descendant_relation
+            JOIN
+              entity as ancestor on ancestor.id = ancestor_descendant_relation.ancestor_id
+            JOIN
+              entity as descendant ON descendant.id = ancestor_descendant_relation.descendant_id
+            WHERE
+              descendant.code IN (${batchOfDescendantCodes.map(() => '?').join(',')})
+            AND
+              ancestor_descendant_relation.entity_hierarchy_id = ?
+            AND
+              ancestor.type = ?
+            ORDER BY
+              generational_distance ASC
+          `,
           [...batchOfDescendantCodes, hierarchyId, ancestorType],
         ],
         maxBoundParameters,
@@ -425,8 +409,8 @@ export class EntityModel extends MaterializedViewLogDatabaseModel {
     });
   }
 
-  async getRelationsOfEntity(ancestorsOrDescendants, entityId, criteria) {
-    const cacheKey = this.getCacheKey(this.getRelationsOfEntity.name, arguments);
+  async getRelationsOfEntities(ancestorsOrDescendants, entityIds, criteria) {
+    const cacheKey = this.getCacheKey(this.getRelationsOfEntities.name, arguments);
     const [joinTablesOn, filterByEntityId] =
       ancestorsOrDescendants === ENTITY_RELATION_TYPE.ANCESTORS
         ? ['ancestor_id', 'descendant_id']
@@ -435,7 +419,7 @@ export class EntityModel extends MaterializedViewLogDatabaseModel {
       const relations = await this.find(
         {
           ...criteria,
-          [filterByEntityId]: entityId,
+          [filterByEntityId]: entityIds,
         },
         {
           joinWith: TYPES.ANCESTOR_DESCENDANT_RELATION,
@@ -446,6 +430,36 @@ export class EntityModel extends MaterializedViewLogDatabaseModel {
       return Promise.all(relations.map(async r => r.getData()));
     });
     return Promise.all(relationData.map(async r => this.generateInstance(r)));
+  }
+
+  async getAncestorsOfEntities(hierarchyId, entityIds, criteria) {
+    return this.getRelationsOfEntities(ENTITY_RELATION_TYPE.ANCESTORS, entityIds, {
+      entity_hierarchy_id: hierarchyId,
+      ...criteria,
+    });
+  }
+
+  async getDescendantsOfEntities(hierarchyId, entityIds, criteria) {
+    return this.getRelationsOfEntities(ENTITY_RELATION_TYPE.DESCENDANTS, entityIds, {
+      entity_hierarchy_id: hierarchyId,
+      ...criteria,
+    });
+  }
+
+  async getRelativesOfEntities(hierarchyId, entityIds, criteria) {
+    // getAncestors() comes sorted closest -> furthest, we want furthest -> closest
+    const ancestors = (await this.getAncestorsOfEntities(hierarchyId, entityIds, criteria))
+      .slice()
+      .reverse();
+
+    const self = await this.find({
+      ...criteria,
+      id: entityIds, // Find an entity that matches the criteria AND themselves
+    });
+
+    const descendants = await this.getDescendantsOfEntities(hierarchyId, entityIds, criteria);
+
+    return [...ancestors, ...self, ...descendants];
   }
 
   getDhisLevel(type) {

--- a/packages/entity-server/src/models/Entity.ts
+++ b/packages/entity-server/src/models/Entity.ts
@@ -31,4 +31,15 @@ export interface EntityType extends EntityFields, Omit<BaseEntityType, 'id'> {
   getRelatives: (hierarchyId: string, criteria?: EntityFilter) => Promise<EntityType[]>;
 }
 
-export interface EntityModel extends Model<BaseEntityModel, EntityFields, EntityType> {}
+export interface EntityModel extends Model<BaseEntityModel, EntityFields, EntityType> {
+  getDescendantsOfEntities: (
+    hierarchyId: string,
+    entityIds: string[],
+    criteria?: EntityFilter,
+  ) => Promise<EntityType[]>;
+  getRelativesOfEntities: (
+    hierarchyId: string,
+    entityIds: string[],
+    criteria?: EntityFilter,
+  ) => Promise<EntityType[]>;
+}

--- a/packages/entity-server/src/routes/hierarchy/MultiEntityDescendantsRoute.ts
+++ b/packages/entity-server/src/routes/hierarchy/MultiEntityDescendantsRoute.ts
@@ -4,7 +4,6 @@
  */
 
 import { Route } from '@tupaia/server-boilerplate';
-import { EntityType } from '../../models';
 import { formatEntitiesForResponse } from './format';
 import {
   MultiEntityRequest,
@@ -24,22 +23,13 @@ export class MultiEntityDescendantsRoute extends Route<MultiEntityDescendantsReq
   async buildResponse() {
     const { hierarchyId, entities, fields, field, filter } = this.req.ctx;
     const { includeRootEntity = false } = this.req.query;
-    const responseEntities: EntityType[] = [];
-    await Promise.all(
-      entities.map(async entity => {
-        const descendants = await entity.getDescendants(hierarchyId, {
-          ...filter,
-        });
-        const entitiesToUse = includeRootEntity ? [entity].concat(descendants) : descendants;
-        responseEntities.push(...entitiesToUse);
-      }),
+    const descendants = await this.req.models.entity.getDescendantsOfEntities(
+      hierarchyId,
+      entities.map(entity => entity.id),
+      { ...filter },
     );
+    const entitiesToUse = includeRootEntity ? entities.concat(descendants) : descendants;
 
-    return formatEntitiesForResponse(
-      this.req.models,
-      this.req.ctx,
-      responseEntities,
-      field || fields,
-    );
+    return formatEntitiesForResponse(this.req.models, this.req.ctx, entitiesToUse, field || fields);
   }
 }

--- a/packages/entity-server/src/routes/hierarchy/MultiEntityRelativesRoute.ts
+++ b/packages/entity-server/src/routes/hierarchy/MultiEntityRelativesRoute.ts
@@ -4,7 +4,6 @@
  */
 
 import { Route } from '@tupaia/server-boilerplate';
-import { EntityType } from '../../models';
 import { formatEntitiesForResponse } from './format';
 import {
   MultiEntityRequest,
@@ -24,19 +23,12 @@ export class MultiEntityRelativesRoute extends Route<MultiEntityRelativesRequest
   async buildResponse() {
     const { hierarchyId, entities, fields, field, filter } = this.req.ctx;
 
-    const responseEntities: EntityType[] = [];
-    await Promise.all(
-      entities.map(async entity => {
-        const entitiesToUse = await entity.getRelatives(hierarchyId, filter);
-        responseEntities.push(...entitiesToUse);
-      }),
+    const relatives = await this.req.models.entity.getRelativesOfEntities(
+      hierarchyId,
+      entities.map(entity => entity.id),
+      { ...filter },
     );
 
-    return formatEntitiesForResponse(
-      this.req.models,
-      this.req.ctx,
-      responseEntities,
-      field || fields,
-    );
+    return formatEntitiesForResponse(this.req.models, this.req.ctx, relatives, field || fields);
   }
 }

--- a/packages/entity-server/src/routes/hierarchy/relationships/EntityRelationshipsRoute.ts
+++ b/packages/entity-server/src/routes/hierarchy/relationships/EntityRelationshipsRoute.ts
@@ -9,6 +9,10 @@ import { ResponseBuilder } from './ResponseBuilder';
 
 export class EntityRelationshipsRoute extends Route<RelationshipsRequest> {
   async buildResponse() {
-    return new ResponseBuilder(this.req.models, this.req.ctx, this.req.query.groupBy).build();
+    return new ResponseBuilder(
+      this.req.models,
+      { ...this.req.ctx, entities: [this.req.ctx.entity] },
+      this.req.query.groupBy,
+    ).build();
   }
 }

--- a/packages/entity-server/src/routes/hierarchy/relationships/MultiEntityRelationshipsRoute.ts
+++ b/packages/entity-server/src/routes/hierarchy/relationships/MultiEntityRelationshipsRoute.ts
@@ -4,28 +4,11 @@
  */
 
 import { Route } from '@tupaia/server-boilerplate';
-import { MultiEntityRelationshipsRequest, RelationshipsResponseBody } from './types';
+import { MultiEntityRelationshipsRequest } from './types';
 import { ResponseBuilder } from './ResponseBuilder';
 
 export class MultiEntityRelationshipsRoute extends Route<MultiEntityRelationshipsRequest> {
   async buildResponse() {
-    const { entities } = this.req.ctx;
-
-    const allResponses: RelationshipsResponseBody = {};
-    await Promise.all(
-      entities.map(async entity => {
-        const singleCtx = { ...this.req.ctx, entity };
-        const response = await new ResponseBuilder(
-          this.req.models,
-          singleCtx,
-          this.req.query.groupBy,
-        ).build();
-        Object.entries(response).forEach(([key, value]) => {
-          allResponses[key] = value;
-        });
-      }),
-    );
-
-    return allResponses;
+    return new ResponseBuilder(this.req.models, this.req.ctx, this.req.query.groupBy).build();
   }
 }

--- a/packages/entity-server/src/routes/hierarchy/relationships/ResponseBuilder.ts
+++ b/packages/entity-server/src/routes/hierarchy/relationships/ResponseBuilder.ts
@@ -7,7 +7,7 @@ import { reduceToDictionary, reduceToArrayDictionary } from '@tupaia/utils';
 import { EntityServerModelRegistry } from '../../../types';
 import { EntityType } from '../../../models';
 import { formatEntitiesForResponse } from '../format';
-import { RelationshipsContext } from './types';
+import { MultiEntityRelationshipsContext } from './types';
 
 type Pair = {
   descendant: string;
@@ -17,19 +17,19 @@ type Pair = {
 export class ResponseBuilder {
   private readonly models: EntityServerModelRegistry;
 
-  private readonly ctx: RelationshipsContext & { ancestor: { type: string } };
+  private readonly ctx: MultiEntityRelationshipsContext & { ancestor: { type: string } };
 
   private readonly groupBy: 'ancestor' | 'descendant';
 
   constructor(
     models: EntityServerModelRegistry,
-    ctx: RelationshipsContext,
+    ctx: MultiEntityRelationshipsContext,
     groupBy: 'ancestor' | 'descendant' = 'ancestor',
   ) {
     this.models = models;
     this.groupBy = groupBy;
 
-    const ancestorType = ctx.ancestor.type || ctx.entity.type;
+    const ancestorType = ctx.ancestor.type || ctx.entities[0]?.type;
     if (ancestorType === null) {
       throw new Error('No explicit ancestorType provided and entity type is null');
     }
@@ -41,7 +41,7 @@ export class ResponseBuilder {
   }
 
   private async buildAncestorCodesAndPairs(descendants: EntityType[]): Promise<[string[], Pair[]]> {
-    const { hierarchyId, entity } = this.ctx;
+    const { hierarchyId, entities } = this.ctx;
     const { type: ancestorType } = this.ctx.ancestor;
     const descendantCodes = descendants.map(descendant => descendant.code);
     const descendantAncestorMapping = await this.models.entity.fetchAncestorDetailsByDescendantCode(
@@ -50,10 +50,12 @@ export class ResponseBuilder {
       ancestorType,
     );
 
-    // Add self to descendant<->ancestor mapping if matching requirements
-    if (descendantCodes.includes(entity.code) && entity.type === ancestorType) {
-      descendantAncestorMapping[entity.code] = { code: entity.code, name: entity.name };
-    }
+    entities.forEach(entity => {
+      // Add self to descendant<->ancestor mapping if matching requirements
+      if (descendantCodes.includes(entity.code) && entity.type === ancestorType) {
+        descendantAncestorMapping[entity.code] = { code: entity.code, name: entity.name };
+      }
+    });
 
     const ancestorCodes = [
       ...new Set(Object.values(descendantAncestorMapping).map(ancestor => ancestor.code)),
@@ -70,7 +72,7 @@ export class ResponseBuilder {
   }
 
   private async getAncestorTypeRelatives(ancestorsWithDescendantsCodes: string[]) {
-    const { entity, hierarchyId } = this.ctx;
+    const { entities, hierarchyId } = this.ctx;
     const { type: ancestorType, filter } = this.ctx.ancestor;
     const { code: filterCode } = filter;
     let codesToUse: string[];
@@ -82,11 +84,15 @@ export class ResponseBuilder {
         : ancestorsWithDescendantsCodes.filter(code => filterCode === code);
     }
 
-    return entity.getRelatives(hierarchyId, {
-      ...filter,
-      type: ancestorType,
-      code: codesToUse,
-    });
+    return this.models.entity.getRelativesOfEntities(
+      hierarchyId,
+      entities.map(entity => entity.id),
+      {
+        ...filter,
+        type: ancestorType,
+        code: codesToUse,
+      },
+    );
   }
 
   private async getFormattedEntitiesByCode(ancestors: EntityType[], descendants: EntityType[]) {
@@ -135,13 +141,17 @@ export class ResponseBuilder {
   }
 
   async build() {
-    const { entity, hierarchyId } = this.ctx;
+    const { entities, hierarchyId } = this.ctx;
     const { type: descendantType, filter } = this.ctx.descendant;
 
-    const descendants = await entity.getRelatives(hierarchyId, {
-      ...filter,
-      type: descendantType,
-    });
+    const descendants = await this.models.entity.getRelativesOfEntities(
+      hierarchyId,
+      entities.map(entity => entity.id),
+      {
+        ...filter,
+        type: descendantType,
+      },
+    );
 
     const [ancestorCodes, pairs] = await this.buildAncestorCodesAndPairs(descendants);
 

--- a/packages/entity-server/src/routes/hierarchy/relationships/types.ts
+++ b/packages/entity-server/src/routes/hierarchy/relationships/types.ts
@@ -57,6 +57,11 @@ export interface RelationshipsRequest
   ctx: RelationshipsContext;
 }
 
+export type MultiEntityRelationshipsContext = Omit<MultiEntityContext, 'fields'> & {
+  ancestor: AncestorSubContext;
+  descendant: DescendantSubContext;
+};
+
 export interface MultiEntityRelationshipsRequest
   extends Request<
     MultiEntityRequestParams,
@@ -64,8 +69,5 @@ export interface MultiEntityRelationshipsRequest
     RequestBody,
     RelationshipsQuery & { entities?: string }
   > {
-  ctx: Omit<MultiEntityContext, 'fields'> & {
-    ancestor: AncestorSubContext;
-    descendant: DescendantSubContext;
-  };
+  ctx: MultiEntityRelationshipsContext;
 }


### PR DESCRIPTION
### Issue https://github.com/beyondessential/tupaia-backlog/issues/2936:

Had 2 key improvements in mind for improving performance for this issue:
1. 76c37b7 - Caching responses from the entity-server in the Aggregator for the lifetime of a single analytics/events fetch
- Had toyed with this idea a few times and had seen good results from it in my testing. Implementing this brought the performance back to a reasonable response time
- Little curious to hear the reviewer's thoughts on this one. While it seems to work effectively, I could see the approach as being a bit hacky. Do we have concerns about a proliferation of various 'caches' on the session object? Are there memory consumption concerns?

2. afabc1b - Re-wrote the `MultiEntity...Routes` to use a single db fetch to get the their descendants/relatives/etc. rather than looping through each requested entity
- This one seemed like a bit of a no-brainer, but surprisingly didn't actually improve performance that much. I suspect that's because, after the first request, we cache the db response so everything is done in memory from then on
- Regardless, it did add a minor performance improvement, and I think it's a worthwhile change. Gives me more confidence that the system could handle a request for 1000+ entities when we need to support that

I'd still like to implement a test suite for this provided there's time. Would give more confidence in being able to make changes to the internal logic of the routes. However chucking up for review now to get early feedback 👍 