### PR TITLE
Support hide from popup in tooltips

### DIFF
--- a/packages/ui-components/src/components/Map/Markers/MeasurePopup.js
+++ b/packages/ui-components/src/components/Map/Markers/MeasurePopup.js
@@ -5,7 +5,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { getFormattedInfo } from '../utils';
+import { PopupDataItemList } from '../PopupDataItemList';
 import { PopupMarker } from './PopupMarker';
 
 const buildHeaderText = (markerData, popupHeaderFormat) => {
@@ -28,19 +28,7 @@ export const MeasurePopup = React.memo(({ markerData, serieses }) => {
       headerText={buildHeaderText(markerData, popupHeaderFormat)}
       coordinates={coordinates}
     >
-      {serieses
-        .filter(series => !series.hideFromPopup)
-        .map(series => {
-          const { key, name } = series;
-          const { formattedValue, valueInfo } = getFormattedInfo(markerData, series);
-
-          return valueInfo.hideFromPopup ? null : (
-            <div key={key}>
-              <span>{`${name}: `}</span>
-              <strong>{formattedValue}</strong>
-            </div>
-          );
-        })}
+      <PopupDataItemList measureOptions={serieses} data={markerData} />
     </PopupMarker>
   );
 });

--- a/packages/ui-components/src/components/Map/PopupDataItemList.js
+++ b/packages/ui-components/src/components/Map/PopupDataItemList.js
@@ -28,7 +28,7 @@ PopupDataItem.propTypes = {
   measureName: PropTypes.string.isRequired,
 };
 
-export const PopupDataItemList = ({ measureOptions, data }) => {
+export const PopupDataItemList = ({ measureOptions, data, showNoDataLabel }) => {
   const popupList = data
     ? measureOptions
         .filter(measureOption => !measureOption.hideFromPopup)
@@ -49,7 +49,7 @@ export const PopupDataItemList = ({ measureOptions, data }) => {
 
   const { name, key } = measureOptions[0];
 
-  return popupList.length === 0
+  return popupList.length === 0 && showNoDataLabel
     ? [<PopupDataItem key={name || key} measureName={name || key} value="No Data" />]
     : popupList;
 };
@@ -65,4 +65,5 @@ PopupDataItemList.propTypes = {
       value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     }),
   ).isRequired,
+  showNoDataLabel: PropTypes.bool,
 };

--- a/packages/ui-components/src/components/Map/PopupDataItemList.js
+++ b/packages/ui-components/src/components/Map/PopupDataItemList.js
@@ -1,0 +1,68 @@
+/*
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ *
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { getFormattedInfo } from './utils';
+
+const getMetadata = (data, key) => {
+  if (data.metadata) {
+    return data.metadata;
+  }
+  const metadataKeys = Object.keys(data).filter(k => k.includes(`${key}_metadata`));
+  return Object.fromEntries(metadataKeys.map(k => [k.replace(`${key}_metadata`, ''), data[k]]));
+};
+
+const PopupDataItem = ({ measureName, value }) => (
+  <div key={measureName}>
+    <span>{`${measureName}: `}</span>
+    <strong>{value}</strong>
+  </div>
+);
+
+PopupDataItem.propTypes = {
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  measureName: PropTypes.string.isRequired,
+};
+
+export const PopupDataItemList = ({ measureOptions, data }) => {
+  const popupList = data
+    ? measureOptions
+        .filter(measureOption => !measureOption.hideFromPopup)
+        .map(measureOption => {
+          const { key, name, organisationUnit, ...otherConfigs } = measureOption;
+          const metadata = getMetadata(data, key);
+          const { formattedValue, valueInfo } = getFormattedInfo(data, measureOption, {
+            key,
+            metadata,
+            ...otherConfigs,
+          });
+          return valueInfo.hideFromPopup ? null : (
+            <PopupDataItem key={name} measureName={name} value={formattedValue} />
+          );
+        })
+        .filter(popupItem => popupItem !== null)
+    : [];
+
+  const { name, key } = measureOptions[0];
+
+  return popupList.length === 0
+    ? [<PopupDataItem key={name || key} measureName={name || key} value="No Data" />]
+    : popupList;
+};
+
+PopupDataItemList.propTypes = {
+  data: PropTypes.object.isRequired,
+  measureOptions: PropTypes.arrayOf(
+    PropTypes.shape({
+      key: PropTypes.string.isRequired,
+      name: PropTypes.string,
+      hideFromPopup: PropTypes.bool,
+      metadata: PropTypes.object,
+      value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    }),
+  ).isRequired,
+};

--- a/packages/ui-components/src/components/Map/index.js
+++ b/packages/ui-components/src/components/Map/index.js
@@ -12,6 +12,7 @@ export * from './MapContainer';
 export * from './MarkerLayer';
 export * from './Markers';
 export * from './PolygonLayer';
+export * from './PopupDataItemList';
 export * from './Table';
 export * from './TileLayer';
 export * from './TilePicker';

--- a/packages/web-frontend/src/components/Marker/PopupMarker.js
+++ b/packages/web-frontend/src/components/Marker/PopupMarker.js
@@ -6,12 +6,12 @@
  */
 
 import React, { PureComponent } from 'react';
+import { PopupDataItemList } from '@tupaia/ui-components/lib/map';
 import PropTypes from 'prop-types';
 import { Popup } from 'react-leaflet';
 import { MARKER_POPUP_STYLE, TOP_BAR_HEIGHT } from '../../styles';
 
 import { MarkerDataPropType, MeasureOptionsGroupPropType } from './propTypes';
-import { getFormattedInfo } from '../../utils/measures';
 
 const PopupHeader = ({ text }) => <h2 style={MARKER_POPUP_STYLE.header}>{text}</h2>;
 
@@ -27,35 +27,6 @@ const PopupCoordinates = ({ coordinates }) => {
 
 PopupCoordinates.propTypes = {
   coordinates: PropTypes.arrayOf(PropTypes.number).isRequired,
-};
-
-const PopupDataItem = ({ value, measureName }) => (
-  <div>
-    <span>{`${measureName}: `}</span>
-    <strong>{value}</strong>
-  </div>
-);
-
-PopupDataItem.propTypes = {
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-  measureName: PropTypes.string.isRequired,
-};
-
-const PopupDataItemList = ({ measureOptions, data }) =>
-  measureOptions
-    .filter(measureOption => !measureOption.hideFromPopup)
-    .map(measureOption => {
-      const { key, name } = measureOption;
-      const { formattedValue, valueInfo } = getFormattedInfo(data, measureOption);
-
-      return valueInfo.hideFromPopup ? null : (
-        <PopupDataItem key={key} measureName={name} value={formattedValue} />
-      );
-    });
-
-PopupDataItemList.propTypes = {
-  data: MarkerDataPropType.isRequired,
-  measureOptions: MeasureOptionsGroupPropType.isRequired,
 };
 
 export class PopupMarker extends PureComponent {
@@ -122,7 +93,7 @@ export const MeasurePopup = ({ data, measureOptions, onOrgUnitClick }) => {
       coordinates={coordinates}
       onDetailButtonClick={() => onOrgUnitClick(organisationUnitCode)}
     >
-      <PopupDataItemList data={data} measureOptions={measureOptions} />
+      <PopupDataItemList measureOptions={measureOptions} data={data} />
     </PopupMarker>
   );
 };

--- a/packages/web-frontend/src/components/Marker/PopupMarker.js
+++ b/packages/web-frontend/src/components/Marker/PopupMarker.js
@@ -93,7 +93,7 @@ export const MeasurePopup = ({ data, measureOptions, onOrgUnitClick }) => {
       coordinates={coordinates}
       onDetailButtonClick={() => onOrgUnitClick(organisationUnitCode)}
     >
-      <PopupDataItemList measureOptions={measureOptions} data={data} />
+      <PopupDataItemList measureOptions={measureOptions} data={data} showNoDataLabel="true" />
     </PopupMarker>
   );
 };

--- a/packages/web-frontend/src/containers/Map/AreaTooltip.js
+++ b/packages/web-frontend/src/containers/Map/AreaTooltip.js
@@ -74,7 +74,12 @@ export class AreaTooltip extends Component {
             {orgUnitName}
           </Heading>
           {hasMeasureValue && (
-            <PopupDataItemList key={1} measureOptions={measureOptions} data={orgUnitMeasureData} />
+            <PopupDataItemList
+              key={1}
+              measureOptions={measureOptions}
+              data={orgUnitMeasureData}
+              showNoDataLabel="true"
+            />
           )}
         </div>
       </Tooltip>

--- a/packages/web-frontend/src/containers/Map/AreaTooltip.js
+++ b/packages/web-frontend/src/containers/Map/AreaTooltip.js
@@ -13,47 +13,16 @@
  */
 
 import React, { Component } from 'react';
+import { PopupDataItemList } from '@tupaia/ui-components/lib/map';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 import { Tooltip } from 'react-leaflet';
-import { getFormattedInfo } from '../../utils/measures';
 
 const Heading = styled.span`
   text-align: center;
   font-weight: ${props => (props.hasMeasureValue ? 'bold' : 'normal')};
 `;
-
-const PopupTextList = ({ measureOptions, orgUnitMeasureData }) => {
-  const getMetadata = (data, key) => {
-    if (data.metadata) {
-      return data.metadata;
-    }
-    const metadataKeys = Object.keys(data).filter(k => k.includes(`${key}_metadata`));
-    return Object.fromEntries(metadataKeys.map(k => [k.replace(`${key}_metadata`, ''), data[k]]));
-  };
-
-  const popUpList = orgUnitMeasureData
-    ? measureOptions
-        .filter(m => !m.hideFromPopup)
-        .map(({ key, name, values, ...otherConfigs }) => {
-          const metadata = getMetadata(orgUnitMeasureData, key);
-          const { formattedValue, valueInfo } = getFormattedInfo(orgUnitMeasureData, {
-            key,
-            metadata,
-            ...otherConfigs,
-          });
-          const formattedKey = name || key;
-          return valueInfo?.hideFromPopup ? null : (
-            <span key={key}>{`${formattedKey}: ${formattedValue}`}</span>
-          );
-        })
-        .filter(popupItem => popupItem !== null)
-    : [];
-
-  const { name, key } = measureOptions[0];
-  return popUpList.length === 0 ? [<span key={key}>{`${name || key}: No Data`}</span>] : popUpList;
-};
 
 export class AreaTooltip extends Component {
   constructor(props) {
@@ -105,10 +74,7 @@ export class AreaTooltip extends Component {
             {orgUnitName}
           </Heading>
           {hasMeasureValue && (
-            <PopupTextList
-              measureOptions={measureOptions}
-              orgUnitMeasureData={orgUnitMeasureData}
-            />
+            <PopupDataItemList key={1} measureOptions={measureOptions} data={orgUnitMeasureData} />
           )}
         </div>
       </Tooltip>


### PR DESCRIPTION
### Issue #:
SOL-711 Support specifying `hideFromPopup` for different values in area tooltips (hover). 

config:

>  "values": [
        {
          "value": null,
          "hideFromPopup": true
        }
      ]

### Change:
Use the same logic in `PopupMarker` for rendering the list and hideFromPopup.