### PR TITLE
Add support for GPI map overlays

### DIFF
--- a/packages/ui-components/src/components/Map/Legend/SpectrumLegend.js
+++ b/packages/ui-components/src/components/Map/Legend/SpectrumLegend.js
@@ -35,6 +35,7 @@ const LabelRight = styled.div`
 
 const getSpectrumLabels = (scaleType, min, max, valueType) => {
   switch (scaleType) {
+    case SCALE_TYPES.GPI:
     case SCALE_TYPES.PERFORMANCE:
     case SCALE_TYPES.PERFORMANCE_DESC:
     case SCALE_TYPES.NEUTRAL:
@@ -77,6 +78,7 @@ const renderSpectrum = ({ min, max, scaleType, scaleColorScheme, valueType }) =>
       }
       break;
     case SCALE_TYPES.PERFORMANCE:
+    case SCALE_TYPES.GPI:
     case SCALE_TYPES.PERFORMANCE_DESC:
     case SCALE_TYPES.NEUTRAL:
     default: {

--- a/packages/ui-components/src/components/Map/__tests__/markerColors.test.js
+++ b/packages/ui-components/src/components/Map/__tests__/markerColors.test.js
@@ -10,36 +10,32 @@ describe('getHeatmapColorByOrder()', () => {
   it('getHeatmapColor() should return expected rgb', () => {
     const value = (Math.random() * 10).toFixed(1);
     let expectedRgb = [];
-    if (value < 0.15) expectedRgb = [255, 255, 204];
-    else if (value >= 0.15 && value < 0.25) expectedRgb = [255, 237, 160];
-    else if (value >= 0.25 && value < 0.35) expectedRgb = [254, 217, 118];
-    else if (value >= 0.35 && value < 0.45) expectedRgb = [254, 178, 76];
-    else if (value >= 0.45 && value < 0.55) expectedRgb = [253, 141, 60];
-    else if (value >= 0.55 && value < 0.65) expectedRgb = [252, 78, 42];
-    else if (value >= 0.65 && value < 0.75) expectedRgb = [227, 26, 28];
-    else if (value >= 0.75 && value < 0.85) expectedRgb = [118, 0, 38];
+    if (value < 0.15) expectedRgb = 'rbg(255, 255, 204)';
+    else if (value >= 0.15 && value < 0.25) expectedRgb = 'rbg(255, 237, 160)';
+    else if (value >= 0.25 && value < 0.35) expectedRgb = 'rbg(254, 217, 118)';
+    else if (value >= 0.35 && value < 0.45) expectedRgb = 'rbg(254, 178, 76)';
+    else if (value >= 0.45 && value < 0.55) expectedRgb = 'rbg(253, 141, 60)';
+    else if (value >= 0.55 && value < 0.65) expectedRgb = 'rbg(252, 78, 42)';
+    else if (value >= 0.65 && value < 0.75) expectedRgb = 'rbg(227, 26, 28)';
+    else if (value >= 0.75 && value < 0.85) expectedRgb = 'rbg(118, 0, 38)';
     else if (value >= 0.85) expectedRgb = [128, 0, 38];
 
-    expect(getHeatmapColor(value)).toEqual(
-      `rgb(${expectedRgb[0]},${expectedRgb[1]},${expectedRgb[2]})`,
-    );
+    expect(getHeatmapColor(value)).toEqual(expectedRgb);
   });
 
   it('getReverseHeatmapColor() should return expected rgb', () => {
     const value = (Math.random() * 10).toFixed(1);
     let expectedRgb = [];
-    if (value < 0.15) expectedRgb = [128, 0, 38];
-    else if (value >= 0.15 && value < 0.25) expectedRgb = [118, 0, 38];
-    else if (value >= 0.25 && value < 0.35) expectedRgb = [227, 26, 28];
-    else if (value >= 0.35 && value < 0.45) expectedRgb = [252, 78, 42];
-    else if (value >= 0.45 && value < 0.55) expectedRgb = [253, 141, 60];
-    else if (value >= 0.55 && value < 0.65) expectedRgb = [254, 178, 76];
-    else if (value >= 0.65 && value < 0.75) expectedRgb = [254, 217, 118];
-    else if (value >= 0.75 && value < 0.85) expectedRgb = [255, 237, 160];
+    if (value < 0.15) expectedRgb = 'rbg(128, 0, 38)';
+    else if (value >= 0.15 && value < 0.25) expectedRgb = 'rbg(118, 0, 38)';
+    else if (value >= 0.25 && value < 0.35) expectedRgb = 'rbg(227, 26, 28)';
+    else if (value >= 0.35 && value < 0.45) expectedRgb = 'rbg(252, 78, 42)';
+    else if (value >= 0.45 && value < 0.55) expectedRgb = 'rbg(253, 141, 60)';
+    else if (value >= 0.55 && value < 0.65) expectedRgb = 'rbg(254, 178, 76)';
+    else if (value >= 0.65 && value < 0.75) expectedRgb = 'rbg(254, 217, 118)';
+    else if (value >= 0.75 && value < 0.85) expectedRgb = 'rbg(255, 237, 160)';
     else if (value >= 0.85) expectedRgb = [255, 255, 204];
 
-    expect(getReverseHeatmapColor(value)).toEqual(
-      `rgb(${expectedRgb[0]},${expectedRgb[1]},${expectedRgb[2]})`,
-    );
+    expect(getReverseHeatmapColor(value)).toEqual(expectedRgb);
   });
 });

--- a/packages/ui-components/src/components/Map/constants/colors.js
+++ b/packages/ui-components/src/components/Map/constants/colors.js
@@ -56,18 +56,7 @@ export const DEFAULT_COLOR_SCHEME = 'default';
 export const REVERSE_DEFAULT_COLOR_SCHEME = 'default-reverse';
 export const PERFORMANCE_COLOR_SCHEME = 'performance';
 export const TIME_COLOR_SCHEME = 'time';
-
-export const HEATMAP_DEFAULT_RGB_SET = [
-  [255, 255, 204],
-  [255, 237, 160],
-  [254, 217, 118],
-  [254, 178, 76],
-  [253, 141, 60],
-  [252, 78, 42],
-  [227, 26, 28],
-  [118, 0, 38],
-  [128, 0, 38],
-];
+export const GPI_COLOR_SCHEME = 'gpi';
 
 export const BREWER_AUTO = [
   BREWER_PALETTE.navy,

--- a/packages/ui-components/src/components/Map/constants/constants.js
+++ b/packages/ui-components/src/components/Map/constants/constants.js
@@ -37,4 +37,5 @@ export const SCALE_TYPES = {
   NEUTRAL: 'neutral',
   NEUTRAL_REVERSE: 'neutralReverse',
   TIME: 'time',
+  GPI: 'gpi',
 };

--- a/packages/ui-components/src/components/Map/utils/markerColors.js
+++ b/packages/ui-components/src/components/Map/utils/markerColors.js
@@ -196,8 +196,7 @@ const GPI_PARITY_LOWER_LIMIT = '0.97';
  */
 export function getGPIColor(value, min, max) {
   if (value > GPI_PARITY_UPPER_LIMIT) {
-    const maxedValue = Math.min(value, 2);
-    const normalisedValue = normaliseToPercentage(maxedValue, GPI_PARITY_UPPER_LIMIT, max);
+    const normalisedValue = normaliseToPercentage(Math.min(value, 2), GPI_PARITY_UPPER_LIMIT, max);
     return getHeatmapColorByOrder({ value: normalisedValue, colorSet: RED_COLOR_SET });
   }
 

--- a/packages/ui-components/src/components/Map/utils/markerColors.js
+++ b/packages/ui-components/src/components/Map/utils/markerColors.js
@@ -113,57 +113,6 @@ export function getTimeHeatmapColor(value, noDataColour) {
   return `hsl(${100 - Math.floor(value * 100)}, 100%, 50%)`;
 }
 
-/**
- *
- * GPI Colors
- */
-const BLUE_COLOR_SET = [
-  blue['900'],
-  blue['900'],
-  blue['800'],
-  blue['800'],
-  blue['700'],
-  blue['600'],
-  blue['500'],
-  blue['400'],
-  blue['300'],
-];
-
-const RED_COLOR_SET = [
-  red['300'],
-  red['400'],
-  red['500'],
-  red['600'],
-  red['700'],
-  red['800'],
-  red['800'],
-  red['900'],
-  red['900'],
-];
-
-const GPI_PARITY_UPPER_LIMIT = '1.03';
-const GPI_PARITY_LOWER_LIMIT = '0.97';
-
-/**
- *
- * @param value - a gpi value between 0 and 2 where 0.97 - 1.03 is considered gender parity
- * @returns {string}
- */
-export function getGPIColor(value, min, max) {
-  if (value > GPI_PARITY_UPPER_LIMIT) {
-    const maxedValue = Math.min(value, 2);
-    const normalisedValue = normaliseToPercentage(maxedValue, GPI_PARITY_UPPER_LIMIT, max);
-    return getHeatmapColorByOrder({ value: normalisedValue, colorSet: RED_COLOR_SET });
-  }
-
-  if (value < GPI_PARITY_LOWER_LIMIT) {
-    const normalisedValue = normaliseToPercentage(value, min, GPI_PARITY_LOWER_LIMIT);
-    return getHeatmapColorByOrder({ value: normalisedValue, colorSet: BLUE_COLOR_SET });
-  }
-
-  return green['500'];
-}
-
 const HEATMAP_DEFAULT_RGB_SET = [
   'rgb(255, 255, 204)',
   'rgb(255, 237, 160)',
@@ -204,4 +153,58 @@ export function getReverseHeatmapColor(value) {
 // This allows measures to still use hex codes and named colors not in the palette.
 export function getColor(colorName) {
   return BREWER_PALETTE[colorName] || colorName;
+}
+
+/**
+ * GPI Colors
+ */
+const BLUE_COLOR_SET = [
+  blue['900'],
+  blue['900'],
+  blue['800'],
+  blue['800'],
+  blue['700'],
+  blue['600'],
+  blue['500'],
+  blue['400'],
+  blue['300'],
+];
+
+const RED_COLOR_SET = [
+  red['300'],
+  red['400'],
+  red['500'],
+  red['600'],
+  red['700'],
+  red['800'],
+  red['800'],
+  red['900'],
+  red['900'],
+];
+
+/**
+ *
+ *  A GPI between 0.97 - 1.03 is considered gender parity
+ */
+const GPI_PARITY_UPPER_LIMIT = '1.03';
+const GPI_PARITY_LOWER_LIMIT = '0.97';
+
+/**
+ *
+ * @param value - GPI value type is number between 0 and 2.
+ * @returns {string}
+ */
+export function getGPIColor(value, min, max) {
+  if (value > GPI_PARITY_UPPER_LIMIT) {
+    const maxedValue = Math.min(value, 2);
+    const normalisedValue = normaliseToPercentage(maxedValue, GPI_PARITY_UPPER_LIMIT, max);
+    return getHeatmapColorByOrder({ value: normalisedValue, colorSet: RED_COLOR_SET });
+  }
+
+  if (value < GPI_PARITY_LOWER_LIMIT) {
+    const normalisedValue = normaliseToPercentage(value, min, GPI_PARITY_LOWER_LIMIT);
+    return getHeatmapColorByOrder({ value: normalisedValue, colorSet: BLUE_COLOR_SET });
+  }
+
+  return green['500'];
 }


### PR DESCRIPTION
### Issue #: Relates to WAI-6

### Changes:

- Add new GPI Spectrum type

This is quite a specific type but considered common enough to have its own type. We did look into making it more generic but we deemed that substantially harder to implement.

---

### Screenshots:
See issue