### PR TITLE
Add e2e report urls

### DIFF
--- a/packages/web-frontend/cypress/config/dashboardReportUrls/default.json
+++ b/packages/web-frontend/cypress/config/dashboardReportUrls/default.json
@@ -653,6 +653,12 @@
     "endDate": "2020-12-31"
   },
   {
+    "code": "Samoa_Covid_Demo_Health_Cons_Per_Flight",
+    "project": "covid_samoa",
+    "orgUnit": "WS",
+    "dashboard": "COVID-19 Samoa"
+  },
+  {
     "code": "Samoa_Covid_Number_Of_Passengers_By_Flight",
     "project": "covid_samoa",
     "orgUnit": "WS",
@@ -789,6 +795,14 @@
     "endDate": "2021-03-31"
   },
   {
+    "code": "TO_HPU_Validation_HP_03",
+    "project": "fanafana",
+    "orgUnit": "TO_VHP",
+    "dashboard": "Health Promotion Unit Validation",
+    "startDate": "2020-08-01",
+    "endDate": "2020-08-31"
+  },
+  {
     "code": "TO_PEHS",
     "project": "explore",
     "orgUnit": "TO",
@@ -849,6 +863,14 @@
     "project": "fanafana",
     "orgUnit": "TO",
     "dashboard": "Reproductive Health Validation"
+  },
+  {
+    "code": "TO_RH_Validation_MCH06",
+    "project": "fanafana",
+    "orgUnit": "TO_KlongaHC",
+    "dashboard": "Reproductive Health Validation",
+    "startDate": "2021-03-01",
+    "endDate": "2021-03-31"
   },
   {
     "code": "TO_Total_Screened_For_NCD_Risk_Factors",


### PR DESCRIPTION
### Issue #:
Testing those reports came up during MEL-87, but I think it's worth adding in the default config as they are interesting cases

Urls (for your convenience)
* `/covid_samoa/WS/COVID-19 Samoa?overlay=Samoa_COVID_Isolation_Beds&report=Samoa_Covid_Demo_Health_Cons_Per_Flight`
* `/fanafana/TO_VHP/Health Promotion Unit Validation?&report=TO_HPU_Validation_HP_03&reportPeriod=1st_Aug_2020-31st_Aug_2020`
* `/fanafana/TO_KlongaHC/Reproductive Health Validation?report=TO_RH_Validation_MCH06&reportPeriod=1st_Mar_2021-31st_Mar_2021` => notice that a few births were of twins 👶 👶 
