### PR TITLE
add support for different legend positions

### DIFF
--- a/packages/lesmis/src/components/ChartTable.js
+++ b/packages/lesmis/src/components/ChartTable.js
@@ -10,12 +10,14 @@ import { Chart, Table } from '@tupaia/ui-components/lib/chart';
 import { FetchLoader } from './FetchLoader';
 
 const Wrapper = styled.div`
-  flex: 1;
   display: flex;
+  flex: 1;
   overflow: auto;
 `;
 
-const ChartWrapper = styled(Wrapper)`
+const ChartWrapper = styled.div`
+  display: flex;
+  flex: 1;
   padding: 0.25rem 1.875rem 0;
 
   .MuiAlert-root {
@@ -33,7 +35,7 @@ export const ChartTable = ({ isLoading, isError, error, viewContent, selectedTab
   <FetchLoader isLoading={isLoading} isError={isError} error={error}>
     {selectedTab === TABS.CHART ? (
       <ChartWrapper>
-        <Chart viewContent={viewContent} />
+        <Chart viewContent={viewContent} legendPosition="top" />
       </ChartWrapper>
     ) : (
       <Wrapper>

--- a/packages/ui-components/src/components/Chart/CartesianChart.js
+++ b/packages/ui-components/src/components/Chart/CartesianChart.js
@@ -85,7 +85,7 @@ const getRealDataKeys = chartConfig =>
  * Cartesian Chart types using recharts
  * @see https://recharts.org
  */
-export const CartesianChart = ({ viewContent, isEnlarged, isExporting }) => {
+export const CartesianChart = ({ viewContent, isEnlarged, isExporting, legendPosition }) => {
   const [chartConfig, setChartConfig] = useState(viewContent.chartConfig || {});
   const [activeDataKeys, setActiveDataKeys] = useState([]);
 
@@ -174,7 +174,7 @@ export const CartesianChart = ({ viewContent, isEnlarged, isExporting }) => {
         margin={
           isExporting
             ? { left: 20, right: 20, top: 20, bottom: 20 }
-            : { left: 0, right: 0, top: 0, bottom: 5 }
+            : { left: 0, right: 0, top: 0, bottom: 20 }
         }
       >
         {referenceAreas && referenceAreas.map(areaProps => <ReferenceArea {...areaProps} />)}
@@ -195,13 +195,14 @@ export const CartesianChart = ({ viewContent, isEnlarged, isExporting }) => {
         />
         {(hasDataSeries || renderLegendForOneItem) && isEnlarged && (
           <Legend
-            verticalAlign="top"
-            align="left"
+            verticalAlign={legendPosition === 'bottom' ? 'bottom' : 'top'}
+            align={legendPosition === 'bottom' ? 'center' : 'left'}
             content={getCartesianLegend({
               chartConfig,
               getIsActiveKey,
               isExporting,
               onClick: onLegendClick,
+              legendPosition,
             })}
           />
         )}
@@ -235,10 +236,12 @@ CartesianChart.propTypes = {
   isEnlarged: PropTypes.bool,
   isExporting: PropTypes.bool,
   viewContent: PropTypes.shape(VIEW_CONTENT_SHAPE),
+  legendPosition: PropTypes.string,
 };
 
 CartesianChart.defaultProps = {
   isEnlarged: false,
   isExporting: false,
   viewContent: null,
+  legendPosition: 'bottom',
 };

--- a/packages/ui-components/src/components/Chart/Chart.js
+++ b/packages/ui-components/src/components/Chart/Chart.js
@@ -65,7 +65,7 @@ const getViewContent = viewContent => {
     : { ...viewContent, data: massagedData };
 };
 
-export const Chart = ({ viewContent, isExporting, isEnlarged, onItemClick }) => {
+export const Chart = ({ viewContent, isExporting, isEnlarged, onItemClick, legendPosition }) => {
   const { chartType } = viewContent;
 
   if (!Object.values(CHART_TYPES).includes(chartType)) {
@@ -89,6 +89,7 @@ export const Chart = ({ viewContent, isExporting, isEnlarged, onItemClick }) => 
       isExporting={isExporting}
       viewContent={viewContentConfig}
       onItemClick={onItemClick}
+      legendPosition={legendPosition}
     />
   );
 };
@@ -102,11 +103,13 @@ Chart.propTypes = {
   isEnlarged: PropTypes.bool,
   isExporting: PropTypes.bool,
   onItemClick: PropTypes.func,
+  legendPosition: PropTypes.string,
 };
 
 Chart.defaultProps = {
   viewContent: null,
   isEnlarged: true,
   isExporting: false,
+  legendPosition: 'bottom',
   onItemClick: () => {},
 };

--- a/packages/ui-components/src/components/Chart/Legend.js
+++ b/packages/ui-components/src/components/Chart/Legend.js
@@ -6,20 +6,17 @@
 import React from 'react';
 import styled from 'styled-components';
 import MuiButton from '@material-ui/core/Button';
+import Tooltip from '@material-ui/core/Tooltip';
 
 const LegendContainer = styled.div`
   display: flex;
   flex-wrap: wrap;
-  padding-bottom: 2rem;
+  justify-content: ${props => (props.position === 'bottom' ? 'center' : 'flex-start')};
+  padding: ${props => (props.position === 'bottom' ? '1rem 0 0 3.5rem' : '0 0 2rem 0')};
 `;
 
 const PieLegendContainer = styled(LegendContainer)`
-  padding-bottom: 0;
-
-  // preview styles
-  &.preview {
-    align-items: flex-start;
-  }
+  padding: 0;
 `;
 
 const getLegendTextColor = (theme, isExporting) => {
@@ -34,13 +31,10 @@ const getLegendTextColor = (theme, isExporting) => {
 };
 
 const LegendItem = styled(({ isExporting, ...props }) => <MuiButton {...props} />)`
-  display: flex;
-  justify-content: flex-start;
-  align-items: center;
   text-align: left;
   font-size: 0.75rem;
-  padding-bottom: 0.3rem;
-  padding-top: 0.3rem;
+  padding-bottom: 0;
+  padding-top: 0;
   margin-right: 1.2rem;
 
   .MuiButton-label {
@@ -59,13 +53,15 @@ const LegendItem = styled(({ isExporting, ...props }) => <MuiButton {...props} /
     padding-bottom: 0.1rem;
     padding-top: 0.1rem;
     margin-right: 0;
-    width: 50%;
-
-    .MuiButton-label {
-      display: flex;
-      align-items: flex-start;
-    }
   }
+`;
+
+const TooltipContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  padding-bottom: 0.3rem;
+  padding-top: 0.3rem;
 `;
 
 const Box = styled.span`
@@ -75,7 +71,7 @@ const Box = styled.span`
   margin-right: 0.625rem;
   border-radius: 3px;
 
-  // non enlarged styles
+  // preview styles
   &.preview {
     width: 0.8rem;
     min-width: 0.8rem;
@@ -90,8 +86,10 @@ const Text = styled.span`
 
 const getDisplayValue = (chartConfig, value) => chartConfig[value]?.label || value;
 
-export const getPieLegend = ({ chartConfig = {}, isEnlarged, isExporting }) => ({ payload }) => (
-  <PieLegendContainer className={isEnlarged ? 'enlarged' : 'preview'}>
+export const getPieLegend = ({ chartConfig = {}, isEnlarged, isExporting, legendPosition }) => ({
+  payload,
+}) => (
+  <PieLegendContainer position={legendPosition}>
     {payload.map(({ color, value }) => (
       <LegendItem
         key={value}
@@ -106,10 +104,14 @@ export const getPieLegend = ({ chartConfig = {}, isEnlarged, isExporting }) => (
   </PieLegendContainer>
 );
 
-export const getCartesianLegend = ({ chartConfig, onClick, getIsActiveKey, isExporting }) => ({
-  payload,
-}) => (
-  <LegendContainer>
+export const getCartesianLegend = ({
+  chartConfig,
+  onClick,
+  getIsActiveKey,
+  isExporting,
+  legendPosition,
+}) => ({ payload }) => (
+  <LegendContainer position={legendPosition}>
     {payload.map(({ color, value, dataKey }) => {
       return (
         <LegendItem
@@ -118,8 +120,12 @@ export const getCartesianLegend = ({ chartConfig, onClick, getIsActiveKey, isExp
           isExporting={isExporting}
           style={{ textDecoration: getIsActiveKey(value) ? '' : 'line-through' }}
         >
-          <Box style={{ background: color }} />
-          <Text>{getDisplayValue(chartConfig, value)}</Text>
+          <Tooltip title="Click to filter data" placement="top" arrow>
+            <TooltipContainer>
+              <Box style={{ background: color }} />
+              <Text>{getDisplayValue(chartConfig, value)}</Text>
+            </TooltipContainer>
+          </Tooltip>
         </LegendItem>
       );
     })}

--- a/packages/ui-components/src/components/Chart/PieChart.js
+++ b/packages/ui-components/src/components/Chart/PieChart.js
@@ -86,7 +86,7 @@ const chartColorAtIndex = (colorArray, index) => {
   return colorArray[index % colorArray.length];
 };
 
-export const PieChart = ({ viewContent, isExporting, isEnlarged, onItemClick }) => {
+export const PieChart = ({ viewContent, isExporting, isEnlarged, onItemClick, legendPosition }) => {
   const [activeIndex, setActiveIndex] = useState(-1);
 
   const handleMouseEnter = (event, index) => {
@@ -163,11 +163,16 @@ export const PieChart = ({ viewContent, isExporting, isEnlarged, onItemClick }) 
         </Pie>
         <Tooltip content={makeCustomTooltip(viewContent)} />
         <Legend
-          content={getPieLegend({ chartConfig: viewContent.chartConfig, isEnlarged, isExporting })}
+          content={getPieLegend({
+            chartConfig: viewContent.chartConfig,
+            isEnlarged,
+            isExporting,
+            legendPosition,
+          })}
           onMouseOver={handleMouseEnter}
           onMouseOut={handleMouseOut}
-          verticalAlign="top"
-          align="left"
+          verticalAlign={legendPosition === 'bottom' ? 'bottom' : 'top'}
+          align={legendPosition === 'bottom' ? 'center' : 'left'}
         />
       </BasePieChart>
     </ResponsiveContainer>
@@ -179,10 +184,12 @@ PieChart.propTypes = {
   isEnlarged: PropTypes.bool,
   isExporting: PropTypes.bool,
   onItemClick: PropTypes.func,
+  legendPosition: PropTypes.string,
 };
 
 PieChart.defaultProps = {
   isEnlarged: false,
   isExporting: false,
   onItemClick: () => {},
+  legendPosition: 'bottom',
 };

--- a/packages/ui-components/stories/chart/barChart.stories.js
+++ b/packages/ui-components/stories/chart/barChart.stories.js
@@ -21,6 +21,7 @@ export const LightTheme = LightThemeChartTemplate.bind({});
 LightTheme.args = {
   viewContent,
   isEnlarged: true,
+  legendPosition: 'top',
 };
 
 export const DarkTheme = DarkThemeTemplate.bind({});

--- a/packages/ui-components/stories/chart/composedChart.stories.js
+++ b/packages/ui-components/stories/chart/composedChart.stories.js
@@ -22,6 +22,7 @@ export const LightTheme = LightThemeChartTemplate.bind({});
 LightTheme.args = {
   viewContent,
   isEnlarged: true,
+  legendPosition: 'top',
 };
 
 export const DarkTheme = DarkThemeTemplate.bind({});

--- a/packages/ui-components/stories/chart/lineChart.stories.js
+++ b/packages/ui-components/stories/chart/lineChart.stories.js
@@ -22,6 +22,7 @@ export const LightTheme = LightThemeChartTemplate.bind({});
 LightTheme.args = {
   viewContent,
   isEnlarged: true,
+  legendPosition: 'top',
 };
 
 export const DarkTheme = DarkThemeTemplate.bind({});

--- a/packages/ui-components/stories/chart/pieChart.stories.js
+++ b/packages/ui-components/stories/chart/pieChart.stories.js
@@ -20,12 +20,12 @@ export default {
 export const LightTheme = LightThemeChartTemplate.bind({});
 LightTheme.args = {
   viewContent,
-  isEnlarged: true,
+  isEnlarged: false,
 };
 
 export const DarkTheme = DarkThemeTemplate.bind({});
 DarkTheme.args = {
   viewContent,
-  isEnlarged: true,
+  isEnlarged: false,
 };
 DarkTheme.parameters = { theme: 'dark' };

--- a/packages/ui-components/stories/chart/stackedBarChart.stories.js
+++ b/packages/ui-components/stories/chart/stackedBarChart.stories.js
@@ -21,6 +21,7 @@ export const LightTheme = LightThemeChartTemplate.bind({});
 LightTheme.args = {
   viewContent,
   isEnlarged: true,
+  legendPosition: 'top',
 };
 
 export const DarkTheme = DarkThemeTemplate.bind({});


### PR DESCRIPTION
### Issue #: [2156](https://github.com/beyondessential/tupaia-backlog/issues/2156) Add support for different legend positions

I have based the position and styling on a new prop called legendPosition. There are other options such as:
- using the theme type (light vs dark)
- adding a project prop (tupaia vs lesmis)
- adding a chartLayout or chartConfig prop

In the end I went with the legendPosition because it is more representative than the first 2 options and simpler than the third. It would be easy to refactor later to add something like chartLayout if needed.

### Changes:
- Add position and style legend based on legendPosition prop
- Added a tooltip to the legend buttons
---

### Screenshots:
see issue