### PR TITLE
2729: Fixes (MEL-92)

### DIFF
--- a/packages/database/src/DatabaseModel.js
+++ b/packages/database/src/DatabaseModel.js
@@ -13,7 +13,7 @@ export class DatabaseModel {
 
     // schema promise will resolve with information about the columns on the table in the database,
     // e.g.: { id: { type: 'text', maxLength: null, nullable: false, defaultValue: null } }
-    this.schemaPromise = this.database.fetchSchemaForTable(this.DatabaseTypeClass.databaseType);
+    this.schemaPromise = this.startSchemaFetch();
 
     this.cache = {};
     this.cachedFunctionInvalidationCancellers = {};
@@ -37,7 +37,7 @@ export class DatabaseModel {
 
       // invalidate cached schema for this model on any change to db schema
       this.database.addSchemaChangeHandler(() => {
-        this.schema = null;
+        this.schemaPromise = this.startSchemaFetch();
         this.fieldNames = null;
       });
     }
@@ -47,6 +47,8 @@ export class DatabaseModel {
   get cacheDependencies() {
     return [];
   }
+
+  startSchemaFetch = () => this.database.fetchSchemaForTable(this.DatabaseTypeClass.databaseType);
 
   // functionArguments should receive the 'arguments' object
   getCacheKey = (functionName, functionArguments) =>

--- a/packages/database/src/changeHandlers/SurveyResponseOutdater.js
+++ b/packages/database/src/changeHandlers/SurveyResponseOutdater.js
@@ -36,6 +36,8 @@ import { isMarkedChange } from '../utilities';
 const DATE_FORMAT = 'YYYY-MM-DD';
 const DATETIME_FORMAT = `${DATE_FORMAT} HH:mm:ss`;
 
+const MAX_DEBUGGING_INFO_ITEMS = 1000;
+
 /**
  * Cache of period ranges keyed by requested period granularity first, then date
  *
@@ -188,7 +190,9 @@ export class SurveyResponseOutdater extends ChangeHandler {
   };
 
   getChangeDebuggingInfo = changedResponses =>
-    `Could not outdate survey responses with ids ${changedResponses.map(sr => sr.id)}`;
+    changedResponses.length > MAX_DEBUGGING_INFO_ITEMS
+      ? `Could not outdate ${changedResponses.length} survey responses`
+      : `Could not outdate survey responses with ids ${changedResponses.map(sr => sr.id)}`;
 
   handleResponsesForSurvey = async (changedResponses, survey) => {
     if (!survey?.['period_granularity']) {

--- a/packages/database/src/utilities/isMarkedChange.js
+++ b/packages/database/src/utilities/isMarkedChange.js
@@ -8,7 +8,7 @@
  * rather than a true database change
  */
 export const isMarkedChange = changeDetails => {
-  const { type, oldRecord, newRecord } = changeDetails;
+  const { type, old_record: oldRecord, new_record: newRecord } = changeDetails;
   // If all fields are the same in an `update` change, the change was marked, since true DB update
   // notifications require at least one changed field
   return type === 'update' && JSON.stringify(oldRecord) === JSON.stringify(newRecord);

--- a/packages/meditrak-server/src/dataAccessors/validateSurveyFields.js
+++ b/packages/meditrak-server/src/dataAccessors/validateSurveyFields.js
@@ -26,5 +26,13 @@ export const validateSurveyFields = async (models, surveyFields) => {
     if (serviceType === 'dhis') {
       throw new Error('Reporting period is not available for dhis surveys');
     }
+
+    const survey = await models.survey.findOne({ code });
+    const hasResponses = survey && (await survey.hasResponses());
+    if (hasResponses && survey.period_granularity !== periodGranularity) {
+      throw new Error(
+        `Cannot change the reporting period for "${survey.name}" while there are still records in the survey_response table`,
+      );
+    }
   }
 };


### PR DESCRIPTION
@edmofro Eventually I decided to follow your advice and disallow updating the reporting period for surveys that have responses against them.

Some of our surveys already have ~ 90,000 responses. As we have discussed, updating them all at once breaks `meditrak-server` and/or the database. I tried batching the changes and adding delays between each batch: this is successful but not robust, since

* Only relatively small batches are guaranteed to not stress the system (eg 1000 responses/minute). Bigger batches often work, but in combination with analytic updates that are triggered at the same time, we cannot guarantee the stability of the system. I guess a more robust solution would be using a db-based queue
* We can assume that people will not change period granularities often
* We can still use migrations to mark survey response as changed and thus outdate them in a controlled way

