### PR TITLE
Support legend order again

### DIFF
--- a/packages/ui-components/src/components/Chart/CartesianChart.js
+++ b/packages/ui-components/src/components/Chart/CartesianChart.js
@@ -28,6 +28,7 @@ import { isMobile } from './utils';
 import { XAxis as XAxisComponent } from './XAxis';
 import { YAxes } from './YAxes';
 import { ReferenceLines } from './ReferenceLines';
+import { compareLegendOrder } from './compareLegendOrder';
 
 const { AREA, BAR, COMPOSED, LINE } = CHART_TYPES;
 
@@ -150,8 +151,13 @@ export const CartesianChart = ({ viewContent, isEnlarged, isExporting }) => {
 
   const config = Object.keys(chartConfig).length > 0 ? chartConfig : { [DEFAULT_DATA_KEY]: {} };
 
-  const sortedChartConfig = Object.entries(config).sort((a, b) => {
-    return CHART_SORT_ORDER[b[1].chartType] - CHART_SORT_ORDER[a[1].chartType];
+  const sortedChartConfig = Object.entries(config).sort(([, a], [, b]) => {
+    // make sure lines are in front of bars
+    const chartTypeOrderDifference = CHART_SORT_ORDER[b.chartType] - CHART_SORT_ORDER[a.chartType];
+    if (chartTypeOrderDifference < 0 || chartTypeOrderDifference > 0) {
+      return chartTypeOrderDifference;
+    }
+    return compareLegendOrder(a, b);
   });
 
   const Chart = CHART_TYPE_TO_CHART[chartType];

--- a/packages/ui-components/src/components/Chart/Legend.js
+++ b/packages/ui-components/src/components/Chart/Legend.js
@@ -6,6 +6,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import MuiButton from '@material-ui/core/Button';
+import { compareLegendOrder } from './compareLegendOrder';
 
 const LegendContainer = styled.div`
   display: flex;
@@ -43,12 +44,16 @@ const getDisplayValue = (chartConfig, value) => chartConfig[value]?.label || val
 
 export const getPieLegend = ({ chartConfig = {} }) => ({ payload }) => (
   <LegendContainer style={{ padding: 0, marginBottom: -10 }}>
-    {payload.map(({ color, value }) => (
-      <LegendItem key={value} disabled>
-        <Box style={{ background: color }} />
-        <Text>{getDisplayValue(chartConfig, value)}</Text>
-      </LegendItem>
-    ))}
+    {payload
+      .sort(({ value: valueA }, { value: valueB }) => {
+        return compareLegendOrder(chartConfig[valueA], chartConfig[valueB]);
+      })
+      .map(({ color, value }) => (
+        <LegendItem key={value} disabled>
+          <Box style={{ background: color }} />
+          <Text>{getDisplayValue(chartConfig, value)}</Text>
+        </LegendItem>
+      ))}
   </LegendContainer>
 );
 

--- a/packages/ui-components/src/components/Chart/compareLegendOrder.js
+++ b/packages/ui-components/src/components/Chart/compareLegendOrder.js
@@ -1,0 +1,12 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+
+// can be passed to sort to order chart config by legend order
+export const compareLegendOrder = (cfg1 = {}, cfg2 = {}) => {
+  if (Number.isNaN(cfg1.legendOrder) && Number.isNaN(cfg2.legendOrder)) return 0;
+  if (Number.isNaN(cfg1.legendOrder)) return -1;
+  if (Number.isNaN(cfg2.legendOrder)) return 1;
+  return cfg1.legendOrder - cfg2.legendOrder;
+};

--- a/packages/ui-components/src/components/Chart/parseChartConfig.js
+++ b/packages/ui-components/src/components/Chart/parseChartConfig.js
@@ -16,7 +16,7 @@ export const parseChartConfig = viewContent => {
     ? createDynamicConfig(restOfConfig, configForAllKeys, data)
     : restOfConfig;
 
-  return addDefaultColorsToConfig(sortChartConfigByLegendOrder(baseConfig), paletteName, chartType);
+  return addDefaultColorsToConfig(baseConfig, paletteName, chartType);
 };
 
 // Adds default colors for every element with no color defined
@@ -47,24 +47,6 @@ const getDefaultPaletteName = (chartType, numberRequired) => {
   return numberRequired > Object.keys(COLOR_PALETTES.CHART_COLOR_PALETTE).length
     ? 'EXPANDED_CHART_COLOR_PALETTE'
     : 'CHART_COLOR_PALETTE';
-};
-
-// Bad practice to rely on object ordering: https://stackoverflow.com/questions/9179680/is-it-acceptable-style-for-node-js-libraries-to-rely-on-object-key-order
-const sortChartConfigByLegendOrder = chartConfig => {
-  return Object.entries(chartConfig)
-    .sort(([, cfg1], [, cfg2]) => {
-      if (Number.isNaN(cfg1.legendOrder) && Number.isNaN(cfg2.legendOrder)) return 0;
-      if (Number.isNaN(cfg1.legendOrder)) return -1;
-      if (Number.isNaN(cfg2.legendOrder)) return 1;
-      return cfg1.legendOrder - cfg2.legendOrder;
-    })
-    .reduce(
-      (newChartConfig, [key, val]) => ({
-        ...newChartConfig,
-        [key]: val,
-      }),
-      {},
-    );
 };
 
 const createDynamicConfig = (chartConfig, dynamicChartConfig, data) => {

--- a/packages/web-frontend/src/components/View/ChartWrapper/compareLegendOrder.js
+++ b/packages/web-frontend/src/components/View/ChartWrapper/compareLegendOrder.js
@@ -1,0 +1,12 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+
+// can be passed to sort to order chart config by legend order
+export const compareLegendOrder = (cfg1 = {}, cfg2 = {}) => {
+  if (Number.isNaN(cfg1.legendOrder) && Number.isNaN(cfg2.legendOrder)) return 0;
+  if (Number.isNaN(cfg1.legendOrder)) return -1;
+  if (Number.isNaN(cfg2.legendOrder)) return 1;
+  return cfg1.legendOrder - cfg2.legendOrder;
+};

--- a/packages/web-frontend/src/components/View/ChartWrapper/parseChartConfig.js
+++ b/packages/web-frontend/src/components/View/ChartWrapper/parseChartConfig.js
@@ -17,10 +17,7 @@ export const parseChartConfig = viewContent => {
 
   const chartConfigs = [baseConfig];
 
-  return chartConfigs
-    .map(sortChartConfigByLegendOrder)
-    .map(addDefaultColors)
-    .map(setOpacityValues)[0]; // must remove from array after mapping
+  return chartConfigs.map(addDefaultColors).map(setOpacityValues)[0]; // must remove from array after mapping
 };
 
 /**
@@ -67,24 +64,6 @@ const getDefaultPaletteName = (chartType, numberRequired) => {
   return numberRequired > Object.keys(COLOR_PALETTES.CHART_COLOR_PALETTE).length
     ? 'EXPANDED_CHART_COLOR_PALETTE'
     : 'CHART_COLOR_PALETTE';
-};
-
-// Bad practice to rely on object ordering: https://stackoverflow.com/questions/9179680/is-it-acceptable-style-for-node-js-libraries-to-rely-on-object-key-order
-const sortChartConfigByLegendOrder = chartConfig => {
-  return Object.entries(chartConfig)
-    .sort(([, cfg1], [, cfg2]) => {
-      if (Number.isNaN(cfg1.legendOrder) && Number.isNaN(cfg2.legendOrder)) return 0;
-      if (Number.isNaN(cfg1.legendOrder)) return -1;
-      if (Number.isNaN(cfg2.legendOrder)) return 1;
-      return cfg1.legendOrder - cfg2.legendOrder;
-    })
-    .reduce(
-      (newChartConfig, [key, val]) => ({
-        ...newChartConfig,
-        [key]: val,
-      }),
-      {},
-    );
 };
 
 const createDynamicConfig = (chartConfig, dynamicChartConfig, data) => {


### PR DESCRIPTION
### Issue #:

No issue, but for reference see [this slack thread](https://beyondessential.slack.com/archives/CDGS6P56K/p1624400632045800)

Any custom legend orders are being clobbered by the later sort that pulls lines in front of bars on composed charts

### Changes:

- Example

---

### Screenshots:
