### PR TITLE
Fix mobile chart legend display

### DIFF
--- a/packages/ui-components/src/components/Chart/Legend.js
+++ b/packages/ui-components/src/components/Chart/Legend.js
@@ -91,14 +91,11 @@ const getPieLegendDisplayValue = (chartConfig, value, item, isEnlarged, viewCont
     return chartConfig[value].label;
   }
 
-  const shouldShowValue = isMobile() && isEnlarged;
   const metadata = item[`${value}_metadata`];
+  const labelSuffix = formatDataValueByType({ value: item.value, metadata }, viewContent.valueType);
 
-  const labelSuffix = shouldShowValue
-    ? ` (${formatDataValueByType({ value: item.value, metadata }, viewContent.valueType)})`
-    : '';
-
-  return value + labelSuffix;
+  // on mobile the legend will show the actual formatDataValueByType after the label value
+  return isMobile() && isEnlarged ? `${value} ${labelSuffix}` : value;
 };
 
 export const getPieLegend = ({

--- a/packages/ui-components/src/components/Chart/Legend.js
+++ b/packages/ui-components/src/components/Chart/Legend.js
@@ -7,6 +7,7 @@ import React from 'react';
 import styled from 'styled-components';
 import MuiButton from '@material-ui/core/Button';
 import Tooltip from '@material-ui/core/Tooltip';
+import { formatDataValueByType } from '@tupaia/utils';
 import { isMobile } from './utils';
 
 const LegendContainer = styled.div`
@@ -51,8 +52,8 @@ const LegendItem = styled(({ isExporting, ...props }) => <MuiButton {...props} /
   // small styles
   &.small {
     font-size: 0.5rem;
-    padding-bottom: 0.1rem;
-    padding-top: 0.1rem;
+    padding-bottom: 0;
+    padding-top: 0;
     margin-right: 0;
   }
 `;
@@ -85,28 +86,55 @@ const Text = styled.span`
   line-height: 1.4;
 `;
 
-const getDisplayValue = (chartConfig, value) => chartConfig[value]?.label || value;
+const getPieLegendDisplayValue = (chartConfig, value, item, isEnlarged, viewContent) => {
+  if (chartConfig[value]?.label) {
+    return chartConfig[value].label;
+  }
 
-export const getPieLegend = ({ chartConfig = {}, isEnlarged, isExporting, legendPosition }) => ({
-  payload,
-}) => (
+  const shouldShowValue = isMobile() && isEnlarged;
+  const metadata = item[`${value}_metadata`];
+
+  const labelSuffix = shouldShowValue
+    ? ` (${formatDataValueByType({ value: item.value, metadata }, viewContent.valueType)})`
+    : '';
+
+  return value + labelSuffix;
+};
+
+export const getPieLegend = ({
+  chartConfig = {},
+  isEnlarged,
+  isExporting,
+  legendPosition,
+  viewContent,
+}) => ({ payload }) => (
   <PieLegendContainer position={legendPosition}>
-    {payload.map(({ color, value }) => (
-      <LegendItem
-        key={value}
-        isExporting={isExporting}
-        className={isEnlarged && !isMobile() ? 'enlarged' : 'small'}
-        disabled
-      >
-        <TooltipContainer>
-          <Box
-            className={isEnlarged && !isMobile() ? 'enlarged' : 'small'}
-            style={{ background: color }}
-          />
-          <Text>{getDisplayValue(chartConfig, value)}</Text>
-        </TooltipContainer>
-      </LegendItem>
-    ))}
+    {payload.map(({ color, value, payload: item }) => {
+      const displayValue = getPieLegendDisplayValue(
+        chartConfig,
+        value,
+        item,
+        isEnlarged,
+        viewContent,
+      );
+
+      return (
+        <LegendItem
+          key={value}
+          isExporting={isExporting}
+          className={isEnlarged && !isMobile() ? 'enlarged' : 'small'}
+          disabled
+        >
+          <TooltipContainer>
+            <Box
+              className={isEnlarged && !isMobile() ? 'enlarged' : 'small'}
+              style={{ background: color }}
+            />
+            <Text>{displayValue}</Text>
+          </TooltipContainer>
+        </LegendItem>
+      );
+    })}
   </PieLegendContainer>
 );
 
@@ -119,6 +147,8 @@ export const getCartesianLegend = ({
 }) => ({ payload }) => (
   <LegendContainer position={legendPosition}>
     {payload.map(({ color, value, dataKey }) => {
+      const displayValue = chartConfig[value]?.label || value;
+
       return (
         <LegendItem
           key={value}
@@ -130,7 +160,7 @@ export const getCartesianLegend = ({
           <Tooltip title="Click to filter data" placement="top" arrow>
             <TooltipContainer>
               <Box className={isMobile() ? 'small' : 'enlarged'} style={{ background: color }} />
-              <Text>{getDisplayValue(chartConfig, value)}</Text>
+              <Text>{displayValue}</Text>
             </TooltipContainer>
           </Tooltip>
         </LegendItem>

--- a/packages/ui-components/src/components/Chart/PieChart.js
+++ b/packages/ui-components/src/components/Chart/PieChart.js
@@ -116,7 +116,7 @@ export const PieChart = ({ viewContent, isExporting, isEnlarged, onItemClick, le
   };
 
   const getValidData = () => {
-    const { data, valueType } = viewContent;
+    const { data } = viewContent;
 
     return data
       .filter(element => element.value > 0)
@@ -126,15 +126,8 @@ export const PieChart = ({ viewContent, isExporting, isEnlarged, onItemClick, le
         let label = getPresentationOption(name, 'label');
         if (!label) label = name;
 
-        const shouldShowValue = isMobile() && isEnlarged;
-        const metadata = item[`${name}_metadata`];
-
-        const labelSuffix = shouldShowValue
-          ? ` (${formatDataValueByType({ value: item.value, metadata }, valueType)})`
-          : '';
-
         return {
-          name: label + labelSuffix,
+          name: label,
           ...otherKeyValues,
           originalItem: item,
         };
@@ -142,8 +135,7 @@ export const PieChart = ({ viewContent, isExporting, isEnlarged, onItemClick, le
       .sort((a, b) => b.value - a.value);
   };
 
-  const palette = CHART_COLOR_PALETTE;
-  const chartColors = Object.values(palette);
+  const chartColors = Object.values(CHART_COLOR_PALETTE);
   const validData = getValidData();
 
   // Due to the way the container margins stack, the pie chart renders
@@ -183,6 +175,7 @@ export const PieChart = ({ viewContent, isExporting, isEnlarged, onItemClick, le
             isEnlarged,
             isExporting,
             legendPosition,
+            viewContent,
           })}
           onMouseOver={handleMouseEnter}
           onMouseOut={handleMouseOut}


### PR DESCRIPTION
### Issue #: [3107](https://github.com/beyondessential/tupaia-backlog/issues/3107) Fix Pie Chart Tooltips on Mobile

### Changes:

- Move handling of mobile legend labels to legend component so that the legend value doesn't display on tooltips on mobile

---
