### PR TITLE
Tweaks to existing LESMIS visuals

### DIFF
--- a/packages/database/src/migrations/20210623032946-AddDropoutRateByGrade-modifies-data.js
+++ b/packages/database/src/migrations/20210623032946-AddDropoutRateByGrade-modifies-data.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { insertObject, generateId, findSingleRecord } from '../utilities';
+import { insertObject, generateId, findSingleRecord, arrayToDbString } from '../utilities';
 
 var dbm;
 var type;
@@ -292,6 +292,12 @@ const removeDashboardItemAndReport = async (db, code) => {
   await db.runSql(`DELETE FROM report WHERE code = '${code}';`);
 };
 
+const OLD_DASHBOARD_ITEMS = [
+  'Laos_Schools_Dropout_Bar_Primary_District',
+  'Laos_Schools_Dropout_Bar_Lower_Secondary_District',
+  'Laos_Schools_Dropout_Bar_Upper_Secondary_District',
+];
+
 exports.up = async function (db) {
   for (const { code, reportConfig, frontEndConfig } of [
     PRIMARY,
@@ -303,11 +309,19 @@ exports.up = async function (db) {
       reportConfig,
       frontEndConfig,
       permissionGroup: 'LESMIS Public',
-      dashboardCode: 'LA_Students',
+      dashboardCode: 'LA_Student_Outcomes',
       entityTypes: ['sub_district'],
       projectCodes: ['laos_schools'],
     });
   }
+
+  // delete old dashboard items and legacy reports that were created for Laos Schools (cascades to relations)
+  await db.runSql(
+    `DELETE FROM dashboard_item WHERE code IN (${arrayToDbString(OLD_DASHBOARD_ITEMS)});`,
+  );
+  await db.runSql(
+    `DELETE FROM legacy_report WHERE code IN (${arrayToDbString(OLD_DASHBOARD_ITEMS)});`,
+  );
 };
 
 exports.down = async function (db) {

--- a/packages/database/src/migrations/20210623032946-AddDropoutRateByGrade-modifies-data.js
+++ b/packages/database/src/migrations/20210623032946-AddDropoutRateByGrade-modifies-data.js
@@ -21,6 +21,7 @@ const BASE_FRONT_END_CONFIG = {
   chartType: 'bar',
   yName: 'Dropout Rate',
   periodGranularity: 'one_year_at_a_time',
+  valueType: 'percentage',
   chartConfig: {
     Male: {
       color: '#f44336',
@@ -92,11 +93,11 @@ const PRIMARY = {
       {
         transform: 'select',
         "'Female'":
-          'sum([$row.dor_district_p1_f, $row.dor_district_p2_f, $row.dor_district_p3_f, $row.dor_district_p4_f, $row.dor_district_p5_f, $row.dor_district_pe_f])',
+          'sum([$row.dor_district_p1_f, $row.dor_district_p2_f, $row.dor_district_p3_f, $row.dor_district_p4_f, $row.dor_district_p5_f, $row.dor_district_pe_f]) / 100',
         "'Male'":
-          'sum([$row.dor_district_p1_m, $row.dor_district_p2_m, $row.dor_district_p3_m, $row.dor_district_p4_m, $row.dor_district_p5_m, $row.dor_district_pe_m])',
+          'sum([$row.dor_district_p1_m, $row.dor_district_p2_m, $row.dor_district_p3_m, $row.dor_district_p4_m, $row.dor_district_p5_m, $row.dor_district_pe_m]) / 100',
         "'Total'":
-          'sum([$row.dor_district_p1_t, $row.dor_district_p2_t, $row.dor_district_p3_t, $row.dor_district_p4_t, $row.dor_district_p5_t, $row.dor_district_pe_t])',
+          'sum([$row.dor_district_p1_t, $row.dor_district_p2_t, $row.dor_district_p3_t, $row.dor_district_p4_t, $row.dor_district_p5_t, $row.dor_district_pe_t]) / 100',
         '...': ['name'],
       },
       {

--- a/packages/database/src/migrations/20210623041504-AddNERGERLESMIS-modifies-data.js
+++ b/packages/database/src/migrations/20210623041504-AddNERGERLESMIS-modifies-data.js
@@ -61,11 +61,11 @@ const REPORT_CONFIG = {
     {
       transform: 'select',
       "'Male'":
-        'sum([$row.enrolment_rate_acronym_lesmis_entity_level_pe_m, $row.enrolment_rate_acronym_lesmis_entity_level_lse_m, $row.enrolment_rate_acronym_lesmis_entity_level_use_m])',
+        'sum([$row.enrolment_rate_acronym_lesmis_entity_level_pe_m, $row.enrolment_rate_acronym_lesmis_entity_level_lse_m, $row.enrolment_rate_acronym_lesmis_entity_level_use_m]) / 100',
       "'Female'":
-        'sum([$row.enrolment_rate_acronym_lesmis_entity_level_pe_f, $row.enrolment_rate_acronym_lesmis_entity_level_lse_f, $row.enrolment_rate_acronym_lesmis_entity_level_use_f])',
+        'sum([$row.enrolment_rate_acronym_lesmis_entity_level_pe_f, $row.enrolment_rate_acronym_lesmis_entity_level_lse_f, $row.enrolment_rate_acronym_lesmis_entity_level_use_f]) / 100',
       "'Total'":
-        'sum([$row.enrolment_rate_acronym_lesmis_entity_level_pe_t, $row.enrolment_rate_acronym_lesmis_entity_level_lse_t, $row.enrolment_rate_acronym_lesmis_entity_level_use_t])',
+        'sum([$row.enrolment_rate_acronym_lesmis_entity_level_pe_t, $row.enrolment_rate_acronym_lesmis_entity_level_lse_t, $row.enrolment_rate_acronym_lesmis_entity_level_use_t]) / 100',
       '...': ['name'],
     },
     {
@@ -110,18 +110,21 @@ const FRONT_END_CONFIG = {
       yName: 'Rate (%)',
       stackId: '1',
       legendOrder: '1',
+      valueType: 'percentage',
     },
     Female: {
       chartType: 'bar',
       color: '#2196f3',
       stackId: '2',
       legendOrder: '2',
+      valueType: 'percentage',
     },
     Total: {
       chartType: 'bar',
       color: '#9c27b0',
       stackId: '3',
       legendOrder: '3',
+      valueType: 'percentage',
     },
   },
 };

--- a/packages/database/src/migrations/20210624211254-AddChildrenOverAgeLESMIS-modifies-data.js
+++ b/packages/database/src/migrations/20210624211254-AddChildrenOverAgeLESMIS-modifies-data.js
@@ -53,9 +53,9 @@ const REPORT_CONFIG = {
     },
     {
       transform: 'select',
-      "'Female'": 'sum([$row.oafg_district_pe_f, $row.oafg_district_lse_f])',
-      "'Male'": 'sum([$row.oafg_district_pe_m, $row.oafg_district_lse_m])',
-      "'Total'": 'sum([$row.oafg_district_pe_t, $row.oafg_district_lse_t])',
+      "'Female'": 'sum([$row.oafg_district_pe_f, $row.oafg_district_lse_f]) / 100',
+      "'Male'": 'sum([$row.oafg_district_pe_m, $row.oafg_district_lse_m]) / 100',
+      "'Total'": 'sum([$row.oafg_district_pe_t, $row.oafg_district_lse_t]) / 100',
       '...': ['name'],
     },
     {
@@ -73,6 +73,7 @@ const FRONT_END_CONFIG = {
   xName: 'Level of Education',
   yName: '%',
   periodGranularity: 'one_year_at_a_time',
+  valueType: 'percentage',
   chartConfig: {
     Male: {
       color: '#f44336',

--- a/packages/database/src/migrations/20210624211254-AddChildrenOverAgeLESMIS-modifies-data.js
+++ b/packages/database/src/migrations/20210624211254-AddChildrenOverAgeLESMIS-modifies-data.js
@@ -17,84 +17,76 @@ exports.setup = function (options, seedLink) {
 };
 
 const DASHBOARD_CODE = 'LESMIS_International_SDGs_students';
-const CODE = 'LESMIS_percent_children_over_age';
 
-const REPORT_CONFIG = {
-  fetch: {
-    dataElements: [
-      'oafg_district_pe_f',
-      'oafg_district_pe_m',
-      'oafg_district_pe_t',
-      'oafg_district_lse_f',
-      'oafg_district_lse_m',
-      'oafg_district_lse_t',
-    ],
-    aggregations: [
+const getReportConfig = educationLevelAcronym => `
+{
+  "fetch": {
+    "aggregations": [
       {
-        type: 'MOST_RECENT',
-        config: {
-          dataSourceEntityType: 'sub_district',
-        },
-      },
+        "type": "MOST_RECENT",
+        "config": {
+          "dataSourceEntityType": "sub_district"
+        }
+      }
     ],
+    "dataElements": [
+      "oafg_district_${educationLevelAcronym}_f",
+      "oafg_district_${educationLevelAcronym}_m",
+      "oafg_district_${educationLevelAcronym}_t"
+    ]
   },
-  transform: [
+  "transform": [
+    "keyValueByDataElementName",
     {
-      transform: 'select',
-      "'name'":
-        "translate($row.dataElement, { oafg_district_pe_f: 'Primary', oafg_district_pe_m: 'Primary', oafg_district_pe_t: 'Primary', oafg_district_lse_f: 'Lower Secondary', oafg_district_lse_m: 'Lower Secondary', oafg_district_lse_t: 'Lower Secondary' })",
-      '...': '*',
-    },
-    'keyValueByDataElementName',
-    {
-      transform: 'aggregate',
-      name: 'group',
-      '...': 'last',
+      "transform": "select",
+      "'timestamp'": "periodToTimestamp($row.period)",
+      "...": "*"
     },
     {
-      transform: 'select',
-      "'Female'": 'sum([$row.oafg_district_pe_f, $row.oafg_district_lse_f]) / 100',
-      "'Male'": 'sum([$row.oafg_district_pe_m, $row.oafg_district_lse_m]) / 100',
-      "'Total'": 'sum([$row.oafg_district_pe_t, $row.oafg_district_lse_t]) / 100',
-      '...': ['name'],
+      "transform": "aggregate",
+      "timestamp": "group",
+      "...": "last"
     },
     {
-      transform: 'sort',
-      by: '$row.name',
-      descending: true,
-    },
-  ],
-};
+      "transform": "select",
+      "'Female'": "$row.oafg_district_${educationLevelAcronym}_f/100",
+      "'Male'": "$row.oafg_district_${educationLevelAcronym}_m/100",
+      "'Total'": "$row.oafg_district_${educationLevelAcronym}_t/100",
+      "...": ["timestamp"]
+    }
+  ]
+}
+`;
 
-const FRONT_END_CONFIG = {
-  name: 'Percentage of children over-age for grade',
-  type: 'chart',
-  chartType: 'bar',
-  xName: 'Level of Education',
-  yName: '%',
-  periodGranularity: 'one_year_at_a_time',
-  valueType: 'percentage',
-  chartConfig: {
-    Male: {
-      color: '#f44336',
-      stackId: '1',
-      legendOrder: '1',
+const getFrontEndConfig = educationLevel => `
+{
+  "name": "Percentage of children over-age for grade (${educationLevel})",
+  "type": "chart",
+  "chartType": "line",
+  "xName": "Year",
+  "yName": "%",
+  "periodGranularity": "one_year_at_a_time",
+  "valueType": "percentage",
+  "ticks": [0,0.25,0.5,0.75,1],
+  "chartConfig": {
+    "Male": {
+      "color": "#f44336",
+      "legendOrder": "1"
     },
-    Female: {
-      color: '#2196f3',
-      stackId: '2',
-      legendOrder: '2',
+    "Female": {
+      "color": "#2196f3",
+      "legendOrder": "2"
     },
-    Total: {
-      color: '#9c27b0',
-      stackId: '3',
-      legendOrder: '3',
-    },
+    "Total": {
+      "color": "#9c27b0",
+      "legendOrder": "3"
+    }
   },
-  presentationOptions: {
-    hideAverage: true,
-  },
-};
+  "presentationOptions": {
+    "hideAverage": true
+  }
+}
+`;
 
 const addNewDashboardItemAndReport = async (
   db,
@@ -147,6 +139,19 @@ const removeDashboardItemAndReport = async (db, code) => {
   await db.runSql(`DELETE FROM report WHERE code = '${code}';`);
 };
 
+const DASHBOARD_ITEMS = [
+  {
+    code: 'LESMIS_percent_children_over_age_pe',
+    educationLevel: 'Primary',
+    educationLevelAcronym: 'pe',
+  },
+  {
+    code: 'LESMIS_percent_children_over_age_lse',
+    educationLevel: 'LSE',
+    educationLevelAcronym: 'lse',
+  },
+];
+
 exports.up = async function (db) {
   await insertObject(db, 'dashboard', {
     id: generateId(),
@@ -154,19 +159,24 @@ exports.up = async function (db) {
     name: 'Students',
     root_entity_code: 'LA',
   });
-  await addNewDashboardItemAndReport(db, {
-    code: CODE,
-    reportConfig: REPORT_CONFIG,
-    frontEndConfig: FRONT_END_CONFIG,
-    permissionGroup: 'LESMIS Public',
-    dashboardCode: DASHBOARD_CODE,
-    entityTypes: ['sub_district'],
-    projectCodes: ['laos_schools'],
-  });
+
+  for (const { code, educationLevel, educationLevelAcronym } of DASHBOARD_ITEMS) {
+    await addNewDashboardItemAndReport(db, {
+      code,
+      reportConfig: getReportConfig(educationLevelAcronym),
+      frontEndConfig: getFrontEndConfig(educationLevel),
+      permissionGroup: 'LESMIS Public',
+      dashboardCode: DASHBOARD_CODE,
+      entityTypes: ['sub_district'],
+      projectCodes: ['laos_schools'],
+    });
+  }
 };
 
 exports.down = async function (db) {
-  await removeDashboardItemAndReport(db, CODE);
+  for (const { code } of DASHBOARD_ITEMS) {
+    await removeDashboardItemAndReport(db, code);
+  }
   await deleteObject(db, 'dashboard', { code: DASHBOARD_CODE });
 };
 

--- a/packages/lesmis/src/views/DashboardView.js
+++ b/packages/lesmis/src/views/DashboardView.js
@@ -149,7 +149,6 @@ const makeDropdownOptions = entityType => [
     ComponentProps: {
       filterSubDashboards: subDashboardFilters.internationalSDGs,
     },
-    useYearSelector: true,
   },
 ];
 


### PR DESCRIPTION
A few tweaks to existing migrations:
- Set up percentages correctly
- Put dropout rate visuals under the correct dashboard
- Delete old (duplicate) dropout rate visuals
- Convert over age report to two time series reports 

Going to merge this straight in so these tweaks are included when the server gets started up for testing on Monday morning, but please review post-hoc @EMcQ-BES 