### PR TITLE
Ensure answers line up with their survey response in exports

### DIFF
--- a/packages/meditrak-server/src/routes/exportSurveyResponses/exportSurveyResponses.js
+++ b/packages/meditrak-server/src/routes/exportSurveyResponses/exportSurveyResponses.js
@@ -140,8 +140,8 @@ export async function exportSurveyResponses(req, res) {
           answers.forEach(({ 'question.id': questionId, text }) => {
             answersByQuestionId[questionId] = text;
           });
-          surveyResponseAnswers.push(answersByQuestionId);
         }
+        surveyResponseAnswers.push(answersByQuestionId);
       };
 
       if (surveyResponse) {


### PR DESCRIPTION
No issue for this, but @julianam-w reported that the answers for survey responses stopped lining up if you deleted all answers from a survey response early in the import file. 