### PR TITLE
[HOT FIX]: Don't consider CI build time a production environment

### DIFF
--- a/packages/meditrak-server/src/devops/getIsProductionEnvironment.js
+++ b/packages/meditrak-server/src/devops/getIsProductionEnvironment.js
@@ -3,4 +3,5 @@
  * Copyright (c) 2017 Beyond Essential Systems Pty Ltd
  */
 
-export const getIsProductionEnvironment = () => process.env.IS_PRODUCTION_ENVIRONMENT === 'true';
+export const getIsProductionEnvironment = () =>
+  process.env.IS_PRODUCTION_ENVIRONMENT === 'true' && !process.env.CI_BUILD_ID;

--- a/packages/web-config-server/src/utils/getIsProductionEnvironment.js
+++ b/packages/web-config-server/src/utils/getIsProductionEnvironment.js
@@ -3,4 +3,5 @@
  * Copyright (c) 2017-2020 Beyond Essential Systems Pty Ltd
  */
 
-export const getIsProductionEnvironment = () => process.env.IS_PRODUCTION_SERVER === 'true';
+export const getIsProductionEnvironment = () =>
+  process.env.IS_PRODUCTION_ENVIRONMENT === 'true' && !process.env.CI_BUILD_ID;


### PR DESCRIPTION
The test suite will bail early if it gets run in a "production environment". Now that we're pulling the appropriate .env files for the current branch in CI/CD, builds to `master` get the production environment variables, so the tests can't run, even on the build machine. This tweaks what is considered a "production environment" to exclude when we are inside a CI/CD process on codeship.

See [this failed build](https://app.codeship.com/projects/70159bc0-0dac-0138-fdcb-260b82737f4e/builds/e3edb781-ba9f-489c-9881-5fc419e97803?component=step_Validate_and_test_Test_Test_meditrak-server) for context