### PR TITLE
3164: Admin Panel returns all dashboard relations when expanding a dashboard in Dashboard tab

### DIFF
--- a/packages/meditrak-server/src/routes/dashboardRelations/assertDashboardRelationsPermissions.js
+++ b/packages/meditrak-server/src/routes/dashboardRelations/assertDashboardRelationsPermissions.js
@@ -204,10 +204,6 @@ export const createDashboardRelationsViaParentDashboardDBFilter = (
   options,
   dashboardId,
 ) => {
-  if (hasBESAdminAccess(accessPolicy)) {
-    return { dbConditions: criteria, dbOptions: options };
-  }
-
   const dbConditions = { ...criteria };
   const allPermissionGroups = accessPolicy.getPermissionGroups();
   const countryCodesByPermissionGroup = {};


### PR DESCRIPTION
### Issue: https://github.com/beyondessential/tupaia-backlog/issues/3164

### Changes:

- Do not return all dashboard relations when expanding a dashboard if user is BES Admin
