### PR TITLE
2961: Allow creating/removing indexes on Analytics Table as the Tupaia database user

### DIFF
--- a/packages/data-api/package.json
+++ b/packages/data-api/package.json
@@ -17,9 +17,11 @@
     "test": "jest",
     "test:coverage": "yarn test --coverage",
     "install-mv-refresh": "scripts/installMvRefreshModule.sh",
+    "uninstall-mv-refresh": "scripts/uninstallMvRefreshModule.sh",
     "build-analytics-table": "scripts/buildAnalyticsMaterializedView.sh",
-    "refresh-analytics-table": "scripts/refreshAnalyticsTable.sh",
-    "full-rebuild-analytics-table": "scripts/fullRebuildAnalyticsMaterializedView.sh"
+    "drop-analytics-table": "scripts/dropAnalyticsMaterializedView.sh",
+    "full-rebuild-analytics-table": "scripts/fullRebuildAnalyticsMaterializedView.sh",
+    "refresh-analytics-table": "scripts/refreshAnalyticsTable.sh"
   },
   "dependencies": {
     "@tupaia/database": "1.0.0",

--- a/packages/data-api/scripts/buildAnalyticsMaterializedView.sh
+++ b/packages/data-api/scripts/buildAnalyticsMaterializedView.sh
@@ -3,5 +3,4 @@ source .env
 cd scripts
 export PGPASSWORD=$DB_PASSWORD
 psql -h $DB_URL -d $DB_NAME -U $DB_USER -f createAnalyticsMaterializedView.sql
-export PGPASSWORD=$DB_MV_PASSWORD
-psql -h $DB_URL -d $DB_NAME -U $DB_MV_USER -f createAnalyticsTableIndexes.sql
+psql -h $DB_URL -d $DB_NAME -U $DB_USER -f createAnalyticsTableIndexes.sql

--- a/packages/data-api/scripts/createAnalyticsTableIndexes.sql
+++ b/packages/data-api/scripts/createAnalyticsTableIndexes.sql
@@ -13,7 +13,7 @@ begin
     AND c.relkind = 'i')
   THEN
     tStartTime := clock_timestamp();
-    PERFORM mv$addIndexToMv$Table(mv$buildAllConstants(), 'public', 'analytics', 'analytics_data_element_entity_date_idx', 'data_element_code, entity_code, date desc');
+    PERFORM mv$addIndexToMv$Table(mv$buildAllConstants(), 'public', 'analytics', tAnalyticsIndexName, 'data_element_code, entity_code, date desc');
     RAISE NOTICE 'Created analytics index, took %', clock_timestamp() - tStartTime;
   ELSE
     RAISE NOTICE 'Analytics index already exists, skipping';
@@ -25,7 +25,7 @@ begin
     AND c.relkind = 'i')
   THEN
     tStartTime := clock_timestamp();
-    PERFORM mv$addIndexToMv$Table(mv$buildAllConstants(), 'public', 'analytics', 'analytics_data_group_entity_event_date_idx', 'data_group_code, entity_code, event_id, date desc');
+    PERFORM mv$addIndexToMv$Table(mv$buildAllConstants(), 'public', 'analytics', tEventsIndexName, 'data_group_code, entity_code, event_id, date desc');
     RAISE NOTICE 'Created events index, took %', clock_timestamp() - tStartTime;
   ELSE
     RAISE NOTICE 'Events index already exists, skipping';

--- a/packages/data-api/scripts/createAnalyticsTableIndexes.sql
+++ b/packages/data-api/scripts/createAnalyticsTableIndexes.sql
@@ -1,16 +1,34 @@
 do $$ 
 declare
   tStartTime TIMESTAMP;
+  tAnalyticsIndexName TEXT := 'analytics_data_element_entity_date_idx';
+  tEventsIndexName TEXT := 'analytics_data_group_entity_event_date_idx';
 
 begin
   RAISE NOTICE 'Creating analytics table indexes...';
   
-  tStartTime := clock_timestamp();
-  CREATE INDEX IF NOT EXISTS analytics_data_element_entity_date_idx ON public.analytics(data_element_code, entity_code, date desc);
-  RAISE NOTICE 'Created [data_element, entity, date] index, took %', clock_timestamp() - tStartTime;
-  
-  tStartTime := clock_timestamp();
-  CREATE INDEX IF NOT EXISTS analytics_data_group_entity_event_date_idx ON public.analytics(data_group_code, entity_code, event_id, date desc);
-  RAISE NOTICE 'Created [data_group, entity, event, date] index, took %', clock_timestamp() - tStartTime;
+  IF (SELECT count(*) = 0
+    FROM pg_class c
+    WHERE c.relname = tAnalyticsIndexName 
+    AND c.relkind = 'i')
+  THEN
+    tStartTime := clock_timestamp();
+    PERFORM mv$addIndexToMv$Table(mv$buildAllConstants(), 'public', 'analytics', 'analytics_data_element_entity_date_idx', 'data_element_code, entity_code, date desc');
+    RAISE NOTICE 'Created analytics index, took %', clock_timestamp() - tStartTime;
+  ELSE
+    RAISE NOTICE 'Analytics index already exists, skipping';
+  END IF;
+
+  IF (SELECT count(*) = 0
+    FROM pg_class c
+    WHERE c.relname = tEventsIndexName 
+    AND c.relkind = 'i')
+  THEN
+    tStartTime := clock_timestamp();
+    PERFORM mv$addIndexToMv$Table(mv$buildAllConstants(), 'public', 'analytics', 'analytics_data_group_entity_event_date_idx', 'data_group_code, entity_code, event_id, date desc');
+    RAISE NOTICE 'Created events index, took %', clock_timestamp() - tStartTime;
+  ELSE
+    RAISE NOTICE 'Events index already exists, skipping';
+  END IF;
 
 end $$;

--- a/packages/data-api/scripts/dropAnalyticsMaterializedView.sh
+++ b/packages/data-api/scripts/dropAnalyticsMaterializedView.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+source .env
+cd scripts
+export PGPASSWORD=$DB_PASSWORD
+psql -h $DB_URL -d $DB_NAME -U $DB_USER -f dropAnalyticsMaterializedView.sql

--- a/packages/data-api/scripts/dropAnalyticsTableIndexes.sql
+++ b/packages/data-api/scripts/dropAnalyticsTableIndexes.sql
@@ -13,7 +13,7 @@ begin
     AND c.relkind = 'i')
   THEN
     tStartTime := clock_timestamp();
-    PERFORM mv$removeIndexFromMv$Table(mv$buildAllConstants(), 'analytics_data_element_entity_date_idx');
+    PERFORM mv$removeIndexFromMv$Table(mv$buildAllConstants(), tAnalyticsIndexName);
     RAISE NOTICE 'Dropped analytics index, took %', clock_timestamp() - tStartTime;
   ELSE
     RAISE NOTICE 'Analytics index doesn''t exist, skipping';
@@ -25,7 +25,7 @@ begin
     AND c.relkind = 'i')
   THEN
     tStartTime := clock_timestamp();
-    PERFORM mv$removeIndexFromMv$Table(mv$buildAllConstants(), 'analytics_data_group_entity_event_date_idx');
+    PERFORM mv$removeIndexFromMv$Table(mv$buildAllConstants(), tEventsIndexName);
     RAISE NOTICE 'Dropped events index, took %', clock_timestamp() - tStartTime;
   ELSE
     RAISE NOTICE 'Events index doesn''t exist, skipping';

--- a/packages/data-api/scripts/dropAnalyticsTableIndexes.sql
+++ b/packages/data-api/scripts/dropAnalyticsTableIndexes.sql
@@ -1,16 +1,34 @@
 do $$
 declare
   tStartTime TIMESTAMP;
+  tAnalyticsIndexName TEXT := 'analytics_data_element_entity_date_idx';
+  tEventsIndexName TEXT := 'analytics_data_group_entity_event_date_idx';
 
 begin
   RAISE NOTICE 'Dropping analytics table indexes...';
 
-  tStartTime := clock_timestamp();
-  DROP INDEX IF EXISTS analytics_data_element_entity_date_idx;
-  RAISE NOTICE 'Dropped [data_element, entity, date] index, took %', clock_timestamp() - tStartTime;
+  IF (SELECT count(*) > 0
+    FROM pg_class c
+    WHERE c.relname = tAnalyticsIndexName 
+    AND c.relkind = 'i')
+  THEN
+    tStartTime := clock_timestamp();
+    PERFORM mv$removeIndexFromMv$Table(mv$buildAllConstants(), 'analytics_data_element_entity_date_idx');
+    RAISE NOTICE 'Dropped analytics index, took %', clock_timestamp() - tStartTime;
+  ELSE
+    RAISE NOTICE 'Analytics index doesn''t exist, skipping';
+  END IF;
 
-  tStartTime := clock_timestamp();
-  DROP INDEX IF EXISTS analytics_data_group_entity_event_date_idx;
-  RAISE NOTICE 'Dropped [data_group, entity, event, date] index, took %', clock_timestamp() - tStartTime;
+  IF (SELECT count(*) > 0
+    FROM pg_class c
+    WHERE c.relname = tEventsIndexName 
+    AND c.relkind = 'i')
+  THEN
+    tStartTime := clock_timestamp();
+    PERFORM mv$removeIndexFromMv$Table(mv$buildAllConstants(), 'analytics_data_group_entity_event_date_idx');
+    RAISE NOTICE 'Dropped events index, took %', clock_timestamp() - tStartTime;
+  ELSE
+    RAISE NOTICE 'Events index doesn''t exist, skipping';
+  END IF;
 
 end $$;

--- a/packages/data-api/scripts/fullRebuildAnalyticsMaterializedView.sh
+++ b/packages/data-api/scripts/fullRebuildAnalyticsMaterializedView.sh
@@ -1,8 +1,4 @@
 #!/bin/bash
-source .env
-cd scripts
-export PGPASSWORD=$DB_PASSWORD
-psql -h $DB_URL -d $DB_NAME -U $DB_USER -f dropAnalyticsMaterializedView.sql
 
-cd ..
+./scripts/dropAnalyticsMaterializedView.sh
 ./scripts/buildAnalyticsMaterializedView.sh

--- a/packages/data-api/scripts/fullRefreshAnalyticsTable.sh
+++ b/packages/data-api/scripts/fullRefreshAnalyticsTable.sh
@@ -3,9 +3,7 @@ echo "Fully refreshing analytics table"
 
 source .env
 cd scripts
-export PGPASSWORD=$DB_MV_PASSWORD
-psql -h $DB_URL -d $DB_NAME -U $DB_MV_USER -f dropAnalyticsTableIndexes.sql
 export PGPASSWORD=$DB_PASSWORD
+psql -h $DB_URL -d $DB_NAME -U $DB_USER -f dropAnalyticsTableIndexes.sql
 psql -h $DB_URL -d $DB_NAME -U $DB_USER -c "SELECT mv\$refreshMaterializedView('analytics', 'public');"
-export PGPASSWORD=$DB_MV_PASSWORD
-psql -h $DB_URL -d $DB_NAME -U $DB_MV_USER -f createAnalyticsTableIndexes.sql
+psql -h $DB_URL -d $DB_NAME -U $DB_USER -f createAnalyticsTableIndexes.sql

--- a/packages/data-api/scripts/uninstallMvRefreshModule.sh
+++ b/packages/data-api/scripts/uninstallMvRefreshModule.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+source .env
+
+export PGPASSWORD=$DB_PG_PASSWORD
+MV_REFRESH_EXISTS=`psql -X -A -h $DB_URL -d $DB_NAME -U $DB_PG_USER -t -c "SELECT schema_name FROM information_schema.schemata WHERE schema_name = '$DB_MV_USER'"`
+
+if [ "$MV_REFRESH_EXISTS" != "$DB_MV_USER" ]; then
+    echo "Fast Refresh module does not exist, skipping uninstallation"
+else
+    git submodule update --init scripts/pg-mv-fast-refresh
+    cd scripts/pg-mv-fast-refresh/
+    export DB_MV_HOME="$PWD"
+    (. dropFastRefreshModule.sh)
+    cd ../..
+fi


### PR DESCRIPTION
### Issue https://github.com/beyondessential/tupaia-backlog/issues/2961:

The core issue at play here is that the `owner` of the analytics table must be the `mvrefresh` role, however only a table `owner` or a `superuser` can add/remove indexes on a table in Postgres. 

There could have been a few ways to address this (open a connection as that `mvrefresh` user, temporarily grant `superuser` to the `tupaia` user, etc.) however I felt the most solid going forward would be to add a function to the `mvrefresh` module that allows us to add/remove indexes. Since the `tupaia` user has full access to the functions in that module, it can use these functions to add/remove indexes from the analytics table 👍 

#### Changes:
Updated pg-mv-fast-refresh and analytics table build scripts
- New version pg-mv-fast-refresh version has functions that allow the tupaia user to add/remove indexes from the analytics table
- New scripts to drop analytics table and uninstall the mvrefresh module


#### Deployment steps:
- [x] https://github.com/beyondessential/pg-mv-fast-refresh/pull/2 must already be merged in `@beyondessential/pg-mv-fast-refresh`
- [ ] A full re-installation of the `mvrefresh` module and the analytics table is required, takes ~10 mins of server downtime