### PR TITLE
Only run change side effects in meditrak-server database

### DIFF
--- a/packages/database/src/ModelRegistry.js
+++ b/packages/database/src/ModelRegistry.js
@@ -14,14 +14,14 @@ export class ModelRegistry {
    * @param {import('./TupaiaDatabase').TupaiaDatabase} database
    * @param {import('./DatabaseModel').DatabaseModel[]} [extraModelClasses]
    */
-  constructor(database, extraModelClasses) {
+  constructor(database, extraModelClasses, useNotifiers = false) {
     this.database = database;
     this.modelClasses = {
       ...baseModelClasses,
       ...extraModelClasses,
     };
     this.generateModels();
-    if (this.database.isSingleton) {
+    if (useNotifiers) {
       this.initialiseNotifiers();
     }
   }

--- a/packages/database/src/testUtilities/getTestDatabase.js
+++ b/packages/database/src/testUtilities/getTestDatabase.js
@@ -18,5 +18,5 @@ export function getTestDatabase() {
 }
 
 export function getTestModels() {
-  return new ModelRegistry(getTestDatabase());
+  return new ModelRegistry(getTestDatabase(), {}, true);
 }

--- a/packages/meditrak-server/src/index.js
+++ b/packages/meditrak-server/src/index.js
@@ -30,7 +30,7 @@ import winston from './log';
  * Set up database
  */
 const database = new TupaiaDatabase();
-const models = new ModelRegistry(database, modelClasses);
+const models = new ModelRegistry(database, modelClasses, true);
 
 /**
  * Set up change handlers e.g. for syncing

--- a/packages/meditrak-server/src/tests/testUtilities/database/getModels.js
+++ b/packages/meditrak-server/src/tests/testUtilities/database/getModels.js
@@ -10,7 +10,7 @@ let modelsSingleton = null;
 export function getModels() {
   if (!modelsSingleton) {
     const database = new TupaiaDatabase();
-    modelsSingleton = new ModelRegistry(database, modelClasses);
+    modelsSingleton = new ModelRegistry(database, modelClasses, true);
   }
 
   return modelsSingleton;


### PR DESCRIPTION
I noticed a secondary (non release-blocking) issue while debugging the meditrak-app sync issue this morning: migrations adding indicators were throwing uncaught errors that showed they were trying to create two data sources for each indicator added.

The reason for this is that `IndicatorModel` has a change handler that creates a data source whenever a new one is added. This model is defined centrally, and imported wherever a `ModelRegistry` is created. When Tupaia is running, model registries are created all over the place - even if you're just running meditrak-server, two will be created (one by data-broker).

This PR stops all those extra model registries from calling the models' notifiers.