### PR TITLE
MEL-412 allow entity import with no location

### DIFF
--- a/packages/admin-panel/src/pages/resources/EntitiesPage.js
+++ b/packages/admin-panel/src/pages/resources/EntitiesPage.js
@@ -64,6 +64,14 @@ const IMPORT_CONFIG = {
         type: 'boolean',
       },
     },
+    {
+      label: 'Automatically fetch GeoJSON (defaults to "Yes")',
+      parameterKey: 'automaticallyFetchGeojson',
+      type: 'boolean',
+      editConfig: {
+        type: 'boolean',
+      },
+    },
   ],
 };
 

--- a/packages/meditrak-server/src/routes/importEntities/importEntities.js
+++ b/packages/meditrak-server/src/routes/importEntities/importEntities.js
@@ -15,9 +15,13 @@ import { assertCanImportEntities } from './assertCanImportEntities';
  */
 export async function importEntities(req, res) {
   try {
-    const { models } = req;
+    const { models, query } = req;
+
     let entitiesByCountryName;
-    const pushToDhis = req?.query?.pushToDhis ? req?.query?.pushToDhis === 'true' : true;
+    const pushToDhis = query?.pushToDhis ? query?.pushToDhis === 'true' : true;
+    const automaticallyFetchGeojson = query?.automaticallyFetchGeojson
+      ? query?.automaticallyFetchGeojson === 'true'
+      : true;
 
     try {
       entitiesByCountryName = extractEntitiesByCountryName(req.file.path);
@@ -44,9 +48,11 @@ export async function importEntities(req, res) {
           pushToDhis,
         );
 
-        // Go through country and all district/subdistricts, and if any are missing coordinates,
-        // attempt to fetch them and populate the database
-        await populateCoordinatesForCountry(transactingModels, country.code);
+        if (automaticallyFetchGeojson) {
+          // Go through country and all district/subdistricts, and if any are missing coordinates,
+          // attempt to fetch them and populate the database
+          await populateCoordinatesForCountry(transactingModels, country.code);
+        }
       }
     });
     respond(res, { message: 'Imported entities' });

--- a/packages/meditrak-server/src/routes/importEntities/populateCoordinatesForCountry.js
+++ b/packages/meditrak-server/src/routes/importEntities/populateCoordinatesForCountry.js
@@ -93,9 +93,10 @@ async function addCoordinatesToEntity(
       }
       writeFileSync(filePath, JSON.stringify(geojson));
     } catch (error) {
-      throw new Error(
-        `Failed to write geojson file for ${name}, ${countryName}. Download manually and save as ${filePath}, or resolve the error: ${error.message}`,
-      );
+      // Previously we would throw the below error here:
+      // `Failed to write geojson file for ${name}, ${countryName}. Download manually and save as ${filePath}, or resolve the error: ${error.message}`,
+      // We now just return because this validation was preventing importing children of "Unknown Districts" etc
+      return;
     }
   }
 
@@ -103,7 +104,7 @@ async function addCoordinatesToEntity(
   // faster if repeated, and b) it allows us to manually tweak the geojson, get it from a
   // different source, or compress it by reducing the number of nodes
   const geojson = JSON.parse(readFileSync(filePath));
-  return transactingModels.entity.updateRegionCoordinates(code, geojson);
+  await transactingModels.entity.updateRegionCoordinates(code, geojson);
 }
 
 // Go through country and all district/subdistricts, and if any are missing coordinates,

--- a/packages/meditrak-server/src/routes/importEntities/populateCoordinatesForCountry.js
+++ b/packages/meditrak-server/src/routes/importEntities/populateCoordinatesForCountry.js
@@ -93,10 +93,9 @@ async function addCoordinatesToEntity(
       }
       writeFileSync(filePath, JSON.stringify(geojson));
     } catch (error) {
-      // Previously we would throw the below error here:
-      // `Failed to write geojson file for ${name}, ${countryName}. Download manually and save as ${filePath}, or resolve the error: ${error.message}`,
-      // We now just return because this validation was preventing importing children of "Unknown Districts" etc
-      return;
+      throw new Error(
+        `Failed to automatically fetch geoJSON for ${name}, ${countryName}. Please add manually in the "geojson" import column and turn off "Automatically fetch GeoJSON".`,
+      );
     }
   }
 
@@ -104,7 +103,7 @@ async function addCoordinatesToEntity(
   // faster if repeated, and b) it allows us to manually tweak the geojson, get it from a
   // different source, or compress it by reducing the number of nodes
   const geojson = JSON.parse(readFileSync(filePath));
-  await transactingModels.entity.updateRegionCoordinates(code, geojson);
+  return transactingModels.entity.updateRegionCoordinates(code, geojson);
 }
 
 // Go through country and all district/subdistricts, and if any are missing coordinates,


### PR DESCRIPTION
### Issue #: https://linear.app/tupaia/issue/MEL-412/allow-entities-to-be-imported-without-a-location-attached-to-a

### Changes:
- We use entities with no location data like "Unknown Island" in Samoa to record some data
- Importing/updating children of these entities is impossible via the admin panel because of the error that was being thrown because these entities don't have location data
- This change allows entities like "Unknown Island" to continue to have no location data and for us to be able to import/update children of this entity in the admin panel