### PR TITLE
NZ-806: Apply email on timeout to exports

### DIFF
--- a/packages/admin-panel/src/api/TupaiaApi.js
+++ b/packages/admin-panel/src/api/TupaiaApi.js
@@ -9,6 +9,14 @@ import { verifyResponseStatus, stringifyQuery } from '@tupaia/utils';
 
 const FETCH_TIMEOUT = 45 * 1000; // 45 seconds in milliseconds
 
+const extractHeadersAndBody = async response => {
+  const body = await response.json();
+  return {
+    headers: response.headers,
+    body,
+  };
+};
+
 export class TupaiaApi {
   constructor() {
     this.store = null; // Redux store for keeping state, will be injected after creation
@@ -57,8 +65,16 @@ export class TupaiaApi {
 
   async download(endpoint, queryParameters, fileName) {
     const response = await this.request(endpoint, queryParameters, this.buildFetchConfig('GET'));
+
+    // first check for JSON response, in case this is an early response indicating it will be emailed
+    const contentType = response.headers.get('content-type');
+    if (contentType.startsWith('application/json')) {
+      return extractHeadersAndBody(response);
+    }
+
     const responseBlob = await response.blob();
     saveAs(responseBlob, fileName);
+    return {};
   }
 
   upload(endpoint, fileName, file, queryParameters) {
@@ -70,11 +86,7 @@ export class TupaiaApi {
 
   async requestJson(...params) {
     const response = await this.request(...params);
-    const responseJson = await response.json();
-    return {
-      headers: response.headers,
-      body: responseJson,
-    };
+    return extractHeadersAndBody(response);
   }
 
   async request(endpoint, queryParameters, fetchConfig) {

--- a/packages/admin-panel/src/importExport/ExportModal.js
+++ b/packages/admin-panel/src/importExport/ExportModal.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import ExportIcon from '@material-ui/icons/GetApp';
 import {
@@ -20,9 +20,8 @@ import { api } from '../api';
 const STATUS = {
   IDLE: 'idle',
   LOADING: 'loading',
-  SUCCESS: 'success',
+  TIMEOUT: 'timeout',
   ERROR: 'error',
-  DISABLED: 'disabled',
 };
 
 export const ExportModal = React.memo(({ title, exportEndpoint, fileName, values, children }) => {
@@ -37,7 +36,7 @@ export const ExportModal = React.memo(({ title, exportEndpoint, fileName, values
     setErrorMessage(null);
   };
 
-  const handleCancel = () => {
+  const handleClose = () => {
     setStatus(STATUS.IDLE);
     setErrorMessage(null);
     setIsOpen(false);
@@ -50,41 +49,65 @@ export const ExportModal = React.memo(({ title, exportEndpoint, fileName, values
 
     try {
       const endpoint = `export/${exportEndpoint}`;
-      await api.download(endpoint, values, fileName);
-      setIsOpen(false);
-      setStatus(STATUS.SUCCESS);
+      const queryParameters = {
+        respondWithEmailTimeout: 2 * 1000, // if an import doesn't finish in 10 seconds, email results
+        ...values,
+      };
+      const { body: response } = await api.download(endpoint, queryParameters, fileName);
+      if (response?.emailTimeoutHit) {
+        setStatus(STATUS.TIMEOUT);
+      } else {
+        handleClose();
+      }
     } catch (error) {
       setStatus(STATUS.ERROR);
       setErrorMessage(error.message);
     }
   };
 
+  const renderButtons = useCallback(() => {
+    switch (status) {
+      case STATUS.TIMEOUT:
+        return <Button onClick={handleClose}>Done</Button>;
+      case STATUS.ERROR:
+        return (
+          <>
+            <OutlinedButton onClick={handleDismiss}>Dismiss</OutlinedButton>
+            <Button disabled>Export</Button>
+          </>
+        );
+      default:
+        return (
+          <>
+            <OutlinedButton onClick={handleClose}>Cancel</OutlinedButton>
+            <Button type="submit" isLoading={status === STATUS.LOADING} onClick={handleSubmit}>
+              Export
+            </Button>
+          </>
+        );
+    }
+  }, [status, handleDismiss, handleClose, handleSubmit]);
+
   return (
     <>
-      <Dialog onClose={handleCancel} open={isOpen} disableBackdropClick>
+      <Dialog onClose={handleClose} open={isOpen} disableBackdropClick>
         <form onSubmit={handleSubmit} noValidate>
           <DialogHeader
-            onClose={handleCancel}
+            onClose={handleClose}
             title={errorMessage ? 'Error' : title}
             color={errorMessage ? 'error' : 'textPrimary'}
           />
           <ModalContentProvider errorMessage={errorMessage} isLoading={status === STATUS.LOADING}>
-            {children}
-          </ModalContentProvider>
-          <DialogFooter>
-            {status === STATUS.ERROR ? (
-              <OutlinedButton onClick={handleDismiss}>Dismiss</OutlinedButton>
+            {status === STATUS.TIMEOUT ? (
+              <p>
+                Export is taking a while, and will continue in the background. You will be emailed
+                the exported file when the process completes.
+              </p>
             ) : (
-              <OutlinedButton onClick={handleCancel}>Cancel</OutlinedButton>
+              children
             )}
-            <Button
-              type="submit"
-              disabled={status === STATUS.ERROR}
-              isLoading={status === STATUS.LOADING}
-            >
-              Export
-            </Button>
-          </DialogFooter>
+          </ModalContentProvider>
+          <DialogFooter>{renderButtons()}</DialogFooter>
         </form>
       </Dialog>
       <LightOutlinedButton

--- a/packages/admin-panel/src/importExport/ExportModal.js
+++ b/packages/admin-panel/src/importExport/ExportModal.js
@@ -50,7 +50,7 @@ export const ExportModal = React.memo(({ title, exportEndpoint, fileName, values
     try {
       const endpoint = `export/${exportEndpoint}`;
       const queryParameters = {
-        respondWithEmailTimeout: 2 * 1000, // if an import doesn't finish in 10 seconds, email results
+        respondWithEmailTimeout: 10 * 1000, // if an import doesn't finish in 10 seconds, email results
         ...values,
       };
       const { body: response } = await api.download(endpoint, queryParameters, fileName);

--- a/packages/meditrak-server/src/apiV2/export/constructExportEmail.js
+++ b/packages/meditrak-server/src/apiV2/export/constructExportEmail.js
@@ -3,6 +3,8 @@
  * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
  */
 
+import { getAttachmentForEmail } from '../../utilities';
+
 const constructMessage = responseBody => {
   const { error } = responseBody;
 
@@ -20,7 +22,7 @@ const constructAttachments = async responseBody => {
   if (!filePath) {
     throw new Error('No export file provided to email responder');
   }
-  return [{ path: filePath }];
+  return getAttachmentForEmail(filePath);
 };
 
 export const constructExportEmail = async responseBody => ({

--- a/packages/meditrak-server/src/apiV2/export/constructExportEmail.js
+++ b/packages/meditrak-server/src/apiV2/export/constructExportEmail.js
@@ -1,0 +1,30 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+
+const constructMessage = responseBody => {
+  const { error } = responseBody;
+
+  if (error) {
+    return `Unfortunately, your export failed.
+
+${error}`;
+  }
+
+  return 'Please find your requested export attached.';
+};
+
+const constructAttachments = async responseBody => {
+  const { filePath } = responseBody;
+  if (!filePath) {
+    throw new Error('No export file provided to email responder');
+  }
+  return [{ path: filePath }];
+};
+
+export const constructExportEmail = async responseBody => ({
+  subject: 'Your export from Tupaia',
+  message: constructMessage(responseBody),
+  attachments: await constructAttachments(responseBody),
+});

--- a/packages/meditrak-server/src/apiV2/export/exportSurveyResponses/exportSurveyResponses.js
+++ b/packages/meditrak-server/src/apiV2/export/exportSurveyResponses/exportSurveyResponses.js
@@ -13,6 +13,7 @@ import {
   DatabaseError,
   addExportedDateAndOriginAtTheSheetBottom,
   getExportDatesString,
+  respondWithDownload,
 } from '@tupaia/utils';
 import { TYPES } from '@tupaia/database';
 import { ANSWER_TYPES, NON_DATA_ELEMENT_ANSWER_TYPES } from '../../../database/models/Answer';
@@ -281,5 +282,5 @@ export async function exportSurveyResponses(req, res) {
   const filePath = `${FILE_LOCATION}/${FILE_PREFIX}_${Date.now()}.xlsx`;
 
   xlsx.writeFile(workbook, filePath);
-  res.download(filePath);
+  respondWithDownload(res, filePath);
 }

--- a/packages/meditrak-server/src/apiV2/export/exportSurveys/exportSurveys.js
+++ b/packages/meditrak-server/src/apiV2/export/exportSurveys/exportSurveys.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2019 Beyond Essential Systems Pty Ltd
  */
 
+import { respondWithDownload } from '@tupaia/utils';
 import { SurveyExporter } from './SurveyExporter';
 
 /**
@@ -17,5 +18,5 @@ export async function exportSurveys(req, res) {
   const { surveyCode } = req.query;
   const exporter = new SurveyExporter(models, assertPermissions);
   const filePath = await exporter.exportToFile(surveyId, surveyCode);
-  res.download(filePath);
+  respondWithDownload(res, filePath);
 }

--- a/packages/meditrak-server/src/apiV2/export/index.js
+++ b/packages/meditrak-server/src/apiV2/export/index.js
@@ -4,13 +4,18 @@
  */
 
 import express from 'express';
-import { catchAsyncErrors } from '../middleware';
+import { catchAsyncErrors, emailAfterTimeout } from '../middleware';
+import { constructExportEmail } from './constructExportEmail';
 import { exportSurveyResponses } from './exportSurveyResponses';
 import { exportSurveys } from './exportSurveys';
 
 const exportRoutes = express.Router();
 
-exportRoutes.get('/surveyResponses', catchAsyncErrors(exportSurveyResponses));
+exportRoutes.get(
+  '/surveyResponses',
+  emailAfterTimeout(constructExportEmail),
+  catchAsyncErrors(exportSurveyResponses),
+);
 exportRoutes.get('/surveyResponses/:surveyResponseId', catchAsyncErrors(exportSurveyResponses));
 exportRoutes.get('/surveys', catchAsyncErrors(exportSurveys));
 exportRoutes.get('/surveys/:surveyId', catchAsyncErrors(exportSurveys));

--- a/packages/meditrak-server/src/apiV2/middleware/emailAfterTimeout.js
+++ b/packages/meditrak-server/src/apiV2/middleware/emailAfterTimeout.js
@@ -6,12 +6,12 @@
 import { respond } from '@tupaia/utils';
 import { sendEmail } from '../../utilities';
 
-const sendResponseAsEmail = (user, subject, message) => {
+const sendResponseAsEmail = (user, subject, message, attachments) => {
   const text = `Hi ${user.first_name},
 
 ${message}
   `;
-  sendEmail(user.email, subject, text);
+  sendEmail(user.email, subject, text, attachments);
 };
 
 const setupEmailResponse = async (req, res, constructEmailFromResponse) => {
@@ -31,9 +31,9 @@ const setupEmailResponse = async (req, res, constructEmailFromResponse) => {
 
   // override the respond function so that when the endpoint handler finishes (or throws an error),
   // the response is sent via email
-  res.overrideRespond = responseBody => {
-    const { subject, message } = constructEmailFromResponse(responseBody);
-    sendResponseAsEmail(user, subject, message);
+  res.overrideRespond = async responseBody => {
+    const { subject, message, attachments } = await constructEmailFromResponse(responseBody);
+    sendResponseAsEmail(user, subject, message, attachments);
   };
 };
 

--- a/packages/meditrak-server/src/utilities/getAttachmentForEmail.js
+++ b/packages/meditrak-server/src/utilities/getAttachmentForEmail.js
@@ -1,0 +1,38 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+
+import fs from 'fs';
+import zlib from 'zlib';
+
+/**
+ * Takes a path to an attachment, and generates the attachments object to pass to nodemailer,
+ * compressing the attachment if it is too large
+ */
+
+const MAX_ATTACHMENT_SIZE = 10 * 1024 * 1024; // some email services only support up to 10MB
+const compress = path =>
+  new Promise((resolve, reject) => {
+    const compressedPath = `${path}.gz`;
+    const fileContents = fs.createReadStream(path);
+    const writeStream = fs.createWriteStream(compressedPath);
+    const zip = zlib.createGzip();
+    fileContents
+      .pipe(zip)
+      .pipe(writeStream)
+      .on('finish', error => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve(compressedPath);
+        }
+      });
+  });
+
+export const getAttachmentForEmail = async path => {
+  if (fs.statSync(path).size > MAX_ATTACHMENT_SIZE) {
+    return [{ path: await compress(path) }];
+  }
+  return [{ path }];
+};

--- a/packages/meditrak-server/src/utilities/index.js
+++ b/packages/meditrak-server/src/utilities/index.js
@@ -4,5 +4,6 @@
  */
 
 export { getApiUrl } from './getApiUrl';
+export { getAttachmentForEmail } from './getAttachmentForEmail';
 export { resourceToRecordType } from './resourceToRecordType';
 export { sendEmail } from './sendEmail';

--- a/packages/meditrak-server/src/utilities/sendEmail.js
+++ b/packages/meditrak-server/src/utilities/sendEmail.js
@@ -5,7 +5,7 @@
 import nodemailer from 'nodemailer';
 import { getIsProductionEnvironment } from '../devops';
 
-export const sendEmail = (to, subject, text) => {
+export const sendEmail = (to, subject, text, attachments) => {
   const { SMTP_HOST, SMTP_USER, SMTP_PASSWORD, SITE_EMAIL_ADDRESS } = process.env;
 
   const transporter = nodemailer.createTransport({
@@ -27,6 +27,7 @@ export const sendEmail = (to, subject, text) => {
     from: SITE_EMAIL_ADDRESS,
     to,
     subject,
+    attachments,
     text: `${text}
 
 Cheers,

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -26,7 +26,7 @@ export { getTokenExpiry } from './getTokenExpiry';
 export * from './object';
 export * from './request';
 export { replaceValues } from './replaceValues';
-export { respond } from './respond';
+export { respond, respondWithDownload } from './respond';
 export * from './runScript';
 export * from './Script';
 export * from './string';

--- a/packages/utils/src/respond.js
+++ b/packages/utils/src/respond.js
@@ -13,10 +13,18 @@ export function respond(res, responseBody, statusCode) {
   // than respond directly to the original http query
   const { overrideRespond } = res;
   if (overrideRespond) {
-    return overrideRespond(responseBody, statusCode);
+    return overrideRespond(responseBody);
   }
   return res
     .status(statusCode || 200)
     .type('json')
     .send(JSON.stringify(responseBody));
+}
+
+export function respondWithDownload(res, filePath) {
+  const { overrideRespond } = res;
+  if (overrideRespond) {
+    return overrideRespond({ filePath });
+  }
+  return res.download(filePath);
 }


### PR DESCRIPTION
### Issue #:
Resolves NZ-806, NZ-805
Towards NZ-803

### Changes:
- Exports now go via download if they take too long
- If a spreadsheet is too large, it will be compressed

Note that the compression is only semi-successful, as depending on how you uncompress it, it may be assumed to be a directory rather than a file. I'm not bothering to fix this as I am currently working on NZ-815