### PR TITLE
3031 fix lesmis chart labels

### DIFF
--- a/packages/lesmis/src/constants/page.js
+++ b/packages/lesmis/src/constants/page.js
@@ -18,8 +18,9 @@ export const ABOUT_PAGE = {
         About LESMIS
       </Typography>
       <Typography>
-        LESMIS is a system to improve data quality, management and utilisation for the Ministry of
-        Education and Sports.
+        The Lao PDR Education and Sports Management Information System (LESMIS) is a GIS-enabled
+        data aggregation, analysis and visualization platform for improved data management and
+        utilization for monitoring and planning.
       </Typography>
     </>
   ),

--- a/packages/ui-components/src/components/Chart/XAxis.js
+++ b/packages/ui-components/src/components/Chart/XAxis.js
@@ -132,7 +132,7 @@ export const XAxis = ({ viewContent, isExporting, isEnlarged }) => {
       tick={getXAxisTickMethod()}
       tickFormatter={formatXAxisTick}
       padding={getXAxisPadding()}
-      tickSize={10}
+      tickSize={6}
       {...(getIsTimeSeries(data) ? AXIS_TIME_PROPS : {})}
     />
   );

--- a/packages/ui-components/src/components/Chart/YAxes.js
+++ b/packages/ui-components/src/components/Chart/YAxes.js
@@ -56,12 +56,12 @@ const calculateYAxisDomain = ({ min, max }) => {
 
 const containsClamp = ({ min, max }) => min.type === 'clamp' || max.type === 'clamp';
 
-const renderYAxisLabel = (label, orientation) => {
+const renderYAxisLabel = (label, orientation, fillColor) => {
   if (label)
     return {
       value: label,
       angle: -90,
-      fill: 'white',
+      fill: fillColor,
       style: { textAnchor: 'middle' },
       position: orientation === 'right' ? 'insideRight' : 'insideLeft',
     };

--- a/packages/ui-components/src/components/Chart/YAxes.js
+++ b/packages/ui-components/src/components/Chart/YAxes.js
@@ -85,20 +85,20 @@ const YAxis = ({ config = {}, viewContent, isExporting }) => {
     <YAxisComponent
       key={yAxisId}
       ticks={ticks}
-      tickSize={10}
+      tickSize={6}
       yAxisId={yAxisId}
       orientation={orientation}
       domain={calculateYAxisDomain(yAxisDomain)}
       allowDataOverflow={valueType === PERCENTAGE || containsClamp(yAxisDomain)}
       // The above 2 props stop floating point imprecision making Y axis go above 100% in stacked charts.
-      label={renderYAxisLabel(yName || yAxisLabel, orientation)}
+      label={renderYAxisLabel(yName || yAxisLabel, orientation, fillColor)}
       tickFormatter={value =>
         formatDataValueByType(
           {
             value,
             metadata: { presentationOptions },
           },
-          (valueType !== NUMBER ? valueType : 'default') || axisValueType,
+          valueType || axisValueType,
         )
       }
       interval={isExporting ? 0 : 'preserveStartEnd'}


### PR DESCRIPTION
### Issue #: [3031](https://github.com/beyondessential/tupaia-backlog/issues/3031) & [3018](https://github.com/beyondessential/tupaia-backlog/issues/3018)

### Changes:

- Fix chart label display color
- Fix label formatter to allow number formatting
- Tweak tick sizing
- Update about page text

---

### Screenshots:
see original issue