### PR TITLE
Increase request timeout

### DIFF
--- a/packages/web-frontend/cypress.json
+++ b/packages/web-frontend/cypress.json
@@ -3,7 +3,7 @@
   "testFiles": "*.spec.js",
   "integrationFolder": "cypress/e2e",
   "projectId": "pty5cc",
-  "requestTimeout": 10000,
+  "requestTimeout": 15000,
   "useRelativeSnapshots": true,
   "viewportHeight": 900,
   "viewportWidth": 1400


### PR DESCRIPTION
Most of the reports in [default.json](https://github.com/beyondessential/tupaia/blob/dev/packages/web-frontend/cypress/config/dashboardReportUrls/default.json) load in 15secs. There are a couple that do not, which prevents us from testing them, but I am a bit hesitant to further increasing the timeout:

* It can act as a performance test (performance degradation can be caught earlier)
* Reports can timeout because they are slow, or because the url doesn't exist. The second scenario may happen because of invalid url configuration or bugs preventing the reports from loading. No reason to wait too long in those cases

Would like to get another opinion on that though. Another option would be using a very generous timeout for data correctness tests, and regularly run performance tests with a stricter timeout.