### PR TITLE
Disable generate source maps to reduce build size

### DIFF
--- a/packages/admin-panel/package.json
+++ b/packages/admin-panel/package.json
@@ -11,7 +11,7 @@
   "author": "Beyond Essential Systems <admin@tupaia.org> (https://beyondessential.com.au)",
   "main": "dist/index.js",
   "scripts": {
-    "build": "react-scripts build",
+    "build": "GENERATE_SOURCEMAP=false react-scripts build",
     "postbuild": "rm -rf served_build && mv build served_build",
     "cypress:open": "cross-env NODE_ENV=test yarn cypress open",
     "cypress:run": "cross-env NODE_ENV=test yarn cypress run",

--- a/packages/lesmis/package.json
+++ b/packages/lesmis/package.json
@@ -11,7 +11,7 @@
   "author": "Beyond Essential Systems <admin@tupaia.org> (https://beyondessential.com.au)",
   "main": "dist/index.js",
   "scripts": {
-    "build": "react-scripts build",
+    "build": "GENERATE_SOURCEMAP=false react-scripts build",
     "postbuild": "rm -rf served_build && mv build served_build",
     "eject": "react-scripts eject",
     "lint": "eslint --ignore-path ../../.gitignore .",

--- a/packages/psss/package.json
+++ b/packages/psss/package.json
@@ -11,7 +11,7 @@
   "author": "Beyond Essential Systems <admin@tupaia.org> (https://beyondessential.com.au)",
   "main": "dist/index.js",
   "scripts": {
-    "build": "react-scripts build",
+    "build": "GENERATE_SOURCEMAP=false react-scripts build",
     "postbuild": "rm -rf served_build && mv build served_build",
     "cypress:open": "cross-env NODE_ENV=test cypress open",
     "cypress:run": "cross-env NODE_ENV=test cypress run",

--- a/packages/web-frontend/package.json
+++ b/packages/web-frontend/package.json
@@ -13,8 +13,8 @@
   "scripts": {
     "analyze": "source-map-explorer build/static/js/main.*",
     "build": "mkdir -p builds && npm run build-desktop && npm run build-mobile",
-    "build-desktop": "react-scripts build && rm -rf builds/desktop && mv build builds/desktop",
-    "build-mobile": "REACT_APP_APP_TYPE=mobile react-scripts build && rm -rf builds/mobile && mv build builds/mobile",
+    "build-desktop": "GENERATE_SOURCEMAP=false react-scripts build && rm -rf builds/desktop && mv build builds/desktop",
+    "build-mobile": "GENERATE_SOURCEMAP=false REACT_APP_APP_TYPE=mobile react-scripts build && rm -rf builds/mobile && mv build builds/mobile",
     "cypress:config": "yarn run:babel cypress/scripts/generateConfig",
     "cypress:format-config": "yarn run:babel cypress/scripts/formatConfig",
     "cypress:open": "cross-env NODE_ENV=test yarn cypress open",


### PR DESCRIPTION
### Changes:

- Disable generate source maps to reduce build size.

### Notes:
- Sandbox environment here: http://chris-dev-clone.tupaia.org
- Can confirm that source maps are not generated in sandbox environment:
![chrisdevclone](https://user-images.githubusercontent.com/63621318/130048145-e20f6b93-296c-45d9-838f-0a189dd6ad23.png)
![tupaiaorg](https://user-images.githubusercontent.com/63621318/130048188-be6d5978-f450-48c6-8289-29c972d3037e.png)

- I haven't checked how much size were reduced in front end builds without generating sourcemaps, but the build was deployed fine without failing here:
https://app.codeship.com/projects/70159bc0-0dac-0138-fdcb-260b82737f4e/builds/9477e7a1-cba7-4024-afbb-5490d03c82f2?component=step_deploy-all_deploy-frontends_deploy-psss
- Tested on sandbox deployment, and the front ends (tupaia, admin-panel, psss, lesmis,...) were working fine