### PR TITLE
SOL-377: Switched 'sum' in report-server to use multi arguments instead of array

### DIFF
--- a/packages/database/src/migrations/20210816070825-SwitchSumInReportServerToAcceptingManyArgs-modifies-data.js
+++ b/packages/database/src/migrations/20210816070825-SwitchSumInReportServerToAcceptingManyArgs-modifies-data.js
@@ -1,0 +1,46 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = async function (db) {
+  const reportsWithSum = (await db.runSql("SELECT * from report WHERE config::text like '%sum([%'"))
+    .rows;
+
+  // Disabling trigger as otherwise encountered an error: payload string too long
+  // This is caused by the trigger trying to pass a payload of over 8000 bytes to the notify channel
+  await db.runSql('ALTER TABLE report DISABLE TRIGGER report_trigger;');
+  for (let i = 0; i < reportsWithSum.length; i++) {
+    const { code, config } = reportsWithSum[i];
+    const fixedConfigString = JSON.stringify(config)
+      .replace(/sum\(\[(.*?)\]\)/g, 'sum($1)')
+      .replace(/'/g, "''");
+    await db.runSql(`
+        UPDATE report
+        SET config = '${fixedConfigString}'::jsonb
+        WHERE code = '${code}';
+      `);
+  }
+  await db.runSql('ALTER TABLE report ENABLE TRIGGER report_trigger;');
+
+  return null;
+};
+
+exports.down = function (db) {
+  return null;
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/packages/report-server/src/__tests__/reportBuilder/functions.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/functions.test.ts
@@ -65,8 +65,7 @@ describe('functions', () => {
     });
 
     describe('length', () => {
-      it('returns the length of an input array', () =>
-         expect(functions.length([1, 2, 3])).toBe(3));
+      it('returns the length of an input array', () => expect(functions.length([1, 2, 3])).toBe(3));
     });
   });
 
@@ -103,25 +102,24 @@ describe('functions', () => {
   });
 
   describe('math', () => {
-    // TODO: Fixup test after getting sum working correctly
-    // describe('sum', () => {
-    //   it('sums a list of numbers', () => expect(functions.sum(1, 2, 3)).toBe(6));
+    describe('sum', () => {
+      it('sums a list of numbers', () => expect(functions.sum(1, 2, 3)).toBe(6));
 
-    //   it('ignores undefined values', () => expect(functions.sum(1, undefined, 3)).toBe(4));
+      it('ignores undefined values', () => expect(functions.sum(1, undefined, 3)).toBe(4));
 
-    //   it('can sum an array', () => expect(functions.sum([1, 2, 3])).toBe(6));
+      it('can sum an array', () => expect(functions.sum([1, 2, 3])).toBe(6));
 
-    //   it('ignores undefined within an array', () =>
-    //     expect(functions.sum([1, undefined, 3])).toBe(4));
+      it('ignores undefined within an array', () =>
+        expect(functions.sum([1, undefined, 3])).toBe(4));
 
-    //   it('can combine numbers and arrays', () =>
-    //     expect(functions.sum([1, undefined, 3], undefined, 2)).toBe(6));
+      it('can combine numbers and arrays', () =>
+        expect(functions.sum([1, undefined, 3], undefined, 2)).toBe(6));
 
-    //   it('returns undefined if all values are undefined', () =>
-    //     expect(functions.sum([undefined, undefined, undefined], undefined, undefined)).toBe(
-    //       undefined,
-    //     ));
-    // });
+      it('returns undefined if all values are undefined', () =>
+        expect(functions.sum([undefined, undefined, undefined], undefined, undefined)).toBe(
+          undefined,
+        ));
+    });
 
     describe('divide', () => {
       it('divides a list of numbers', () => expect(functions.divide(12, 3, 2)).toBe(2));

--- a/packages/report-server/src/reportBuilder/functions/math.ts
+++ b/packages/report-server/src/reportBuilder/functions/math.ts
@@ -7,12 +7,22 @@ import { sum as mathjsSum, divide as mathjsDivide, Matrix, filter } from 'mathjs
 
 const isDefined = <T>(value: T): value is Exclude<T, undefined> => value !== undefined;
 
-export const sum = (numbers?: Matrix): number | undefined => {
-  if (numbers === undefined) {
+export const sum = (
+  ...args: (number | undefined | (number | undefined)[])[]
+): number | undefined => {
+  const numbers = args.flat();
+
+  const validNumbers = numbers.filter(isDefined);
+
+  if (validNumbers.length === 0) {
     return undefined;
   }
 
-  return mathjsSum(filter(numbers, number => number !== undefined));
+  if (validNumbers.length === 1) {
+    return validNumbers[0];
+  }
+
+  return mathjsSum(validNumbers);
 };
 
 export const divide = (


### PR DESCRIPTION
### Issue SOL-377:

Switching `sum` over to taking multiple arguments like `divide` does. I think this format in general should be preferred over taking an array as an argument.