### PR TITLE
Release hotfix: add missing config file

### DIFF
--- a/e2e.Dockerfile
+++ b/e2e.Dockerfile
@@ -25,6 +25,9 @@ COPY packages/utils/package.json ./packages/utils
 
 RUN SKIP_BUILD_INTERNAL_DEPENDENCIES=true yarn install
 
+# Copy TS config used in internal dependencies
+COPY tsconfig-js.json ./
+
 COPY packages/access-policy/. ./packages/access-policy
 COPY packages/auth/. ./packages/auth
 COPY packages/database/. ./packages/database

--- a/full-testable-package.Dockerfile
+++ b/full-testable-package.Dockerfile
@@ -69,6 +69,9 @@ COPY packages/web-frontend/package.json ./packages/web-frontend
 ## within internal dependencies invalidating it
 RUN SKIP_BUILD_INTERNAL_DEPENDENCIES=true yarn install
 
+# Copy TS config used in internal dependencies
+COPY tsconfig-js.json ./
+
 ## add content of all internal dependency packages ready for internal dependencies to be built
 COPY packages/access-policy/. ./packages/access-policy
 COPY packages/aggregator/. ./packages/aggregator


### PR DESCRIPTION
Bug introduced in https://github.com/beyondessential/tupaia/commit/a426843ca4127b3460597fc00ef8444a2f0a5daf. At that time I spun up a new EC2 instance and everything went fine, but now I believe this was just because of cached layers in the build.

I will wait for the build to pass to make sure that this works as intended