### PR TITLE
MEL-449: Added BES Data Admin permission restrictions on /testReport endpoint

### DIFF
--- a/packages/report-server/src/routes/TestReportRoute.ts
+++ b/packages/report-server/src/routes/TestReportRoute.ts
@@ -22,11 +22,43 @@ export type TestReportRequest = Request<
   ReportRouteQuery
 >;
 
+const BES_DATA_ADMIN_PERMISSION_GROUP = 'BES Data Admin';
+
 export class TestReportRoute extends Route<TestReportRequest> {
+  async checkUserHasAccessToReport(hierarchy = 'explore', requestedOrgUnitCodes: string[]) {
+    const { accessPolicy, ctx } = this.req;
+
+    const foundOrgUnits = await ctx.microServices.entityApi.getEntities(
+      hierarchy,
+      requestedOrgUnitCodes,
+      {
+        fields: ['code', 'country_code'],
+      },
+    );
+    const foundOrgUnitCodes = foundOrgUnits.map(orgUnit => orgUnit.code);
+
+    const missingOrgUnitCodes = requestedOrgUnitCodes.filter(
+      orgUnitCode => !foundOrgUnitCodes.includes(orgUnitCode),
+    );
+    if (missingOrgUnitCodes.length > 0) {
+      throw new Error(`No entities found with codes ${missingOrgUnitCodes}`);
+    }
+
+    const countryCodes = new Set(foundOrgUnits.map(orgUnit => orgUnit.country_code));
+    countryCodes.forEach(countryCode => {
+      if (
+        countryCode === null ||
+        !accessPolicy.allows(countryCode, BES_DATA_ADMIN_PERMISSION_GROUP)
+      ) {
+        throw new Error(`No ${BES_DATA_ADMIN_PERMISSION_GROUP} access for user to ${countryCode}`);
+      }
+    });
+  }
+
   async buildResponse() {
     const { query, body } = this.req;
     const { testData, testConfig, ...restOfBody } = body;
-    const { organisationUnitCodes, ...restOfParams } = { ...query, ...restOfBody };
+    const { organisationUnitCodes, hierarchy, ...restOfParams } = { ...query, ...restOfBody };
     if (!organisationUnitCodes) {
       throw new Error('Must provide organisationUnitCodes URL parameter');
     }
@@ -34,6 +66,8 @@ export class TestReportRoute extends Route<TestReportRequest> {
     const organisationUnitCodesArray = Array.isArray(organisationUnitCodes)
       ? organisationUnitCodes
       : organisationUnitCodes.split(',');
+
+    await this.checkUserHasAccessToReport(hierarchy, organisationUnitCodesArray);
 
     const aggregator = createAggregator(Aggregator, this.req.ctx);
     const reportBuilder = new ReportBuilder();
@@ -43,6 +77,7 @@ export class TestReportRoute extends Route<TestReportRequest> {
     }
     return reportBuilder.build(aggregator, {
       organisationUnitCodes: organisationUnitCodesArray,
+      hierarchy,
       ...restOfParams,
     });
   }


### PR DESCRIPTION
### Issue MEL-449:

Had a couple options of how we could enforce permissions here:
1. Give access to all org units for users with 'BES Admin' access
2. Give access to org units if user has 'BES Data Admin' access to that org unit

It seems that generally in Admin Panel we allow users to do operations if they have 'BES Admin' access to any country. However, for viewing data in our applications, we restrict it per org unit, and the highest org unit level permission you can be given is 'BES Data Admin'. For this reason, I felt it was more appropriate to go with the second option.