### PR TITLE
FQS links open in new tab

### DIFF
--- a/packages/lesmis/src/views/PageView.js
+++ b/packages/lesmis/src/views/PageView.js
@@ -105,7 +105,7 @@ export const TwoColumnPageView = ({ content }) => {
                   </CardHeader>
                   <CardBody>
                     {links.map(({ name, link }) => (
-                      <Link key={name} href={link}>
+                      <Link key={name} href={link} target="_blank" rel="noopener">
                         <ArrowForwardIcon />
                         {name}
                       </Link>

--- a/packages/lesmis/src/views/PageView.js
+++ b/packages/lesmis/src/views/PageView.js
@@ -105,7 +105,7 @@ export const TwoColumnPageView = ({ content }) => {
                   </CardHeader>
                   <CardBody>
                     {links.map(({ name, link }) => (
-                      <Link key={name} href={link} target="_blank" rel="noopener">
+                      <Link key={name} href={link} target="_blank">
                         <ArrowForwardIcon />
                         {name}
                       </Link>


### PR DESCRIPTION
This is just a suggestion - @enunan do you think the FQS links should open in a new tab or just replace the LESMIS page and stay on the same tab?