### PR TITLE
Add stacktrace to logged errors

### DIFF
--- a/packages/utils/src/errors.js
+++ b/packages/utils/src/errors.js
@@ -14,7 +14,7 @@ class LoggedError extends Error {
   constructor(message) {
     super(message);
     this.message = message;
-    winston.error(this.message);
+    winston.error(this.message, { stack: this.stack });
   }
 }
 


### PR DESCRIPTION
Example:
<img width="840" alt="Screen Shot 2021-09-06 at 3 04 55 pm" src="https://user-images.githubusercontent.com/667652/132163444-699a9f17-de9a-4c0c-9859-274177a68863.png">
