### PR TITLE
Switched output over to using yup validation for report-server output step

### DIFF
--- a/packages/report-server/src/__tests__/reportBuilder/output/output.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/output/output.test.ts
@@ -116,6 +116,29 @@ describe('output', () => {
     });
 
     describe('handle categoryField', () => {
+      it('throws error if categoryField matches any columns', () => {
+        const output = buildOutput({
+          type: 'matrix',
+          categoryField: 'InfrastructureType',
+          rowField: 'FacilityType',
+          columns: ['InfrastructureType', 'Laos', 'Tonga'],
+        });
+        expect(() => {
+          output(MULTIPLE_TRANSFORMED_DATA_WITH_CATEGORIES);
+        }).toThrow();
+      });
+
+      it('throws error if categoryField matches rowField', () => {
+        const output = buildOutput({
+          type: 'matrix',
+          categoryField: 'FacilityType',
+          rowField: 'FacilityType',
+        });
+        expect(() => {
+          output(MULTIPLE_TRANSFORMED_DATA_WITH_CATEGORIES);
+        }).toThrow();
+      });
+
       it('can perform with categoryField', () => {
         const expectedData = {
           columns: [
@@ -213,6 +236,89 @@ describe('output', () => {
       });
     });
 
-    // TODO: it('can perform with subCategoryField', () =>{})
+    describe('handle rowField', () => {
+      it('throws error if rowField matches any columns', () => {
+        const output = buildOutput({
+          type: 'matrix',
+          categoryField: 'InfrastructureType',
+          rowField: 'FacilityType',
+          columns: ['FacilityType', 'Laos', 'Tonga'],
+        });
+        expect(() => {
+          output(MULTIPLE_TRANSFORMED_DATA_WITH_CATEGORIES);
+        }).toThrow();
+      });
+
+      it('throws error if rowField matches categoryField', () => {
+        const output = buildOutput({
+          type: 'matrix',
+          categoryField: 'FacilityType',
+          rowField: 'FacilityType',
+        });
+        expect(() => {
+          output(MULTIPLE_TRANSFORMED_DATA_WITH_CATEGORIES);
+        }).toThrow();
+      });
+
+      it('throws error if rowField not provided ', () => {
+        const output = buildOutput({
+          type: 'matrix',
+          categoryField: 'FacilityType',
+        });
+        expect(() => {
+          output(MULTIPLE_TRANSFORMED_DATA_WITH_CATEGORIES);
+        }).toThrow();
+      });
+
+      it('can perform with rowField', () => {
+        const expectedData = {
+          columns: [
+            {
+              key: 'InfrastructureType',
+              title: 'InfrastructureType',
+            },
+            {
+              key: 'Laos',
+              title: 'Laos',
+            },
+            {
+              key: 'Tonga',
+              title: 'Tonga',
+            },
+          ],
+          rows: [
+            {
+              InfrastructureType: 'medical center',
+              dataElement: 'hospital',
+              Laos: 3,
+              Tonga: 0,
+            },
+            {
+              InfrastructureType: 'medical center',
+              dataElement: 'clinic',
+              Laos: 4,
+              Tonga: 9,
+            },
+            {
+              InfrastructureType: 'others',
+              dataElement: 'park',
+              Laos: 2,
+              Tonga: 0,
+            },
+            {
+              InfrastructureType: 'others',
+              dataElement: 'library',
+              Laos: 0,
+              Tonga: 5,
+            },
+          ],
+        };
+        const output = buildOutput({
+          type: 'matrix',
+          rowField: 'FacilityType',
+        });
+        expect(output(MULTIPLE_TRANSFORMED_DATA_WITH_CATEGORIES)).toEqual(expectedData);
+      });
+    });
   });
 });

--- a/packages/report-server/src/__tests__/reportBuilder/output/output.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/output/output.test.ts
@@ -75,8 +75,8 @@ describe('output', () => {
           columns: 1,
         });
         expect(() => {
-          output(MULTIPLE_TRANSFORMED_DATA_WITH_CATEGORIES);
-        }).toThrow();
+          output([]);
+        }).toThrow("columns must be either '*' or an array");
       });
 
       it('can return only specified columns', () => {
@@ -124,8 +124,10 @@ describe('output', () => {
           columns: ['InfrastructureType', 'Laos', 'Tonga'],
         });
         expect(() => {
-          output(MULTIPLE_TRANSFORMED_DATA_WITH_CATEGORIES);
-        }).toThrow();
+          output([]);
+        }).toThrow(
+          'categoryField cannot be one of: [InfrastructureType,Laos,Tonga] they are already specified as columns',
+        );
       });
 
       it('throws error if categoryField matches rowField', () => {
@@ -135,8 +137,8 @@ describe('output', () => {
           rowField: 'FacilityType',
         });
         expect(() => {
-          output(MULTIPLE_TRANSFORMED_DATA_WITH_CATEGORIES);
-        }).toThrow();
+          output([]);
+        }).toThrow('rowField cannot be: FacilityType, it is already specified as categoryField');
       });
 
       it('can perform with categoryField', () => {
@@ -245,8 +247,10 @@ describe('output', () => {
           columns: ['FacilityType', 'Laos', 'Tonga'],
         });
         expect(() => {
-          output(MULTIPLE_TRANSFORMED_DATA_WITH_CATEGORIES);
-        }).toThrow();
+          output([]);
+        }).toThrow(
+          'rowField cannot be one of: [FacilityType,Laos,Tonga] they are already specified as columns',
+        );
       });
 
       it('throws error if rowField matches categoryField', () => {
@@ -256,8 +260,8 @@ describe('output', () => {
           rowField: 'FacilityType',
         });
         expect(() => {
-          output(MULTIPLE_TRANSFORMED_DATA_WITH_CATEGORIES);
-        }).toThrow();
+          output([]);
+        }).toThrow('rowField cannot be: FacilityType, it is already specified as categoryField');
       });
 
       it('throws error if rowField not provided ', () => {
@@ -266,8 +270,8 @@ describe('output', () => {
           categoryField: 'FacilityType',
         });
         expect(() => {
-          output(MULTIPLE_TRANSFORMED_DATA_WITH_CATEGORIES);
-        }).toThrow();
+          output([]);
+        }).toThrow('rowField is a required field');
       });
 
       it('can perform with rowField', () => {

--- a/packages/report-server/src/reportBuilder/output/functions/matrix/matrix.ts
+++ b/packages/report-server/src/reportBuilder/output/functions/matrix/matrix.ts
@@ -14,22 +14,42 @@ const paramsValidator = yup.object().shape(
     columns: yup.lazy((value: unknown) =>
       Array.isArray(value)
         ? yup.array().of(yup.string().required())
-        : yup.mixed<'*'>().oneOf(['*']),
+        : yup.mixed<'*'>().oneOf(['*'], "columns must be either '*' or an array"),
     ),
     rowField: yup
       .string()
       .required()
       .when('categoryField', (categoryField: string | undefined, schema: yup.StringSchema) =>
-        categoryField !== undefined ? schema.notOneOf([categoryField]) : schema,
+        categoryField !== undefined
+          ? schema.notOneOf(
+              [categoryField],
+              `rowField cannot be: ${categoryField}, it is already specified as categoryField`,
+            )
+          : schema,
       )
       .when('columns', (columns: '*' | string[] | undefined, schema: yup.StringSchema) =>
-        Array.isArray(columns) ? schema.notOneOf(columns) : schema,
+        Array.isArray(columns)
+          ? schema.notOneOf(
+              columns,
+              `rowField cannot be one of: [${columns}] they are already specified as columns`,
+            )
+          : schema,
       ),
     categoryField: yup
       .string()
-      .when('rowField', (rowField: string, schema: yup.StringSchema) => schema.notOneOf([rowField]))
+      .when('rowField', (rowField: string, schema: yup.StringSchema) =>
+        schema.notOneOf(
+          [rowField],
+          `categoryField cannot be: ${rowField}, it is already specified as rowField`,
+        ),
+      )
       .when('columns', (columns: '*' | string[] | undefined, schema: yup.StringSchema) =>
-        Array.isArray(columns) ? schema.notOneOf(columns) : schema,
+        Array.isArray(columns)
+          ? schema.notOneOf(
+              columns,
+              `categoryField cannot be one of: [${columns}] they are already specified as columns`,
+            )
+          : schema,
       ),
   },
   [['rowField', 'categoryField']],

--- a/packages/report-server/src/reportBuilder/output/functions/matrix/matrixBuilder.ts
+++ b/packages/report-server/src/reportBuilder/output/functions/matrix/matrixBuilder.ts
@@ -63,10 +63,13 @@ export class MatrixBuilder {
     const { rowField, categoryField } = this.params.rows;
 
     this.rows.forEach(row => {
-      const { [categoryField]: categoryId, [rowField]: rowFieldData, ...restOfRow } = row;
-      const newRows: Row = { [ROW_FIELD_KEY]: rowFieldData, ...restOfRow };
-      if (categoryId) {
-        newRows[CATEGORY_FIELD_KEY] = categoryId;
+      let newRows: Row;
+      if (categoryField) {
+        const { [rowField]: rowFieldData, [categoryField]: categoryId, ...restOfRow } = row;
+        newRows = { [ROW_FIELD_KEY]: rowFieldData, [CATEGORY_FIELD_KEY]: categoryId, ...restOfRow };
+      } else {
+        const { [rowField]: rowFieldData, ...restOfRow } = row;
+        newRows = { [ROW_FIELD_KEY]: rowFieldData, ...restOfRow };
       }
       rows.push(newRows);
     });

--- a/packages/report-server/src/reportBuilder/output/functions/matrix/types.ts
+++ b/packages/report-server/src/reportBuilder/output/functions/matrix/types.ts
@@ -2,7 +2,7 @@ import { Row } from '../../../types';
 
 export type MatrixParams = {
   columns: { includeFields: string[] | '*'; excludeFields: string[] };
-  rows: { rowField: string; categoryField: string };
+  rows: { rowField: string; categoryField: string | undefined };
 };
 
 export type Matrix = {


### PR DESCRIPTION
Just a small refactor here to use `yup` object validation over our original hand crafted version. Will be using these changes later down the line when adding functionality for: https://linear.app/bes/issue/RN-28/date-selector-shows-latest-data-by-default