### PR TITLE
RN-82: Auto refresh analytics when any source table changes

### DIFF
--- a/packages/database/src/changeHandlers/AnalyticsRefresher.js
+++ b/packages/database/src/changeHandlers/AnalyticsRefresher.js
@@ -15,6 +15,10 @@ export class AnalyticsRefresher extends ChangeHandler {
     this.changeTranslators = {
       answer: () => [],
       surveyResponse: () => [],
+      survey: () => [],
+      entity: () => [],
+      question: () => [],
+      dataSource: () => [],
     };
   }
 


### PR DESCRIPTION
### Issue RN-82:
Due to the performance improvements in the latest pg-mv-fast-refresh version, I think we can try allowing the auto refresh behaviour when any source table changes. Previously we were refraining from refreshing some of the more sensitive tables as it seemed to have poor performance and we didn't want to refresh in the middle of a large import (entities for instance). Now that the behaviour seems fast across all tables, we can try always auto refreshing. The benefit of this is that changes will be integrated faster and more reliably, and large log table backlogs are less likely to build up.

### Changes:
- Bump pg-mv-fast-refresh version to include performance improvements
- Now we can try refresh if any of the source tables change

---

### Screenshots:
