### PR TITLE
Hotfix: Meditrak-App AppCenter build fix

### DIFF
--- a/packages/meditrak-app/android/app/build.gradle
+++ b/packages/meditrak-app/android/app/build.gradle
@@ -133,7 +133,7 @@ android {
         ndk {
             abiFilters "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
         }
-        ndkVersion 20.1.5948944
+        ndkVersion "20.1.5948944"
     }
     signingConfigs {
         debug {

--- a/packages/meditrak-app/android/app/build.gradle
+++ b/packages/meditrak-app/android/app/build.gradle
@@ -119,8 +119,6 @@ def (major, minor, patch) = getAppVersion().tokenize('.')
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     
-    andriod.ndkVersion "20.1.5948944"
-
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8

--- a/packages/meditrak-app/android/app/build.gradle
+++ b/packages/meditrak-app/android/app/build.gradle
@@ -118,6 +118,8 @@ def (major, minor, patch) = getAppVersion().tokenize('.')
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
+    
+    andriod.ndkVersion "20.1.5948944"
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -133,8 +135,8 @@ android {
         ndk {
             abiFilters "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
         }
-        ndkVersion "20.1.5948944"
     }
+
     signingConfigs {
         debug {
             storeFile file('debug.keystore')

--- a/packages/meditrak-app/android/app/build.gradle
+++ b/packages/meditrak-app/android/app/build.gradle
@@ -133,6 +133,7 @@ android {
         ndk {
             abiFilters "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
         }
+        ndkVersion 20.1.5948944
     }
     signingConfigs {
         debug {

--- a/packages/meditrak-app/android/app/src/main/AndroidManifest.xml
+++ b/packages/meditrak-app/android/app/src/main/AndroidManifest.xml
@@ -12,7 +12,6 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <uses-sdk
-        android:minSdkVersion="19"
         android:targetSdkVersion="26" />
 
     <application

--- a/packages/meditrak-app/android/appcenter-gradle.properties
+++ b/packages/meditrak-app/android/appcenter-gradle.properties
@@ -10,5 +10,5 @@ android.enableJetifier=true
 
 org.gradle.jvmargs=-XX\:MaxHeapSize\=1024m -Xmx1024m
 
-# Manually specify the NDK Version to be 22 to avoid build failures in appcenter
-android.ndkVersion=22.1.7171670
+# Manually specify the NDK Version to be 20 to avoid build failures in appcenter
+android.ndkVersion=20.1.5948944

--- a/packages/meditrak-app/android/appcenter-gradle.properties
+++ b/packages/meditrak-app/android/appcenter-gradle.properties
@@ -9,3 +9,6 @@ android.useAndroidX=true
 android.enableJetifier=true
 
 org.gradle.jvmargs=-XX\:MaxHeapSize\=1024m -Xmx1024m
+
+# Manually specify the NDK Version to be 22 to avoid build failures in appcenter
+android.ndkVersion=22.1.7171670

--- a/packages/meditrak-app/android/appcenter-gradle.properties
+++ b/packages/meditrak-app/android/appcenter-gradle.properties
@@ -9,6 +9,3 @@ android.useAndroidX=true
 android.enableJetifier=true
 
 org.gradle.jvmargs=-XX\:MaxHeapSize\=1024m -Xmx1024m
-
-# Manually specify the NDK Version to be 20 to avoid build failures in appcenter
-android.ndkVersion=20.1.5948944

--- a/packages/meditrak-app/android/build.gradle
+++ b/packages/meditrak-app/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:3.5.3'
         classpath 'com.google.gms:google-services:4.3.4'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/packages/meditrak-app/android/build.gradle
+++ b/packages/meditrak-app/android/build.gradle
@@ -42,7 +42,3 @@ ext {
     targetSdkVersion = 29
     googlePlayServicesVersion = "15.0.1"
 }
-
-android {
-    ndkVersion = "20.1.5948944"
-}

--- a/packages/meditrak-app/android/build.gradle
+++ b/packages/meditrak-app/android/build.gradle
@@ -44,5 +44,5 @@ ext {
 }
 
 android {
-    ndkVersion = 20.1.5948944
+    ndkVersion = "20.1.5948944"
 }

--- a/packages/meditrak-app/android/build.gradle
+++ b/packages/meditrak-app/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:4.0.1'
         classpath 'com.google.gms:google-services:4.3.4'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/packages/meditrak-app/android/build.gradle
+++ b/packages/meditrak-app/android/build.gradle
@@ -42,3 +42,7 @@ ext {
     targetSdkVersion = 29
     googlePlayServicesVersion = "15.0.1"
 }
+
+android {
+    ndkVersion = 20.1.5948944
+}


### PR DESCRIPTION
### Issue https://beyondessential.slack.com/archives/C01MAA3NKM1/p1632710469006000

So I believe this issue was caused by the release of NDK 23 (https://developer.android.com/ndk/downloads/revision_history)

I'm not sure which version our appcenter builds were using previously, but I think we've been bumped up to the latest version which does play nicely with gradle tools lower than 4.0.

I tried manually setting our NDK version to 22, but I couldn't get this to work. Instead I went with bumping our gradle tools version to 4.0.1 which was easier and seems the better fix 👍 