### PR TITLE
Fix not showing no data label

### DIFF
--- a/packages/ui-components/src/components/Map/PopupDataItemList.js
+++ b/packages/ui-components/src/components/Map/PopupDataItemList.js
@@ -28,7 +28,7 @@ PopupDataItem.propTypes = {
   measureName: PropTypes.string.isRequired,
 };
 
-export const PopupDataItemList = ({ measureOptions, data, showNoDataLabel }) => {
+export const PopupDataItemList = ({ measureOptions, data }) => {
   const popupList = data
     ? measureOptions
         .filter(measureOption => !measureOption.hideFromPopup)
@@ -49,7 +49,7 @@ export const PopupDataItemList = ({ measureOptions, data, showNoDataLabel }) => 
 
   const { name, key } = measureOptions[0];
 
-  return popupList.length === 0 && showNoDataLabel
+  return popupList.length === 0
     ? [<PopupDataItem key={name || key} measureName={name || key} value="No Data" />]
     : popupList;
 };


### PR DESCRIPTION
### Issue #:
https://beyondessential.slack.com/archives/C01MAA3NKM1/p1632719896018900
Issue in tupaia-release 

### Changes:
Previously `showNoDataLabel` is used for lesmis and tupaia separately, but now they can use the same code.
