### PR TITLE
Maintain long lived ModelRegistry in data-broker (fixes memory leak)

### DIFF
--- a/packages/data-broker/src/DataBroker.js
+++ b/packages/data-broker/src/DataBroker.js
@@ -10,19 +10,19 @@ import { ModelRegistry, TupaiaDatabase } from '@tupaia/database';
 import { countDistinct, toArray } from '@tupaia/utils';
 import { createService } from './services';
 
-let database;
+let modelRegistry;
 
-const getDatabaseInstance = () => {
-  if (!database) {
-    database = new TupaiaDatabase();
+const getModelRegistry = () => {
+  if (!modelRegistry) {
+    modelRegistry = new ModelRegistry(new TupaiaDatabase());
   }
-  return database;
+  return modelRegistry;
 };
 
 export class DataBroker {
   constructor(context = {}) {
     this.context = context;
-    this.models = new ModelRegistry(getDatabaseInstance());
+    this.models = getModelRegistry();
     this.resultMergers = {
       [this.getDataSourceTypes().DATA_ELEMENT]: this.mergeAnalytics,
       [this.getDataSourceTypes().DATA_GROUP]: this.mergeEvents,


### PR DESCRIPTION
Found the memory leak in web-config-server

How the memory leaks:
- A request for a dashboard report comes in to web-config-server
- It requests the data from aggregator
- Aggregator spins up a new DataBroker instance
- The DataBroker instance spins up a new ModelRegistry (but reuses the TupaiaDatabase instance, so same db connection)
- The ModelRegistry adds notification handlers to listen for changes, in order to have cache invalidation and trigger side effects
- These notification handlers are callbacks back into each model, and the ModelRegistry as a whole
- The callbacks are retained by the long-lived TupaiaDatabase instance, and each captures a reference to the database model that made it
- The data is returned back through the pipeline, and DataBroker instance is shut down, but the long-lived TupaiaDatabase instance still has the references to the models in the registry (via the notification handler callbacks), meaning they can't be garbage collected

And this happens on every request that involves data building!

This fix:
- Makes the ModelRegistry long-lived as well, so it doesn't create a new instance of the registry and each model, and notification handlers for each, for every request

Alternative fixes that may be better, but would mean a slower turnaround:
- Have short lived ModelRegistry instances not add notification handlers (requires them to somehow know they are short-lived)
- Have a cleanup function within the ModelRegistry that removes all of the callbacks from TupaiaDatabase, and call that cleanup when the DataBroker shuts down 

Would suggest we just release this fix, and address the underlying issue if we need many short-lived model registries in future. In the meantime will make the dev team aware that model registries should be created once per service