### PR TITLE
2931: Process survey response imports in the background, email when done

### DIFF
--- a/packages/admin-panel/src/pages/resources/SurveyResponsesPage.js
+++ b/packages/admin-panel/src/pages/resources/SurveyResponsesPage.js
@@ -138,6 +138,7 @@ const IMPORT_CONFIG = {
     importEndpoint: 'surveyResponses',
     extraQueryParameters: {
       timeZone: getBrowserTimeZone(),
+      respondWithEmailTimeout: 10 * 1000, // if an import doesn't finish in 10 seconds, email results
     },
   },
   queryParameters: [

--- a/packages/data-broker/src/__tests__/services/weather/WeatherService.stubs.js
+++ b/packages/data-broker/src/__tests__/services/weather/WeatherService.stubs.js
@@ -52,7 +52,7 @@ export const createMockEntity = async fieldValues => {
 
 export const createMockModelsStub = responseMap => {
   const mockModels = {
-    entity: new EntityModel({}), // no database
+    entity: new EntityModel({ fetchSchemaForTable: () => {} }), // no database
     dataSource: {
       getTypes: () => ({ DATA_ELEMENT: 'dataElement', DATA_GROUP: 'dataGroup' }),
     },

--- a/packages/database/src/DatabaseModel.js
+++ b/packages/database/src/DatabaseModel.js
@@ -11,11 +11,9 @@ export class DatabaseModel {
   constructor(database) {
     this.database = database;
 
-    // this.schema contains information about the columns on the table in the database, e.g.:
-    // { id: { type: 'text', maxLength: null, nullable: false, defaultValue: null } }
-    // it will be populated on the first call to this.fetchSchema(), and should not be accessed
-    // directly
-    this.schema = null;
+    // schema promise will resolve with information about the columns on the table in the database,
+    // e.g.: { id: { type: 'text', maxLength: null, nullable: false, defaultValue: null } }
+    this.schemaPromise = this.database.fetchSchemaForTable(this.DatabaseTypeClass.databaseType);
 
     this.cache = {};
     this.cachedFunctionInvalidationCancellers = {};
@@ -58,10 +56,7 @@ export class DatabaseModel {
     this.database.addChangeHandlerForCollection(this.DatabaseTypeClass.databaseType, handler);
 
   async fetchSchema() {
-    if (!this.schema) {
-      this.schema = await this.database.fetchSchemaForTable(this.DatabaseTypeClass.databaseType);
-    }
-    return this.schema;
+    return this.schemaPromise;
   }
 
   async fetchFieldNames() {

--- a/packages/database/src/tests/modelClasses/DataSource.test.js
+++ b/packages/database/src/tests/modelClasses/DataSource.test.js
@@ -9,7 +9,9 @@ import { DataSourceModel, DataSourceType } from '../../modelClasses/DataSource';
 
 describe('DataSource', () => {
   describe('sanitizeConfig()', () => {
-    const database = {};
+    const database = {
+      fetchSchemaForTable: () => {},
+    };
 
     const createDataSource = ({ type = 'dataElement', serviceType = 'tupaia', config }) =>
       new DataSourceType(new DataSourceModel(database), {

--- a/packages/meditrak-server/src/routes/importSurveyResponses/SurveyResponseUpdatePersistor.js
+++ b/packages/meditrak-server/src/routes/importSurveyResponses/SurveyResponseUpdatePersistor.js
@@ -119,12 +119,11 @@ export class SurveyResponseUpdatePersistor {
           await transactingModels.answer.createMany(newAnswers);
         });
       } catch (error) {
-        failures.push(
-          ...batchOfCreates.map(c => ({
-            ...c,
-            error: `Error creating survey responses in bulk: ${error.message}`,
-          })),
-        );
+        const batchOfFailures = batchOfCreates.map(c => ({
+          ...c,
+          error: `Error creating survey responses in bulk: ${error.message}`,
+        }));
+        failures.push(...batchOfFailures);
       }
     }
     return { failures };
@@ -190,14 +189,12 @@ export class SurveyResponseUpdatePersistor {
           const surveyResponseIds = batchOfDeletes.map(({ surveyResponseId }) => surveyResponseId);
           await transactingModels.surveyResponse.delete({ id: surveyResponseIds });
         });
-        return { failures: [] };
       } catch (error) {
-        failures.push(
-          ...batchOfDeletes.map(d => ({
-            ...d,
-            error: `Error deleting survey responses in bulk: ${error.message}`,
-          })),
-        );
+        const batchOfFailures = batchOfDeletes.map(d => ({
+          ...d,
+          error: `Error deleting survey responses in bulk: ${error.message}`,
+        }));
+        failures.push(...batchOfFailures);
       }
     }
     return { failures };

--- a/packages/meditrak-server/src/routes/importSurveyResponses/SurveyResponseUpdatePersistor.js
+++ b/packages/meditrak-server/src/routes/importSurveyResponses/SurveyResponseUpdatePersistor.js
@@ -1,0 +1,219 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+
+const RECORDS_PER_BULK_BATCH = 5000; // number of records (survey responses + answers) processed per bulk insert/delete
+
+export const CREATE = 'create';
+export const UPDATE = 'update';
+export const DELETE = 'delete';
+
+function batchCreates(creates) {
+  const batches = [[]];
+  let currentBatchIndex = 0;
+  let currentBatchRecordCount = 0;
+  for (const create of creates) {
+    const answerCount = create.answers.upserts.length;
+    const recordCount = answerCount + 1; // +1 for the response itself
+    if (currentBatchRecordCount + recordCount > RECORDS_PER_BULK_BATCH) {
+      batches.push([]);
+      currentBatchIndex++;
+      currentBatchRecordCount = 0;
+    }
+    batches[currentBatchIndex].push(create);
+    currentBatchRecordCount += recordCount;
+  }
+  return batches;
+}
+
+function batchDeletes(deletes) {
+  const batches = [];
+  for (let i = 0; i < deletes.length; i += RECORDS_PER_BULK_BATCH) {
+    batches.push(deletes.slice(i, i + RECORDS_PER_BULK_BATCH));
+  }
+  return batches;
+}
+
+/**
+ * This class will hold on to all of the creates, updates, and deletes that a survey response import
+ * process wants to make, and allow running them all in batches once the whole spreadsheet is parsed
+ *
+ * The idea is that we can separate out the actual database updates from the parsing, validation,
+ * and formatting elements of the process. Those earlier parts can then run and synchronously return
+ * to the user with any validation errors. The db updates can then run in batches in the background.
+ */
+export class SurveyResponseUpdatePersistor {
+  constructor(models) {
+    this.models = models;
+    // maintain a map of response ids to update details, where update details looks like
+    // { sheetName, surveyResponseId, type, newSurveyResponse, newDataTime, answersToUpsert, answersToDelete }
+    // n.b. all but sheetName, surveyResponseId, and type are optional
+    this.updatesByResponseId = {};
+  }
+
+  count() {
+    return Object.keys(this.updatesByResponseId).length;
+  }
+
+  setupColumnsForSheet(sheetName, surveyResponseIds) {
+    surveyResponseIds.forEach((surveyResponseId, columnIndex) => {
+      if (!surveyResponseId) return; // array contains some empty slots representing info columns
+      this.updatesByResponseId[surveyResponseId] = {
+        type: UPDATE,
+        sheetName,
+        columnIndex,
+        surveyResponseId,
+        newSurveyResponse: null, // only populated if a new survey response is to be created
+        newDataTime: null, // only populated if submission time is to be updated
+        answers: {
+          upserts: [], // populated for new or updated survey responses
+          deletes: [], // populated for existing survey responses if answers are to be deleted
+        },
+      };
+    });
+  }
+
+  createSurveyResponse(surveyResponseId, newSurveyResponse) {
+    this.updatesByResponseId[surveyResponseId].type = CREATE;
+    this.updatesByResponseId[surveyResponseId].newSurveyResponse = newSurveyResponse;
+  }
+
+  deleteSurveyResponse(surveyResponseId) {
+    this.updatesByResponseId[surveyResponseId].type = DELETE;
+  }
+
+  updateDataTime(surveyResponseId, newDataTime) {
+    this.updatesByResponseId[surveyResponseId].newDataTime = newDataTime;
+  }
+
+  upsertAnswer(surveyResponseId, details) {
+    this.updatesByResponseId[surveyResponseId].answers.upserts.push(details);
+  }
+
+  deleteAnswer(surveyResponseId, details) {
+    this.updatesByResponseId[surveyResponseId].answers.deletes.push(details);
+  }
+
+  // ---- process creates in bulk, batching to avoid running out of memory ----
+
+  async processCreates(creates) {
+    const failures = [];
+    for (const batchOfCreates of batchCreates(creates)) {
+      try {
+        await this.models.wrapInTransaction(async transactingModels => {
+          const newSurveyResponses = batchOfCreates.map(
+            ({ newSurveyResponse }) => newSurveyResponse,
+          );
+          const newAnswers = batchOfCreates
+            .map(({ answers }) =>
+              answers.upserts.map(({ surveyResponseId, questionId, type, text }) => ({
+                survey_response_id: surveyResponseId,
+                question_id: questionId,
+                type,
+                text,
+              })),
+            )
+            .flat();
+          await transactingModels.surveyResponse.createMany(newSurveyResponses);
+          await transactingModels.answer.createMany(newAnswers);
+        });
+      } catch (error) {
+        failures.push(
+          ...batchOfCreates.map(c => ({
+            ...c,
+            error: `Error creating survey responses in bulk: ${error.message}`,
+          })),
+        );
+      }
+    }
+    return { failures };
+  }
+
+  // ---- process updates in serial, recording individual failures ----
+
+  async processUpdates(updates) {
+    const failures = [];
+    for (const update of updates) {
+      try {
+        // wrap each survey response in a transaction so that if any update to an individual
+        // answer etc. fails, the whole survey response is rolled back and marked as a failure
+        await this.models.wrapInTransaction(async transactingModels =>
+          this.processUpdate(transactingModels, update),
+        );
+      } catch (error) {
+        failures.push({ ...update, error: error.message });
+      }
+    }
+    return { failures };
+  }
+
+  async processUpdate(transactingModels, { surveyResponseId, newDataTime, answers }) {
+    if (newDataTime) {
+      await transactingModels.surveyResponse.updateById(surveyResponseId, {
+        data_time: newDataTime,
+      });
+    }
+    await this.processUpsertAnswers(transactingModels, surveyResponseId, answers.upserts);
+    await this.processDeleteAnswers(transactingModels, surveyResponseId, answers.deletes);
+  }
+
+  async processUpsertAnswers(transactingModels, surveyResponseId, answers) {
+    await Promise.all(
+      answers.map(({ questionId, text, type }) =>
+        transactingModels.answer.updateOrCreate(
+          { survey_response_id: surveyResponseId, question_id: questionId },
+          { text, type },
+        ),
+      ),
+    );
+  }
+
+  async processDeleteAnswers(transactingModels, surveyResponseId, answers) {
+    await Promise.all(
+      answers.map(({ questionId }) =>
+        transactingModels.answer.delete({
+          survey_response_id: surveyResponseId,
+          question_id: questionId,
+        }),
+      ),
+    );
+  }
+
+  // ---- process deletes in bulk, batching to avoid running out of memory ----
+
+  async processDeletes(deletes) {
+    const failures = [];
+    for (const batchOfDeletes of batchDeletes(deletes)) {
+      try {
+        await this.models.wrapInTransaction(async transactingModels => {
+          const surveyResponseIds = batchOfDeletes.map(({ surveyResponseId }) => surveyResponseId);
+          await transactingModels.surveyResponse.delete({ id: surveyResponseIds });
+        });
+        return { failures: [] };
+      } catch (error) {
+        failures.push(
+          ...batchOfDeletes.map(d => ({
+            ...d,
+            error: `Error deleting survey responses in bulk: ${error.message}`,
+          })),
+        );
+      }
+    }
+    return { failures };
+  }
+
+  async process() {
+    const allUpdates = Object.values(this.updatesByResponseId);
+    const creates = allUpdates.filter(({ type }) => type === CREATE);
+    const { failures: createFailures } = await this.processCreates(creates);
+
+    const updates = allUpdates.filter(({ type }) => type === UPDATE);
+    const { failures: updateFailures } = await this.processUpdates(updates);
+
+    const deletes = allUpdates.filter(({ type }) => type === DELETE);
+    const { failures: deleteFailures } = await this.processDeletes(deletes);
+
+    return { failures: [...createFailures, ...updateFailures, ...deleteFailures] };
+  }
+}

--- a/packages/meditrak-server/src/routes/importSurveyResponses/getFailureMessage.js
+++ b/packages/meditrak-server/src/routes/importSurveyResponses/getFailureMessage.js
@@ -1,0 +1,26 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+
+import { columnIndexToColumnCode } from '../utilities';
+import { CREATE, UPDATE, DELETE } from './SurveyResponseUpdatePersistor';
+
+const getUpdateTypePart = (type, surveyResponseId) => {
+  switch (type) {
+    case CREATE:
+      return 'create new response';
+    case UPDATE:
+      return `update existing response ${surveyResponseId}`;
+    case DELETE:
+      return `delete existing response ${surveyResponseId}`;
+    default:
+      return '';
+  }
+};
+
+export const getFailureMessage = ({ sheetName, surveyResponseId, type, columnIndex, error }) =>
+  `${sheetName}, Column ${columnIndexToColumnCode(columnIndex)}: Failed to ${getUpdateTypePart(
+    type,
+    surveyResponseId,
+  )} with the error "${error}"`;

--- a/packages/meditrak-server/src/routes/importSurveyResponses/getFailureMessage.js
+++ b/packages/meditrak-server/src/routes/importSurveyResponses/getFailureMessage.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
  */
 
-import { columnIndexToColumnCode } from '../utilities';
+import { columnIndexToCode } from '../utilities';
 import { CREATE, UPDATE, DELETE } from './SurveyResponseUpdatePersistor';
 
 const getUpdateTypePart = (type, surveyResponseId) => {
@@ -20,7 +20,7 @@ const getUpdateTypePart = (type, surveyResponseId) => {
 };
 
 export const getFailureMessage = ({ sheetName, surveyResponseId, type, columnIndex, error }) =>
-  `${sheetName}, Column ${columnIndexToColumnCode(columnIndex)}: Failed to ${getUpdateTypePart(
+  `${sheetName}, Column ${columnIndexToCode(columnIndex)}: Failed to ${getUpdateTypePart(
     type,
     surveyResponseId,
   )} with the error "${error}"`;

--- a/packages/meditrak-server/src/routes/importSurveyResponses/importSurveyResponses.js
+++ b/packages/meditrak-server/src/routes/importSurveyResponses/importSurveyResponses.js
@@ -5,6 +5,7 @@
 
 import xlsx from 'xlsx';
 import moment from 'moment';
+import { generateId } from '@tupaia/database';
 import {
   constructIsOneOf,
   constructRecordExistsWithId,
@@ -19,7 +20,6 @@ import {
 } from '@tupaia/utils';
 import { getArrayQueryParameter, extractTabNameFromQuery } from '../utilities';
 import { ANSWER_TYPES } from '../../database/models/Answer';
-import { DEFAULT_DATABASE_TIMEZONE } from '../../database';
 import { constructAnswerValidator } from '../utilities/constructAnswerValidator';
 import {
   EXPORT_DATE_FORMAT,
@@ -28,6 +28,8 @@ import {
 } from '../exportSurveyResponses';
 import { assertCanImportSurveyResponses } from './assertCanImportSurveyResponses';
 import { assertAnyPermissions, assertBESAdminAccess } from '../../permissions';
+import { SurveyResponseUpdatePersistor } from './SurveyResponseUpdatePersistor';
+import { getFailureMessage } from './getFailureMessage';
 
 /**
  * Creates or updates survey responses by importing the new answers from an Excel file, and either
@@ -38,183 +40,175 @@ export async function importSurveyResponses(req, res) {
     if (!req.file) {
       throw new UploadError();
     }
-    const surveyNames = getArrayQueryParameter(req?.query?.surveyNames);
-    const timeZone = req?.query?.timeZone;
+    const { models, query, userId } = req;
+    const surveyNames = getArrayQueryParameter(query.surveyNames);
+    const { timeZone } = query;
     if (!timeZone) {
-      throw new Error(
-        `Timezone is required`,
-      );
+      throw new Error(`Timezone is required`);
     }
-    const { models } = req;
-    await models.wrapInTransaction(async transactingModels => {
-      const workbook = xlsx.readFile(req.file.path);
-      // Go through each sheet in the workbook and process the updated survey responses
-      const entitiesBySurveyName = await getEntitiesBySurveyName(
-        transactingModels,
-        workbook.Sheets,
-        surveyNames,
-      );
+    const config = { timeZone, userId, surveyNames };
+    const updatePersistor = new SurveyResponseUpdatePersistor(models);
+    const workbook = xlsx.readFile(req.file.path);
+    // Go through each sheet in the workbook and process the updated survey responses
+    const entitiesBySurveyName = await getEntitiesBySurveyName(
+      models,
+      workbook.Sheets,
+      surveyNames,
+    );
 
-      const importSurveyResponsePermissionsChecker = async accessPolicy => {
-        await assertCanImportSurveyResponses(accessPolicy, transactingModels, entitiesBySurveyName);
-      };
+    const importSurveyResponsePermissionsChecker = async accessPolicy => {
+      await assertCanImportSurveyResponses(accessPolicy, models, entitiesBySurveyName);
+    };
 
-      await req.assertPermissions(
-        assertAnyPermissions([assertBESAdminAccess, importSurveyResponsePermissionsChecker]),
-      );
+    await req.assertPermissions(
+      assertAnyPermissions([assertBESAdminAccess, importSurveyResponsePermissionsChecker]),
+    );
 
-      for (const surveySheets of Object.entries(workbook.Sheets)) {
-        const [tabName, sheet] = surveySheets;
-        const deletedColumnHeaders = new Set();
-        const questionIds = [];
-        const newSurveyResponseIds = {};
+    for (const surveySheets of Object.entries(workbook.Sheets)) {
+      const [tabName, sheet] = surveySheets;
+      const deletedResponseIds = new Set();
+      const questionIds = [];
 
-        // Create new survey responses where required
-        const { maxColumnIndex, maxRowIndex } = getMaxRowColumnIndex(sheet);
+      // extract response ids and set up update batcher
+      const { maxColumnIndex, maxRowIndex } = getMaxRowColumnIndex(sheet);
+      const minSurveyResponseIndex = INFO_COLUMN_HEADERS.length;
+      const surveyResponseIds = [];
+      for (let columnIndex = minSurveyResponseIndex; columnIndex <= maxColumnIndex; columnIndex++) {
+        const columnHeader = getColumnHeader(sheet, columnIndex);
+        if (checkIsNewSurveyResponse(columnHeader)) {
+          surveyResponseIds[columnIndex] = generateId();
+        } else {
+          surveyResponseIds[columnIndex] = columnHeader;
+        }
+      }
+      updatePersistor.setupColumnsForSheet(tabName, surveyResponseIds);
 
-        for (let columnIndex = 0; columnIndex <= maxColumnIndex; columnIndex++) {
-          const columnHeader = getColumnHeader(sheet, columnIndex);
-          if (!isInfoColumn(columnIndex)) {
-            // A column representing a survey response
-            try {
-              if (checkIsNewSurveyResponse(columnHeader)) {
-                if (!surveyNames) {
-                  throw new Error(
-                    'When importing new survey responses, you must specify the names of the surveys they are for',
-                  );
-                }
-                const surveyName = extractTabNameFromQuery(tabName, surveyNames);
-                const survey = await transactingModels.survey.findOne({ name: surveyName });
-                const entityCode = getInfoForColumn(sheet, columnIndex, 'Entity Code');
-                const entity = await transactingModels.entity.findOne({ code: entityCode });
-                const user = await transactingModels.user.findById(req.userId);
-                // 'Date of Data' is pulled from spreadsheet, 'Date of Survey' is current time
-                const surveyDate = getDateForColumn(sheet, columnIndex);
-                const importDate = moment();
-                const newSurveyResponse = await transactingModels.surveyResponse.create({
-                  survey_id: survey.id, // All survey responses within a sheet should be for the same survey
-                  assessor_name: `${user.first_name} ${user.last_name}`,
-                  user_id: user.id,
-                  entity_id: entity.id,
-                  start_time: importDate,
-                  end_time: importDate,
-                  data_time: stripTimezoneFromDate(surveyDate),
-                  timezone: timeZone,
-                });
-                newSurveyResponseIds[columnIndex] = newSurveyResponse.id;
-              } else {
-                // Validate that every header takes id form, i.e. is an existing or deleted response
-                await hasContent(columnHeader);
-                await takesIdForm(columnHeader);
-              }
-            } catch (error) {
-              throw new ImportValidationError(
-                `Invalid survey response id ${columnHeader} causing message: ${
-                  error.message
-                } at column ${columnIndex + 1} on tab ${tabName}`,
-              );
-            }
+      for (let columnIndex = minSurveyResponseIndex; columnIndex <= maxColumnIndex; columnIndex++) {
+        const columnHeader = getColumnHeader(sheet, columnIndex);
+        if (checkIsNewSurveyResponse(columnHeader)) {
+          const surveyResponseId = surveyResponseIds[columnIndex];
+          const surveyResponseDetails = await constructNewSurveyResponseDetails(
+            models,
+            tabName,
+            sheet,
+            columnIndex,
+            { id: surveyResponseId, ...config },
+          );
+          updatePersistor.createSurveyResponse(surveyResponseId, surveyResponseDetails);
+        } else {
+          try {
+            // Validate that every header takes id form, i.e. is an existing or deleted response
+            await hasContent(columnHeader);
+            await takesIdForm(columnHeader);
+          } catch (error) {
+            throw new ImportValidationError(
+              `Invalid column header ${columnHeader} causing message: ${error.message} at column ${
+                columnIndex + 1
+              } on tab ${tabName} (should be a survey response id or "NEW" for new responses)`,
+            );
           }
         }
+      }
 
-        const infoValidator = new ObjectValidator(constructInfoColumnValidators(transactingModels));
-        const ignoredRowTypes = [ANSWER_TYPES.INSTRUCTION, ANSWER_TYPES.PRIMARY_ENTITY];
-        for (let rowIndex = 1; rowIndex <= maxRowIndex; rowIndex++) {
-          const excelRowNumber = rowIndex + 1; // +1 to make up for header
-          const rowType = getInfoForRow(sheet, rowIndex, 'Type');
-          if (ignoredRowTypes.includes(rowType)) {
-            continue;
+      const infoValidator = new ObjectValidator(constructInfoColumnValidators(models));
+      const ignoredRowTypes = [ANSWER_TYPES.INSTRUCTION, ANSWER_TYPES.PRIMARY_ENTITY];
+      for (let rowIndex = 1; rowIndex <= maxRowIndex; rowIndex++) {
+        const excelRowNumber = rowIndex + 1; // +1 to make up for header
+        const rowType = getInfoForRow(sheet, rowIndex, 'Type');
+        if (ignoredRowTypes.includes(rowType)) {
+          continue;
+        }
+
+        // Validate every cell in rows other than the header rows
+        let answerValidator;
+        const questionId = getInfoForRow(sheet, rowIndex, 'Id');
+        if (questionId !== 'N/A') {
+          if (questionIds.includes(questionId)) {
+            throw new ImportValidationError(
+              `Question id ${questionId} is not unique`,
+              excelRowNumber,
+            );
           }
-
-          // Validate every cell in rows other than the header rows
-          let answerValidator;
-          const questionId = getInfoForRow(sheet, rowIndex, 'Id');
-          if (questionId !== 'N/A') {
-            if (questionIds.includes(questionId)) {
-              throw new ImportValidationError(
-                `Question id ${questionId} is not unique`,
-                excelRowNumber,
-              );
-            }
-            questionIds.push(questionId);
-            const rowInfo = {};
-            for (const infoKey of INFO_COLUMN_HEADERS) {
-              rowInfo[infoKey] = getInfoForRow(sheet, rowIndex, infoKey);
-            }
-            await infoValidator.validate(rowInfo);
-            const question = await transactingModels.question.findById(questionId);
-            answerValidator = new ObjectValidator({}, constructAnswerValidator(models, question));
+          questionIds.push(questionId);
+          const rowInfo = {};
+          for (const infoKey of INFO_COLUMN_HEADERS) {
+            rowInfo[infoKey] = getInfoForRow(sheet, rowIndex, infoKey);
           }
+          await infoValidator.validate(rowInfo);
+          const question = await models.question.findById(questionId);
+          answerValidator = new ObjectValidator({}, constructAnswerValidator(models, question));
+        }
 
-          for (let columnIndex = 0; columnIndex <= maxColumnIndex; columnIndex++) {
-            const columnHeader = getColumnHeader(sheet, columnIndex);
-            const cellValue = getCellContents(sheet, columnIndex, rowIndex);
-            // If we already deleted this survey response wholesale, no need to check specific rows
-            if (
-              columnHeader &&
-              columnIndex !== '' &&
-              !deletedColumnHeaders.has(columnHeader) &&
-              !INFO_COLUMN_HEADERS.includes(columnHeader)
-            ) {
-              if (answerValidator) {
-                const constructImportValidationError = message =>
-                  new ImportValidationError(message, excelRowNumber, columnHeader, tabName);
-                await answerValidator.validate(
-                  { answer: cellValue },
-                  constructImportValidationError,
-                );
-              }
-              const surveyResponseId = checkIsNewSurveyResponse(columnHeader)
-                ? newSurveyResponseIds[columnIndex]
-                : columnHeader;
-              if (!surveyResponseId || surveyResponseId === '') {
-                throw new ImportValidationError('Missing survey response id', excelRowNumber);
-              }
-              if (questionId === 'N/A') {
-                // Info row (e.g. entity name): if no content delete the survey response wholesale
-                if (checkIsCellEmpty(cellValue)) {
-                  await transactingModels.surveyResponse.deleteById(surveyResponseId);
-                  deletedColumnHeaders.add(columnHeader);
-                } else {
-                  // Not deleting, make sure the submission date is set as defined in the spreadsheet
-                  // TODO need to only update if the date has actually changed
-                  const newSubmissionTime = getDateStringForColumn(sheet, columnIndex);
-                  await updateSubmissionTimeIfRequired(
-                    transactingModels,
-                    surveyResponseId,
-                    newSubmissionTime,
-                  );
-                }
-              } else if (checkIsCellEmpty(cellValue)) {
-                // Empty question row: delete any matching answer
-                await transactingModels.answer.delete({
-                  survey_response_id: surveyResponseId,
-                  question_id: questionId,
-                });
-              } else if (
-                rowType === ANSWER_TYPES.DATE_OF_DATA ||
-                rowType === ANSWER_TYPES.SUBMISSION_DATE
-              ) {
-                // Don't save an answer for date of data rows, instead update the date_time of the
-                // survey response. Note that this will override what is in the Date info row
-                await updateSubmissionTimeIfRequired(
-                  transactingModels,
-                  surveyResponseId,
-                  cellValue.toString(),
-                );
+        for (
+          let columnIndex = minSurveyResponseIndex;
+          columnIndex <= maxColumnIndex;
+          columnIndex++
+        ) {
+          const columnHeader = getColumnHeader(sheet, columnIndex);
+          const surveyResponseId = surveyResponseIds[columnIndex];
+          const cellValue = getCellContents(sheet, columnIndex, rowIndex);
+          // If we already deleted this survey response wholesale, no need to check specific rows
+          if (surveyResponseId && !deletedResponseIds.has(surveyResponseId)) {
+            if (answerValidator) {
+              const constructImportValidationError = message =>
+                new ImportValidationError(message, excelRowNumber, columnHeader, tabName);
+              await answerValidator.validate({ answer: cellValue }, constructImportValidationError);
+            }
+            if (questionId === 'N/A') {
+              // Info row (e.g. entity name): if no content delete the survey response wholesale
+              if (checkIsCellEmpty(cellValue)) {
+                updatePersistor.deleteSurveyResponse(surveyResponseId);
+                deletedResponseIds.add(surveyResponseId);
               } else {
-                // Normal question row with content: update or create an answer
-                await transactingModels.answer.updateOrCreate(
-                  { survey_response_id: surveyResponseId, question_id: questionId },
-                  { text: cellValue.toString(), type: rowType },
+                // Not deleting, make sure the submission date is set as defined in the spreadsheet
+                const dataTimeInSheet = getDateStringForColumn(sheet, columnIndex);
+                const newDataTime = await getNewDataTimeIfRequired(
+                  models,
+                  surveyResponseId,
+                  dataTimeInSheet,
                 );
+                if (newDataTime) {
+                  updatePersistor.updateDataTime(surveyResponseId, newDataTime);
+                }
               }
+            } else if (checkIsCellEmpty(cellValue)) {
+              // Empty question row: delete any matching answer
+              updatePersistor.deleteAnswer(surveyResponseId, { questionId });
+            } else if (
+              rowType === ANSWER_TYPES.DATE_OF_DATA ||
+              rowType === ANSWER_TYPES.SUBMISSION_DATE
+            ) {
+              // Don't save an answer for date of data rows, instead update the date_time of the
+              // survey response. Note that this will override what is in the Date info row
+              const newDataTime = await getNewDataTimeIfRequired(
+                models,
+                surveyResponseId,
+                cellValue.toString(),
+              );
+              if (newDataTime) {
+                updatePersistor.updateDataTime(surveyResponseId, newDataTime);
+              }
+            } else {
+              // Normal question row with content: update or create an answer
+              updatePersistor.upsertAnswer(surveyResponseId, {
+                surveyResponseId,
+                questionId,
+                text: cellValue.toString(),
+                type: rowType,
+              });
             }
           }
         }
       }
-    });
-    respond(res, { message: 'Imported survey responses' });
+    }
+
+    const { failures } = await updatePersistor.process();
+    const message =
+      failures.length > 0
+        ? `Not all responses were successfully processed:
+${failures.map(getFailureMessage).join('\n')}`
+        : null;
+    respond(res, { message, failures });
   } catch (error) {
     if (error.respond) {
       throw error; // Already a custom error with a responder
@@ -223,6 +217,40 @@ export async function importSurveyResponses(req, res) {
     }
   }
 }
+
+const constructNewSurveyResponseDetails = async (models, tabName, sheet, columnIndex, config) => {
+  const { id, surveyNames, userId, timeZone } = config;
+  if (!surveyNames) {
+    throw new Error(
+      'When importing new survey responses, you must specify the names of the surveys they are for',
+    );
+  }
+  const surveyName = extractTabNameFromQuery(tabName, surveyNames);
+  const survey = await models.survey.findOne({ name: surveyName });
+  if (!survey) {
+    throw new Error(`No survey named ${surveyName}`);
+  }
+  const entityCode = getInfoForColumn(sheet, columnIndex, 'Entity Code');
+  const entity = await models.entity.findOne({ code: entityCode });
+  if (!entity) {
+    throw new Error(`No entity with code ${entityCode}`);
+  }
+  const user = await models.user.findById(userId);
+  // 'Date of Data' is pulled from spreadsheet, 'Date of Survey' is current time
+  const surveyDate = getDateStringForColumn(sheet, columnIndex);
+  const importDate = moment();
+  return {
+    id,
+    survey_id: survey.id, // All survey responses within a sheet should be for the same survey
+    assessor_name: `${user.first_name} ${user.last_name}`,
+    user_id: user.id,
+    entity_id: entity.id,
+    start_time: importDate,
+    end_time: importDate,
+    data_time: stripTimezoneFromDate(surveyDate),
+    timezone: timeZone,
+  };
+};
 
 /**
  * Return all the entitites of the submitted survey responses, grouped by the survey name (sheet name) that the survey responses belong to
@@ -268,29 +296,23 @@ const getMaxRowColumnIndex = sheet => {
   return { maxColumnIndex, maxRowIndex };
 };
 
-async function updateSubmissionTimeIfRequired(models, surveyResponseId, newSubmissionTimeString) {
+async function getNewDataTimeIfRequired(models, surveyResponseId, newDataTime) {
   const surveyResponse = await models.surveyResponse.findById(surveyResponseId);
-  if (!surveyResponse) return; // Survey response is probably deleted
+  if (!surveyResponse) return null; // probably in the process of being created, no need to update
   const currentDataTime = surveyResponse.data_time;
-  const isInExportFormat = moment(newSubmissionTimeString, EXPORT_DATE_FORMAT, true).isValid();
-  const newDataTime = isInExportFormat
-    ? stripTimezoneFromDate(moment(newSubmissionTimeString, EXPORT_DATE_FORMAT).toDate())
-    : stripTimezoneFromDate(moment(newSubmissionTimeString).toDate());
 
   if (!moment(currentDataTime).isSame(newDataTime, 'minute')) {
-    await models.surveyResponse.updateById(surveyResponseId, {
-      data_time: stripTimezoneFromDate(newDataTime),
-    });
+    return stripTimezoneFromDate(newDataTime);
   }
+  return null;
 }
 
 function getDateStringForColumn(sheet, columnIndex) {
-  return getInfoForColumn(sheet, columnIndex, 'Date');
-}
-
-function getDateForColumn(sheet, columnIndex) {
-  const dateString = getDateStringForColumn(sheet, columnIndex);
-  return moment.utc(dateString, EXPORT_DATE_FORMAT).toDate();
+  const dateString = getInfoForColumn(sheet, columnIndex, 'Date');
+  const isInExportFormat = moment(dateString, EXPORT_DATE_FORMAT, true).isValid();
+  return isInExportFormat
+    ? stripTimezoneFromDate(moment(dateString, EXPORT_DATE_FORMAT).toDate())
+    : stripTimezoneFromDate(moment(dateString).toDate());
 }
 
 function checkIsCellEmpty(cellValue) {

--- a/packages/meditrak-server/src/routes/importSurveyResponses/importSurveyResponses.js
+++ b/packages/meditrak-server/src/routes/importSurveyResponses/importSurveyResponses.js
@@ -29,6 +29,7 @@ import {
 import { assertCanImportSurveyResponses } from './assertCanImportSurveyResponses';
 import { assertAnyPermissions, assertBESAdminAccess } from '../../permissions';
 import { SurveyResponseUpdatePersistor } from './SurveyResponseUpdatePersistor';
+import { setupEmailResponseTimeout } from './setupEmailResponseTimeout';
 import { getFailureMessage } from './getFailureMessage';
 
 /**
@@ -36,6 +37,7 @@ import { getFailureMessage } from './getFailureMessage';
  * updating or creating each answer as appropriate
  */
 export async function importSurveyResponses(req, res) {
+  setupEmailResponseTimeout(req, res); // if the import takes too long, the results will be emailed
   try {
     if (!req.file) {
       throw new UploadError();

--- a/packages/meditrak-server/src/routes/importSurveyResponses/importSurveyResponses.js
+++ b/packages/meditrak-server/src/routes/importSurveyResponses/importSurveyResponses.js
@@ -240,6 +240,9 @@ const constructNewSurveyResponseDetails = async (models, tabName, sheet, columnI
   const user = await models.user.findById(userId);
   // 'Date of Data' is pulled from spreadsheet, 'Date of Survey' is current time
   const surveyDate = getDateStringForColumn(sheet, columnIndex);
+  if (!surveyDate) {
+    throw new Error('No date of data provided');
+  }
   const importDate = moment();
   return {
     id,

--- a/packages/meditrak-server/src/routes/importSurveyResponses/importSurveyResponses.js
+++ b/packages/meditrak-server/src/routes/importSurveyResponses/importSurveyResponses.js
@@ -239,10 +239,10 @@ const constructNewSurveyResponseDetails = async (models, tabName, sheet, columnI
   }
   const user = await models.user.findById(userId);
   // 'Date of Data' is pulled from spreadsheet, 'Date of Survey' is current time
-  const surveyDate = getDateStringForColumn(sheet, columnIndex);
-  if (!surveyDate) {
+  if (!getInfoForColumn(sheet, columnIndex, 'Date')) {
     throw new Error('No date of data provided');
   }
+  const surveyDate = getDateStringForColumn(sheet, columnIndex);
   const importDate = moment();
   return {
     id,

--- a/packages/meditrak-server/src/routes/importSurveyResponses/setupEmailResponseTimeout.js
+++ b/packages/meditrak-server/src/routes/importSurveyResponses/setupEmailResponseTimeout.js
@@ -1,0 +1,77 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+
+import { respond } from '@tupaia/utils';
+import { sendEmail } from '../../utilities';
+import { getFailureMessage } from './getFailureMessage';
+
+const constructFailuresMessage = failures => {
+  const message = `Your survey responses have finished processing, but some were not able to be imported. Please fix the following and try again:
+${failures.map(failure => `  - ${getFailureMessage(failure)}`).join('\n')}
+
+Any responses not listed here have been successfully imported, and can be removed for your next attempt.`;
+  return message;
+};
+
+const constructMessageBody = responseBody => {
+  const { error, failures = [] } = responseBody;
+
+  // global error, whole import has failed
+  if (error) {
+    return `Unfortunately, your survey response import failed.
+
+${error}`;
+  }
+
+  // at least one response failed, but import finished processing
+  if (failures.length > 0) {
+    return constructFailuresMessage(failures);
+  }
+
+  return 'Your survey responses have been successfully imported.';
+};
+
+const sendResponseAsEmail = (user, responseBody) => {
+  const messageBody = constructMessageBody(responseBody);
+  const message = `Hi ${user.first_name},
+
+${messageBody}
+  `;
+  sendEmail(user.email, 'Tupaia Survey Response Import', message);
+};
+
+const setupEmailResponse = async (req, res) => {
+  const { models, userId } = req;
+  const user = await models.user.findById(userId);
+
+  if (res.headersSent) {
+    // no need to do anything if the import responded successfully within the timeout
+    // n.b. this check needs to stay below any async stuff above, so that we don't end up in a half
+    // way state where the successful response happens e.g. during looking up the user
+    return;
+  }
+
+  respond(res, {
+    message:
+      'Import is taking a while, and will continue in the background. You will be emailed when the import process completes.',
+  });
+  // override the respond function so that when the import finishes (or a validation error is
+  // thrown), the response is sent via email
+  res.overrideRespond = responseBody => sendResponseAsEmail(user, responseBody);
+};
+
+// if the import takes too long, the results will be emailed
+// this pattern could be utilised to wrap other endpoints quite easily
+export const setupEmailResponseTimeout = (req, res) => {
+  const { respondWithEmailTimeout } = req.query;
+  if (respondWithEmailTimeout === undefined) {
+    return;
+  }
+  const timeout = parseInt(respondWithEmailTimeout, 10);
+  if (Number.isNaN(timeout)) {
+    throw new Error('respondWithEmailTimeout must be a number');
+  }
+  setTimeout(() => setupEmailResponse(req, res), timeout);
+};

--- a/packages/meditrak-server/src/routes/requestCountryAccess.js
+++ b/packages/meditrak-server/src/routes/requestCountryAccess.js
@@ -28,16 +28,16 @@ const sendRequest = (userName, countryNames, message, project) => {
   const { COUNTRY_REQUEST_EMAIL_ADDRESS } = process.env;
 
   const emailText = `
-  ${userName} has requested access to countries:
+${userName} has requested access to countries:
 ${countryNames.map(n => `  -  ${n}`).join('\n')}
 ${
   project
     ? `
-  For the project ${project.code} (linked to permission groups: ${project.user_groups.join(', ')})
+For the project ${project.code} (linked to permission groups: ${project.user_groups.join(', ')})
     `
     : ''
 }
-  With the message: '${message}'
+With the message: '${message}'
 `;
   return sendEmail(COUNTRY_REQUEST_EMAIL_ADDRESS, 'Tupaia Country Access Request', emailText);
 };

--- a/packages/meditrak-server/src/routes/requestPasswordReset.js
+++ b/packages/meditrak-server/src/routes/requestPasswordReset.js
@@ -29,14 +29,15 @@ export const requestPasswordReset = async (req, res) => {
   });
 
   const resetUrl = process.env.PASSWORD_RESET_URL.replace('{token}', token);
-  const emailText = `Dear ${user.fullName},\n
-    You are receiving this email because someone requested a password reset for
-    this user account on Tupaia.org. To reset your password follow the link below.
+  const emailText = `Dear ${user.fullName},
 
-    ${resetUrl}
+You are receiving this email because someone requested a password reset for
+this user account on Tupaia.org. To reset your password follow the link below.
 
-    If you believe this email was sent to you in error, please contact us immediately at
-    admin@tupaia.org.`;
+${resetUrl}
+
+If you believe this email was sent to you in error, please contact us immediately at
+admin@tupaia.org.`;
 
   sendEmail(user.email, 'Password reset on Tupaia.org', emailText);
 

--- a/packages/meditrak-server/src/routes/utilities/excel.js
+++ b/packages/meditrak-server/src/routes/utilities/excel.js
@@ -45,3 +45,15 @@ export const splitOnNewLinesOrCommas = string => {
   if (!string) return [];
   return string.includes('\n') ? splitStringOn(string, '\n') : splitStringOnComma(string);
 };
+
+export const columnIndexToColumnCode = columnIndex => {
+  let columnNumber = columnIndex + 1;
+  let code = '';
+  while (columnNumber > 0) {
+    const thisLetterInteger = (columnNumber - 1) % 26;
+    const newLetter = String.fromCharCode(thisLetterInteger + 65);
+    code = `${newLetter}${code}`;
+    columnNumber = (columnNumber - thisLetterInteger - 1) / 26;
+  }
+  return code;
+};

--- a/packages/meditrak-server/src/routes/utilities/excel.js
+++ b/packages/meditrak-server/src/routes/utilities/excel.js
@@ -46,12 +46,12 @@ export const splitOnNewLinesOrCommas = string => {
   return string.includes('\n') ? splitStringOn(string, '\n') : splitStringOnComma(string);
 };
 
-export const columnIndexToColumnCode = columnIndex => {
+export const columnIndexToCode = columnIndex => {
   let columnNumber = columnIndex + 1;
   let code = '';
   while (columnNumber > 0) {
     const thisLetterInteger = (columnNumber - 1) % 26;
-    const newLetter = String.fromCharCode(thisLetterInteger + 65);
+    const newLetter = String.fromCharCode('A'.charCodeAt() + thisLetterInteger);
     code = `${newLetter}${code}`;
     columnNumber = (columnNumber - thisLetterInteger - 1) / 26;
   }

--- a/packages/meditrak-server/src/routes/utilities/index.js
+++ b/packages/meditrak-server/src/routes/utilities/index.js
@@ -5,13 +5,7 @@
 
 export { constructAnswerValidator } from './constructAnswerValidator';
 export { constructNewRecordValidationRules } from './constructNewRecordValidationRules';
-export {
-  extractTabNameFromQuery,
-  splitStringOn,
-  splitStringOnFirstOccurrence,
-  splitStringOnComma,
-  splitOnNewLinesOrCommas,
-} from './excel';
+export * from './excel';
 export {
   fetchCountryIdsByPermissionGroupId,
   fetchCountryCodesByPermissionGroupId,

--- a/packages/meditrak-server/src/utilities/sendEmail.js
+++ b/packages/meditrak-server/src/utilities/sendEmail.js
@@ -29,7 +29,7 @@ export const sendEmail = (to, subject, text) => {
     subject,
     text: `${text}
 
-    Cheers,
-    The Tupaia Team`,
+Cheers,
+The Tupaia Team`,
   });
 };

--- a/packages/utils/src/respond.js
+++ b/packages/utils/src/respond.js
@@ -6,9 +6,17 @@
 /**
  * Helper function to call the response res with some json
  */
-export function respond(res, jsonResponse, statusCode) {
-  res
+export function respond(res, responseBody, statusCode) {
+  // we allow a "overrideRespond" function to be attached to `res`, so that we can change the
+  // response mechanism in certain situations
+  // motivating use case: if an import process will take too long, we email them the response rather
+  // than respond directly to the original http query
+  const { overrideRespond } = res;
+  if (overrideRespond) {
+    return overrideRespond(responseBody, statusCode);
+  }
+  return res
     .status(statusCode || 200)
     .type('json')
-    .send(JSON.stringify(jsonResponse));
+    .send(JSON.stringify(responseBody));
 }


### PR DESCRIPTION
### Issue #:
https://github.com/beyondessential/tupaia-backlog/issues/2931

### Changes:

- If you upload a file that takes 10 seconds or less to process, there is no change
- If you upload a file that takes more than 10 seconds, it will continue in the background and email the user when done
- The admin panel will show a message in the modal indicating that the user will be emailed (see screenshot in issue)
- The email will contain any validation messages or db update failures

Changes are separated into four commits:
1. Separating out the db processing from parsing and validation, and making inserts and deletes happen in bulk batches
2. A minor fix to the inconsistent indentation we have across our Tupaia emails, semi-related to the emails sent in the next commit
3. Add a pattern for responding via email if an import takes too long, specifically applied here to importing survey responses
4. Ensure that fetching schema for a model is only done once per instance - turns out this is a tiny change but a hugely significant factor, as the Answer model has a notifier running on every change that was generating an instance, which in turn was fetching the schema, but because thousands were hitting the db at once they were all independently fetching the schema and overwhelming the db

---

### Screenshots: 

In the issue: https://github.com/beyondessential/tupaia-backlog/issues/2931#issuecomment-862797942

