### PR TITLE
NZ-19: Fix Lesmis Dashboard Loading More Than Once

### DIFF
--- a/packages/lesmis/src/api/queries/useDashboardReportData.js
+++ b/packages/lesmis/src/api/queries/useDashboardReportData.js
@@ -24,12 +24,15 @@ export const useDashboardReportData = ({
     type: 'dashboard',
   };
 
+  // only make a request if there is a valid start and end date
+  const enabled = startDate !== undefined && endDate !== undefined;
+
   return useQuery(
     ['dashboardReport', entityCode, reportCode, params],
     () =>
       get(`report/${entityCode}/${reportCode}`, {
         params,
       }),
-    { staleTime: 60 * 60 * 1000, refetchOnWindowFocus: false, keepPreviousData: true },
+    { staleTime: 60 * 60 * 1000, refetchOnWindowFocus: false, keepPreviousData: true, enabled },
   );
 };


### PR DESCRIPTION
### Issue #: NZ-19: Fix Lesmis Dashboard Loading More Than Once

### Changes:

The dashboard report modal was firing off a request even though it wasn't open and there wasn't a date set yet (it needs to be on the page before it is open for the nice animation). Fix it by only making a dashboard report request if there is a valid start and end date.

---
