### PR TITLE
Update CircleProportionMarker.js

### DIFF
--- a/packages/ui-components/src/components/Map/Markers/CircleProportionMarker.js
+++ b/packages/ui-components/src/components/Map/Markers/CircleProportionMarker.js
@@ -30,8 +30,10 @@ export const CircleProportionMarker = React.memo(({ radius, children, coordinate
     <HoverCircle
       center={coordinates}
       radius={displayRadius}
-      color={colorValue}
-      fillColor={colorValue}
+      pathOptions={{
+        color: colorValue,
+        fillColor: colorValue,
+      }}
     >
       {children}
     </HoverCircle>


### PR DESCRIPTION
### Issue #: WAI-22: Map Overlays Refactoring
Fix this regression bug: https://linear.app/bes/issue/WAI-22#comment-06c4eb5a

The issue was that leaflet needs us to use the pathOptions api for the color props to be mutable in the newer version. I checked other components that are similar and they seem to be fine as they are as best I can tell.