### PR TITLE
WAI-950: Write temporary files to system tmp directory

### DIFF
--- a/packages/devops/Set up server.md
+++ b/packages/devops/Set up server.md
@@ -425,6 +425,23 @@ export LASTPASS_PASSWORD=xxx
 
 (get actual credentials from LastPass)
 
+# Temporary files
+
+Add a rule so that temporary files (like uploads and exports) are only deleted after 20 days, rather
+than immediately on any reboot
+
+`sudo vi /etc/tmpfiles.d/tmp.conf`
+
+Paste in
+
+```
+#/etc/tmpfiles.d/tmp.conf
+
+d /tmp 1777 root root 20d
+```
+
+And save.
+
 # ssh (optional)
 
 ### On local machine, set .ssh/config to ignore known_hosts for dev ip (it changes every day so gets annoying to remove and re-add it)

--- a/packages/meditrak-server/src/apiV2/export/getExportPathForUser.js
+++ b/packages/meditrak-server/src/apiV2/export/getExportPathForUser.js
@@ -2,17 +2,6 @@
  * Tupaia
  * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
  */
-import fs from 'fs';
+import { getTempDirectory } from '../../utilities';
 
-const EXPORT_BASE_PATH = 'exports';
-export const getExportPathForUser = userId => {
-  const exportPath = `${EXPORT_BASE_PATH}/${userId}`;
-
-  // Make the export directory if it doesn't already exist
-  try {
-    fs.statSync(exportPath);
-  } catch (e) {
-    fs.mkdirSync(exportPath);
-  }
-  return exportPath;
-};
+export const getExportPathForUser = userId => getTempDirectory(`exports/${userId}`);

--- a/packages/meditrak-server/src/apiV2/import/index.js
+++ b/packages/meditrak-server/src/apiV2/import/index.js
@@ -15,11 +15,12 @@ import { importSurveys } from './importSurveys';
 import { importUsers } from './importUsers';
 import { importSurveyResponses, constructImportEmail } from './importSurveyResponses';
 import { importDisaster } from './importDisaster';
+import { getTempDirectory } from '../../utilities';
 
 // create upload handler
 const upload = multer({
   storage: multer.diskStorage({
-    destination: './uploads/',
+    destination: getTempDirectory('uploads'),
     filename: (req, file, callback) => {
       callback(null, `${Date.now()}_${file.originalname}`);
     },

--- a/packages/meditrak-server/src/utilities/getTempDirectory.js
+++ b/packages/meditrak-server/src/utilities/getTempDirectory.js
@@ -1,0 +1,19 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+export function getTempDirectory(name) {
+  const directoryPath = path.join(os.tmpdir(), 'tupaia', name);
+
+  try {
+    fs.statSync(directoryPath);
+  } catch (e) {
+    fs.mkdirSync(directoryPath, { recursive: true });
+  }
+  return directoryPath;
+}

--- a/packages/meditrak-server/src/utilities/index.js
+++ b/packages/meditrak-server/src/utilities/index.js
@@ -4,5 +4,6 @@
  */
 
 export { getApiUrl } from './getApiUrl';
+export { getTempDirectory } from './getTempDirectory';
 export { resourceToRecordType } from './resourceToRecordType';
 export { sendEmail } from './sendEmail';


### PR DESCRIPTION
### Issue #:
- WAI-950

### Changes:
- Uploads and exports are written to the temporary folder defined by the OS

Note that on most systems this means they will be deleted on restart, so I've also tweaked the instructions for setting up a new EC2 instance to preserve them for 20 days