### PR TITLE
PHX-47: Allow using org unit names in report-server analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@types/express": "^4.17.8",
     "@types/jsonwebtoken": "^8.5.0",
     "@types/lodash.groupby": "^4.6.0",
+    "@types/lodash.isplainobject": "^4.0.6",
     "@types/lodash.keyby": "^4.6.6",
     "@types/lodash.pick": "^4.4.0",
     "@types/multer": "^1.4.7",

--- a/packages/expression-parser/src/__tests__/expression-parser/ExpressionParser.test.js
+++ b/packages/expression-parser/src/__tests__/expression-parser/ExpressionParser.test.js
@@ -62,22 +62,4 @@ describe('ExpressionParser', () => {
       expect(functions).toStrictEqual(expected);
     });
   });
-
-  describe('Using custom calculation prefix', () => {
-    const parser = new (class extends ExpressionParser {
-      CALCULATION_PREFIX = '=';
-    })();
-
-    it('getVariables()', () => {
-      const variables = parser.getVariables('=x + y');
-      const expected = ['x', 'y'];
-      expect(variables).toStrictEqual(expected);
-    });
-
-    it('getFunctions()', () => {
-      const functions = parser.getFunctions('=cos(90) + sin(90)');
-      const expected = ['cos', 'sin'];
-      expect(functions).toStrictEqual(expected);
-    });
-  });
 });

--- a/packages/expression-parser/src/__tests__/expression-parser/ExpressionParser.test.js
+++ b/packages/expression-parser/src/__tests__/expression-parser/ExpressionParser.test.js
@@ -25,4 +25,59 @@ describe('ExpressionParser', () => {
       expect(result).toEqual(0);
     });
   });
+
+  describe('getVariables()', () => {
+    const testData = [
+      ['single variable', 'x', ['x']],
+      ['multiple variables', '2 * x + y + 1', ['x', 'y']],
+      ['expression with parentheses', '(x + y) / z', ['x', 'y', 'z']],
+      ['expression with functions', 'sqrt(cos(x)^2 + sin(y)^2)', ['x', 'y']],
+      ['variable is repeated', '(x - y) / x', ['x', 'y']],
+      ['longer variable names', 'alpha + beta - delta', ['alpha', 'beta', 'delta']],
+      ['left side variable', 'x = 1', ['x']],
+      ['variables at both sides', 'x = y', ['x', 'y']],
+    ];
+
+    const parser = new ExpressionParser();
+
+    it.each(testData)('%s', (_, expression, expected) => {
+      const variables = parser.getVariables(expression);
+      expect(variables).toStrictEqual(expected);
+    });
+  });
+
+  describe('getFunctions()', () => {
+    const testData = [
+      ['single function', 'cos(90)', ['cos']],
+      ['multiple functions', 'cos(90) + sin(90)', ['cos', 'sin']],
+      ['expression with parentheses', '(cos(3) + sin(30)) / sqrt(4)', ['cos', 'sin', 'sqrt']],
+      ['same function is repeated', 'sin(45) / sin(30)', ['sin']],
+      ['two-sided expression', 'x = sin(45)', ['sin']],
+    ];
+
+    const parser = new ExpressionParser();
+
+    it.each(testData)('%s', (_, expression, expected) => {
+      const functions = parser.getFunctions(expression);
+      expect(functions).toStrictEqual(expected);
+    });
+  });
+
+  describe('Using custom calculation prefix', () => {
+    const parser = new (class extends ExpressionParser {
+      CALCULATION_PREFIX = '=';
+    })();
+
+    it('getVariables()', () => {
+      const variables = parser.getVariables('=x + y');
+      const expected = ['x', 'y'];
+      expect(variables).toStrictEqual(expected);
+    });
+
+    it('getFunctions()', () => {
+      const functions = parser.getFunctions('=cos(90) + sin(90)');
+      const expected = ['cos', 'sin'];
+      expect(functions).toStrictEqual(expected);
+    });
+  });
 });

--- a/packages/expression-parser/src/expression-parser/ExpressionParser.js
+++ b/packages/expression-parser/src/expression-parser/ExpressionParser.js
@@ -15,14 +15,6 @@ import { create, all, factory } from 'mathjs';
  */
 
 /**
- * @typedef {Object} FactoryParams
- * @property {string[]} dependencies
- * @property {(dependencies: Record<string, Function>) => Function} create
- *
- * @see https://mathjs.org/docs/core/extension.html#factory-functions
- */
-
-/**
  * Usage:
  * const expressionParser = new ExpressionParser();
  *
@@ -57,12 +49,6 @@ const ADDITIONAL_ALPHA_CHARS = ['@'];
 
 export class ExpressionParser {
   /**
-   * Override in child classes to use a custom prefix
-   * @protected
-   */
-  CALCULATION_PREFIX = '';
-
-  /**
    * Can pass in a custom scope
    * @param {Scope} customScope
    */
@@ -83,13 +69,13 @@ export class ExpressionParser {
     this.validExpressionCache = new Set();
   }
 
-  isCalculation = expression =>
-    expression.length > 0 && expression.startsWith(this.CALCULATION_PREFIX);
-
-  readExpression = expression =>
-    this.CALCULATION_PREFIX
-      ? expression.replace(new RegExp(`^${this.CALCULATION_PREFIX}`), '')
-      : expression;
+  /**
+   * Can override in child classes to allow custom expression formats
+   * @protected
+   */
+  readExpression(input) {
+    return input;
+  }
 
   /**
    * @param {string} name
@@ -105,11 +91,13 @@ export class ExpressionParser {
     }
   }
 
-  isFunctionName = name => this.customFunctionNames.includes(name) || this.isBuiltInFunction(name);
+  isFunctionName(name) {
+    return this.customFunctionNames.includes(name) || this.isBuiltInFunction(name);
+  }
 
   /**
    * Return the variable names in an expression.
-   * @param {string} expression
+   * @param {*} expression
    */
   getVariables(expression) {
     return this.extractSymbols(expression, node => !this.isFunctionName(node.name));
@@ -117,7 +105,7 @@ export class ExpressionParser {
 
   /**
    * Return the function names in an expression.
-   * @param {string} expression
+   * @param {*} expression
    */
   getFunctions(expression) {
     return this.extractSymbols(expression, node => this.isFunctionName(node.name));
@@ -136,7 +124,7 @@ export class ExpressionParser {
 
   /**
    * Validate an expression and throw an error if it's invalid.
-   * @param {string} expression
+   * @param {*} expression
    */
   validate(expression) {
     const expr = this.readExpression(expression);
@@ -157,7 +145,7 @@ export class ExpressionParser {
 
   /**
    * Evaluate an expression. Also validate the expression beforehand
-   * @param {string} expression
+   * @param {*} expression
    */
   evaluate(expression) {
     const expr = this.readExpression(expression);
@@ -169,7 +157,7 @@ export class ExpressionParser {
    * Evaluate an expression and cast boolean results to 1 or 0. Also validate the expression beforehand.
    *
    * Note this could also return a string, array, or object (potentially others too)
-   * @param {string} expression
+   * @param {*} expression
    */
   evaluateToNumber(expression) {
     const expr = this.readExpression(expression);
@@ -250,6 +238,6 @@ export class ExpressionParser {
   }
 
   factory(...args) {
-    return factory(...args);
+    return this.math.factory(...args);
   }
 }

--- a/packages/report-server/package.json
+++ b/packages/report-server/package.json
@@ -41,7 +41,6 @@
     "dotenv": "^8.2.0",
     "express": "^4.16.2",
     "lodash.isplainobject": "^4.0.6",
-    "lodash.keyby": "^4.6.0",
     "lodash.pick": "^4.4.0",
     "mathjs": "^9.4.0",
     "winston": "^3.2.1"

--- a/packages/report-server/package.json
+++ b/packages/report-server/package.json
@@ -40,6 +40,8 @@
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",
     "express": "^4.16.2",
+    "lodash.isplainobject": "^4.0.6",
+    "lodash.keyby": "^4.6.0",
     "lodash.pick": "^4.4.0",
     "mathjs": "^9.4.0",
     "winston": "^3.2.1"

--- a/packages/report-server/src/__tests__/reportBuilder/context/buildContext.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/context/buildContext.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+
+import pick from 'lodash.pick';
+
+import { buildContext, ReqContext } from '../../../reportBuilder/context/buildContext';
+
+describe('buildContext', () => {
+  const HIERARCHY = 'test_hierarchy';
+  const ENTITIES = {
+    test_hierarchy: [
+      { id: 'ouId1', code: 'AU', name: 'Australia' },
+      { id: 'ouId2', code: 'FJ', name: 'Fiji' },
+      { id: 'ouId3', code: 'KI', name: 'Kiribati' },
+      { id: 'ouId4', code: 'TO', name: 'Tonga' },
+    ],
+  };
+
+  const entityApiMock = {
+    getEntities: async (
+      hierarchyName: keyof typeof ENTITIES,
+      entityCodes: string[],
+      queryOptions: { fields?: string[] } = {},
+    ) => {
+      const entities = ENTITIES[hierarchyName]?.filter(e => entityCodes.includes(e.code));
+      const { fields } = queryOptions;
+      return fields ? entities.map(e => pick(e, fields)) : entities;
+    },
+  };
+
+  const reqContext: ReqContext = {
+    hierarchy: HIERARCHY,
+    services: {
+      entity: entityApiMock,
+    } as ReqContext['services'],
+  };
+
+  describe('orgUnitMap', () => {
+    it('builds orgUnitMap using fetched analytics', async () => {
+      const transform = [
+        {
+          insert: {
+            name: '=orgUnitCodeToName($organisationUnit)',
+          },
+          transform: 'updateColumns',
+        },
+      ];
+      const analytics = [
+        { dataElement: 'BCD1', organisationUnit: 'TO', period: '20210101', value: 1 },
+        { dataElement: 'BCD1', organisationUnit: 'FJ', period: '20210101', value: 2 },
+      ];
+      const data = { results: analytics };
+
+      const context = await buildContext(transform, reqContext, data);
+      const expectedContext = {
+        orgUnitMap: {
+          TO: { code: 'TO', name: 'Tonga' },
+          FJ: { code: 'FJ', name: 'Fiji' },
+        },
+      };
+      expect(context).toStrictEqual(expectedContext);
+    });
+
+    it('builds orgUnitMap using fetched events', async () => {
+      const transform = [
+        {
+          insert: {
+            name: '=orgUnitCodeToName($orgUnit)',
+          },
+          transform: 'updateColumns',
+        },
+      ];
+      const events = [
+        { event: 'evId1', eventDate: '2021-01-01T12:00:00', orgUnit: 'TO', orgUnitName: 'Tonga' },
+        { event: 'evId2', eventDate: '2021-01-01T12:00:00', orgUnit: 'FJ', orgUnitName: 'Fiji' },
+      ];
+      const data = { results: events };
+
+      const context = await buildContext(transform, reqContext, data);
+      const expectedContext = {
+        orgUnitMap: {
+          TO: { code: 'TO', name: 'Tonga' },
+          FJ: { code: 'FJ', name: 'Fiji' },
+        },
+      };
+      expect(context).toStrictEqual(expectedContext);
+    });
+
+    it('ignores unknown entities', async () => {
+      const transform = [
+        {
+          insert: {
+            name: '=orgUnitCodeToName($organisationUnit)',
+          },
+          transform: 'updateColumns',
+        },
+      ];
+      const analytics = [
+        { dataElement: 'BCD1', organisationUnit: 'Unknown_entity', period: '20210101', value: 1 },
+      ];
+      const data = { results: analytics };
+
+      const context = await buildContext(transform, reqContext, data);
+      const expectedContext = {
+        orgUnitMap: {},
+      };
+      expect(context).toStrictEqual(expectedContext);
+    });
+  });
+});

--- a/packages/report-server/src/__tests__/reportBuilder/context/buildContext.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/context/buildContext.test.ts
@@ -37,8 +37,8 @@ describe('buildContext', () => {
     } as ReqContext['services'],
   };
 
-  describe('orgUnitMap', () => {
-    it('builds orgUnitMap using fetched analytics', async () => {
+  describe('orgUnits', () => {
+    it('builds orgUnits using fetched analytics', async () => {
       const transform = [
         {
           insert: {
@@ -55,15 +55,15 @@ describe('buildContext', () => {
 
       const context = await buildContext(transform, reqContext, data);
       const expectedContext = {
-        orgUnitMap: {
-          TO: { code: 'TO', name: 'Tonga' },
-          FJ: { code: 'FJ', name: 'Fiji' },
-        },
+        orgUnits: [
+          { code: 'FJ', name: 'Fiji' },
+          { code: 'TO', name: 'Tonga' },
+        ],
       };
       expect(context).toStrictEqual(expectedContext);
     });
 
-    it('builds orgUnitMap using fetched events', async () => {
+    it('builds orgUnits using fetched events', async () => {
       const transform = [
         {
           insert: {
@@ -80,10 +80,10 @@ describe('buildContext', () => {
 
       const context = await buildContext(transform, reqContext, data);
       const expectedContext = {
-        orgUnitMap: {
-          TO: { code: 'TO', name: 'Tonga' },
-          FJ: { code: 'FJ', name: 'Fiji' },
-        },
+        orgUnits: [
+          { code: 'FJ', name: 'Fiji' },
+          { code: 'TO', name: 'Tonga' },
+        ],
       };
       expect(context).toStrictEqual(expectedContext);
     });
@@ -104,7 +104,7 @@ describe('buildContext', () => {
 
       const context = await buildContext(transform, reqContext, data);
       const expectedContext = {
-        orgUnitMap: {},
+        orgUnits: [],
       };
       expect(context).toStrictEqual(expectedContext);
     });

--- a/packages/report-server/src/__tests__/reportBuilder/transform/parser/TransformParser.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/transform/parser/TransformParser.test.ts
@@ -6,8 +6,6 @@
 import { TransformParser } from '../../../../reportBuilder/transform/parser/TransformParser';
 
 describe('TransformParser', () => {
-  const parser = new TransformParser();
-
   // Use inline class extending the testable class to make protected methods testable
   const testParser = new (class extends TransformParser {
     public readExpression(input: unknown) {
@@ -28,7 +26,7 @@ describe('TransformParser', () => {
     ];
 
     it.each(testData)('%s', (_, input, received) => {
-      const result = parser.isExpression(input);
+      const result = TransformParser.isExpression(input);
       expect(result).toBe(received);
     });
   });

--- a/packages/report-server/src/__tests__/reportBuilder/transform/parser/TransformParser.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/transform/parser/TransformParser.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+
+import { TransformParser } from '../../../../reportBuilder/transform/parser/TransformParser';
+
+describe('TransformParser', () => {
+  const parser = new TransformParser();
+
+  // Use inline class extending the testable class to make protected methods testable
+  const testParser = new (class extends TransformParser {
+    public readExpression(input: unknown) {
+      return super.readExpression(input);
+    }
+  })();
+
+  describe('isExpression', () => {
+    const testData: [string, unknown, unknown][] = [
+      ['undefined', undefined, false],
+      ['string literal (truthy)', 'name', false],
+      ['string literal (falsy)', '', false],
+      ['number (truthy)', 1, false],
+      ['number (falsy)', 0, false],
+      ['boolean (truthy)', true, false],
+      ['boolean (falsy)', false, false],
+      ['expression', '=orgUnitCodeToName($orgUnit)', true],
+    ];
+
+    it.each(testData)('%s', (_, input, received) => {
+      const result = parser.isExpression(input);
+      expect(result).toBe(received);
+    });
+  });
+
+  describe('readExpression()', () => {
+    const testData: [string, unknown, unknown][] = [
+      ['undefined', undefined, undefined],
+      ['string literal (truthy)', 'name', 'name'],
+      ['string literal (falsy)', '', ''],
+      ['number (truthy)', 1, 1],
+      ['number (falsy)', 0, 0],
+      ['boolean (truthy)', true, true],
+      ['boolean (falsy)', false, false],
+      ['expression', '=orgUnitCodeToName($orgUnit)', 'orgUnitCodeToName($orgUnit)'],
+    ];
+
+    it.each(testData)('%s', (_, input, received) => {
+      const result = testParser.readExpression(input);
+      expect(result).toBe(received);
+    });
+  });
+});

--- a/packages/report-server/src/__tests__/reportBuilder/transform/parser/functions.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/transform/parser/functions.test.ts
@@ -78,10 +78,10 @@ describe('functions', () => {
   describe('context', () => {
     describe('orgUnitCodeToName', () => {
       const context = {
-        orgUnitMap: {
-          FJ: { code: 'FJ', name: 'Fiji' },
-          TO: { code: 'TO', name: 'Tonga' },
-        },
+        orgUnits: [
+          { code: 'FJ', name: 'Fiji' },
+          { code: 'TO', name: 'Tonga' },
+        ],
       };
 
       it('converts given org unit code to name', () => {

--- a/packages/report-server/src/__tests__/reportBuilder/transform/parser/functions.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/transform/parser/functions.test.ts
@@ -75,6 +75,27 @@ describe('functions', () => {
     });
   });
 
+  describe('context', () => {
+    describe('orgUnitCodeToName', () => {
+      const context = {
+        orgUnitMap: {
+          FJ: { code: 'FJ', name: 'Fiji' },
+          TO: { code: 'TO', name: 'Tonga' },
+        },
+      };
+
+      it('converts given org unit code to name', () => {
+        const parser = new TransformParser(undefined, context);
+        expect(parser.evaluate("=orgUnitCodeToName('TO')")).toBe('Tonga');
+      });
+
+      it('returns undefined if the org unit code is not found', () => {
+        const parser = new TransformParser(undefined, context);
+        expect(parser.evaluate("=orgUnitCodeToName('WS')")).toBe(undefined);
+      });
+    });
+  });
+
   describe('utils', () => {
     describe('convertToPeriod', () => {
       it('converts given period to target type', () =>

--- a/packages/report-server/src/reportBuilder/context/buildContext.ts
+++ b/packages/report-server/src/reportBuilder/context/buildContext.ts
@@ -1,0 +1,71 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+
+import keyBy from 'lodash.keyby';
+
+import { MicroServiceRequestContext } from '@tupaia/server-boilerplate';
+import { getUniqueEntries } from '@tupaia/utils';
+
+import { FetchResponse } from '../fetch';
+import { extractContextProps } from './extractContextProps';
+import { Context, ContextProp } from './types';
+
+export type ReqContext = {
+  hierarchy: string;
+  services: MicroServiceRequestContext['services'];
+};
+
+type ContextBuilder<K extends keyof Context> = (
+  reqContext: ReqContext,
+  data: FetchResponse,
+) => Promise<Context[K]>;
+
+const isEventResponse = (data: FetchResponse) => data.results.some(result => 'event' in result);
+
+const buildOrgUnitMap = async (reqContext: ReqContext, data: FetchResponse) => {
+  const orgUnitCodes = isEventResponse(data)
+    ? data.results.map(d => d.orgUnit)
+    : data.results.map(d => d.organisationUnit);
+
+  const entities = await reqContext.services.entity.getEntities(
+    reqContext.hierarchy,
+    getUniqueEntries(orgUnitCodes),
+    { fields: ['code', 'name'] },
+  );
+
+  return keyBy(entities, 'code');
+};
+
+const contextBuilders: Record<ContextProp, ContextBuilder<ContextProp>> = {
+  orgUnitMap: buildOrgUnitMap,
+};
+
+function validateContextProp(key: string): asserts key is keyof typeof contextBuilders {
+  if (!(key in contextBuilders)) {
+    throw new Error(
+      `Invalid context dependency: ${key}, must be one of ${Object.keys(contextBuilders)}`,
+    );
+  }
+}
+
+export const buildContext = async (
+  transform: unknown,
+  reqContext: ReqContext,
+  data: FetchResponse,
+): Promise<Context> => {
+  const contextProps = extractContextProps(transform);
+
+  const context = {
+    orgUnitMap: {},
+  };
+
+  for (const key of contextProps) {
+    validateContextProp(key);
+    const builder = contextBuilders[key];
+    context[key] = await builder(reqContext, data);
+  }
+
+  return context;
+};

--- a/packages/report-server/src/reportBuilder/context/extractContextProps.ts
+++ b/packages/report-server/src/reportBuilder/context/extractContextProps.ts
@@ -1,0 +1,57 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+
+import isPlainObject from 'lodash.isplainobject';
+
+import { getUniqueEntries } from '@tupaia/utils';
+
+import { contextConfig, TransformParams, TransformParser } from '../transform';
+import { ContextProp } from './types';
+
+const extractContextPropsFromExpressions = (expressions: string[]) => {
+  const parser = new TransformParser();
+  const functions = expressions
+    .filter(parser.isCalculation)
+    .map(calcExpression => {
+      return parser.getFunctions(calcExpression);
+    })
+    .flat();
+
+  const contextProps = Object.entries(contextConfig)
+    .filter(([fnName]) => functions.includes(fnName))
+    .map(([, config]) => config.contextProps)
+    .flat();
+
+  return getUniqueEntries(contextProps);
+};
+
+export const extractContextProps = (transform: unknown): ContextProp[] => {
+  if (!Array.isArray(transform)) {
+    return [];
+  }
+
+  const expressions = (transform as TransformParams[])
+    .map(transformStep => {
+      if (typeof transformStep === 'string' || !isPlainObject(transformStep)) {
+        // Skipping aliased transformations
+        return undefined;
+      }
+
+      const {
+        transform: transformType,
+        title,
+        description,
+        ...restOfTransformParams
+      } = transformStep;
+
+      return Object.values(restOfTransformParams).map(param => {
+        return typeof param !== 'object' ? [param] : Object.entries(param);
+      });
+    })
+    .flat(3)
+    .filter(d => !!d);
+
+  return extractContextPropsFromExpressions(expressions as string[]);
+};

--- a/packages/report-server/src/reportBuilder/context/extractContextProps.ts
+++ b/packages/report-server/src/reportBuilder/context/extractContextProps.ts
@@ -13,9 +13,7 @@ import { ContextProp } from './types';
 const extractContextPropsFromExpressions = (expressions: string[]) => {
   const parser = new TransformParser();
   const functions = expressions
-    .filter(expression => {
-      return parser.isExpression(expression);
-    })
+    .filter(TransformParser.isExpression)
     .map(calcExpression => {
       return parser.getFunctions(calcExpression);
     })

--- a/packages/report-server/src/reportBuilder/context/extractContextProps.ts
+++ b/packages/report-server/src/reportBuilder/context/extractContextProps.ts
@@ -13,7 +13,9 @@ import { ContextProp } from './types';
 const extractContextPropsFromExpressions = (expressions: string[]) => {
   const parser = new TransformParser();
   const functions = expressions
-    .filter(parser.isCalculation)
+    .filter(expression => {
+      return parser.isExpression(expression);
+    })
     .map(calcExpression => {
       return parser.getFunctions(calcExpression);
     })
@@ -35,7 +37,7 @@ export const extractContextProps = (transform: unknown): ContextProp[] => {
   const expressions = (transform as TransformParams[])
     .map(transformStep => {
       if (typeof transformStep === 'string' || !isPlainObject(transformStep)) {
-        // Skipping aliased transformations
+        // Skipping aliased transforms
         return undefined;
       }
 

--- a/packages/report-server/src/reportBuilder/context/extractContextProps.ts
+++ b/packages/report-server/src/reportBuilder/context/extractContextProps.ts
@@ -50,7 +50,7 @@ export const extractContextProps = (transform: unknown): ContextProp[] => {
         return typeof param !== 'object' ? [param] : Object.entries(param);
       });
     })
-    .flat(3)
+    .flat(5)
     .filter(d => !!d);
 
   return extractContextPropsFromExpressions(expressions as string[]);

--- a/packages/report-server/src/reportBuilder/context/index.ts
+++ b/packages/report-server/src/reportBuilder/context/index.ts
@@ -1,2 +1,2 @@
-export * from './buildContext';
-export * from './types';
+export { buildContext, ReqContext } from './buildContext';
+export { Context, ContextProp } from './types';

--- a/packages/report-server/src/reportBuilder/context/index.ts
+++ b/packages/report-server/src/reportBuilder/context/index.ts
@@ -1,0 +1,2 @@
+export * from './buildContext';
+export * from './types';

--- a/packages/report-server/src/reportBuilder/context/types.ts
+++ b/packages/report-server/src/reportBuilder/context/types.ts
@@ -4,7 +4,7 @@
  */
 
 export interface Context {
-  orgUnitMap: Record<string, { code: string; name: string }>;
+  orgUnits: { code: string; name: string }[];
 }
 
 export type ContextProp = keyof Context;

--- a/packages/report-server/src/reportBuilder/context/types.ts
+++ b/packages/report-server/src/reportBuilder/context/types.ts
@@ -1,0 +1,10 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+
+export interface Context {
+  orgUnitMap: Record<string, { code: string; name: string }>;
+}
+
+export type ContextProp = keyof Context;

--- a/packages/report-server/src/reportBuilder/fetch/index.ts
+++ b/packages/report-server/src/reportBuilder/fetch/index.ts
@@ -4,3 +4,4 @@
  */
 
 export { buildFetch } from './fetch';
+export { FetchResponse } from './types';

--- a/packages/report-server/src/reportBuilder/transform/aliases/aggregateAliases.ts
+++ b/packages/report-server/src/reportBuilder/transform/aliases/aggregateAliases.ts
@@ -3,35 +3,45 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
+import { Context } from '../../context';
 import { buildTransform } from '..';
 
-export const mostRecentValuePerOrgUnit = () =>
-  buildTransform([
-    {
-      transform: 'sortRows',
-      by: 'period',
-    },
-    {
-      transform: 'mergeRows',
-      groupBy: 'organisationUnit',
-      using: 'last',
-    },
-  ]);
+export const mostRecentValuePerOrgUnit = (context: Context) =>
+  buildTransform(
+    [
+      {
+        transform: 'sortRows',
+        by: 'period',
+      },
+      {
+        transform: 'mergeRows',
+        groupBy: 'organisationUnit',
+        using: 'last',
+      },
+    ],
+    context,
+  );
 
-export const firstValuePerPeriodPerOrgUnit = () =>
-  buildTransform([
-    {
-      transform: 'mergeRows',
-      groupBy: ['organisationUnit', 'period'],
-      using: 'first',
-    },
-  ]);
+export const firstValuePerPeriodPerOrgUnit = (context: Context) =>
+  buildTransform(
+    [
+      {
+        transform: 'mergeRows',
+        groupBy: ['organisationUnit', 'period'],
+        using: 'first',
+      },
+    ],
+    context,
+  );
 
-export const lastValuePerPeriodPerOrgUnit = () =>
-  buildTransform([
-    {
-      transform: 'mergeRows',
-      groupBy: ['organisationUnit', 'period'],
-      using: 'last',
-    },
-  ]);
+export const lastValuePerPeriodPerOrgUnit = (context: Context) =>
+  buildTransform(
+    [
+      {
+        transform: 'mergeRows',
+        groupBy: ['organisationUnit', 'period'],
+        using: 'last',
+      },
+    ],
+    context,
+  );

--- a/packages/report-server/src/reportBuilder/transform/aliases/periodConversionAliases.ts
+++ b/packages/report-server/src/reportBuilder/transform/aliases/periodConversionAliases.ts
@@ -3,26 +3,33 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
+import { Context } from '../../context';
 import { buildTransform } from '..';
 
-export const convertPeriodToWeek = () =>
-  buildTransform([
-    {
-      transform: 'updateColumns',
-      insert: {
-        period: "=convertToPeriod($period, 'WEEK')",
+export const convertPeriodToWeek = (context: Context) =>
+  buildTransform(
+    [
+      {
+        transform: 'updateColumns',
+        insert: {
+          period: "=convertToPeriod($period, 'WEEK')",
+        },
+        include: '*',
       },
-      include: '*',
-    },
-  ]);
+    ],
+    context,
+  );
 
-export const convertEventDateToWeek = () =>
-  buildTransform([
-    {
-      transform: 'updateColumns',
-      insert: {
-        period: "=convertToPeriod($eventDate, 'WEEK')",
+export const convertEventDateToWeek = (context: Context) =>
+  buildTransform(
+    [
+      {
+        transform: 'updateColumns',
+        insert: {
+          period: "=convertToPeriod($eventDate, 'WEEK')",
+        },
+        include: '*',
       },
-      include: '*',
-    },
-  ]);
+    ],
+    context,
+  );

--- a/packages/report-server/src/reportBuilder/transform/functions/excludeColumns.ts
+++ b/packages/report-server/src/reportBuilder/transform/functions/excludeColumns.ts
@@ -4,6 +4,7 @@
  */
 
 import { yup } from '@tupaia/utils';
+import { Context } from '../../context';
 import { TransformParser } from '../parser';
 import { buildWhere } from './where';
 import { Row } from '../../types';
@@ -20,8 +21,8 @@ const paramsValidator = yup.object().shape({
   where: yup.string(),
 });
 
-const excludeColumns = (rows: Row[], params: ExcludeColumnsParams): Row[] => {
-  const parser = new TransformParser(rows);
+const excludeColumns = (rows: Row[], params: ExcludeColumnsParams, context: Context): Row[] => {
+  const parser = new TransformParser(rows, context);
   return rows.map(row => {
     const matchesWhere = params.where(parser);
     if (!matchesWhere) {
@@ -52,7 +53,7 @@ const buildParams = (params: unknown): ExcludeColumnsParams => {
   return { shouldIncludeColumn, where: buildWhere(params) };
 };
 
-export const buildExcludeColumns = (params: unknown) => {
+export const buildExcludeColumns = (params: unknown, context: Context) => {
   const builtParams = buildParams(params);
-  return (rows: Row[]) => excludeColumns(rows, builtParams);
+  return (rows: Row[]) => excludeColumns(rows, builtParams, context);
 };

--- a/packages/report-server/src/reportBuilder/transform/functions/excludeRows.ts
+++ b/packages/report-server/src/reportBuilder/transform/functions/excludeRows.ts
@@ -5,14 +5,15 @@
 
 import { TransformParser } from '../parser';
 import { buildWhere } from './where';
+import { Context } from '../../context';
 import { Row } from '../../types';
 
 type ExcludeRowsParams = {
   where: (parser: TransformParser) => boolean;
 };
 
-const excludeRows = (rows: Row[], params: ExcludeRowsParams): Row[] => {
-  const parser = new TransformParser(rows);
+const excludeRows = (rows: Row[], params: ExcludeRowsParams, context: Context): Row[] => {
+  const parser = new TransformParser(rows, context);
   return rows.filter(() => {
     const filterResult = !params.where(parser);
     parser.next();
@@ -24,7 +25,7 @@ const buildParams = (params: unknown): ExcludeRowsParams => {
   return { where: buildWhere(params) };
 };
 
-export const buildExcludeRows = (params: unknown) => {
+export const buildExcludeRows = (params: unknown, context: Context) => {
   const builtParams = buildParams(params);
-  return (rows: Row[]) => excludeRows(rows, builtParams);
+  return (rows: Row[]) => excludeRows(rows, builtParams, context);
 };

--- a/packages/report-server/src/reportBuilder/transform/functions/index.ts
+++ b/packages/report-server/src/reportBuilder/transform/functions/index.ts
@@ -3,6 +3,9 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
+import { Context } from '../../context';
+import { Row } from '../../types';
+
 import { buildInsertColumns } from './insertColumns';
 import { buildExcludeColumns } from './excludeColumns';
 import { buildUpdateColumns } from './updateColumns';
@@ -11,7 +14,9 @@ import { buildSortRows } from './sortRows';
 import { buildExcludeRows } from './excludeRows';
 import { buildInsertRows } from './insertRows';
 
-export const transformBuilders = {
+type TransformBuilder = (params: unknown, context: Context) => (rows: Row[]) => Row[];
+
+export const transformBuilders: Record<string, TransformBuilder> = {
   insertColumns: buildInsertColumns,
   excludeColumns: buildExcludeColumns,
   updateColumns: buildUpdateColumns,

--- a/packages/report-server/src/reportBuilder/transform/functions/insertColumns.ts
+++ b/packages/report-server/src/reportBuilder/transform/functions/insertColumns.ts
@@ -5,9 +5,10 @@
 
 import { yup } from '@tupaia/utils';
 
+import { Context } from '../../context';
+import { Row } from '../../types';
 import { TransformParser } from '../parser';
 import { buildWhere } from './where';
-import { Row } from '../../types';
 import { mapStringToStringValidator } from './transformValidators';
 
 type InsertColumnsParams = {
@@ -20,8 +21,8 @@ const paramsValidator = yup.object().shape({
   where: yup.string(),
 });
 
-const insertColumns = (rows: Row[], params: InsertColumnsParams): Row[] => {
-  const parser = new TransformParser(rows);
+const insertColumns = (rows: Row[], params: InsertColumnsParams, context: Context): Row[] => {
+  const parser = new TransformParser(rows, context);
   return rows.map(row => {
     const returnNewRow = params.where(parser);
     if (!returnNewRow) {
@@ -53,7 +54,7 @@ const buildParams = (params: unknown): InsertColumnsParams => {
   };
 };
 
-export const buildInsertColumns = (params: unknown) => {
+export const buildInsertColumns = (params: unknown, context: Context) => {
   const builtParams = buildParams(params);
-  return (rows: Row[]) => insertColumns(rows, builtParams);
+  return (rows: Row[]) => insertColumns(rows, builtParams, context);
 };

--- a/packages/report-server/src/reportBuilder/transform/functions/insertRows.ts
+++ b/packages/report-server/src/reportBuilder/transform/functions/insertRows.ts
@@ -5,9 +5,10 @@
 
 import { yup } from '@tupaia/utils';
 
+import { Row } from '../../types';
+import { Context } from '../../context';
 import { TransformParser } from '../parser';
 import { buildWhere } from './where';
-import { Row } from '../../types';
 import { mapStringToStringValidator } from './transformValidators';
 
 type InsertParams = {
@@ -31,9 +32,9 @@ const paramsValidator = yup.object().shape({
     .default('after'),
 });
 
-const insertRows = (rows: Row[], params: InsertParams): Row[] => {
+const insertRows = (rows: Row[], params: InsertParams, context: Context): Row[] => {
   const returnArray = [...rows];
-  const parser = new TransformParser(rows);
+  const parser = new TransformParser(rows, context);
   const rowsToInsert = returnArray.map(() => {
     const shouldInsertNewRow = params.where(parser);
     if (!shouldInsertNewRow) {
@@ -74,7 +75,7 @@ const buildParams = (params: unknown): InsertParams => {
   };
 };
 
-export const buildInsertRows = (params: unknown) => {
+export const buildInsertRows = (params: unknown, context: Context) => {
   const builtParams = buildParams(params);
-  return (rows: Row[]) => insertRows(rows, builtParams);
+  return (rows: Row[]) => insertRows(rows, builtParams, context);
 };

--- a/packages/report-server/src/reportBuilder/transform/functions/mergeRows/mergeRows.ts
+++ b/packages/report-server/src/reportBuilder/transform/functions/mergeRows/mergeRows.ts
@@ -5,10 +5,11 @@
 
 import { yup } from '@tupaia/utils';
 
+import { Context } from '../../../context';
 import { TransformParser } from '../../parser';
 import { mergeStrategies } from './mergeStrategies';
 import { buildWhere } from '../where';
-import { Context, Row, FieldValue } from '../../../types';
+import { Row, FieldValue } from '../../../types';
 import { buildCreateGroupKey } from './createGroupKey';
 import { buildGetMergeStrategy } from './getMergeStrategy';
 import { starSingleOrMultipleColumnsValidator } from '../transformValidators';
@@ -99,8 +100,8 @@ const mergeGroups = (groups: Group[], params: MergeRowsParams): Row[] => {
   });
 };
 
-const mergeRows = (rows: Row[], params: MergeRowsParams): Row[] => {
-  const { groups, ungroupedRows } = groupRows(rows, params);
+const mergeRows = (rows: Row[], params: MergeRowsParams, context: Context): Row[] => {
+  const { groups, ungroupedRows } = groupRows(rows, params, context);
   const mergedRows = mergeGroups(groups, params);
   return mergedRows.concat(ungroupedRows);
 };
@@ -117,7 +118,7 @@ const buildParams = (params: unknown): MergeRowsParams => {
   };
 };
 
-export const buildMergeRows = (params: unknown) => {
+export const buildMergeRows = (params: unknown, context: Context) => {
   const builtParams = buildParams(params);
-  return (rows: Row[]) => mergeRows(rows, builtParams);
+  return (rows: Row[]) => mergeRows(rows, builtParams, context);
 };

--- a/packages/report-server/src/reportBuilder/transform/functions/mergeRows/mergeRows.ts
+++ b/packages/report-server/src/reportBuilder/transform/functions/mergeRows/mergeRows.ts
@@ -8,7 +8,7 @@ import { yup } from '@tupaia/utils';
 import { TransformParser } from '../../parser';
 import { mergeStrategies } from './mergeStrategies';
 import { buildWhere } from '../where';
-import { Row, FieldValue } from '../../../types';
+import { Context, Row, FieldValue } from '../../../types';
 import { buildCreateGroupKey } from './createGroupKey';
 import { buildGetMergeStrategy } from './getMergeStrategy';
 import { starSingleOrMultipleColumnsValidator } from '../transformValidators';
@@ -58,9 +58,9 @@ type Group = {
   [fieldKey: string]: FieldValue[];
 };
 
-const groupRows = (rows: Row[], params: MergeRowsParams) => {
+const groupRows = (rows: Row[], params: MergeRowsParams, context: Context) => {
   const groupsByKey: Record<string, Group> = {};
-  const parser = new TransformParser(rows);
+  const parser = new TransformParser(rows, context);
   const ungroupedRows: Row[] = []; // Rows that don't match the 'where' clause are left ungrouped
 
   rows.forEach((row: Row) => {

--- a/packages/report-server/src/reportBuilder/transform/functions/sortRows.ts
+++ b/packages/report-server/src/reportBuilder/transform/functions/sortRows.ts
@@ -72,9 +72,8 @@ const getCustomRowSortFunction = (expression: string, direction: 'asc' | 'desc')
 };
 
 const sortRows = (rows: Row[], params: SortParams): Row[] => {
-  const sortParser = new TransformParser();
   const { by, direction } = params;
-  if (typeof by === 'string' && sortParser.isExpression(by)) {
+  if (typeof by === 'string' && TransformParser.isExpression(by)) {
     const firstDirection = Array.isArray(direction) ? direction[0] : direction;
     return rows.sort(getCustomRowSortFunction(by, firstDirection));
   }

--- a/packages/report-server/src/reportBuilder/transform/functions/sortRows.ts
+++ b/packages/report-server/src/reportBuilder/transform/functions/sortRows.ts
@@ -72,8 +72,9 @@ const getCustomRowSortFunction = (expression: string, direction: 'asc' | 'desc')
 };
 
 const sortRows = (rows: Row[], params: SortParams): Row[] => {
+  const sortParser = new TransformParser();
   const { by, direction } = params;
-  if (typeof by === 'string' && TransformParser.isExpression(by)) {
+  if (typeof by === 'string' && sortParser.isExpression(by)) {
     const firstDirection = Array.isArray(direction) ? direction[0] : direction;
     return rows.sort(getCustomRowSortFunction(by, firstDirection));
   }

--- a/packages/report-server/src/reportBuilder/transform/functions/updateColumns.ts
+++ b/packages/report-server/src/reportBuilder/transform/functions/updateColumns.ts
@@ -5,9 +5,10 @@
 
 import { yup } from '@tupaia/utils';
 
+import { Context } from '../../context';
+import { Row } from '../../types';
 import { TransformParser } from '../parser';
 import { buildWhere } from './where';
-import { Row } from '../../types';
 import {
   mapStringToStringValidator,
   starSingleOrMultipleColumnsValidator,
@@ -27,8 +28,8 @@ const paramsValidator = yup.object().shape({
   where: yup.string(),
 });
 
-const updateColumns = (rows: Row[], params: UpdateColumnsParams): Row[] => {
-  const parser = new TransformParser(rows);
+const updateColumns = (rows: Row[], params: UpdateColumnsParams, context: Context): Row[] => {
+  const parser = new TransformParser(rows, context);
   return rows.map(row => {
     const returnNewRow = params.where(parser);
     if (!returnNewRow) {
@@ -77,7 +78,7 @@ const buildParams = (params: unknown): UpdateColumnsParams => {
   };
 };
 
-export const buildUpdateColumns = (params: unknown) => {
+export const buildUpdateColumns = (params: unknown, context: Context) => {
   const builtParams = buildParams(params);
-  return (rows: Row[]) => updateColumns(rows, builtParams);
+  return (rows: Row[]) => updateColumns(rows, builtParams, context);
 };

--- a/packages/report-server/src/reportBuilder/transform/index.ts
+++ b/packages/report-server/src/reportBuilder/transform/index.ts
@@ -3,4 +3,5 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
-export { buildTransform } from './transform';
+export { contextConfig, TransformParser } from './parser';
+export { buildTransform, TransformParams } from './transform';

--- a/packages/report-server/src/reportBuilder/transform/parser/TransformParser.ts
+++ b/packages/report-server/src/reportBuilder/transform/parser/TransformParser.ts
@@ -4,8 +4,15 @@
  */
 
 import { ExpressionParser } from '@tupaia/expression-parser';
+
+import { Context } from '../../context';
 import { Row, FieldValue } from '../../types';
-import { customFunctions, functionsExtensions, functionOverrides } from './functions';
+import {
+  customFunctions,
+  contextConfig,
+  functionsExtensions,
+  functionOverrides,
+} from './functions';
 import { TransformScope } from './TransformScope';
 
 type RowLookup = {
@@ -33,13 +40,18 @@ type Lookups = {
 };
 
 export class TransformParser extends ExpressionParser {
+  protected readonly CALCULATION_PREFIX = '=';
+
   private currentRow = 0;
 
   private rows: Row[];
 
   private lookups: Lookups;
 
-  public constructor(rows: Row[] = []) {
+  // eslint-disable-next-line react/static-property-placement
+  private context?: Context;
+
+  public constructor(rows: Row[] = [], context?: Context) {
     super(new TransformScope());
 
     this.rows = rows;
@@ -65,6 +77,8 @@ export class TransformParser extends ExpressionParser {
       });
       this.set('where', this.whereFunction); // no '@' prefix for where
     }
+
+    this.context = context;
   }
 
   public evaluate(expression: string) {
@@ -120,7 +134,14 @@ export class TransformParser extends ExpressionParser {
   };
 
   protected getCustomFunctions() {
-    return { ...super.getCustomFunctions(), ...customFunctions };
+    const { functions: factoryFunctions, dependencies } = this.buildFactoryFunctions();
+
+    return {
+      ...super.getCustomFunctions(),
+      ...customFunctions,
+      ...factoryFunctions,
+      ...dependencies,
+    };
   }
 
   protected getFunctionExtensions() {
@@ -129,6 +150,21 @@ export class TransformParser extends ExpressionParser {
 
   protected getFunctionOverrides() {
     return { ...super.getFunctionOverrides(), ...functionOverrides };
+  }
+
+  private buildFactoryFunctions() {
+    const dependencies = {
+      getContext: () => this.context,
+    };
+
+    const functions = Object.fromEntries(
+      Object.entries(contextConfig).map(([fnName, { create }]) => [
+        fnName,
+        this.factory(fnName, ['getContext'], create),
+      ]),
+    );
+
+    return { functions, dependencies };
   }
 
   public static isExpression(expression: string) {

--- a/packages/report-server/src/reportBuilder/transform/parser/TransformParser.ts
+++ b/packages/report-server/src/reportBuilder/transform/parser/TransformParser.ts
@@ -40,7 +40,7 @@ type Lookups = {
 };
 
 export class TransformParser extends ExpressionParser {
-  private readonly EXPRESSION_PREFIX = '=';
+  private static readonly EXPRESSION_PREFIX = '=';
 
   private currentRow = 0;
 
@@ -81,18 +81,18 @@ export class TransformParser extends ExpressionParser {
     this.context = context;
   }
 
-  public isExpression(input: unknown) {
-    return typeof input === 'string' && input.startsWith(this.EXPRESSION_PREFIX);
+  public static isExpression(input: unknown) {
+    return typeof input === 'string' && input.startsWith(TransformParser.EXPRESSION_PREFIX);
   }
 
   protected readExpression(input: unknown) {
-    return this.isExpression(input)
-      ? (input as string).replace(new RegExp(`^${this.EXPRESSION_PREFIX}`), '')
+    return TransformParser.isExpression(input)
+      ? (input as string).replace(new RegExp(`^${TransformParser.EXPRESSION_PREFIX}`), '')
       : input;
   }
 
   public evaluate(input: unknown) {
-    return this.isExpression(input) ? super.evaluate(input) : input;
+    return TransformParser.isExpression(input) ? super.evaluate(input) : input;
   }
 
   public next() {

--- a/packages/report-server/src/reportBuilder/transform/parser/TransformParser.ts
+++ b/packages/report-server/src/reportBuilder/transform/parser/TransformParser.ts
@@ -40,7 +40,7 @@ type Lookups = {
 };
 
 export class TransformParser extends ExpressionParser {
-  protected readonly CALCULATION_PREFIX = '=';
+  private readonly EXPRESSION_PREFIX = '=';
 
   private currentRow = 0;
 
@@ -81,12 +81,18 @@ export class TransformParser extends ExpressionParser {
     this.context = context;
   }
 
-  public evaluate(expression: string) {
-    if (TransformParser.isExpression(expression)) {
-      return super.evaluate(expression.substring(1));
-    }
+  public isExpression(input: unknown) {
+    return typeof input === 'string' && input.startsWith(this.EXPRESSION_PREFIX);
+  }
 
-    return expression;
+  protected readExpression(input: unknown) {
+    return this.isExpression(input)
+      ? (input as string).replace(new RegExp(`^${this.EXPRESSION_PREFIX}`), '')
+      : input;
+  }
+
+  public evaluate(input: unknown) {
+    return this.isExpression(input) ? super.evaluate(input) : input;
   }
 
   public next() {
@@ -165,10 +171,6 @@ export class TransformParser extends ExpressionParser {
     );
 
     return { functions, dependencies };
-  }
-
-  public static isExpression(expression: string) {
-    return expression.startsWith('=');
   }
 }
 

--- a/packages/report-server/src/reportBuilder/transform/parser/functions/context.ts
+++ b/packages/report-server/src/reportBuilder/transform/parser/functions/context.ts
@@ -8,19 +8,21 @@ import { reduceToDictionary } from '@tupaia/utils';
 import { Context, ContextProp } from '../../../context';
 
 /**
- * `contextProps`: props that will be required by the function
- * `create`: factory method that creates the function by injecting the context
+ * Config for functions that use `context`
+ *
+ * `contextProps`: declares the part of the context that will be used by the function
+ * `create`: factory method that creates a closure that can access the context
  */
-type ContextParams = {
+type ContextFunctionConfig = {
   contextProps: ContextProp[];
-  create: (deps: { getContext: () => Context }) => (...args: any[]) => unknown;
+  create: (dependencies: { getContext: () => Context }) => (...args: any[]) => unknown;
 };
 
-export const orgUnitCodeToName: ContextParams = {
-  contextProps: ['orgUnitMap'],
+export const orgUnitCodeToName: ContextFunctionConfig = {
+  contextProps: ['orgUnits'],
   create: ({ getContext }) => (orgUnitCode: string) => {
-    const { orgUnitMap } = getContext();
-    const codeToName = reduceToDictionary(Object.values(orgUnitMap), 'code', 'name');
+    const { orgUnits } = getContext();
+    const codeToName = reduceToDictionary(orgUnits, 'code', 'name');
     return codeToName[orgUnitCode];
   },
 };

--- a/packages/report-server/src/reportBuilder/transform/parser/functions/context.ts
+++ b/packages/report-server/src/reportBuilder/transform/parser/functions/context.ts
@@ -1,0 +1,26 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+
+import { reduceToDictionary } from '@tupaia/utils';
+
+import { Context, ContextProp } from '../../../context';
+
+/**
+ * `contextProps`: props that will be required by the function
+ * `create`: factory method that creates the function by injecting the context
+ */
+type ContextParams = {
+  contextProps: ContextProp[];
+  create: (deps: { getContext: () => Context }) => (...args: any[]) => unknown;
+};
+
+export const orgUnitCodeToName: ContextParams = {
+  contextProps: ['orgUnitMap'],
+  create: ({ getContext }) => (orgUnitCode: string) => {
+    const { orgUnitMap } = getContext();
+    const codeToName = reduceToDictionary(Object.values(orgUnitMap), 'code', 'name');
+    return codeToName[orgUnitCode];
+  },
+};

--- a/packages/report-server/src/reportBuilder/transform/parser/functions/index.ts
+++ b/packages/report-server/src/reportBuilder/transform/parser/functions/index.ts
@@ -4,6 +4,7 @@
  */
 
 import { value, last, eq, notEq, exists, notExists, gt, length, any, all } from './basic';
+import { orgUnitCodeToName } from './context';
 import {
   convertToPeriod,
   dateStringToPeriod,
@@ -32,6 +33,10 @@ export const customFunctions = {
   formatAsFractionAndPercentage,
   any,
   all,
+};
+
+export const contextConfig = {
+  orgUnitCodeToName,
 };
 
 /**

--- a/packages/report-server/src/reportBuilder/transform/parser/index.ts
+++ b/packages/report-server/src/reportBuilder/transform/parser/index.ts
@@ -3,4 +3,5 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
+export { contextConfig } from './functions';
 export { TransformParser } from './TransformParser';

--- a/packages/report-server/src/reportBuilder/transform/transform.ts
+++ b/packages/report-server/src/reportBuilder/transform/transform.ts
@@ -52,12 +52,12 @@ const transform = (rows: Row[], transformSteps: BuiltTransformParams[]): Row[] =
   return transformedRows;
 };
 
-const buildParams = (params: unknown, context?: Context): BuiltTransformParams => {
+const buildParams = (params: unknown, context: Context): BuiltTransformParams => {
   const validatedParams: TransformParams = transformParamsValidator.validateSync(params);
   if (typeof validatedParams === 'string') {
     return {
       name: validatedParams,
-      apply: aliases[validatedParams](),
+      apply: aliases[validatedParams](context),
     };
   }
 
@@ -71,11 +71,11 @@ const buildParams = (params: unknown, context?: Context): BuiltTransformParams =
   return {
     title,
     name: transformStep,
-    apply: transformBuilders[transformStep](restOfTransformParams, context as Context),
+    apply: transformBuilders[transformStep](restOfTransformParams, context),
   };
 };
 
-export const buildTransform = (params: unknown, context?: Context) => {
+export const buildTransform = (params: unknown, context: Context) => {
   const validatedParams = paramsValidator.validateSync(params);
 
   const builtParams = validatedParams.map(param => buildParams(param, context));

--- a/packages/report-server/src/reportBuilder/transform/transform.ts
+++ b/packages/report-server/src/reportBuilder/transform/transform.ts
@@ -10,14 +10,7 @@ import { Context } from '../context';
 import { transformBuilders } from './functions';
 import { aliases } from './aliases';
 
-export type TransformParams =
-  | keyof typeof aliases
-  | {
-      [key: string]: string | Record<string, string> | undefined;
-      transform: string;
-      title?: string;
-      description?: string;
-    };
+export type TransformParams = yup.InferType<typeof transformParamsValidator>;
 
 type BuiltTransformParams = {
   title?: string;

--- a/packages/report-server/src/reportBuilder/transform/transform.ts
+++ b/packages/report-server/src/reportBuilder/transform/transform.ts
@@ -6,10 +6,20 @@
 import { yup } from '@tupaia/utils';
 
 import { Row } from '../types';
+import { Context } from '../context';
 import { transformBuilders } from './functions';
 import { aliases } from './aliases';
 
-type TransformParams = {
+export type TransformParams =
+  | keyof typeof aliases
+  | {
+      [key: string]: string | Record<string, string> | undefined;
+      transform: string;
+      title?: string;
+      description?: string;
+    };
+
+type BuiltTransformParams = {
   title?: string;
   name: string;
   apply: (rows: Row[]) => Row[];
@@ -35,9 +45,9 @@ const transformParamsValidator = yup.lazy((value: unknown) => {
 
 const paramsValidator = yup.array().required();
 
-const transform = (rows: Row[], transformSteps: TransformParams[]): Row[] => {
+const transform = (rows: Row[], transformSteps: BuiltTransformParams[]): Row[] => {
   let transformedRows: Row[] = rows;
-  transformSteps.forEach((transformStep: TransformParams, index: number) => {
+  transformSteps.forEach((transformStep: BuiltTransformParams, index: number) => {
     try {
       transformedRows = transformStep.apply(transformedRows);
     } catch (e) {
@@ -49,8 +59,8 @@ const transform = (rows: Row[], transformSteps: TransformParams[]): Row[] => {
   return transformedRows;
 };
 
-const buildParams = (params: unknown): TransformParams => {
-  const validatedParams = transformParamsValidator.validateSync(params);
+const buildParams = (params: unknown, context?: Context): BuiltTransformParams => {
+  const validatedParams: TransformParams = transformParamsValidator.validateSync(params);
   if (typeof validatedParams === 'string') {
     return {
       name: validatedParams,
@@ -68,13 +78,13 @@ const buildParams = (params: unknown): TransformParams => {
   return {
     title,
     name: transformStep,
-    apply: transformBuilders[transformStep](restOfTransformParams),
+    apply: transformBuilders[transformStep](restOfTransformParams, context as Context),
   };
 };
 
-export const buildTransform = (params: unknown) => {
+export const buildTransform = (params: unknown, context?: Context) => {
   const validatedParams = paramsValidator.validateSync(params);
 
-  const builtParams = validatedParams.map(param => buildParams(param));
+  const builtParams = validatedParams.map(param => buildParams(param, context));
   return (rows: Row[]) => transform(rows, builtParams);
 };

--- a/packages/report-server/src/routes/FetchReportRoute.ts
+++ b/packages/report-server/src/routes/FetchReportRoute.ts
@@ -53,11 +53,18 @@ export class FetchReportRoute extends Route<FetchReportRequest> {
       this.req.accessPolicy,
     );
 
-    const aggregator = createAggregator(Aggregator, this.req.ctx);
-    return new ReportBuilder().setConfig(report.config).build(aggregator, {
+    const reqContext = {
+      hierarchy,
+      services: this.req.ctx.services,
+    };
+    const reportBuilder = new ReportBuilder(reqContext).setConfig(report.config);
+    const reportQuery = {
       organisationUnitCodes: accessibleOrgUnitCodes,
       hierarchy,
       ...restOfParams,
-    });
+    };
+
+    const aggregator = createAggregator(Aggregator, this.req.ctx);
+    return reportBuilder.build(aggregator, reportQuery);
   }
 }

--- a/packages/report-server/src/routes/TestReportRoute.ts
+++ b/packages/report-server/src/routes/TestReportRoute.ts
@@ -59,14 +59,18 @@ export class TestReportRoute extends Route<TestReportRequest> {
     const { query, body } = this.req;
     const { testData, testConfig, ...restOfBody } = body;
     const reportQuery = { ...query, ...restOfBody };
+    const { hierarchy = 'explore' } = reportQuery;
 
-    const reportBuilder = new ReportBuilder();
+    const reqContext = {
+      hierarchy,
+      services: this.req.ctx.services,
+    };
+    const reportBuilder = new ReportBuilder(reqContext);
     reportBuilder.setConfig(body.testConfig);
 
     if (testData) {
       reportBuilder.setTestData(testData);
     } else {
-      const { hierarchy = 'explore' } = reportQuery;
       const orgUnitCodes = parseOrgUnitCodes(reportQuery);
 
       reportQuery.hierarchy = hierarchy;

--- a/packages/report-server/src/routes/helpers.ts
+++ b/packages/report-server/src/routes/helpers.ts
@@ -3,8 +3,10 @@
  * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
  */
 
-import type { EntityApi } from '@tupaia/api-client';
-import type { AccessPolicy } from '@tupaia/access-policy';
+import { AccessPolicy } from '@tupaia/access-policy';
+import { MicroServiceRequestContext } from '@tupaia/server-boilerplate';
+
+type EntityApi = MicroServiceRequestContext['services']['entity'];
 
 export const getAccessibleOrgUnitCodes = async (
   permissionGroupName: string,

--- a/packages/report-server/src/routes/helpers.ts
+++ b/packages/report-server/src/routes/helpers.ts
@@ -3,10 +3,8 @@
  * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
  */
 
+import type { TupaiaApiClient } from '@tupaia/api-client';
 import { AccessPolicy } from '@tupaia/access-policy';
-import { MicroServiceRequestContext } from '@tupaia/server-boilerplate';
-
-type EntityApi = MicroServiceRequestContext['services']['entity'];
 
 export const getAccessibleOrgUnitCodes = async (
   permissionGroupName: string,
@@ -30,7 +28,7 @@ export const getAccessibleOrgUnitCodes = async (
 export const getRequestedOrgUnitObjects = async (
   hierarchy: string,
   orgUnitCodes: string | string[],
-  entityApi: EntityApi,
+  entityApi: TupaiaApiClient['entity'],
 ) => {
   const orgUnitCodesInArray = Array.isArray(orgUnitCodes) ? orgUnitCodes : orgUnitCodes.split(',');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8525,17 +8525,7 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@^2.25.0":
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.34.0.tgz#6f8ce8a46c7dea4a6f1d171d2bb8fbae6dac2be9"
-  integrity sha512-4zY3Z88rEE99+CNvTbXSyovv2z9PNOVffTWD2W8QF5s2prBQtwN2zadqERcrHpcR7O/+KMI3fcTAmUUhK/iQcQ==
-  dependencies:
-    "@typescript-eslint/experimental-utils" "2.34.0"
-    functional-red-black-tree "^1.0.1"
-    regexpp "^3.0.0"
-    tsutils "^3.17.1"
-
-"@typescript-eslint/eslint-plugin@^4.18.0", "@typescript-eslint/eslint-plugin@^4.5.0":
+"@typescript-eslint/eslint-plugin@^2.25.0", "@typescript-eslint/eslint-plugin@^4.18.0", "@typescript-eslint/eslint-plugin@^4.5.0":
   version "4.18.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.18.0.tgz#50fbce93211b5b690895d20ebec6fe8db48af1f6"
   integrity sha512-Lzkc/2+7EoH7+NjIWLS2lVuKKqbEmJhtXe3rmfA8cyiKnZm3IfLf51irnBcmow8Q/AptVV0XBZmBJKuUJTe6cQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -8177,6 +8177,13 @@
   dependencies:
     "@types/lodash" "*"
 
+"@types/lodash.isplainobject@^4.0.6":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#757d2dcdecbb32f4452018b285a586776092efd1"
+  integrity sha512-8G41YFhmOl8Ck6NrwLK5hhnbz6ADfuDJP+zusDnX3PoYhfC60+H/rQE6zmdO4yFzPCPJPY4oGZK2spbXm6gYEA==
+  dependencies:
+    "@types/lodash" "*"
+
 "@types/lodash.keyby@^4.6.6":
   version "4.6.6"
   resolved "https://registry.yarnpkg.com/@types/lodash.keyby/-/lodash.keyby-4.6.6.tgz#49fcbd6a42dae30f8b271bca4ecb076f310c129d"
@@ -8518,7 +8525,17 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@^2.25.0", "@typescript-eslint/eslint-plugin@^4.18.0", "@typescript-eslint/eslint-plugin@^4.5.0":
+"@typescript-eslint/eslint-plugin@^2.25.0":
+  version "2.34.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.34.0.tgz#6f8ce8a46c7dea4a6f1d171d2bb8fbae6dac2be9"
+  integrity sha512-4zY3Z88rEE99+CNvTbXSyovv2z9PNOVffTWD2W8QF5s2prBQtwN2zadqERcrHpcR7O/+KMI3fcTAmUUhK/iQcQ==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "2.34.0"
+    functional-red-black-tree "^1.0.1"
+    regexpp "^3.0.0"
+    tsutils "^3.17.1"
+
+"@typescript-eslint/eslint-plugin@^4.18.0", "@typescript-eslint/eslint-plugin@^4.5.0":
   version "4.18.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.18.0.tgz#50fbce93211b5b690895d20ebec6fe8db48af1f6"
   integrity sha512-Lzkc/2+7EoH7+NjIWLS2lVuKKqbEmJhtXe3rmfA8cyiKnZm3IfLf51irnBcmow8Q/AptVV0XBZmBJKuUJTe6cQ==


### PR DESCRIPTION
### Issue #:
PHX-47

Based off [rn-83-convert-sum-to-typed-func](https://github.com/beyondessential/tupaia/tree/rn-83-convert-sum-to-typed-func) since it has the latest in `report-server`
