### PR TITLE
Sanitize jsonb arrays

### DIFF
--- a/packages/database/src/TupaiaDatabase.js
+++ b/packages/database/src/TupaiaDatabase.js
@@ -513,6 +513,10 @@ function buildQuery(connection, queryConfig, where = {}, options = {}) {
     query.returning('*');
   }
 
+  if (process.env.DB_VERBOSE === 'true') {
+    winston.info(query.toString());
+  }
+
   // Now constructed, the query can either be 'awaited' (in which case it will execute and return
   // the result), or passed back in to this.query as part of a nested query.
   return query;


### PR DESCRIPTION
### Issue #:
https://github.com/beyondessential/tupaia/pull/3273 is failing tests because of an issue inserting test data into the db. The problem is that knex doesn't handle json/jsonb columns where the root of the object is an array, see https://knexjs.org/#Schema-json 