### PR TITLE
Fix boolean label within JsonInputField

### DIFF
--- a/packages/admin-panel/src/widgets/JsonInputField.js
+++ b/packages/admin-panel/src/widgets/JsonInputField.js
@@ -34,6 +34,7 @@ const GreyCard = styled(Card)`
 `;
 
 const Container = styled.div`
+  position: relative;
   margin-bottom: 20px;
 `;
 


### PR DESCRIPTION
### Issue #: nz-919 Fix boolean label within JsonInputField

### Changes:

- Fix label z-index issue. I do not fully understand why but the legend is getting positioned behind other layers and position relative brings it into the right pane. I tested on chroms, firefox and safari and works as expected.

---

### Screenshots:
See issue