### PR TITLE
3202: Added 'most_recent' aggregation function to the database

### DIFF
--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -40,7 +40,7 @@ e2e:
     - /dev/shm:/dev/shm
 
 db:
-  image: mdillon/postgis:9.6-alpine
+  image: mdillon/postgis:10-alpine
   cached: true
   encrypted_dockercfg_path: dockercfg.encrypted
 

--- a/packages/database/src/migrations/20210715093133-AddMostRecentAggregationFunction-modifies-schema.js
+++ b/packages/database/src/migrations/20210715093133-AddMostRecentAggregationFunction-modifies-schema.js
@@ -1,0 +1,69 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function (db) {
+  return db.runSql(`
+
+  drop aggregate if exists most_recent(text, timestamp);
+  
+  drop function if exists most_recent_fn;
+  
+  drop function if exists most_recent_final_fn;
+
+  drop type if exists value_and_date;
+
+  create type value_and_date as (
+    value text,
+    date timestamp
+  );
+  
+  create FUNCTION most_recent_fn(value_and_date,text,timestamp) RETURNS value_and_date AS $$
+    SELECT 
+      case
+        when $3 > $1.date then ($2, $3)::value_and_date 
+        else $1
+      end
+  $$ LANGUAGE SQL; 
+  
+  create FUNCTION most_recent_final_fn(value_and_date) RETURNS text AS $$
+      SELECT $1.value;
+  $$ LANGUAGE SQL; 
+  
+  create AGGREGATE most_recent(text, timestamp) (
+      sfunc = most_recent_fn,
+      stype = value_and_date, 
+      finalfunc = most_recent_final_fn,
+      initcond = '(NULL,-infinity)'
+  );
+  `);
+};
+
+exports.down = function (db) {
+  return db.runSql(`
+  
+  drop aggregate if exists most_recent(text, timestamp);
+  
+  drop function if exists most_recent_fn;
+  
+  drop function if exists most_recent_final_fn;
+
+  drop type if exists value_and_date;
+  `);
+};
+
+exports._meta = {
+  version: 1,
+};


### PR DESCRIPTION
### Issue https://github.com/beyondessential/tupaia-backlog/issues/3202:

Part of: https://github.com/beyondessential/tupaia/pull/2887
Can be merged independently

Here we're adding a new aggregation function to the database. In order to ensure the tests pass, I've also updated the docker image we use for the database during tests to be version 10 of postgres (the same as we use in deployment instances).

- [x] Test that when merging this branch to a branch that has the older version of postgres, the image updates and gets cached correctly