### PR TITLE
Fix dump database script - dump location

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build-admin-panel": "yarn workspace @tupaia/admin-panel build",
     "build-internal-dependencies": "./scripts/bash/buildInternalDependencies.sh",
     "build-web-frontend": "yarn workspace @tupaia/web-frontend build",
-    "dump-database": "yarn workspace @tupaia/database dump-database",
+    "dump-database": "yarn workspace @tupaia/database dump-database --target ../../",
     "migrate": "yarn workspace @tupaia/database migrate",
     "migrate-create": "yarn workspace @tupaia/database migrate-create",
     "migrate-down": "yarn workspace @tupaia/database migrate-down",

--- a/packages/database/scripts/dumpDatabase.sh
+++ b/packages/database/scripts/dumpDatabase.sh
@@ -3,42 +3,55 @@
 # Exit when any command fails
 set -e
 
-USAGE="Usage: dumpDb identity_file [-s --server =dev] [-t --target =.]"
+function print_help() {
+    cat <<EOF
+dumpDatabase.sh <identity_file>
+
+Options:
+  -h, --help     Show help                                                       [boolean]
+  -s, --server   Stage name of the EC2 instance that will be used (default: dev) [string]
+  -t, --target   Directory to store the dump under                               [string]
+EOF
+}
+
 DUMP_FILE_NAME="dump.sql"
 
+identity_file=""
 server="dev"
 target_dir="."
-identity_file="$1"
 
-if [ "$identity_file" == "" ]; then
-    echo "No identity file provided"
-    echo $USAGE
-    exit 1
-fi
-
-while [ "$2" != "" ]; do
-    case $2 in
+while [ "$1" != "" ]; do
+    case $1 in
     -s | --server)
         shift
-        server=$2
+        server=$1
         shift
         ;;
     -t | --target)
         shift
-        target_dir=$2
+        target_dir=$1
         shift
         ;;
     -h | --help)
-        echo "Will download a dump of the latest Tupaia database into the specified target path"
-        echo $USAGE
+        print_help
         exit
         ;;
     *)
-        echo $USAGE
-        exit 1
+        if [ "$identity_file" == "" ]; then
+            identity_file=$1
+            shift
+        else
+            print_help
+            exit 1
+        fi
         ;;
     esac
 done
+
+if [ "$identity_file" == "" ]; then
+    print_help
+    exit 1
+fi
 
 domain=$server-ssh.tupaia.org
 host="ubuntu@$domain"

--- a/packages/devops/scripts/ci/validateBranchName.sh
+++ b/packages/devops/scripts/ci/validateBranchName.sh
@@ -60,7 +60,6 @@ function validate_name_chars() {
 }
 
 branch_name=$(get_branch_name)
-check_name_is_not_reserved $branch_name
 validate_name_ending $branch_name
 validate_name_length $branch_name
 validate_name_chars $branch_name


### PR DESCRIPTION
After I recently move those scripts under the `packages/database` folder, the `dumpDatabase` script will download the dump file in that location.

The previous behaviour was downloading the dump in the monorepo root by default. This is also assumed by the `yarn refresh-database` script defined in the root `package.json`, which expects the dump to be in the root. This script re-instates the previous behaviour regarding dump default locations