### PR TITLE
Fix login not working now that cacheBreaker removed

### DIFF
--- a/packages/web-config-server/src/apiV1/getUser.js
+++ b/packages/web-config-server/src/apiV1/getUser.js
@@ -1,4 +1,4 @@
 export const getUser = () => (req, res) => {
-  const { userName, email } = req.session.userJson;
+  const { userName, email } = req.userJson;
   res.send({ name: userName, email });
 };

--- a/packages/web-config-server/src/apiV1/projects.js
+++ b/packages/web-config-server/src/apiV1/projects.js
@@ -59,7 +59,7 @@ async function buildProjectDataForFrontend(project, req) {
   const homeEntityCode = getHomeEntityCode(project, entitiesWithAccess);
 
   // Only want to check pending if no access
-  const { userId } = req.session.userJson;
+  const { userId } = req.userJson;
   const hasPendingAccess = hasAccess
     ? false
     : await fetchHasPendingProjectAccess(projectId, userId, req);

--- a/packages/web-config-server/src/appServer/handlers/changePassword.js
+++ b/packages/web-config-server/src/appServer/handlers/changePassword.js
@@ -5,8 +5,8 @@ import { fetchFromMeditrakServerUsingTokens } from '/appServer/requestHelpers';
  * Required fields in req.body: 'oldPassword', 'password', 'passwordConfirm'
  */
 export const changePassword = async req => {
-  const { session, models, body } = req;
-  const { userName } = session.userJson;
+  const { models, body } = req;
+  const { userName } = req.userJson;
   const endpoint = 'me/changePassword';
 
   return fetchFromMeditrakServerUsingTokens(models, endpoint, body, null, userName);

--- a/packages/web-config-server/src/appServer/handlers/getCountryAccessList.js
+++ b/packages/web-config-server/src/appServer/handlers/getCountryAccessList.js
@@ -5,8 +5,8 @@ import { fetchFromMeditrakServerUsingTokens } from '/appServer/requestHelpers';
  * logged in user's access to them
  */
 export const getCountryAccessList = async req => {
-  const { session, models } = req;
-  const { userName } = session.userJson;
+  const { models } = req;
+  const { userName } = req.userJson;
   const endpoint = 'me/countries';
   return fetchFromMeditrakServerUsingTokens(models, endpoint, null, null, userName);
 };

--- a/packages/web-config-server/src/appServer/handlers/requestCountryAccess.js
+++ b/packages/web-config-server/src/appServer/handlers/requestCountryAccess.js
@@ -5,8 +5,8 @@ import { fetchFromMeditrakServerUsingTokens } from '/appServer/requestHelpers';
  * logged in user's access to them
  */
 export const requestCountryAccess = async req => {
-  const { session, models, body } = req;
-  const { userName } = session.userJson;
+  const { models, body } = req;
+  const { userName } = req.userJson;
   const endpoint = 'me/requestCountryAccess';
   return fetchFromMeditrakServerUsingTokens(models, endpoint, body, null, userName);
 };

--- a/packages/web-config-server/src/authSession/authSession.js
+++ b/packages/web-config-server/src/authSession/authSession.js
@@ -23,6 +23,7 @@ const auth = () => async (req, res, next) => {
     // if logged in
     const userId = req.session?.userJson?.userId;
     if (userId) {
+      req.userJson = req.session.userJson;
       req.accessPolicy = req.accessPolicy || (await getAccessPolicyForUser(authenticator, userId));
       next();
       return;
@@ -36,7 +37,7 @@ const auth = () => async (req, res, next) => {
     }
 
     // no previous login, authenticate as public user
-    setSession(req, { userName: PUBLIC_USER_NAME }); // store new session as public user
+    req.userJson = { userName: PUBLIC_USER_NAME };
     req.accessPolicy = await getAccessPolicyForUser(authenticator, PUBLIC_USER_NAME);
   } catch (error) {
     next(new UnauthenticatedError(error.message));

--- a/packages/web-config-server/src/authSession/authSession.js
+++ b/packages/web-config-server/src/authSession/authSession.js
@@ -7,8 +7,6 @@ import { getUserFromAuthHeader } from './getUserFromAuthHeader';
 import { getAccessPolicyForUser } from './getAccessPolicyForUser';
 import { PUBLIC_USER_NAME } from './publicAccess';
 
-const allowedUnauthRoutes = ['/login', '/version'];
-
 // auth is a middleware that runs on every request
 const auth = () => async (req, res, next) => {
   const { authenticator } = req;
@@ -22,9 +20,9 @@ const auth = () => async (req, res, next) => {
       return;
     }
 
-    // if logged in or logging in continue
+    // if logged in
     const userId = req.session?.userJson?.userId;
-    if (!!userId || checkAllowedUnauthRoutes(req)) {
+    if (userId) {
       req.accessPolicy = req.accessPolicy || (await getAccessPolicyForUser(authenticator, userId));
       next();
       return;
@@ -45,9 +43,6 @@ const auth = () => async (req, res, next) => {
   }
   next();
 };
-
-const checkAllowedUnauthRoutes = req =>
-  allowedUnauthRoutes.some(allowedRoute => req.originalUrl.endsWith(allowedRoute));
 
 export const setSession = (req, userInfo) => {
   req.accessPolicy = null; // reset access policy cache so it is rebuilt


### PR DESCRIPTION
The issue was that checkAllowedUnauthRoutes logic was wrong, because it considered query string.

Requests for /api/v1/login?cacheBreaker=xyz would return false, and the control flow would fall to the public access policy.

Removing cacheBreaker made checkAllowedUnauthRoutes return true, which caused a higher up if block to execute, which caused an error where a userId was expected but undefined.