### PR TITLE
PHX-45 Allow displaying objects in vizbuilder

### DIFF
--- a/packages/admin-panel/src/VizBuilderApp/components/PreviewSection.js
+++ b/packages/admin-panel/src/VizBuilderApp/components/PreviewSection.js
@@ -89,6 +89,18 @@ const EditorContainer = styled.div`
   }
 `;
 
+const convertValueToPrimitive = val => {
+  if (val === null) return val;
+  switch (typeof val) {
+    case 'object':
+      return JSON.stringify(val);
+    case 'function':
+      return '[Function]';
+    default:
+      return val;
+  }
+};
+
 const getColumns = data => {
   const columnKeys = [...new Set(data.map(d => Object.keys(d)).flat())];
   const indexColumn = {
@@ -99,7 +111,7 @@ const getColumns = data => {
   const columns = columnKeys.map(columnKey => {
     return {
       Header: columnKey,
-      accessor: row => row[columnKey],
+      accessor: row => convertValueToPrimitive(row[columnKey]),
     };
   });
 


### PR DESCRIPTION
### Issue #: PHX-45

![image](https://user-images.githubusercontent.com/32168886/133021004-4ffeac3c-6c4a-4357-8254-40f265c4e681.png)

This just transforms all values to primitives, otherwise the table will error, I took a look at the react table docs (which is where this is eventually rendered) and they say that accessor can only return a primitive value. I hope this is ok to slip in, as it will only ever matter when val is an object or a function, where previously it would give an unhelpful error `Something went wrong`