### PR TITLE
Allow composed graphs to specify individual labelTypes (and use those on GPI visuals)

### DIFF
--- a/packages/database/src/migrations/20210622234149-LESMISStudentCountToStackedBar-modifies-data.js
+++ b/packages/database/src/migrations/20210622234149-LESMISStudentCountToStackedBar-modifies-data.js
@@ -83,6 +83,8 @@ const REPORT_CONFIG = {
     {
       transform: 'select',
       "'GPI'": '$row.Female/$row.Male',
+      "'Male_metadata'": '{ total: $row.Male + $row.Female }',
+      "'Female_metadata'": '{ total: $row.Male + $row.Female }',
       '...': '*',
     },
   ],
@@ -103,6 +105,7 @@ const FRONT_END_CONFIG = {
     },
     Male: {
       chartType: 'bar',
+      labelType: 'fraction',
       color: '#f44336',
       stackId: '1',
       yName: 'Number of Students',
@@ -110,6 +113,7 @@ const FRONT_END_CONFIG = {
     },
     Female: {
       chartType: 'bar',
+      labelType: 'fraction',
       color: '#2196f3',
       stackId: '1',
       valueType: 'number',

--- a/packages/database/src/migrations/20210628030723-AddNumberTeachersByEducationLevel-modifies-data.js
+++ b/packages/database/src/migrations/20210628030723-AddNumberTeachersByEducationLevel-modifies-data.js
@@ -63,6 +63,8 @@ const REPORT_CONFIG = {
     {
       transform: 'select',
       "'GPI'": '$row.Female/$row.Male',
+      "'Male_metadata'": '{ total: $row.Male + $row.Female }',
+      "'Female_metadata'": '{ total: $row.Male + $row.Female }',
       '...': '*',
     },
     {
@@ -77,7 +79,7 @@ const REPORT_CONFIG = {
     },
     {
       transform: 'select',
-      '...': ['name', 'Male', 'Female', 'Total', 'GPI'],
+      '...': ['name', 'Male', 'Female', 'GPI', 'Male_metadata', 'Female_metadata'],
     },
   ],
 };
@@ -101,12 +103,14 @@ const FRONT_END_CONFIG = {
       stackId: '1',
       yName: 'Number of Students',
       valueType: 'number',
+      labelType: 'fraction',
     },
     Female: {
       chartType: 'bar',
       color: '#2196f3',
       stackId: '1',
       valueType: 'number',
+      labelType: 'fraction',
     },
   },
 };

--- a/packages/ui-components/src/components/Chart/Tooltip.js
+++ b/packages/ui-components/src/components/Chart/Tooltip.js
@@ -69,7 +69,11 @@ const MultiValueTooltip = ({
   const valueLabels = payload.map(({ dataKey, value, color }) => {
     const options = chartConfig && chartConfig[dataKey];
     const label = (options && options.label) || dataKey;
-    const valueTypeForLabel = labelType || valueType || get(chartConfig, [dataKey, 'valueType']);
+    const valueTypeForLabel =
+      labelType ||
+      valueType ||
+      get(chartConfig, [dataKey, 'labelType']) ||
+      get(chartConfig, [dataKey, 'valueType']);
 
     const metadata = data[`${dataKey}_metadata`] || data[`${data.name}_metadata`] || {};
 


### PR DESCRIPTION
### Issue #: 
- https://github.com/beyondessential/tupaia-backlog/issues/3024
- https://github.com/beyondessential/tupaia-backlog/issues/2850

### Changes:

- Look up the labelType on the individual chartConfigs in a composed chart
- Update migrations to add metadata and labelTypes 

---

### Screenshots:
New screenshots attached to tickets