### PR TITLE
2813 spinner behind modal new (#2708)

### DIFF
--- a/packages/web-frontend/src/screens/desktop/RootScreen/index.js
+++ b/packages/web-frontend/src/screens/desktop/RootScreen/index.js
@@ -41,8 +41,8 @@ export const RootScreen = ({ enlargedDialogIsVisible, isLoading }) => {
         <OverlayDiv />
         <SessionExpiredDialog />
         {enlargedDialogIsVisible ? <EnlargedDialog /> : null}
+        <LoadingScreen isLoading={isLoading} />
       </OverlayContainer>
-      <LoadingScreen isLoading={isLoading} />
       <Map />
     </div>
   );


### PR DESCRIPTION
### Issue #: [2813](https://github.com/beyondessential/tupaia-backlog/issues/2813)

### Changes:
* pulled package.json from remote dev branch

* Loading spinner is now displaying behind popup window

* Update package.json

Co-authored-by: Tom Caiger <caigertom@gmail.com>

