### PR TITLE
MEL-453: admin-panel-server typescript cleanups

### DIFF
--- a/packages/admin-panel-server/examples.http
+++ b/packages/admin-panel-server/examples.http
@@ -16,12 +16,13 @@ content-type: {{contentType}}
 }
 
 ### Fetch Dashboard Preview Data
-POST {{baseUrl}}/fetchReportPreviewData?entityCode=TO
+POST {{baseUrl}}/fetchReportPreviewData?hierarchy=explore&entityCode=TO
 content-type: {{contentType}}
 Authorization: {{authorization}}
 
 {
     "previewConfig": {
+        "code": "test",
         "data": {
             "dataElements": [
                 "BCD46",
@@ -45,9 +46,9 @@ Authorization: {{authorization}}
                     "transform": "select",
                     "'Doctors'": "$row.BCD46",
                     "'Midwives'": "$row.BCD47",
-                    "'Nurses'": "sum([$row.BCD48, $row.BCD48a, $row.BCD48b])",
+                    "'Nurses'": "sum($row.BCD48, $row.BCD48a, $row.BCD48b)",
                     "'Aides'": "$row.BCD49",
-                    "'Others'": "sum([$row.BCD50, $row.BCD51, $row.BCD52, $row.BCD53, $row.BCD54, $row.BCD55])",
+                    "'Others'": "sum($row.BCD50, $row.BCD51, $row.BCD52, $row.BCD53, $row.BCD54, $row.BCD55)",
                     "...": ["period", "organisationUnit"]
                 },
                 {
@@ -98,9 +99,9 @@ Authorization: {{authorization}}
                     "transform": "select",
                     "'Doctors'": "$row.BCD46",
                     "'Midwives'": "$row.BCD47",
-                    "'Nurses'": "sum([$row.BCD48, $row.BCD48a, $row.BCD48b])",
+                    "'Nurses'": "sum($row.BCD48, $row.BCD48a, $row.BCD48b)",
                     "'Aides'": "$row.BCD49",
-                    "'Others'": "sum([$row.BCD50, $row.BCD51, $row.BCD52, $row.BCD53, $row.BCD54, $row.BCD55])",
+                    "'Others'": "sum($row.BCD50, $row.BCD51, $row.BCD52, $row.BCD53, $row.BCD54, $row.BCD55)",
                     "...": ["period", "organisationUnit"]
                 },
                 {
@@ -122,7 +123,7 @@ Authorization: {{authorization}}
 }
 
 ### Save dashboard visualisation (report + dashboard_item)
-POST {{baseUrl}}/saveDashboardVisualisation
+POST {{baseUrl}}/dashboardVisualisation
 content-type: {{contentType}}
 Authorization: {{authorization}}
 
@@ -154,9 +155,9 @@ Authorization: {{authorization}}
                     "transform": "select",
                     "'Doctors'": "$row.BCD46",
                     "'Midwives'": "$row.BCD47",
-                    "'Nurses'": "sum([$row.BCD48, $row.BCD48a, $row.BCD48b])",
+                    "'Nurses'": "sum($row.BCD48, $row.BCD48a, $row.BCD48b)",
                     "'Aides'": "$row.BCD49",
-                    "'Others'": "sum([$row.BCD50, $row.BCD51, $row.BCD52, $row.BCD53, $row.BCD54, $row.BCD55])",
+                    "'Others'": "sum($row.BCD50, $row.BCD51, $row.BCD52, $row.BCD53, $row.BCD54, $row.BCD55)",
                     "...": ["period", "organisationUnit"]
                 },
                 {

--- a/packages/admin-panel-server/package.json
+++ b/packages/admin-panel-server/package.json
@@ -38,6 +38,7 @@
     "case": "^1.6.3",
     "client-sessions": "^0.8.0",
     "cors": "^2.8.5",
+    "dotenv": "^8.2.0",
     "express": "^4.16.2",
     "http-proxy-middleware": "^2.0.1",
     "lodash": "^4.17.4",

--- a/packages/admin-panel-server/src/@types/express/index.d.ts
+++ b/packages/admin-panel-server/src/@types/express/index.d.ts
@@ -1,0 +1,21 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+import { AccessPolicy } from '@tupaia/access-policy';
+
+import { AdminPanelSessionType } from '../../models';
+
+declare global {
+  namespace Express {
+    export interface Request {
+      accessPolicy: AccessPolicy;
+      session: AdminPanelSessionType;
+    }
+
+    export interface Response {
+      accessPolicy: AccessPolicy;
+      session: AdminPanelSessionType;
+    }
+  }
+}

--- a/packages/admin-panel-server/src/app/createApp.ts
+++ b/packages/admin-panel-server/src/app/createApp.ts
@@ -19,11 +19,17 @@ import { AdminPanelSessionModel } from '../models';
 import { hasTupaiaAdminPanelAccess } from '../utils';
 import { attachAuthorizationHeader, upload, verifyBESAdminAccess } from '../middleware';
 import {
+  ExportDashboardVisualisationRequest,
   ExportDashboardVisualisationRoute,
+  FetchDashboardVisualisationRequest,
   FetchDashboardVisualisationRoute,
+  FetchHierarchyEntitiesRequest,
   FetchHierarchyEntitiesRoute,
+  FetchReportPreviewDataRequest,
   FetchReportPreviewDataRoute,
+  ImportDashboardVisualisationRequest,
   ImportDashboardVisualisationRoute,
+  SaveDashboardVisualisationRequest,
   SaveDashboardVisualisationRoute,
   UserRoute,
 } from '../routes';
@@ -44,8 +50,9 @@ const useForwardUnhandledRequestsToMeditrak = (app: Express) => {
       return path;
     },
     onProxyReq: fixRequestBody,
-    onProxyRes: function (proxyRes: IncomingMessage, req: IncomingMessage, res: ServerResponse) {
+    onProxyRes: (proxyRes: IncomingMessage, req: IncomingMessage, res: ServerResponse) => {
       // To get around CORS because Admin Panel has credentials: true in fetch for session cookies
+      // eslint-disable-next-line no-param-reassign
       proxyRes.headers['Access-Control-Allow-Origin'] = res.get('Access-Control-Allow-Origin');
     },
   };
@@ -62,37 +69,37 @@ export function createApp() {
     .useSessionModel(AdminPanelSessionModel)
     .verifyLogin(hasTupaiaAdminPanelAccess)
     .get('/v1/user', handleWith(UserRoute))
-    .get(
+    .get<FetchHierarchyEntitiesRequest>(
       '/v1/hierarchy/:hierarchyName/:entityCode',
       verifyBESAdminAccess,
       handleWith(FetchHierarchyEntitiesRoute),
     )
-    .post(
+    .post<FetchReportPreviewDataRequest>(
       '/v1/fetchReportPreviewData',
       verifyBESAdminAccess,
       handleWith(FetchReportPreviewDataRoute),
     )
-    .post(
+    .post<SaveDashboardVisualisationRequest>(
       '/v1/dashboardVisualisation',
       verifyBESAdminAccess,
       handleWith(SaveDashboardVisualisationRoute),
     )
-    .put(
+    .put<SaveDashboardVisualisationRequest>(
       '/v1/dashboardVisualisation/:dashboardVisualisationId',
       verifyBESAdminAccess,
       handleWith(SaveDashboardVisualisationRoute),
     )
-    .get(
+    .get<FetchDashboardVisualisationRequest>(
       '/v1/dashboardVisualisation/:dashboardVisualisationId',
       verifyBESAdminAccess,
       handleWith(FetchDashboardVisualisationRoute),
     )
-    .post(
+    .post<ExportDashboardVisualisationRequest>(
       '/v1/export/dashboardVisualisation',
       verifyBESAdminAccess,
       handleWith(ExportDashboardVisualisationRoute),
     )
-    .post(
+    .post<ImportDashboardVisualisationRequest>(
       '/v1/import/dashboardVisualisations',
       verifyBESAdminAccess,
       upload.single('dashboardVisualisations'),

--- a/packages/admin-panel-server/src/connections/MeditrakConnection.ts
+++ b/packages/admin-panel-server/src/connections/MeditrakConnection.ts
@@ -12,7 +12,7 @@ import { BES_ADMIN_PERMISSION_GROUP } from '../constants';
 const { MEDITRAK_API_URL = 'http://localhost:8090/v2' } = process.env;
 
 const isBESAdmin = (policy: Record<string, string[]>) => {
-  return new AccessPolicy(policy).allowsSome(null, BES_ADMIN_PERMISSION_GROUP);
+  return new AccessPolicy(policy).allowsSome(undefined, BES_ADMIN_PERMISSION_GROUP);
 };
 
 export class MeditrakConnection extends ApiConnection {

--- a/packages/admin-panel-server/src/index.ts
+++ b/packages/admin-panel-server/src/index.ts
@@ -5,11 +5,13 @@
 
 import '@babel/polyfill';
 
-import {} from 'dotenv/config'; // Load the environment variables into process.env
+import * as dotenv from 'dotenv';
 import http from 'http';
 
 import { createApp } from './app';
 import winston from './log';
+
+dotenv.config(); // Load the environment variables into process.env
 
 /**
  * Set up app with routes etc.

--- a/packages/admin-panel-server/src/models/index.ts
+++ b/packages/admin-panel-server/src/models/index.ts
@@ -3,4 +3,4 @@
  * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
  */
 
-export { AdminPanelSessionModel } from './AdminPanelSession';
+export { AdminPanelSessionType, AdminPanelSessionModel } from './AdminPanelSession';

--- a/packages/admin-panel-server/src/routes/ExportDashboardVisualisationRoute.ts
+++ b/packages/admin-panel-server/src/routes/ExportDashboardVisualisationRoute.ts
@@ -4,9 +4,20 @@
  *
  */
 
+import { Request } from 'express';
+
 import { Route } from '@tupaia/server-boilerplate';
 
-export class ExportDashboardVisualisationRoute extends Route {
+import { DashboardVisualisationObject } from '../viz-builder';
+
+export type ExportDashboardVisualisationRequest = Request<
+  Record<string, never>,
+  { contents: DashboardVisualisationObject; filePath: string; type: string },
+  { visualisation: DashboardVisualisationObject },
+  Record<string, never>
+>;
+
+export class ExportDashboardVisualisationRoute extends Route<ExportDashboardVisualisationRequest> {
   protected readonly type = 'download';
 
   async buildResponse() {

--- a/packages/admin-panel-server/src/routes/FetchDashboardVisualisationRoute.ts
+++ b/packages/admin-panel-server/src/routes/FetchDashboardVisualisationRoute.ts
@@ -9,12 +9,19 @@ import { Request, Response, NextFunction } from 'express';
 import { Route } from '@tupaia/server-boilerplate';
 
 import { MeditrakConnection } from '../connections';
-import { DashboardVisualisationCombiner } from '../viz-builder';
+import { DashboardVisualisationCombiner, DashboardVisualisationObject } from '../viz-builder';
 
-export class FetchDashboardVisualisationRoute extends Route {
+export type FetchDashboardVisualisationRequest = Request<
+  { dashboardVisualisationId: string },
+  { visualisation: DashboardVisualisationObject },
+  Record<string, never>,
+  Record<string, never>
+>;
+
+export class FetchDashboardVisualisationRoute extends Route<FetchDashboardVisualisationRequest> {
   private readonly meditrakConnection: MeditrakConnection;
 
-  constructor(req: Request, res: Response, next: NextFunction) {
+  constructor(req: FetchDashboardVisualisationRequest, res: Response, next: NextFunction) {
     super(req, res, next);
 
     this.meditrakConnection = new MeditrakConnection(req.session);
@@ -26,11 +33,8 @@ export class FetchDashboardVisualisationRoute extends Route {
       `dashboardVisualisations/${dashboardVisualisationId}`,
     );
 
-    const extractor = new DashboardVisualisationCombiner(
-      dashboardItem,
-      report,
-    );
-    const visualisation = extractor.getVisualisation();
+    const combiner = new DashboardVisualisationCombiner(dashboardItem, report);
+    const visualisation = combiner.getVisualisation();
 
     return {
       visualisation,

--- a/packages/admin-panel-server/src/routes/FetchHierarchyEntitiesRoute.ts
+++ b/packages/admin-panel-server/src/routes/FetchHierarchyEntitiesRoute.ts
@@ -10,10 +10,17 @@ import { QueryParameters, Route } from '@tupaia/server-boilerplate';
 
 import { EntityConnection } from '../connections';
 
-export class FetchHierarchyEntitiesRoute extends Route {
+export type FetchHierarchyEntitiesRequest = Request<
+  { hierarchyName: string; entityCode: string },
+  Record<string, unknown>[],
+  Record<string, never>,
+  { fields?: string; search?: string }
+>;
+
+export class FetchHierarchyEntitiesRoute extends Route<FetchHierarchyEntitiesRequest> {
   private readonly entityConnection: EntityConnection;
 
-  constructor(req: Request, res: Response, next: NextFunction) {
+  constructor(req: FetchHierarchyEntitiesRequest, res: Response, next: NextFunction) {
     super(req, res, next);
 
     this.entityConnection = new EntityConnection(req.session);
@@ -22,9 +29,10 @@ export class FetchHierarchyEntitiesRoute extends Route {
   async buildResponse() {
     const { hierarchyName, entityCode } = this.req.params;
     const { fields, search } = this.req.query;
-    const queryParams: QueryParameters = {
-      fields: fields as string,
-    };
+    const queryParams: QueryParameters = {};
+    if (fields) {
+      queryParams.fields = fields;
+    }
     if (search) {
       queryParams.filter = `name=@${search}`;
     }

--- a/packages/admin-panel-server/src/routes/FetchReportPreviewDataRoute.ts
+++ b/packages/admin-panel-server/src/routes/FetchReportPreviewDataRoute.ts
@@ -11,15 +11,22 @@ import { Route } from '@tupaia/server-boilerplate';
 import { ReportConnection } from '../connections';
 import {
   DashboardVisualisationExtractor,
-  DraftDashboardItemValidator,
-  DraftReportValidator,
+  draftDashboardItemValidator,
+  draftReportValidator,
+  PreviewMode,
 } from '../viz-builder';
-import { PreviewMode } from '../viz-builder/types';
 
-export class FetchReportPreviewDataRoute extends Route {
+export type FetchReportPreviewDataRequest = Request<
+  { dashboardVisualisationId: string },
+  Record<string, unknown>,
+  { previewConfig?: Record<string, unknown> },
+  { entityCode?: string; hierarchy?: string; previewMode?: PreviewMode }
+>;
+
+export class FetchReportPreviewDataRoute extends Route<FetchReportPreviewDataRequest> {
   private readonly reportConnection: ReportConnection;
 
-  constructor(req: Request, res: Response, next: NextFunction) {
+  constructor(req: FetchReportPreviewDataRequest, res: Response, next: NextFunction) {
     super(req, res, next);
 
     this.reportConnection = new ReportConnection(req.session);
@@ -43,9 +50,9 @@ export class FetchReportPreviewDataRoute extends Route {
 
     const { config: reportConfig } = new DashboardVisualisationExtractor(
       previewConfig,
-      new DraftDashboardItemValidator(),
-      new DraftReportValidator(),
-    ).getReport(previewMode as PreviewMode);
+      draftDashboardItemValidator,
+      draftReportValidator,
+    ).getReport(previewMode);
 
     return this.reportConnection.testReport(
       {

--- a/packages/admin-panel-server/src/routes/ImportDashboardVisualisationRoute.ts
+++ b/packages/admin-panel-server/src/routes/ImportDashboardVisualisationRoute.ts
@@ -38,7 +38,7 @@ export class ImportDashboardVisualisationRoute extends Route<ImportDashboardVisu
       throw new UploadError();
     }
 
-    const visualisation = readJsonFile(this.req.file.path) as Record<string, unknown>;
+    const visualisation = readJsonFile<Record<string, unknown>>(this.req.file.path);
     fs.unlinkSync(this.req.file.path);
 
     const extractor = new DashboardVisualisationExtractor(

--- a/packages/admin-panel-server/src/routes/ImportDashboardVisualisationRoute.ts
+++ b/packages/admin-panel-server/src/routes/ImportDashboardVisualisationRoute.ts
@@ -13,14 +13,21 @@ import { readJsonFile, UploadError } from '@tupaia/utils';
 import { MeditrakConnection } from '../connections';
 import {
   DashboardVisualisationExtractor,
-  DraftDashboardItemValidator,
-  DraftReportValidator,
+  draftDashboardItemValidator,
+  draftReportValidator,
 } from '../viz-builder';
 
-export class ImportDashboardVisualisationRoute extends Route {
+export type ImportDashboardVisualisationRequest = Request<
+  Record<string, never>,
+  { id: string; message: string },
+  Record<string, never>,
+  Record<string, never>
+>;
+
+export class ImportDashboardVisualisationRoute extends Route<ImportDashboardVisualisationRequest> {
   private readonly meditrakConnection: MeditrakConnection;
 
-  constructor(req: Request, res: Response, next: NextFunction) {
+  constructor(req: ImportDashboardVisualisationRequest, res: Response, next: NextFunction) {
     super(req, res, next);
 
     this.meditrakConnection = new MeditrakConnection(req.session);
@@ -31,17 +38,15 @@ export class ImportDashboardVisualisationRoute extends Route {
       throw new UploadError();
     }
 
-    const visualisation = readJsonFile(this.req.file.path);
+    const visualisation = readJsonFile(this.req.file.path) as Record<string, unknown>;
     fs.unlinkSync(this.req.file.path);
 
-    const dashItemValidator = new DraftDashboardItemValidator();
-    const reportValidator = new DraftReportValidator();
     const extractor = new DashboardVisualisationExtractor(
       visualisation,
-      dashItemValidator,
-      reportValidator,
+      draftDashboardItemValidator,
+      draftReportValidator,
     );
-    const body = extractor.extractDashboardVisualisationResource();
+    const body = extractor.getDashboardVisualisationResource();
     const existingId = await this.findExistingVisualisationId(visualisation);
 
     const id = existingId
@@ -52,7 +57,7 @@ export class ImportDashboardVisualisationRoute extends Route {
     return { id, message: `Visualisation ${action} successfully` };
   }
 
-  private findExistingVisualisationId = async (visualisation: Record<string, string>) => {
+  private findExistingVisualisationId = async (visualisation: Record<string, unknown>) => {
     const { id, code } = visualisation;
 
     const [viz] = await this.meditrakConnection.fetchResources('dashboardVisualisations', {

--- a/packages/admin-panel-server/src/routes/SaveDashboardVisualisationRoute.ts
+++ b/packages/admin-panel-server/src/routes/SaveDashboardVisualisationRoute.ts
@@ -11,14 +11,21 @@ import { Route } from '@tupaia/server-boilerplate';
 import { MeditrakConnection } from '../connections';
 import {
   DashboardVisualisationExtractor,
-  DraftDashboardItemValidator,
-  DraftReportValidator,
+  draftDashboardItemValidator,
+  draftReportValidator,
 } from '../viz-builder';
 
-export class SaveDashboardVisualisationRoute extends Route {
+export type SaveDashboardVisualisationRequest = Request<
+  { dashboardVisualisationId?: string },
+  { id: string; message: string },
+  { visualisation?: Record<string, unknown> },
+  Record<string, never>
+>;
+
+export class SaveDashboardVisualisationRoute extends Route<SaveDashboardVisualisationRequest> {
   private readonly meditrakConnection: MeditrakConnection;
 
-  constructor(req: Request, res: Response, next: NextFunction) {
+  constructor(req: SaveDashboardVisualisationRequest, res: Response, next: NextFunction) {
     super(req, res, next);
 
     this.meditrakConnection = new MeditrakConnection(req.session);
@@ -34,10 +41,10 @@ export class SaveDashboardVisualisationRoute extends Route {
 
     const extractor = new DashboardVisualisationExtractor(
       visualisation,
-      new DraftDashboardItemValidator(),
-      new DraftReportValidator(),
+      draftDashboardItemValidator,
+      draftReportValidator,
     );
-    const body = extractor.extractDashboardVisualisationResource();
+    const body = extractor.getDashboardVisualisationResource();
 
     let result;
 

--- a/packages/admin-panel-server/src/routes/index.ts
+++ b/packages/admin-panel-server/src/routes/index.ts
@@ -5,9 +5,9 @@
  */
 
 export * from './UserRoute';
-export { ExportDashboardVisualisationRoute } from './ExportDashboardVisualisationRoute';
-export { ImportDashboardVisualisationRoute } from './ImportDashboardVisualisationRoute';
-export { FetchHierarchyEntitiesRoute } from './FetchHierarchyEntitiesRoute';
-export { FetchReportPreviewDataRoute } from './FetchReportPreviewDataRoute';
-export { SaveDashboardVisualisationRoute } from './SaveDashboardVisualisationRoute';
-export { FetchDashboardVisualisationRoute } from './FetchDashboardVisualisationRoute';
+export * from './ExportDashboardVisualisationRoute';
+export * from './ImportDashboardVisualisationRoute';
+export * from './FetchHierarchyEntitiesRoute';
+export * from './FetchReportPreviewDataRoute';
+export * from './SaveDashboardVisualisationRoute';
+export * from './FetchDashboardVisualisationRoute';

--- a/packages/admin-panel-server/src/utils/hasBESAdminAccess.ts
+++ b/packages/admin-panel-server/src/utils/hasBESAdminAccess.ts
@@ -10,7 +10,7 @@ import { PermissionsError } from '@tupaia/utils';
 import { BES_ADMIN_PERMISSION_GROUP } from '../constants';
 
 export const hasBESAdminAccess = (accessPolicy: AccessPolicy) => {
-  const hasAccess = accessPolicy.allowsSome(null, BES_ADMIN_PERMISSION_GROUP);
+  const hasAccess = accessPolicy.allowsSome(undefined, BES_ADMIN_PERMISSION_GROUP);
   if (!hasAccess) {
     throw new PermissionsError(`Need ${BES_ADMIN_PERMISSION_GROUP} access`);
   }

--- a/packages/admin-panel-server/src/utils/hasTupaiaAdminPanelAccess.ts
+++ b/packages/admin-panel-server/src/utils/hasTupaiaAdminPanelAccess.ts
@@ -9,8 +9,8 @@ import { PermissionsError } from '@tupaia/utils';
 
 import { TUPAIA_ADMIN_PANEL_PERMISSION_GROUP } from '../constants';
 
-export const hasTupaiaAdminPanelAccess = (policy: Record<string, string[]>) => {
-  const hasAccess = new AccessPolicy(policy).allowsSome(null, TUPAIA_ADMIN_PANEL_PERMISSION_GROUP);
+export const hasTupaiaAdminPanelAccess = (policy: AccessPolicy) => {
+  const hasAccess = policy.allowsSome(undefined, TUPAIA_ADMIN_PANEL_PERMISSION_GROUP);
   if (!hasAccess) {
     throw new PermissionsError('Your permissions for Tupaia do not allow you to use Admin Panel');
   }

--- a/packages/admin-panel-server/src/viz-builder/dashboardVisualisation/DashboardVisualisationCombiner.ts
+++ b/packages/admin-panel-server/src/viz-builder/dashboardVisualisation/DashboardVisualisationCombiner.ts
@@ -52,7 +52,7 @@ export class DashboardVisualisationCombiner {
     const { permissionGroup } = this.report;
     const data = this.getData();
     const presentation = this.getPresentation();
-  
+
     return {
       id,
       code,

--- a/packages/admin-panel-server/src/viz-builder/dashboardVisualisation/DashboardVisualisationExtractor.ts
+++ b/packages/admin-panel-server/src/viz-builder/dashboardVisualisation/DashboardVisualisationExtractor.ts
@@ -5,43 +5,53 @@
 
 import { isNil, omitBy } from 'lodash';
 
-import { snakeKeys } from '@tupaia/utils';
-import {
-  DashboardItem,
-  DashboardVisualisationObject,
-  DashboardVisualisationResource,
-  PreviewMode,
-  Report,
-  CamelKeysToSnake,
-  VisualisationValidator,
-} from '../types';
+import { snakeKeys, yup } from '@tupaia/utils';
+import { PreviewMode, CamelKeysToSnake } from '../types';
 
-export class DashboardVisualisationExtractor {
-  private readonly visualisation: DashboardVisualisationObject;
+import { baseVisualisationValidator } from './validators';
 
-  private readonly dashboardItemValidator: VisualisationValidator;
+// expands object types recursively
+// TODO: Move this type to a generic @tupaia/utils-ts package
+type ExpandType<T> = T extends Record<string, unknown>
+  ? T extends infer O
+    ? {
+        [K in keyof O]: ExpandType<O[K]>;
+      }
+    : never
+  : T;
 
-  private readonly reportValidator: VisualisationValidator;
+export class DashboardVisualisationExtractor<
+  DashboardItemValidator extends yup.AnyObjectSchema,
+  ReportValidator extends yup.AnyObjectSchema
+> {
+  private readonly visualisation: ExpandType<yup.InferType<typeof baseVisualisationValidator>>;
+
+  private readonly dashboardItemValidator: DashboardItemValidator;
+
+  private readonly reportValidator: ReportValidator;
 
   constructor(
-    visualisation: DashboardVisualisationObject,
-    dashboardItemValidator: VisualisationValidator,
-    reportValidator: VisualisationValidator,
+    visualisation: Record<string, unknown>,
+    dashboardItemValidator: DashboardItemValidator,
+    reportValidator: ReportValidator,
   ) {
-    this.visualisation = visualisation;
+    this.visualisation = baseVisualisationValidator.validateSync(visualisation);
     this.dashboardItemValidator = dashboardItemValidator;
     this.reportValidator = reportValidator;
   }
 
-  public extractDashboardVisualisationResource = (): DashboardVisualisationResource => {
+  public getDashboardVisualisationResource = () => {
     // Resources (like the ones passed to meditrak-server for upsert) use snake_case keys
-    const dashboardItem = snakeKeys(this.getDashboardItem()) as CamelKeysToSnake<DashboardItem>;
-    const report = snakeKeys(this.getReport()) as CamelKeysToSnake<Report>;
+    const dashboardItem = this.getDashboardItem();
+    const report = this.getReport();
 
-    return { dashboardItem, report };
+    return { dashboardItem: snakeKeys(dashboardItem), report: snakeKeys(report) } as {
+      dashboardItem: ExpandType<CamelKeysToSnake<typeof dashboardItem>>;
+      report: ExpandType<CamelKeysToSnake<typeof report>>;
+    };
   };
 
-  extractDashboardItem(): DashboardItem {
+  private vizToDashboardItem() {
     const { id, code, name, presentation } = this.visualisation;
     return {
       id,
@@ -62,15 +72,14 @@ export class DashboardVisualisationExtractor {
     };
   }
 
-  getDashboardItem() {
+  public getDashboardItem(): ExpandType<yup.InferType<DashboardItemValidator>> {
     if (!this.dashboardItemValidator) {
       throw new Error('No validator provided for extracting dashboard item');
     }
-    this.dashboardItemValidator.validate(this.visualisation);
-    return this.extractDashboardItem();
+    return this.dashboardItemValidator.validateSync(this.vizToDashboardItem());
   }
 
-  extractReport(previewMode?: PreviewMode): Report {
+  private vizToReport(previewMode?: PreviewMode) {
     const { code, permissionGroup, data, presentation } = this.visualisation;
     const { dataElements, dataGroups, aggregations } = data;
 
@@ -101,11 +110,10 @@ export class DashboardVisualisationExtractor {
     };
   }
 
-  getReport(previewMode?: PreviewMode) {
+  public getReport(previewMode?: PreviewMode): ExpandType<yup.InferType<ReportValidator>> {
     if (!this.reportValidator) {
       throw new Error('No validator provided for extracting report');
     }
-    this.reportValidator.validate(this.visualisation);
-    return this.extractReport(previewMode);
+    return this.reportValidator.validateSync(this.vizToReport(previewMode));
   }
 }

--- a/packages/admin-panel-server/src/viz-builder/dashboardVisualisation/validators.ts
+++ b/packages/admin-panel-server/src/viz-builder/dashboardVisualisation/validators.ts
@@ -5,70 +5,52 @@
 
 import { yup } from '@tupaia/utils';
 
-import { VisualisationValidator, DashboardVisualisationObject } from '../types';
+export const baseVisualisationValidator = yup.object().shape({
+  presentation: yup.object(),
+  data: yup.object(),
+});
 
-export class DraftReportValidator implements VisualisationValidator {
-  validationSchema: yup.ObjectSchema;
+export const draftReportValidator = yup.object().shape({
+  code: yup.string().required('Requires "code" for the visualisation'),
+  config: yup.object().shape({
+    fetch: yup.object().shape(
+      {
+        dataElements: yup
+          .array()
+          .of(yup.string())
+          .when('dataGroups', {
+            // dataGroups is required if there are no dataElements
+            is: (dataGroups: string[]) => !dataGroups || dataGroups.length === 0,
+            then: yup
+              .array()
+              .of(yup.string())
+              .required('Requires "dataGroups" or "dataElements"')
+              .min(1),
+            otherwise: yup.array().of(yup.string()),
+          }),
+        dataGroups: yup
+          .array()
+          .of(yup.string())
+          .when('dataElements', {
+            // dataElements is required if there are no dataGroups
+            is: (dataElements: string[]) => !dataElements || dataElements.length === 0,
+            then: yup
+              .array()
+              .of(yup.string())
+              .required('Requires "dataGroups" or "dataElements"')
+              .min(1),
+            otherwise: yup.array().of(yup.string()),
+          }),
+        aggregations: yup.array(),
+      },
+      [['dataElements', 'dataGroups']],
+    ),
+    transform: yup.array(),
+    output: yup.object(),
+  }),
+});
 
-  constructor() {
-    this.validationSchema = yup.object().shape({
-      code: yup.string().required('Requires "code" for the visualisation'),
-      data: yup.object().shape(
-        {
-          dataElements: yup
-            .array()
-            .of(yup.string())
-            .when('dataGroups', {
-              // dataGroups is required if there are no dataElements
-              is: (dataGroups: string[]) => !dataGroups || dataGroups.length === 0,
-              then: yup
-                .array()
-                .of(yup.string())
-                .required('Requires "dataGroups" or "dataElements"')
-                .min(1),
-              otherwise: yup.array().of(yup.string()),
-            }),
-          dataGroups: yup
-            .array()
-            .of(yup.string())
-            .when('dataElements', {
-              // dataElements is required if there are no dataGroups
-              is: (dataElements: string[]) => !dataElements || dataElements.length === 0,
-              then: yup
-                .array()
-                .of(yup.string())
-                .required('Requires "dataGroups" or "dataElements"')
-                .min(1),
-              otherwise: yup.array().of(yup.string()),
-            }),
-          aggregations: yup.array(),
-          transform: yup.array(),
-        },
-        ['dataElements', 'dataGroups'],
-      ),
-    });
-  }
-
-  validate(visualisation: DashboardVisualisationObject) {
-    this.validationSchema.validateSync(visualisation);
-  }
-}
-
-export class DraftDashboardItemValidator implements VisualisationValidator {
-  validationSchema: yup.ObjectSchema;
-
-  constructor() {
-    this.validationSchema = yup.object().shape({
-      code: yup.string().required('Requires "code" for the visualisation'),
-      presentation: yup.object().shape({
-        type: yup.string().required('Requires "type" in chart config'),
-        config: yup.object(),
-        output: yup.object(),
-      }),
-    });
-  }
-
-  validate(visualisation: DashboardVisualisationObject) {
-    this.validationSchema.validateSync(visualisation);
-  }
-}
+export const draftDashboardItemValidator = yup.object().shape({
+  code: yup.string().required('Requires "code" for the visualisation'),
+  config: yup.object().shape({ type: yup.string().required('Requires "type" in chart config') }),
+});

--- a/packages/admin-panel-server/src/viz-builder/dashboardVisualisation/validators.ts
+++ b/packages/admin-panel-server/src/viz-builder/dashboardVisualisation/validators.ts
@@ -53,4 +53,5 @@ export const draftReportValidator = yup.object().shape({
 export const draftDashboardItemValidator = yup.object().shape({
   code: yup.string().required('Requires "code" for the visualisation'),
   config: yup.object().shape({ type: yup.string().required('Requires "type" in chart config') }),
+  reportCode: yup.string().required('Requires "code" for the visualisation'),
 });

--- a/packages/admin-panel-server/src/viz-builder/index.ts
+++ b/packages/admin-panel-server/src/viz-builder/index.ts
@@ -4,3 +4,4 @@
  */
 
 export * from './dashboardVisualisation';
+export { DashboardVisualisationObject, PreviewMode } from './types';

--- a/packages/admin-panel-server/src/viz-builder/types.ts
+++ b/packages/admin-panel-server/src/viz-builder/types.ts
@@ -3,8 +3,6 @@
  * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
  */
 
-import { yup } from '@tupaia/utils';
-
 type AggregationObject = {
   readonly type: string;
   readonly config?: Record<string, unknown>;
@@ -21,9 +19,10 @@ type DataObject = {
   transform: Transform[];
 };
 
-type PresentationObject = {
-  readonly type: 'view' | 'chart' | 'matrix';
-  readonly config: Record<string, unknown>;
+type VizType = 'view' | 'chart' | 'matrix';
+
+type PresentationObject = Record<string, unknown> & {
+  readonly type: VizType;
   readonly output: Record<string, unknown>;
 };
 
@@ -35,21 +34,20 @@ export enum PreviewMode {
 export type DashboardVisualisationObject = {
   id?: string;
   code: string;
-  name: string;
+  name?: string;
   permissionGroup: string;
   data: DataObject;
   presentation: PresentationObject;
 };
 
 export interface VisualisationValidator {
-  validationSchema: yup.ObjectSchema;
   validate: (object: DashboardVisualisationObject) => void;
 }
 
 export type DashboardItem = {
   id?: string;
   code: string;
-  config: Record<string, unknown>;
+  config: { name?: string } & { type: VizType } & Record<string, unknown>;
   reportCode: string;
   legacy: boolean;
 };

--- a/packages/admin-panel/src/authentication/reducer.js
+++ b/packages/admin-panel/src/authentication/reducer.js
@@ -43,7 +43,7 @@ const logoutStateUpdater = (payload, currentState) => ({
 });
 
 const isBESAdmin = policy => {
-  return new AccessPolicy(policy).allowsSome(null, BES_ADMIN_PERMISSION_GROUP);
+  return new AccessPolicy(policy).allowsSome(undefined, BES_ADMIN_PERMISSION_GROUP);
 };
 
 const stateChanges = {

--- a/packages/lesmis-server/src/utils/accessPolicy.ts
+++ b/packages/lesmis-server/src/utils/accessPolicy.ts
@@ -7,11 +7,8 @@ import { AccessPolicy } from '@tupaia/access-policy';
 import { PermissionsError } from '@tupaia/utils';
 import { LESMIS_COUNTRY_CODE, LESMIS_PERMISSION_GROUPS } from '../constants';
 
-export const hasLesmisAccess = (policy: Record<string, string[]>) => {
-  const hasAccess = new AccessPolicy(policy).allows(
-    LESMIS_COUNTRY_CODE,
-    LESMIS_PERMISSION_GROUPS.PUBLIC,
-  );
+export const hasLesmisAccess = (policy: AccessPolicy) => {
+  const hasAccess = policy.allows(LESMIS_COUNTRY_CODE, LESMIS_PERMISSION_GROUPS.PUBLIC);
   if (!hasAccess) {
     throw new PermissionsError('Your permissions for Tupaia do not allow you to login to LESMIS');
   }

--- a/packages/meditrak-server/src/permissions/assertions.js
+++ b/packages/meditrak-server/src/permissions/assertions.js
@@ -56,10 +56,10 @@ export const assertAnyPermissions = (assertions, errorMessage) => async accessPo
  * specific permissions assertions
  */
 export const hasLESMISAdminAccess = accessPolicy =>
-  accessPolicy.allowsSome(null, LESMIS_ADMIN_PERMISSION_GROUP);
+  accessPolicy.allowsSome(undefined, LESMIS_ADMIN_PERMISSION_GROUP);
 
 export const hasBESAdminAccess = accessPolicy =>
-  accessPolicy.allowsSome(null, BES_ADMIN_PERMISSION_GROUP);
+  accessPolicy.allowsSome(undefined, BES_ADMIN_PERMISSION_GROUP);
 
 export const assertBESAdminAccess = accessPolicy => {
   if (hasBESAdminAccess(accessPolicy)) {
@@ -70,7 +70,7 @@ export const assertBESAdminAccess = accessPolicy => {
 };
 
 export const hasTupaiaAdminPanelAccess = accessPolicy =>
-  accessPolicy.allowsSome(null, TUPAIA_ADMIN_PANEL_PERMISSION_GROUP);
+  accessPolicy.allowsSome(undefined, TUPAIA_ADMIN_PANEL_PERMISSION_GROUP);
 
 export const assertAdminPanelAccess = accessPolicy => {
   if (hasTupaiaAdminPanelAccess(accessPolicy) || hasLESMISAdminAccess(accessPolicy)) {

--- a/packages/report-server/package.json
+++ b/packages/report-server/package.json
@@ -38,6 +38,7 @@
     "api-error-handler": "^1.0.0",
     "body-parser": "^1.18.3",
     "cors": "^2.8.5",
+    "dotenv": "^8.2.0",
     "express": "^4.16.2",
     "lodash.pick": "^4.4.0",
     "mathjs": "^7.3.0",

--- a/packages/server-boilerplate/src/orchestrator/routes/LoginRoute.ts
+++ b/packages/server-boilerplate/src/orchestrator/routes/LoginRoute.ts
@@ -13,7 +13,7 @@ import { Credentials } from '../types';
 
 export interface LoginRequest extends Request<EmptyObject, AuthResponse, Credentials> {
   ctx: {
-    verifyLogin?: (accessPolicy: any) => void;
+    verifyLogin?: (accessPolicy: AccessPolicy) => void;
   };
 }
 
@@ -32,7 +32,7 @@ export class LoginRoute extends Route<LoginRequest> {
     const response = await this.authConnection.login(credentials);
 
     if (this.req.ctx.verifyLogin) {
-      this.req.ctx.verifyLogin(response.accessPolicy);
+      this.req.ctx.verifyLogin(new AccessPolicy(response.accessPolicy));
     }
 
     const session = await this.req.sessionModel.createSession(response);

--- a/packages/utils/src/filesystem.js
+++ b/packages/utils/src/filesystem.js
@@ -6,6 +6,10 @@ import sanitize from 'sanitize-filename';
 import fs from 'fs';
 import path from 'path';
 
+/**
+ *  @template T the type of expected file contents
+ *  @returns {T}
+ */
 export const readJsonFile = filePath =>
   JSON.parse(fs.readFileSync(filePath, { encoding: 'utf-8' }));
 


### PR DESCRIPTION
### Issue MEL-453:

The main change here was a bit of a refactor to the `DashboardExtractor` logic. It's been switched to just directly using `yup` validators, rather than a wrapper class, as the validators actually provide really nice typescript integrations.

### Changes:
- Added @types/express/index.d.ts
- Added explicit defintions for routes
- Refactored validators
- Fixed up examples.http
