### PR TITLE
Hack to get front-end builds running again

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -132,9 +132,9 @@
     {
       "files": ["packages/meditrak-app/**"],
       "plugins": ["react-native"],
-      "env": {
-        "react-native/react-native": true
-      },
+      // "env": {
+      //   "react-native/react-native": true
+      // },
       "rules": {
         "react/destructuring-assignment": "off",
         "react/prop-types": ["error", { "ignore": ["navigation"] }]


### PR DESCRIPTION
Front-end builds are currently failing due to not being able to resolve the eslintc react-native package (or something like that).

![image](https://user-images.githubusercontent.com/59544282/133366176-576b2fae-ca1a-4461-bb8c-705da1801879.png)

Since the new flow involves new builds deleting the existing builds directories, this means that Tupaia ends up 'Under Maintenance' each time a new build comes in. 

This is a short term hack to get builds working again.

We need to follow up by:
1. Fixing up the eslint dependencies
2. Ensure that if building the frontend packages fails, the build fails and we don't deploy over the existing build