### PR TITLE
Treat includeRootEntity param in URL as string in entity server

### DIFF
--- a/packages/entity-server/src/routes/hierarchy/EntityDescendantsRoute.ts
+++ b/packages/entity-server/src/routes/hierarchy/EntityDescendantsRoute.ts
@@ -17,12 +17,13 @@ export type DescendantsRequest = SingleEntityRequest<
   SingleEntityRequestParams,
   EntityResponse[],
   RequestBody,
-  EntityRequestQuery & { includeRootEntity?: boolean }
+  EntityRequestQuery & { includeRootEntity?: string }
 >;
 export class EntityDescendantsRoute extends Route<DescendantsRequest> {
   async buildResponse() {
     const { hierarchyId, entity, fields, field, filter } = this.req.ctx;
-    const { includeRootEntity = false } = this.req.query;
+    const { includeRootEntity: includeRootEntityString = 'false' } = this.req.query;
+    const includeRootEntity = includeRootEntityString?.toLowerCase() === 'true';
     const descendants = await entity.getDescendants(hierarchyId, {
       ...filter,
     });

--- a/packages/entity-server/src/routes/hierarchy/MultiEntityDescendantsRoute.ts
+++ b/packages/entity-server/src/routes/hierarchy/MultiEntityDescendantsRoute.ts
@@ -17,12 +17,13 @@ export type MultiEntityDescendantsRequest = MultiEntityRequest<
   MultiEntityRequestParams,
   EntityResponse[],
   MultiEntityRequestBody,
-  EntityRequestQuery & { includeRootEntity?: boolean }
+  EntityRequestQuery & { includeRootEntity?: string }
 >;
 export class MultiEntityDescendantsRoute extends Route<MultiEntityDescendantsRequest> {
   async buildResponse() {
     const { hierarchyId, entities, fields, field, filter } = this.req.ctx;
-    const { includeRootEntity = false } = this.req.query;
+    const { includeRootEntity: includeRootEntityString = 'false' } = this.req.query;
+    const includeRootEntity = includeRootEntityString?.toLowerCase() === 'true';
     const descendants = await this.req.models.entity.getDescendantsOfEntities(
       hierarchyId,
       entities.map(entity => entity.id),


### PR DESCRIPTION
### Issue #:
entity-server endpoint: entities getDescendants() always return root entities. 

### Changes:
treat `includeRootEntity` param in URL as string in entity server


