### PR TITLE
Add environment variable to front end builds on startup

### DIFF
--- a/packages/devops/scripts/deployment/deployPackages.sh
+++ b/packages/devops/scripts/deployment/deployPackages.sh
@@ -60,7 +60,7 @@ for PACKAGE in ${PACKAGES[@]}; do
     else
         # It's a static package, build it
         echo "Building ${PACKAGE}"
-        yarn build
+        REACT_APP_BRANCH=${BRANCH} yarn build
     fi
 
     if [[ $PACKAGE == 'meditrak-server' ]]; then


### PR DESCRIPTION
https://github.com/beyondessential/tupaia/pull/3192 introduced a great new environment banner, but because we have two build paths (one through CI/CD, the other on server startup), the same env var needs to be applied to the other place