### PR TITLE
Rename viz builder store

### DIFF
--- a/packages/admin-panel/src/VizBuilderApp/App.js
+++ b/packages/admin-panel/src/VizBuilderApp/App.js
@@ -10,7 +10,7 @@ import { FullPageLoader } from '@tupaia/ui-components';
 import { Main } from './views/Main';
 import { CreateNew } from './views/CreateNew';
 import { useUser } from './api/queries';
-import { StoreProvider } from './store';
+import { VizBuilderConfigProvider as StateProvider } from './vizBuilderConfigStore';
 
 const Container = styled.main`
   display: flex;
@@ -33,7 +33,7 @@ export const App = ({ Navbar, Footer }) => {
   const user = { ...data, name: `${data.firstName} ${data.lastName}` };
 
   return (
-    <StoreProvider>
+    <StateProvider>
       <Container>
         {Navbar && <Navbar user={user} isBESAdmin={isBESAdmin} />}
         <Switch>
@@ -46,7 +46,7 @@ export const App = ({ Navbar, Footer }) => {
         </Switch>
         {Footer && <Footer />}
       </Container>
-    </StoreProvider>
+    </StateProvider>
   );
 };
 

--- a/packages/admin-panel/src/VizBuilderApp/components/MetadataForm.js
+++ b/packages/admin-panel/src/VizBuilderApp/components/MetadataForm.js
@@ -7,11 +7,11 @@ import PropTypes from 'prop-types';
 import { useForm } from 'react-hook-form';
 import { Autocomplete, TextField } from '@tupaia/ui-components';
 import { usePermissionGroups, useProjects } from '../api/queries';
-import { useStore } from '../store';
+import { useVizBuilderConfig } from '../vizBuilderConfigStore';
 
 export const MetadataForm = ({ Header, Body, Footer, onSubmit }) => {
   const { handleSubmit, register, errors } = useForm();
-  const [state, { setValue, setProject }] = useStore();
+  const [state, { setValue, setProject }] = useVizBuilderConfig();
   const { data: projects = [], isLoading: isLoadingProjects } = useProjects();
   const {
     data: permissionGroups = [],

--- a/packages/admin-panel/src/VizBuilderApp/components/Panel.js
+++ b/packages/admin-panel/src/VizBuilderApp/components/Panel.js
@@ -12,7 +12,7 @@ import { FlexColumn, FlexSpaceBetween } from '@tupaia/ui-components';
 import { TabPanel } from './TabPanel';
 import { JsonEditor } from './JsonEditor';
 import { PlayButton } from './PlayButton';
-import { useStore } from '../store';
+import { useVizBuilderConfig } from '../vizBuilderConfigStore';
 
 const Container = styled(FlexColumn)`
   position: relative;
@@ -70,7 +70,7 @@ const PanelTabPanel = styled.div`
 
 export const Panel = ({ setEnabled }) => {
   const [tab, setTab] = useState(0);
-  const [{ data: dataConfig }, { setDataConfig, setFetchConfig }] = useStore();
+  const [{ data: dataConfig }, { setDataConfig, setFetchConfig }] = useVizBuilderConfig();
 
   const { dataElements, dataGroups, aggregations, transform } = dataConfig;
 

--- a/packages/admin-panel/src/VizBuilderApp/components/PreviewOptions.js
+++ b/packages/admin-panel/src/VizBuilderApp/components/PreviewOptions.js
@@ -9,7 +9,7 @@ import debounce from 'lodash.debounce';
 import MuiPaper from '@material-ui/core/Paper';
 import { Autocomplete as AutocompleteComponent, FlexStart } from '@tupaia/ui-components';
 import { useLocations } from '../api/queries';
-import { useStore } from '../store';
+import { useVizBuilderConfig } from '../vizBuilderConfigStore';
 
 const Container = styled(FlexStart)`
   padding-top: 24px;
@@ -48,7 +48,7 @@ const PaperComponent = styled(MuiPaper)`
 
 const LocationField = () => {
   const [search, setSearch] = useState('');
-  const [{ project, location }, { setValue }] = useStore();
+  const [{ project, location }, { setValue }] = useVizBuilderConfig();
 
   // Show the default options in the dropdown when an item is selected.
   // Otherwise it shows no options

--- a/packages/admin-panel/src/VizBuilderApp/components/PreviewSection.js
+++ b/packages/admin-panel/src/VizBuilderApp/components/PreviewSection.js
@@ -10,7 +10,7 @@ import MuiTabs from '@material-ui/core/Tabs';
 import { Chart, Table } from '@tupaia/ui-components/lib/chart';
 import { FlexSpaceBetween, FetchLoader } from '@tupaia/ui-components';
 import { TabPanel } from './TabPanel';
-import { useStore } from '../store';
+import { useVizBuilderConfig } from '../vizBuilderConfigStore';
 import { useReportPreview } from '../api';
 import { JsonEditor } from './JsonEditor';
 import { IdleMessage } from './IdleMessage';
@@ -87,7 +87,7 @@ const EditorContainer = styled.div`
 `;
 
 export const PreviewSection = ({ enabled, setEnabled }) => {
-  const [state, { setPresentation }] = useStore();
+  const [state, { setPresentation }] = useVizBuilderConfig();
   const { data = [], isIdle, isLoading, isFetching, isError, error } = useReportPreview(
     state,
     enabled,

--- a/packages/admin-panel/src/VizBuilderApp/components/SaveButton.js
+++ b/packages/admin-panel/src/VizBuilderApp/components/SaveButton.js
@@ -5,10 +5,10 @@
 
 import React from 'react';
 import { Button } from '@tupaia/ui-components';
-import { useStore } from '../store';
+import { useVizBuilderConfig } from '../vizBuilderConfigStore';
 
 export const SaveButton = () => {
-  const [config] = useStore();
+  const [config] = useVizBuilderConfig();
 
   const handleSave = () => {
     alert(JSON.stringify(config, null, 2));

--- a/packages/admin-panel/src/VizBuilderApp/components/Toolbar.js
+++ b/packages/admin-panel/src/VizBuilderApp/components/Toolbar.js
@@ -13,7 +13,7 @@ import { FlexStart, FlexEnd } from '@tupaia/ui-components';
 import { SaveButton } from './SaveButton';
 import { ReactComponent as DocumentIcon } from './DocumentIcon.svg';
 import { EditModal } from './EditModal';
-import { useStore } from '../store';
+import { useVizBuilderConfig } from '../vizBuilderConfigStore';
 
 const Wrapper = styled.div`
   width: 100%;
@@ -53,7 +53,7 @@ const Description = styled(Typography)`
 `;
 
 export const Toolbar = () => {
-  const [{ name, permissionGroup, summary, project }] = useStore();
+  const [{ name, permissionGroup, summary, project }] = useVizBuilderConfig();
 
   return (
     <Wrapper>

--- a/packages/admin-panel/src/VizBuilderApp/vizBuilderConfigStore.js
+++ b/packages/admin-panel/src/VizBuilderApp/vizBuilderConfigStore.js
@@ -4,7 +4,12 @@
  */
 import React, { useReducer, createContext, useContext, useCallback } from 'react';
 
-const initialState = {
+/**
+ * This store is designed to hold the state for the vizBuilderConfig
+ * All other app state should be managed elsewhere. Try to keep the app state as low as
+ * possible in the component tree.
+ */
+const initialConfigState = {
   name: null,
   summary: null,
   project: null,
@@ -25,7 +30,7 @@ const SET_DATA_CONFIG = 'SET_DATA_CONFIG';
 const SET_FETCH_CONFIG = 'SET_FETCH_CONFIG';
 const SET_PRESENTATION_CONFIG = 'SET_PRESENTATION_CONFIG';
 
-function appReducer(state, action) {
+function configReducer(state, action) {
   const { type } = action;
 
   switch (type) {
@@ -75,8 +80,8 @@ function appReducer(state, action) {
   }
 }
 
-const useAppState = () => {
-  const [state, dispatch] = useReducer(appReducer, initialState);
+const useConfigStore = () => {
+  const [state, dispatch] = useReducer(configReducer, initialConfigState);
 
   const setValue = useCallback((key, value) => dispatch({ type: SET_VALUE, key, value }), []);
   const setProject = useCallback(value => dispatch({ type: SET_PROJECT, value }), []);
@@ -102,24 +107,24 @@ const useAppState = () => {
   ];
 };
 
-const store = createContext(initialState);
-const { Provider } = store;
+const vizBuilderConfigStore = createContext(initialConfigState);
+const { Provider } = vizBuilderConfigStore;
 
 // eslint-disable-next-line react/prop-types
-const StoreProvider = ({ children }) => {
-  const obj = useAppState();
+const VizBuilderConfigProvider = ({ children }) => {
+  const store = useConfigStore();
 
   return (
-    <Provider value={obj} displayName="VizBuilder">
+    <Provider value={store} displayName="VizBuilder">
       {children}
     </Provider>
   );
 };
 
-const useStore = () => {
-  return useContext(store);
+const useVizBuilderConfig = () => {
+  return useContext(vizBuilderConfigStore);
 };
 
-// Note: the store can be degged in dev tools using a chrome plugin.
+// Note: the store can be debugged in dev tools using a chrome plugin.
 // https://chrome.google.com/webstore/detail/react-context-devtool/oddhnidmicpefilikhgeagedibnefkcf?hl=en
-export { useStore, StoreProvider };
+export { useVizBuilderConfig, VizBuilderConfigProvider };

--- a/packages/admin-panel/src/rootReducer.js
+++ b/packages/admin-panel/src/rootReducer.js
@@ -5,19 +5,19 @@
 import { combineReducers } from 'redux';
 import { reducer as authentication, LOGOUT } from './authentication';
 import { reducer as tables } from './table';
-import { reducer as autocomplete } from './autocomplete';
+import { reducer as autocomplete } from './autocomplete/reducer'; // Needs to be imported from reducer file or console shows autocomplete not found error
 import { reducer as editor } from './editor';
 import { reducer as dataChangeListener } from './dataChangeListener';
 
-export const rootReducer = (state, action) => {
-  const appReducer = combineReducers({
-    authentication,
-    tables,
-    autocomplete,
-    editor,
-    dataChangeListener,
-  });
+const appReducer = combineReducers({
+  authentication,
+  tables,
+  autocomplete,
+  editor,
+  dataChangeListener,
+});
 
+export const rootReducer = (state, action) => {
   // on logout, wipe all redux state except auth
   if (action.type === LOGOUT) {
     return appReducer({ authentication: state.authentication }, action);


### PR DESCRIPTION
### Issue #: Relates to all viz builder issues

### Changes:
This is just a refactor to rename the store in the vizBuilder app to be `vizBuilderConfigStore` and change its api to expose `VizBuilderConfigProvider ` and `useVizBuilderConfig ` to signpost to developers the purpose of the store.


