### PR TITLE
SOL-395: Filter out answers for non-exported questions

### DIFF
--- a/packages/meditrak-server/src/apiV2/export/exportSurveyResponses/exportResponsesToFile.js
+++ b/packages/meditrak-server/src/apiV2/export/exportSurveyResponses/exportResponsesToFile.js
@@ -240,13 +240,15 @@ export async function exportResponsesToFile(
     const responseIdToIndex = Object.fromEntries(
       surveyResponses.map((response, index) => [response.id, index]),
     );
-    answers.forEach(answer => {
-      const surveyResponseIndex = responseIdToIndex[answer['survey_response.id']];
-      const questionIndex = questionIdToIndex[answer['question.id']];
-      const exportRow = preQuestionRowCount + questionIndex;
-      const exportColumn = infoColumnKeys.length + surveyResponseIndex;
-      exportData[exportRow][exportColumn] = answer?.text || '';
-    });
+    answers
+      .filter(answer => !!questionIdToIndex[answer['question.id']]) // filter out answers for a non-exported question, e.g. DateOfData
+      .forEach(answer => {
+        const surveyResponseIndex = responseIdToIndex[answer['survey_response.id']];
+        const questionIndex = questionIdToIndex[answer['question.id']];
+        const exportRow = preQuestionRowCount + questionIndex;
+        const exportColumn = infoColumnKeys.length + surveyResponseIndex;
+        exportData[exportRow][exportColumn] = answer?.text || '';
+      });
 
     // If there is no data, add a message at the top
     if (answers.length === 0) {


### PR DESCRIPTION
### Issue #:
SOL-395

Hot fix as it is breaking downloads in prod

### Changes:
My changes for long running exports had not properly filtered out non-exported answers, which was causing a bug as it didn't know where on the spreadsheet it should go.