### PR TITLE
Startup script should exit if any command fails

### DIFF
--- a/packages/devops/scripts/deployment/startup.sh
+++ b/packages/devops/scripts/deployment/startup.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # This script deploys the repositories on startup
 
+# Exit when any command fails
+set -e
+
 # Set PATH to include depencencies
 export PATH=/home/ubuntu/.local/bin:/home/ubuntu/.yarn/bin:/home/ubuntu/.config/yarn/global/node_modules/.bin:/home/ubuntu/.nvm/versions/node/v12.18.3/bin:/usr/local/bin:$PATH
 


### PR DESCRIPTION
In https://linear.app/bes/issue/WAI-930#comment-09e03aa1 we experienced an issue where all appeared fine with the feature instance, but that was because it was serving the previously built production code. This means the startup script would exit early rather than getting to the part where nginx fires up and makes it look like it's finished successfully
