### PR TITLE
Bugfix: Historical data in list visual

### DIFF
--- a/packages/database/src/migrations/20210705232632-AddECEGoalsDrillDowns-modifies-data.js
+++ b/packages/database/src/migrations/20210705232632-AddECEGoalsDrillDowns-modifies-data.js
@@ -28,21 +28,14 @@ const generateIndicator = (code, dataElement, target) => ({
   builder: 'analyticArithmetic',
   config: {
     formula: `${target}`,
-    aggregation: { [dataElement]: 'MOST_RECENT' },
+    aggregation: { [dataElement]: 'FINAL_EACH_YEAR' },
   },
 });
 
 const generateReport = (dataElement, target) => ({
   fetch: {
     dataElements: target ? [dataElement, target] : [dataElement],
-    aggregations: [
-      {
-        type: 'MOST_RECENT',
-        config: {
-          dataSourceEntityType: 'sub_district',
-        },
-      },
-    ],
+    aggregations: ['FINAL_EACH_YEAR'],
   },
   transform: [
     'keyValueByDataElementName',

--- a/packages/database/src/migrations/20210708023241-LESMISListVisualSummaryReport-modifies-data.js
+++ b/packages/database/src/migrations/20210708023241-LESMISListVisualSummaryReport-modifies-data.js
@@ -27,7 +27,7 @@ const generateIndicator = (code, dataElement, target) => ({
   code,
   builder: 'analyticArithmetic',
   config: {
-    formula: `${dataElement} >= ${target} ? 1 : ${dataElement} >= firstExistingValue(value1YearAgo, value2YearsAgo, value3YearsAgo, value4YearsAgo, value5YearsAgo, Infinity) ? 0 : -1`,
+    formula: `${dataElement} >= (${target} * 100) ? 1 : ${dataElement} >= firstExistingValue(value1YearAgo, value2YearsAgo, value3YearsAgo, value4YearsAgo, value5YearsAgo, Infinity) ? 0 : -1`,
     parameters: [
       {
         builder: 'analyticArithmetic',
@@ -115,7 +115,7 @@ const generateIndicator = (code, dataElement, target) => ({
         },
       },
     ],
-    aggregation: 'MOST_RECENT',
+    aggregation: 'FINAL_EACH_YEAR',
     defaultValues: {
       value1YearAgo: 'undefined',
       value2YearsAgo: 'undefined',
@@ -131,14 +131,7 @@ const CODE = 'LESMIS_ESSDP_ECE_SubSector_List';
 const REPORT_CONFIG = {
   fetch: {
     dataElements: ['er_summary_ece_0_2_t', 'er_summary_ece_5_t'],
-    aggregations: [
-      {
-        type: 'MOST_RECENT',
-        config: {
-          dataSourceEntityType: 'sub_district',
-        },
-      },
-    ],
+    aggregations: ['FINAL_EACH_YEAR'],
   },
   transform: [
     'keyValueByDataElementName',

--- a/packages/database/src/migrations/20210708023241-LESMISListVisualSummaryReport-modifies-data.js
+++ b/packages/database/src/migrations/20210708023241-LESMISListVisualSummaryReport-modifies-data.js
@@ -131,7 +131,7 @@ const CODE = 'LESMIS_ESSDP_ECE_SubSector_List';
 const REPORT_CONFIG = {
   fetch: {
     dataElements: ['er_summary_ece_0_2_t', 'er_summary_ece_5_t'],
-    aggregations: ['FINAL_EACH_YEAR'],
+    aggregations: ['MOST_RECENT'],
   },
   transform: [
     'keyValueByDataElementName',


### PR DESCRIPTION
### Issue #:
NZ-62

### Changes:

- Change reports and indicators to use `FINAL_EACH_YEAR` instead of `MOST_RECENT` so they actually show historical data
- Compare target and actual values at the same scale
