### PR TITLE
Avoid creating spurious countries, throw error instead

### DIFF
--- a/packages/utils/src/getCountryCode.js
+++ b/packages/utils/src/getCountryCode.js
@@ -10,13 +10,7 @@ export const getCountryCode = (countryName, entityObjects = []) => {
   }
 
   const { getCode: getCountryIsoCode } = require('countrynames');
-  // Use the country ISO code if there's a direct match,
-  //otherwise base on the two letter facility code prefix
-  const countryCode =
-    getCountryIsoCode(countryName) || entityObjects.length
-      ? entityObjects[0].code.substring(0, 2)
-      : null;
-
+  const countryCode = getCountryIsoCode(countryName);
   if (!countryCode) throw new ImportValidationError(`${countryName} is not a recognised country`);
   return countryCode;
 };


### PR DESCRIPTION
@avaek is looking into why project entity imports are not getting a match on the country ISO code, but in the meantime we might as well get rid of the behaviour that's causing this and leave it as an error instead.