### PR TITLE
MEL-472 Remove default to zero for empty string

### DIFF
--- a/packages/expression-parser/src/expression-parser/ExpressionParser.js
+++ b/packages/expression-parser/src/expression-parser/ExpressionParser.js
@@ -114,8 +114,7 @@ export class ExpressionParser {
    */
   setScope(scope = {}) {
     Object.entries(scope).forEach(([name, value]) => {
-      const expressionValue = value || 0;
-      this.set(name, expressionValue);
+      this.set(name, value);
     });
   }
 


### PR DESCRIPTION
Currently if a data value is `''` (empty string), it will be converted to 0 before being passed in to the parser. This is not an appropriate default since empty string is a valid data value representing no data. This also means you can not differentiate between empty string and zero in the expression formula.

The change I went with is to remove the defaulting. 

Any indicators/reports that rely on `'' -> 0` should fail outright due to errors being thrown inside internal mathjs functions which only work on number type arguments not string, and the fix for these broken vizes (if any) is to convert empty string to a number explicitly in the formula, e.g. `(equalText('', a) ? 0 : a) + 5`. We may also want to add a helper function for this if this use case becomes common.

Any indicators/reports that rely on `null|undefined -> 0` should fail similarly, with mathjs throwing errors due to the type, and the fix for these broken vizes (if any) is to define defaultValues e.g. `indicator.config: { "formula": "a + 5", "defaultValues": { "a": 0 }}`.