### PR TITLE
SOL-396: Hotfix error in STRIVE Facility EpiCurve dashboard

### DIFF
--- a/packages/data-api/src/TupaiaDataApi.js
+++ b/packages/data-api/src/TupaiaDataApi.js
@@ -6,11 +6,11 @@
 import groupBy from 'lodash.groupby';
 
 import moment from 'moment';
-import { getSortByKey, momentToDateString, DEFAULT_BINARY_OPTIONS } from '@tupaia/utils';
+import { getSortByKey, DEFAULT_BINARY_OPTIONS } from '@tupaia/utils';
 import { SqlQuery } from './SqlQuery';
 import { AnalyticsFetchQuery } from './AnalyticsFetchQuery';
 import { EventsFetchQuery } from './EventsFetchQuery';
-import { sanitizeDataValue } from './utils';
+import { sanitizeMetadataValue, sanitizeAnalyticsTableValue } from './utils';
 import { validateEventOptions, validateAnalyticsOptions } from './validation';
 import { sanitiseFetchDataOptions } from './sanitiseFetchDataOptions';
 
@@ -20,7 +20,7 @@ const buildEventDataValues = resultsForEvent =>
   resultsForEvent.reduce(
     (values, { dataElementCode, type, value }) => ({
       ...values,
-      [dataElementCode]: sanitizeDataValue(value, type),
+      [dataElementCode]: sanitizeAnalyticsTableValue(value, type),
     }),
     {},
   );
@@ -62,7 +62,7 @@ export class TupaiaDataApi {
         organisationUnit: entityCode,
         dataElement: dataElementCode,
         period,
-        value: sanitizeDataValue(value, type),
+        value: sanitizeAnalyticsTableValue(value, type),
       })),
       numAggregationsProcessed,
     };
@@ -203,10 +203,10 @@ export class TupaiaDataApi {
         // options coming from option_set are actual JSON objects
         const optionObject = typeof option === 'string' ? JSON.parse(option) : option;
         const { value, label } = optionObject;
-        optionsMetadata[sanitizeDataValue(value, type)] = label || value;
+        optionsMetadata[sanitizeMetadataValue(value, type)] = label || value;
       } catch (error) {
         // Exception is thrown when option is a plain string
-        optionsMetadata[sanitizeDataValue(option, type)] = option;
+        optionsMetadata[sanitizeMetadataValue(option, type)] = option;
       }
     });
 

--- a/packages/data-api/src/utils.js
+++ b/packages/data-api/src/utils.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
-export const sanitizeDataValue = (value, type) => {
+export const sanitizeMetadataValue = (value, type) => {
   switch (type) {
     case 'Number': {
       const sanitizedValue = parseFloat(value);
@@ -12,6 +12,23 @@ export const sanitizeDataValue = (value, type) => {
     case 'Binary':
     case 'Checkbox':
       return value === 'Yes' ? 1 : 0;
+    default:
+      return value;
+  }
+};
+
+/**
+ * Analytics table values have already been partially sanitized
+ * see: `build_analytics_table()` database function
+ */
+export const sanitizeAnalyticsTableValue = (value, type) => {
+  switch (type) {
+    case 'Binary':
+    case 'Checkbox':
+    case 'Number': {
+      const sanitizedValue = parseFloat(value);
+      return Number.isNaN(sanitizedValue) ? '' : sanitizedValue;
+    }
     default:
       return value;
   }

--- a/packages/database/src/migrations/20210827024648-UpdateAnalyticsTableToHandleYesNoAnswers-modifies-schema.js
+++ b/packages/database/src/migrations/20210827024648-UpdateAnalyticsTableToHandleYesNoAnswers-modifies-schema.js
@@ -1,0 +1,132 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = async function (db) {
+  await db.runSql(`
+    CREATE OR REPLACE FUNCTION build_analytics_table(force BOOLEAN default FALSE) RETURNS void AS $$
+    declare
+      tStartTime TIMESTAMP;
+      source_table TEXT;
+      source_tables_array TEXT[] := array['answer', 'survey_response', 'entity', 'survey', 'question', 'data_source'];
+      pSqlStatement TEXT := '
+        SELECT
+          entity.code as entity_code,
+          entity.name as entity_name,
+          question.code as data_element_code,
+          survey.code as data_group_code,
+          survey_response.id as event_id,
+          CASE 
+            WHEN question.type = ''Binary'' OR question.type = ''Checkbox'' 
+            THEN CASE 
+              WHEN answer.text = ''Yes'' THEN ''1'' 
+              ELSE ''0'' 
+            END 
+            ELSE answer.text
+          END as value,
+          question.type as type,
+          to_char(survey_response.data_time, ''YYYYMMDD'') as "day_period",
+          concat(
+            extract (isoyear from survey_response.data_time), 
+            ''W'', 
+            to_char(extract (week from survey_response.data_time), ''FM09'')) 
+          as "week_period",
+          to_char(survey_response.data_time, ''YYYYMM'') as "month_period",
+          to_char(survey_response.data_time, ''YYYY'') as "year_period",
+          survey_response.data_time as "date"
+        FROM
+          survey_response
+        INNER JOIN
+          answer ON answer.survey_response_id = survey_response.id
+        INNER JOIN
+          entity ON entity.id = survey_response.entity_id
+        INNER JOIN
+          survey ON survey.id = survey_response.survey_id
+        INNER JOIN
+          question ON question.id = answer.question_id
+        INNER JOIN
+          data_source ON data_source.id = question.data_source_id
+        WHERE data_source.service_type = ''tupaia'' AND survey_response.outdated IS FALSE';
+    
+    begin
+      RAISE NOTICE 'Creating Materialized View Logs...';
+    
+      FOREACH source_table IN ARRAY source_tables_array LOOP
+        IF (SELECT NOT EXISTS (
+          SELECT FROM pg_tables
+          WHERE schemaname = 'public'
+          AND tablename   = 'log$_' || source_table
+        ))
+        THEN
+          EXECUTE 'ALTER TABLE ' || source_table || ' DISABLE TRIGGER ' || source_table || '_trigger';
+          tStartTime := clock_timestamp();
+          PERFORM mv$createMaterializedViewlog(source_table, 'public');
+          RAISE NOTICE 'Created Materialized View Log for % table, took %', source_table, clock_timestamp() - tStartTime;
+          EXECUTE 'ALTER TABLE ' || source_table || ' ENABLE TRIGGER ' || source_table || '_trigger';
+        ELSE
+          RAISE NOTICE 'Materialized View Log for % table already exists, skipping', source_table;
+        END IF;
+      END LOOP;
+    
+    
+      RAISE NOTICE 'Creating analytics materialized view...';
+      IF (SELECT NOT EXISTS (
+        SELECT FROM pg_tables
+        WHERE schemaname = 'public'
+        AND tablename   = 'analytics'
+      ))
+      THEN
+        tStartTime := clock_timestamp();
+        PERFORM mv$createMaterializedView(
+            pViewName           => 'analytics',
+            pSelectStatement    =>  pSqlStatement,
+            pOwner              => 'public',
+            pFastRefresh        =>  TRUE
+        );
+        RAISE NOTICE 'Created analytics table, took %', clock_timestamp() - tStartTime;
+      ELSE
+        IF (force)
+        THEN
+        RAISE NOTICE 'Force rebuilding analytics table';
+          tStartTime := clock_timestamp();
+          PERFORM mv$createMaterializedView(
+              pViewName           => 'analytics_tmp',
+              pSelectStatement    =>  pSqlStatement,
+              pOwner              => 'public',
+              pFastRefresh        =>  TRUE
+          );
+          RAISE NOTICE 'Created analytics table, took %', clock_timestamp() - tStartTime;
+          PERFORM mv$removeMaterializedView('analytics', 'public');
+          PERFORM mv$renameMaterializedView('analytics_tmp', 'analytics', 'public');
+        ELSE
+          RAISE NOTICE 'Analytics Materialized View already exists, skipping';
+        END IF;
+      END IF;
+    end $$ LANGUAGE plpgsql;
+  `);
+
+  // Force rebuild the analytics table so it uses the period formats
+  await db.runSql('SELECT build_analytics_table(true);');
+  await db.runSql('SELECT create_analytics_table_indexes();');
+  return null;
+};
+
+exports.down = function (db) {
+  return null;
+};
+
+exports._meta = {
+  version: 1,
+};


### PR DESCRIPTION
### Issue SOL-396:

Proposing this as a hotfix.

The root cause issue here is that we're performing a numerical aggregation function `SUM` over a non-numeric answer `'Yes' / 'No'`. Normally we don't encounter this error because the aggregation is being performed _after_ we sanitize the answer, however with aggregation in the database we aggregate before doing this, so we may encounter this problem.

I decided to go with the approach of pre-sanitizing the data in the analytics table (ie. converting 'Yes' / 'No' answers to 1 / 0). This makes sense to me since the records in the analytics table are meant to represent the actual analytics that get passed through the system.

Alternatively, we could reconsider performing numeric operations across these types of answers in the first place? And possibly introduce new aggregations to handle them instead? I know some people have found it a little confusing that 'Yes' / 'No' answers become 1 / 0 in our system...

If we don't wanna make the call either way right here and now, we can also disable aggregation for the specific type that causes this dashboard to break (`SUM_EACH_WEEK`)?

### Changes:
- Convert Binary and Checkbox answers to 1/0 in analytics table
