### PR TITLE
3032: Use POST for MultiEntity routes in Entity-Server  (#2823) test

### DIFF
--- a/packages/aggregator/src/connections/EntityConnection.js
+++ b/packages/aggregator/src/connections/EntityConnection.js
@@ -21,11 +21,14 @@ export class EntityConnection extends ApiConnection {
     dataSourceEntityType,
     dataSourceEntityFilter = {}, // TODO: Add support for dataSourceEntityFilter https://github.com/beyondessential/tupaia-backlog/issues/2660
   ) {
-    return this.get(`hierarchy/${hierarchyName}/relatives`, {
-      entities: entityCodes.join(','),
-      descendant_filter: `type:${dataSourceEntityType}`,
-      field: 'code',
-    });
+    return this.post(
+      `hierarchy/${hierarchyName}/relatives`,
+      {
+        filter: `type:${dataSourceEntityType}`,
+        field: 'code',
+      },
+      { entities: entityCodes },
+    );
   }
 
   async getDataSourceEntitiesAndRelationships(
@@ -36,7 +39,6 @@ export class EntityConnection extends ApiConnection {
     dataSourceEntityFilter = {}, // TODO: Add support for dataSourceEntityFilter https://github.com/beyondessential/tupaia-backlog/issues/2660
   ) {
     const query = {
-      entities: entityCodes.join(','),
       descendant_filter: `type:${dataSourceEntityType}`,
       field: 'code',
       groupBy: 'descendant',
@@ -47,7 +49,9 @@ export class EntityConnection extends ApiConnection {
       query.ancestor_filter = `type:${aggregationEntityType}`;
     }
 
-    const response = await this.get(`hierarchy/${hierarchyName}/relationships`, query);
+    const response = await this.post(`hierarchy/${hierarchyName}/relationships`, query, {
+      entities: entityCodes,
+    });
 
     const formattedRelationships = {};
     Object.entries(response).forEach(([descendant, ancestor]) => {

--- a/packages/entity-server/examples.http
+++ b/packages/entity-server/examples.http
@@ -29,9 +29,13 @@ content-type: {{contentType}}
 Authorization: {{authorization}}
 
 ### Fetch descendants of multiple entities
-GET http://{{host}}/{{version}}/hierarchy/explore/descendants?entities=TO,PG&field=code&includeRootEntity=true HTTP/1.1
+POST http://{{host}}/{{version}}/hierarchy/explore/descendants?field=code&includeRootEntity=true HTTP/1.1
 content-type: {{contentType}}
 Authorization: {{authorization}}
+
+{
+    "entities" : ["TO","PG"]
+}
 
 ### Fetch relatives of an entity
 GET http://{{host}}/{{version}}/hierarchy/explore/TO_Tongatapu_Mua/relatives?field=code HTTP/1.1
@@ -44,9 +48,13 @@ content-type: {{contentType}}
 Authorization: {{authorization}}
 
 ### Fetch relatives of multiple entities
-GET http://{{host}}/{{version}}/hierarchy/explore/relatives?entities=TO_Tongatapu_Haatafu,PG_Sau_ASP&field=code HTTP/1.1
+POST http://{{host}}/{{version}}/hierarchy/explore/relatives?field=code HTTP/1.1
 content-type: {{contentType}}
 Authorization: {{authorization}}
+
+{
+    "entities": ["TO_Tongatapu_Haatafu","PG_Sau_ASP"]
+}
 
 ### Fetch relationships among relatives of an entity
 GET http://{{host}}/{{version}}/hierarchy/explore/TO/relationships?descendant_filter=type:village&ancestor_field=code&descendant_field=name&groupBy=ancestor HTTP/1.1
@@ -59,6 +67,10 @@ content-type: {{contentType}}
 Authorization: {{authorization}}
 
 ### Fetch relationships among relatives of multiple entities
-GET http://{{host}}/{{version}}/hierarchy/explore/relationships?entities=TO_Tongatapu_Haatafu,PG_Sau_ASP&descendant_filter=type:district&ancestor_filter=type:country&ancestor_field=code&descendant_field=name&groupBy=descendant HTTP/1.1
+POST http://{{host}}/{{version}}/hierarchy/explore/relationships?descendant_filter=type:district&ancestor_filter=type:country&ancestor_field=code&descendant_field=name&groupBy=descendant HTTP/1.1
 content-type: {{contentType}}
 Authorization: {{authorization}}
+
+{
+    "entities":["TO_Tongatapu_Haatafu","PG_Sau_ASP"]
+}

--- a/packages/entity-server/src/app/createApp.ts
+++ b/packages/entity-server/src/app/createApp.ts
@@ -39,11 +39,11 @@ export function createApp() {
     .use<MultiEntityRequest>('hierarchy/:hierarchyName/descendants', attachMultiEntityContext)
     .use<MultiEntityRequest>('hierarchy/:hierarchyName/relatives', attachMultiEntityContext)
     .use<MultiEntityRequest>('hierarchy/:hierarchyName/relationships', attachMultiEntityContext)
-    .get<MultiEntityDescendantsRequest>(
+    .post<MultiEntityDescendantsRequest>(
       'hierarchy/:hierarchyName/descendants',
       handleWith(MultiEntityDescendantsRoute),
     )
-    .get<MultiEntityRelativesRequest>(
+    .post<MultiEntityRelativesRequest>(
       'hierarchy/:hierarchyName/relatives',
       handleWith(MultiEntityRelativesRoute),
     )
@@ -51,7 +51,7 @@ export function createApp() {
       'hierarchy/:hierarchyName/relationships',
       attachRelationshipsContext,
     )
-    .get<MultiEntityRelationshipsRequest>(
+    .post<MultiEntityRelationshipsRequest>(
       'hierarchy/:hierarchyName/relationships',
       handleWith(MultiEntityRelationshipsRoute),
     )

--- a/packages/entity-server/src/routes/hierarchy/EntityDescendantsRoute.ts
+++ b/packages/entity-server/src/routes/hierarchy/EntityDescendantsRoute.ts
@@ -9,7 +9,7 @@ import {
   SingleEntityRequest,
   SingleEntityRequestParams,
   RequestBody,
-  SingleEntityRequestQuery,
+  EntityRequestQuery,
   EntityResponse,
 } from './types';
 
@@ -17,7 +17,7 @@ export type DescendantsRequest = SingleEntityRequest<
   SingleEntityRequestParams,
   EntityResponse[],
   RequestBody,
-  SingleEntityRequestQuery & { includeRootEntity?: boolean }
+  EntityRequestQuery & { includeRootEntity?: boolean }
 >;
 export class EntityDescendantsRoute extends Route<DescendantsRequest> {
   async buildResponse() {

--- a/packages/entity-server/src/routes/hierarchy/EntityRelativesRoute.ts
+++ b/packages/entity-server/src/routes/hierarchy/EntityRelativesRoute.ts
@@ -9,7 +9,7 @@ import {
   SingleEntityRequest,
   SingleEntityRequestParams,
   RequestBody,
-  SingleEntityRequestQuery,
+  EntityRequestQuery,
   EntityResponse,
 } from './types';
 
@@ -17,7 +17,7 @@ export type RelativesRequest = SingleEntityRequest<
   SingleEntityRequestParams,
   EntityResponse[],
   RequestBody,
-  SingleEntityRequestQuery
+  EntityRequestQuery
 >;
 export class EntityRelativesRoute extends Route<RelativesRequest> {
   async buildResponse() {

--- a/packages/entity-server/src/routes/hierarchy/MultiEntityDescendantsRoute.ts
+++ b/packages/entity-server/src/routes/hierarchy/MultiEntityDescendantsRoute.ts
@@ -8,16 +8,16 @@ import { formatEntitiesForResponse } from './format';
 import {
   MultiEntityRequest,
   MultiEntityRequestParams,
-  RequestBody,
-  MultiEntityRequestQuery,
+  MultiEntityRequestBody,
+  EntityRequestQuery,
   EntityResponse,
 } from './types';
 
 export type MultiEntityDescendantsRequest = MultiEntityRequest<
   MultiEntityRequestParams,
   EntityResponse[],
-  RequestBody,
-  MultiEntityRequestQuery & { includeRootEntity?: boolean }
+  MultiEntityRequestBody,
+  EntityRequestQuery & { includeRootEntity?: boolean }
 >;
 export class MultiEntityDescendantsRoute extends Route<MultiEntityDescendantsRequest> {
   async buildResponse() {

--- a/packages/entity-server/src/routes/hierarchy/MultiEntityRelativesRoute.ts
+++ b/packages/entity-server/src/routes/hierarchy/MultiEntityRelativesRoute.ts
@@ -5,19 +5,11 @@
 
 import { Route } from '@tupaia/server-boilerplate';
 import { formatEntitiesForResponse } from './format';
-import {
-  MultiEntityRequest,
-  MultiEntityRequestParams,
-  RequestBody,
-  MultiEntityRequestQuery,
-  EntityResponse,
-} from './types';
+import { MultiEntityRequest, MultiEntityRequestParams, EntityResponse } from './types';
 
 export type MultiEntityRelativesRequest = MultiEntityRequest<
   MultiEntityRequestParams,
-  EntityResponse[],
-  RequestBody,
-  MultiEntityRequestQuery
+  EntityResponse[]
 >;
 export class MultiEntityRelativesRoute extends Route<MultiEntityRelativesRequest> {
   async buildResponse() {

--- a/packages/entity-server/src/routes/hierarchy/middleware/attachEntityContext.ts
+++ b/packages/entity-server/src/routes/hierarchy/middleware/attachEntityContext.ts
@@ -76,11 +76,10 @@ export const attachMultiEntityContext = async (
   next: NextFunction,
 ) => {
   try {
-    const { entities: queryEntities } = req.query;
-    if (!queryEntities) {
-      throw new Error('Must provide entities=code1,code2,.. url parameter');
+    const { entities: entityCodes } = req.body;
+    if (!entityCodes) {
+      throw new Error('Must provide { "entities": [code1,code2,...] } in request body');
     }
-    const entityCodes = queryEntities.split(',');
 
     const context = await validateEntitiesAndBuildContext(req, entityCodes);
 

--- a/packages/entity-server/src/routes/hierarchy/relationships/types.ts
+++ b/packages/entity-server/src/routes/hierarchy/relationships/types.ts
@@ -8,7 +8,8 @@ import {
   SingleEntityRequestParams,
   MultiEntityRequestParams,
   RequestBody,
-  SingleEntityRequestQuery,
+  MultiEntityRequestBody,
+  EntityRequestQuery,
   SingleEntityContext,
   MultiEntityContext,
   FlattableEntityFields,
@@ -20,7 +21,7 @@ export type Prefix<T, P extends string> = {
   [field in keyof T & string as `${P}_${field}`]: T[field];
 };
 
-export type RelationshipsSubQuery = Omit<SingleEntityRequestQuery, 'fields'>;
+export type RelationshipsSubQuery = Omit<EntityRequestQuery, 'fields'>;
 export type RelationshipsQuery = RelationshipsSubQuery & {
   groupBy?: 'ancestor' | 'descendant';
 } & Partial<Prefix<RelationshipsSubQuery, 'ancestor'>> &
@@ -66,8 +67,8 @@ export interface MultiEntityRelationshipsRequest
   extends Request<
     MultiEntityRequestParams,
     RelationshipsResponseBody,
-    RequestBody,
-    RelationshipsQuery & { entities?: string }
+    MultiEntityRequestBody,
+    RelationshipsQuery
   > {
   ctx: MultiEntityRelationshipsContext;
 }

--- a/packages/entity-server/src/routes/hierarchy/types.ts
+++ b/packages/entity-server/src/routes/hierarchy/types.ts
@@ -19,14 +19,14 @@ export interface MultiEntityRequestParams {
 
 export type RequestBody = Record<string, unknown>;
 
-export interface SingleEntityRequestQuery {
+export type MultiEntityRequestBody = RequestBody & {
+  entities?: string[];
+};
+
+export interface EntityRequestQuery {
   fields?: string;
   field?: string;
   filter?: string;
-}
-
-export interface MultiEntityRequestQuery extends SingleEntityRequestQuery {
-  entities?: string;
 }
 
 export type ExtendedFieldFunctions = Readonly<
@@ -76,7 +76,7 @@ export interface SingleEntityRequest<
   P = SingleEntityRequestParams,
   ResBody = EntityResponse,
   ReqBody = RequestBody,
-  ReqQuery = SingleEntityRequestQuery
+  ReqQuery = EntityRequestQuery
 > extends Request<P, ResBody, ReqBody, ReqQuery> {
   ctx: SingleEntityContext;
 }
@@ -84,8 +84,8 @@ export interface SingleEntityRequest<
 export interface MultiEntityRequest<
   P = MultiEntityRequestParams,
   ResBody = EntityResponse,
-  ReqBody = RequestBody,
-  ReqQuery = MultiEntityRequestQuery
+  ReqBody = MultiEntityRequestBody,
+  ReqQuery = EntityRequestQuery
 > extends Request<P, ResBody, ReqBody, ReqQuery> {
   ctx: MultiEntityContext;
 }

--- a/packages/server-boilerplate/src/microService/api/ApiBuilder.ts
+++ b/packages/server-boilerplate/src/microService/api/ApiBuilder.ts
@@ -81,6 +81,14 @@ export class ApiBuilder {
     return this;
   }
 
+  post<T extends ExpressRequest<T> = Request>(
+    path: string,
+    handler: RequestHandler<Params<T>, ResBody<T>, ReqBody<T>, Query<T>>,
+  ) {
+    this.app.post(this.formatPath(path), handler);
+    return this;
+  }
+
   build() {
     /**
      * Test Route


### PR DESCRIPTION
* 3032: Switch entity-server multi entity routes to POST instead of GET

* 3032: Fixed bug in EntityConnection in Aggregator where incorrect param was being used to filter dataSourceEntities

Co-authored-by: Bindu madhavi tammireddy <41365985+BinduMadhaviTammireddy@users.noreply.github.com>

### Issue #:

### Changes:

- Example

---

### Screenshots:
