### PR TITLE
[HotFix] Fix covid-samoa household overlay

### DIFF
--- a/packages/database/src/migrations/20210804054649-CovidSamoaReinstateHouseholdOverlay-modifies-data.js
+++ b/packages/database/src/migrations/20210804054649-CovidSamoaReinstateHouseholdOverlay-modifies-data.js
@@ -1,0 +1,58 @@
+'use strict';
+
+import { codeToId, insertObject, generateId } from '../utilities';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+const mapOverlayGroupCode = 'COVID19_Samoa';
+const mapOverlayId = 'WS_COVID_Household_Vaccination_Status';
+const reportCode = 'WS_COVID_Household_Vaccination_Status';
+
+const mapOverlayGroupRelation = groupId => ({
+  id: generateId(),
+  map_overlay_group_id: groupId,
+  child_id: mapOverlayId,
+  child_type: 'mapOverlay',
+  sort_order: 4,
+});
+
+exports.up = async function (db) {
+  const mapOverlayGroupId = await codeToId(db, 'map_overlay_group', mapOverlayGroupCode);
+  await insertObject(db, 'map_overlay_group_relation', mapOverlayGroupRelation(mapOverlayGroupId));
+  await db.runSql(`
+    update report
+        set config = jsonb_set(config, '{transform,1,where}', '"notEq($row.HVS_covidstatus, ''Fully vaccinated'')"')
+        where code = '${reportCode}';
+  `);
+  // add fetchOnLevel config
+  await db.runSql(`
+    update "mapOverlay" 
+      set "presentationOptions" = "presentationOptions" || '{"fetchOnlyDisplayLevel": true}'
+      where id = '${mapOverlayId}';
+  `);
+  return null;
+};
+
+exports.down = function (db) {
+  return db.runSql(`
+    delete from "map_overlay_group_relation" where "child_id" = '${mapOverlayId}';
+    update "mapOverlay" 
+      set "presentationOptions" = "presentationOptions" - 'fetchOnlyDisplayLevel'
+      where id = '${mapOverlayId}';
+  `);
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/packages/database/src/migrations/20210804054649-CovidSamoaReinstateHouseholdOverlay-modifies-data.js
+++ b/packages/database/src/migrations/20210804054649-CovidSamoaReinstateHouseholdOverlay-modifies-data.js
@@ -35,21 +35,12 @@ exports.up = async function (db) {
         set config = jsonb_set(config, '{transform,1,where}', '"notEq($row.HVS_covidstatus, ''Fully vaccinated'')"')
         where code = '${reportCode}';
   `);
-  // add fetchOnLevel config
-  await db.runSql(`
-    update "mapOverlay" 
-      set "presentationOptions" = "presentationOptions" || '{"fetchOnlyDisplayLevel": true}'
-      where id = '${mapOverlayId}';
-  `);
   return null;
 };
 
 exports.down = function (db) {
   return db.runSql(`
     delete from "map_overlay_group_relation" where "child_id" = '${mapOverlayId}';
-    update "mapOverlay" 
-      set "presentationOptions" = "presentationOptions" - 'fetchOnlyDisplayLevel'
-      where id = '${mapOverlayId}';
   `);
 };
 

--- a/packages/database/src/migrations/20210805035710-CovidSamoaAddHouseholdPointdata-modifies-data.js
+++ b/packages/database/src/migrations/20210805035710-CovidSamoaAddHouseholdPointdata-modifies-data.js
@@ -38,7 +38,6 @@ const updatePoint = (db, entityCode, point) => {
 };
 
 exports.up = async function (db) {
-  // console.log('samoaHouseholds', samoaHouseholds);
   const results = await Promise.all(
     samoaHouseholds.map(async entity => {
       const point = entity.latitude

--- a/packages/database/src/migrations/20210805035710-CovidSamoaAddHouseholdPointdata-modifies-data.js
+++ b/packages/database/src/migrations/20210805035710-CovidSamoaAddHouseholdPointdata-modifies-data.js
@@ -1,0 +1,62 @@
+'use strict';
+
+import samoaHouseholds from './migrationData/20210803014704-CovidSamoaAddSubDistrictEntities/Entities - households.json';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+const countryCode = 'WS';
+
+const extractEntitiesFromGeoData = geoData =>
+  geoData.features.map(feature => ({
+    code: feature.properties.code,
+    parent_code: feature.properties.parent_code,
+    name: feature.properties.name,
+    type: feature.properties.entity_type,
+    country_code: countryCode,
+    geometry: feature.geometry,
+  }));
+
+const updatePoint = (db, entityCode, point) => {
+  return db.runSql(`
+    update entity 
+    set point = ST_Force2D(ST_GeomFromGeoJSON('${JSON.stringify(point)}')),
+    bounds = ST_Expand(ST_Envelope(ST_GeomFromGeoJSON('${JSON.stringify(point)}')::geometry), 1)
+    where code = '${entityCode}';
+  `);
+};
+
+exports.up = async function (db) {
+  // console.log('samoaHouseholds', samoaHouseholds);
+  const results = await Promise.all(
+    samoaHouseholds.map(async entity => {
+      const point = entity.latitude
+        ? { type: 'Point', coordinates: [entity.longitude, entity.latitude] }
+        : null;
+      if (!point) {
+        return null;
+      }
+      return updatePoint(db, entity.code, point);
+    }),
+  );
+  return results;
+};
+
+exports.down = function (db) {
+  return null;
+};
+
+exports._meta = {
+  version: 1,
+};


### PR DESCRIPTION
Hotfix

- Unvaccinated households down to 3k which is acceptable to reinstate the household overlay while a better performance enhancement goes through usual test cycle.
- Re-add point data correcting original import mistake

Also includes https://github.com/beyondessential/tupaia/pull/3149