### PR TITLE
RN-28: Added support for 'useDatesOfData' as the defaultTimePeriod for the Date Picker

### DIFF
--- a/packages/report-server/src/__tests__/reportBuilder/output/output.fixtures.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/output/output.fixtures.ts
@@ -3,23 +3,43 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
-export const MULTIPLE_TRANSFORMED_DATA = [
-  { FacilityType: 'hospital', Laos: 3, Tonga: 0 },
-  { FacilityType: 'clinic', Laos: 4, Tonga: 9 },
-  { FacilityType: 'park', Laos: 2, Tonga: 0 },
-  { FacilityType: 'library', Laos: 0, Tonga: 5 },
-];
+export const MULTIPLE_TRANSFORMED_DATA = {
+  results: [
+    { FacilityType: 'hospital', Laos: 3, Tonga: 0 },
+    { FacilityType: 'clinic', Laos: 4, Tonga: 9 },
+    { FacilityType: 'park', Laos: 2, Tonga: 0 },
+    { FacilityType: 'library', Laos: 0, Tonga: 5 },
+  ],
+};
 
-export const MULTIPLE_TRANSFORMED_DATA_WITH_CATEGORIES = [
-  { InfrastructureType: 'medical center', FacilityType: 'hospital', Laos: 3, Tonga: 0 },
-  { InfrastructureType: 'medical center', FacilityType: 'clinic', Laos: 4, Tonga: 9 },
-  { InfrastructureType: 'others', FacilityType: 'park', Laos: 2, Tonga: 0 },
-  { InfrastructureType: 'others', FacilityType: 'library', Laos: 0, Tonga: 5 },
-];
+export const MULTIPLE_TRANSFORMED_DATA_WITH_PERIOD = {
+  results: [
+    { period: '20210920', FacilityType: 'hospital', Laos: 3, Tonga: 0 },
+    { period: '20210921', FacilityType: 'clinic', Laos: 4, Tonga: 9 },
+    { period: '20210922', FacilityType: 'park', Laos: 2, Tonga: 0 },
+    { period: '20210923', FacilityType: 'library', Laos: 0, Tonga: 5 },
+  ],
+  period: {
+    requested: '20210919;20210920;20210921;20210922;20210923;20210924',
+    earliestAvailable: '20210920',
+    latestAvailable: '20210923',
+  },
+};
 
-export const MULTIPLE_TRANSFORMED_DATA_FOR_SPECIFIED_COLUMNS = [
-  { InfrastructureType: 'medical center', FacilityType: 'hospital', Laos: 3, Tonga: 0 },
-  { InfrastructureType: 'medical center', FacilityType: 'clinic', Laos: 4, Tonga: 9 },
-  { InfrastructureType: 'others', FacilityType: 'park', Tonga: 0 },
-  { InfrastructureType: 'others', FacilityType: 'library', Tonga: 5 },
-];
+export const MULTIPLE_TRANSFORMED_DATA_WITH_CATEGORIES = {
+  results: [
+    { InfrastructureType: 'medical center', FacilityType: 'hospital', Laos: 3, Tonga: 0 },
+    { InfrastructureType: 'medical center', FacilityType: 'clinic', Laos: 4, Tonga: 9 },
+    { InfrastructureType: 'others', FacilityType: 'park', Laos: 2, Tonga: 0 },
+    { InfrastructureType: 'others', FacilityType: 'library', Laos: 0, Tonga: 5 },
+  ],
+};
+
+export const MULTIPLE_TRANSFORMED_DATA_FOR_SPECIFIED_COLUMNS = {
+  results: [
+    { InfrastructureType: 'medical center', FacilityType: 'hospital', Laos: 3, Tonga: 0 },
+    { InfrastructureType: 'medical center', FacilityType: 'clinic', Laos: 4, Tonga: 9 },
+    { InfrastructureType: 'others', FacilityType: 'park', Tonga: 0 },
+    { InfrastructureType: 'others', FacilityType: 'library', Tonga: 5 },
+  ],
+};

--- a/packages/report-server/src/__tests__/reportBuilder/output/output.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/output/output.test.ts
@@ -5,68 +5,14 @@
 
 import { buildOutput } from '../../../reportBuilder/output';
 import {
-  MULTIPLE_TRANSFORMED_DATA,
   MULTIPLE_TRANSFORMED_DATA_WITH_CATEGORIES,
   MULTIPLE_TRANSFORMED_DATA_FOR_SPECIFIED_COLUMNS,
+  MULTIPLE_TRANSFORMED_DATA_WITH_PERIOD,
 } from './output.fixtures';
 
 describe('output', () => {
   describe('matrix', () => {
     describe('handle columns', () => {
-      const expectedData = {
-        columns: [
-          {
-            key: 'Laos',
-            title: 'Laos',
-          },
-          {
-            key: 'Tonga',
-            title: 'Tonga',
-          },
-        ],
-        rows: [
-          {
-            categoryId: 'medical center',
-            dataElement: 'hospital',
-            Laos: 3,
-            Tonga: 0,
-          },
-          {
-            categoryId: 'medical center',
-            dataElement: 'clinic',
-            Laos: 4,
-            Tonga: 9,
-          },
-          {
-            categoryId: 'others',
-            dataElement: 'park',
-            Laos: 2,
-            Tonga: 0,
-          },
-          {
-            categoryId: 'others',
-            dataElement: 'library',
-            Laos: 0,
-            Tonga: 5,
-          },
-          {
-            category: 'medical center',
-          },
-          {
-            category: 'others',
-          },
-        ],
-      };
-
-      it('can perform without columns', () => {
-        const output = buildOutput({
-          type: 'matrix',
-          categoryField: 'InfrastructureType',
-          rowField: 'FacilityType',
-        });
-        expect(output(MULTIPLE_TRANSFORMED_DATA_WITH_CATEGORIES)).toEqual(expectedData);
-      });
-
       it("throw error when columns is not '*' or string array", () => {
         const output = buildOutput({
           type: 'matrix',
@@ -75,33 +21,90 @@ describe('output', () => {
           columns: 1,
         });
         expect(() => {
-          output([]);
+          output({ results: [] });
         }).toThrow("columns must be either '*' or an array");
+      });
+
+      it('can perform without columns', () => {
+        const expectedData = {
+          results: {
+            columns: [
+              {
+                key: 'Laos',
+                title: 'Laos',
+              },
+              {
+                key: 'Tonga',
+                title: 'Tonga',
+              },
+            ],
+            rows: [
+              {
+                categoryId: 'medical center',
+                dataElement: 'hospital',
+                Laos: 3,
+                Tonga: 0,
+              },
+              {
+                categoryId: 'medical center',
+                dataElement: 'clinic',
+                Laos: 4,
+                Tonga: 9,
+              },
+              {
+                categoryId: 'others',
+                dataElement: 'park',
+                Laos: 2,
+                Tonga: 0,
+              },
+              {
+                categoryId: 'others',
+                dataElement: 'library',
+                Laos: 0,
+                Tonga: 5,
+              },
+              {
+                category: 'medical center',
+              },
+              {
+                category: 'others',
+              },
+            ],
+          },
+        };
+        const output = buildOutput({
+          type: 'matrix',
+          categoryField: 'InfrastructureType',
+          rowField: 'FacilityType',
+        });
+        expect(output(MULTIPLE_TRANSFORMED_DATA_WITH_CATEGORIES)).toEqual(expectedData);
       });
 
       it('can return only specified columns', () => {
         const expectedDataForThisCase = {
-          columns: [
-            {
-              key: 'Laos',
-              title: 'Laos',
-            },
-          ],
-          rows: [
-            {
-              categoryId: 'medical center',
-              dataElement: 'hospital',
-              Laos: 3,
-            },
-            {
-              categoryId: 'medical center',
-              dataElement: 'clinic',
-              Laos: 4,
-            },
-            {
-              category: 'medical center',
-            },
-          ],
+          results: {
+            columns: [
+              {
+                key: 'Laos',
+                title: 'Laos',
+              },
+            ],
+            rows: [
+              {
+                categoryId: 'medical center',
+                dataElement: 'hospital',
+                Laos: 3,
+              },
+              {
+                categoryId: 'medical center',
+                dataElement: 'clinic',
+                Laos: 4,
+              },
+              {
+                category: 'medical center',
+              },
+            ],
+          },
         };
         const output = buildOutput({
           type: 'matrix',
@@ -124,7 +127,7 @@ describe('output', () => {
           columns: ['InfrastructureType', 'Laos', 'Tonga'],
         });
         expect(() => {
-          output([]);
+          output({ results: [] });
         }).toThrow(
           'categoryField cannot be one of: [InfrastructureType,Laos,Tonga] they are already specified as columns',
         );
@@ -137,104 +140,64 @@ describe('output', () => {
           rowField: 'FacilityType',
         });
         expect(() => {
-          output([]);
+          output({ results: [] });
         }).toThrow('rowField cannot be: FacilityType, it is already specified as categoryField');
       });
 
       it('can perform with categoryField', () => {
         const expectedData = {
-          columns: [
-            {
-              key: 'Laos',
-              title: 'Laos',
-            },
-            {
-              key: 'Tonga',
-              title: 'Tonga',
-            },
-          ],
-          rows: [
-            {
-              categoryId: 'medical center',
-              dataElement: 'hospital',
-              Laos: 3,
-              Tonga: 0,
-            },
-            {
-              categoryId: 'medical center',
-              dataElement: 'clinic',
-              Laos: 4,
-              Tonga: 9,
-            },
-            {
-              categoryId: 'others',
-              dataElement: 'park',
-              Laos: 2,
-              Tonga: 0,
-            },
-            {
-              categoryId: 'others',
-              dataElement: 'library',
-              Laos: 0,
-              Tonga: 5,
-            },
-            {
-              category: 'medical center',
-            },
-            {
-              category: 'others',
-            },
-          ],
+          results: {
+            columns: [
+              {
+                key: 'Laos',
+                title: 'Laos',
+              },
+              {
+                key: 'Tonga',
+                title: 'Tonga',
+              },
+            ],
+            rows: [
+              {
+                categoryId: 'medical center',
+                dataElement: 'hospital',
+                Laos: 3,
+                Tonga: 0,
+              },
+              {
+                categoryId: 'medical center',
+                dataElement: 'clinic',
+                Laos: 4,
+                Tonga: 9,
+              },
+              {
+                categoryId: 'others',
+                dataElement: 'park',
+                Laos: 2,
+                Tonga: 0,
+              },
+              {
+                categoryId: 'others',
+                dataElement: 'library',
+                Laos: 0,
+                Tonga: 5,
+              },
+              {
+                category: 'medical center',
+              },
+              {
+                category: 'others',
+              },
+            ],
+          },
         };
+
         const output = buildOutput({
           type: 'matrix',
           categoryField: 'InfrastructureType',
           rowField: 'FacilityType',
-          columns: '*',
         });
         expect(output(MULTIPLE_TRANSFORMED_DATA_WITH_CATEGORIES)).toEqual(expectedData);
-      });
-
-      it('perform with no categoryField', () => {
-        const expectedData = {
-          columns: [
-            {
-              key: 'Laos',
-              title: 'Laos',
-            },
-            {
-              key: 'Tonga',
-              title: 'Tonga',
-            },
-          ],
-          rows: [
-            {
-              dataElement: 'hospital',
-              Laos: 3,
-              Tonga: 0,
-            },
-            {
-              dataElement: 'clinic',
-              Laos: 4,
-              Tonga: 9,
-            },
-            {
-              dataElement: 'park',
-              Laos: 2,
-              Tonga: 0,
-            },
-            {
-              dataElement: 'library',
-              Laos: 0,
-              Tonga: 5,
-            },
-          ],
-        };
-        const output = buildOutput({
-          type: 'matrix',
-          rowField: 'FacilityType',
-        });
-        expect(output(MULTIPLE_TRANSFORMED_DATA)).toEqual(expectedData);
       });
     });
 
@@ -247,7 +210,7 @@ describe('output', () => {
           columns: ['FacilityType', 'Laos', 'Tonga'],
         });
         expect(() => {
-          output([]);
+          output({ results: [] });
         }).toThrow(
           'rowField cannot be one of: [FacilityType,Laos,Tonga] they are already specified as columns',
         );
@@ -260,7 +223,7 @@ describe('output', () => {
           rowField: 'FacilityType',
         });
         expect(() => {
-          output([]);
+          output({ results: [] });
         }).toThrow('rowField cannot be: FacilityType, it is already specified as categoryField');
       });
 
@@ -270,16 +233,70 @@ describe('output', () => {
           categoryField: 'FacilityType',
         });
         expect(() => {
-          output([]);
+          output({ results: [] });
         }).toThrow('rowField is a required field');
       });
 
       it('can perform with rowField', () => {
         const expectedData = {
+          results: {
+            columns: [
+              {
+                key: 'InfrastructureType',
+                title: 'InfrastructureType',
+              },
+              {
+                key: 'Laos',
+                title: 'Laos',
+              },
+              {
+                key: 'Tonga',
+                title: 'Tonga',
+              },
+            ],
+            rows: [
+              {
+                InfrastructureType: 'medical center',
+                dataElement: 'hospital',
+                Laos: 3,
+                Tonga: 0,
+              },
+              {
+                InfrastructureType: 'medical center',
+                dataElement: 'clinic',
+                Laos: 4,
+                Tonga: 9,
+              },
+              {
+                InfrastructureType: 'others',
+                dataElement: 'park',
+                Laos: 2,
+                Tonga: 0,
+              },
+              {
+                InfrastructureType: 'others',
+                dataElement: 'library',
+                Laos: 0,
+                Tonga: 5,
+              },
+            ],
+          },
+        };
+        const output = buildOutput({
+          type: 'matrix',
+          rowField: 'FacilityType',
+        });
+        expect(output(MULTIPLE_TRANSFORMED_DATA_WITH_CATEGORIES)).toEqual(expectedData);
+      });
+    });
+
+    it('adds earliest and latest periods', () => {
+      const expectedData = {
+        results: {
           columns: [
             {
-              key: 'InfrastructureType',
-              title: 'InfrastructureType',
+              key: 'period',
+              title: 'period',
             },
             {
               key: 'Laos',
@@ -292,37 +309,96 @@ describe('output', () => {
           ],
           rows: [
             {
-              InfrastructureType: 'medical center',
+              period: '20210920',
               dataElement: 'hospital',
               Laos: 3,
               Tonga: 0,
             },
             {
-              InfrastructureType: 'medical center',
+              period: '20210921',
               dataElement: 'clinic',
               Laos: 4,
               Tonga: 9,
             },
             {
-              InfrastructureType: 'others',
+              period: '20210922',
               dataElement: 'park',
               Laos: 2,
               Tonga: 0,
             },
             {
-              InfrastructureType: 'others',
+              period: '20210923',
               dataElement: 'library',
               Laos: 0,
               Tonga: 5,
             },
           ],
-        };
-        const output = buildOutput({
-          type: 'matrix',
-          rowField: 'FacilityType',
-        });
-        expect(output(MULTIPLE_TRANSFORMED_DATA_WITH_CATEGORIES)).toEqual(expectedData);
+        },
+        period: {
+          requested: '20210919;20210920;20210921;20210922;20210923;20210924',
+          earliestAvailable: '20210920',
+          latestAvailable: '20210923',
+          reportStart: '20210920',
+          reportEnd: '20210923',
+        },
+      };
+      const output = buildOutput({
+        type: 'matrix',
+        rowField: 'FacilityType',
       });
+      expect(output(MULTIPLE_TRANSFORMED_DATA_WITH_PERIOD)).toEqual(expectedData);
+    });
+
+    it('can exclude certain fields', () => {
+      const expectedData = {
+        results: {
+          columns: [
+            {
+              key: 'Laos',
+              title: 'Laos',
+            },
+            {
+              key: 'Tonga',
+              title: 'Tonga',
+            },
+          ],
+          rows: [
+            {
+              dataElement: 'hospital',
+              Laos: 3,
+              Tonga: 0,
+            },
+            {
+              dataElement: 'clinic',
+              Laos: 4,
+              Tonga: 9,
+            },
+            {
+              dataElement: 'park',
+              Laos: 2,
+              Tonga: 0,
+            },
+            {
+              dataElement: 'library',
+              Laos: 0,
+              Tonga: 5,
+            },
+          ],
+        },
+        period: {
+          requested: '20210919;20210920;20210921;20210922;20210923;20210924',
+          earliestAvailable: '20210920',
+          latestAvailable: '20210923',
+          reportStart: '20210920',
+          reportEnd: '20210923',
+        },
+      };
+      const output = buildOutput({
+        type: 'matrix',
+        rowField: 'FacilityType',
+        excludeFields: ['period'],
+      });
+      expect(output(MULTIPLE_TRANSFORMED_DATA_WITH_PERIOD)).toEqual(expectedData);
     });
   });
 });

--- a/packages/report-server/src/reportBuilder/fetch/types.ts
+++ b/packages/report-server/src/reportBuilder/fetch/types.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
-import { Row, PeriodMetadata } from '../types';
+import { Row, DataElementsMetadata, PeriodMetadata } from '../types';
 
-export interface FetchResponse extends PeriodMetadata {
+export interface FetchResponse extends DataElementsMetadata, PeriodMetadata {
   results: Row[];
 }

--- a/packages/report-server/src/reportBuilder/fetch/types.ts
+++ b/packages/report-server/src/reportBuilder/fetch/types.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
-import { Row } from '../types';
+import { Row, PeriodMetadata } from '../types';
 
-export interface FetchResponse {
+export interface FetchResponse extends PeriodMetadata {
   results: Row[];
 }

--- a/packages/report-server/src/reportBuilder/index.ts
+++ b/packages/report-server/src/reportBuilder/index.ts
@@ -3,5 +3,5 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
-export { ReportBuilder, BuiltReport } from './reportBuilder';
+export { ReportBuilder } from './reportBuilder';
 export { Row } from './types';

--- a/packages/report-server/src/reportBuilder/output/functions/default.ts
+++ b/packages/report-server/src/reportBuilder/output/functions/default.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
  */
 
-import { Row } from '../../types';
+import { Response } from '../types';
 
 export const buildDefault = () => {
-  return (rows: Row[]) => rows;
+  return (response: Response) => response;
 };

--- a/packages/report-server/src/reportBuilder/output/functions/index.ts
+++ b/packages/report-server/src/reportBuilder/output/functions/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+
+export { outputBuilders, ReportOutput } from './outputBuilders';

--- a/packages/report-server/src/reportBuilder/output/functions/outputBuilders.ts
+++ b/packages/report-server/src/reportBuilder/output/functions/outputBuilders.ts
@@ -6,7 +6,9 @@
 import { buildDefault } from './default';
 import { buildMatrix } from './matrix';
 
-export type OutputType = ReturnType<ReturnType<typeof outputBuilders[keyof typeof outputBuilders]>>;
+export type ReportOutput = ReturnType<
+  ReturnType<typeof outputBuilders[keyof typeof outputBuilders]>
+>;
 
 export const outputBuilders = {
   matrix: buildMatrix,

--- a/packages/report-server/src/reportBuilder/output/index.ts
+++ b/packages/report-server/src/reportBuilder/output/index.ts
@@ -4,3 +4,4 @@
  */
 
 export { buildOutput } from './output';
+export { ReportOutput } from './functions';

--- a/packages/report-server/src/reportBuilder/output/output.ts
+++ b/packages/report-server/src/reportBuilder/output/output.ts
@@ -5,8 +5,8 @@
 
 import { yup } from '@tupaia/utils';
 
-import { Row } from '../types';
-import { outputBuilders } from './functions/outputBuilders';
+import { Response } from './types';
+import { outputBuilders } from './functions';
 
 type OutputParams = {
   type: keyof typeof outputBuilders;
@@ -19,11 +19,11 @@ const paramsValidator = yup.object().shape({
     .oneOf(Object.keys(outputBuilders) as (keyof typeof outputBuilders)[]),
 });
 
-const output = (rows: Row[], params: OutputParams) => {
+const output = (response: Response, params: OutputParams) => {
   const { type, config } = params;
 
   const outputBuilder = outputBuilders[type](config);
-  return outputBuilder(rows);
+  return outputBuilder(response);
 };
 
 const buildParams = (params: unknown): OutputParams => {
@@ -34,5 +34,5 @@ const buildParams = (params: unknown): OutputParams => {
 
 export const buildOutput = (params: unknown) => {
   const builtParams = buildParams(params);
-  return (rows: Row[]) => output(rows, builtParams);
+  return (response: Response) => output(response, builtParams);
 };

--- a/packages/report-server/src/reportBuilder/output/types.ts
+++ b/packages/report-server/src/reportBuilder/output/types.ts
@@ -1,0 +1,10 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+
+import { Row, PeriodMetadata } from '../types';
+
+export interface Response extends PeriodMetadata {
+  results: Row[];
+}

--- a/packages/report-server/src/reportBuilder/output/types.ts
+++ b/packages/report-server/src/reportBuilder/output/types.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
  */
 
-import { Row, PeriodMetadata } from '../types';
+import { Row, DataElementsMetadata, PeriodMetadata } from '../types';
 
-export interface Response extends PeriodMetadata {
+export interface Response extends DataElementsMetadata, PeriodMetadata {
   results: Row[];
 }

--- a/packages/report-server/src/reportBuilder/types.ts
+++ b/packages/report-server/src/reportBuilder/types.ts
@@ -9,6 +9,12 @@ export interface Row {
   [field: string]: FieldValue;
 }
 
+export interface DataElementsMetadata {
+  metadata?: {
+    dataElementCodeToName?: Record<string, string>;
+  };
+}
+
 export interface PeriodMetadata {
   period?: {
     requested?: string;

--- a/packages/report-server/src/reportBuilder/types.ts
+++ b/packages/report-server/src/reportBuilder/types.ts
@@ -8,3 +8,13 @@ export type FieldValue = string | number | boolean | undefined | null;
 export interface Row {
   [field: string]: FieldValue;
 }
+
+export interface PeriodMetadata {
+  period?: {
+    requested?: string;
+    earliestAvailable?: string;
+    latestAvailable?: string;
+    reportStart?: string;
+    reportEnd?: string;
+  };
+}

--- a/packages/report-server/src/routes/FetchReportRoute.ts
+++ b/packages/report-server/src/routes/FetchReportRoute.ts
@@ -9,13 +9,14 @@ import { createAggregator } from '@tupaia/aggregator';
 import { Route } from '@tupaia/server-boilerplate';
 
 import { Aggregator } from '../aggregator';
-import { ReportBuilder, BuiltReport } from '../reportBuilder';
+import { ReportBuilder } from '../reportBuilder';
+import { ReportOutput } from '../reportBuilder/output';
 import { ReportRouteQuery, ReportRouteBody } from './types';
 import { getRequestedOrgUnitObjects, getAccessibleOrgUnitCodes } from './helpers';
 
 export type FetchReportRequest = Request<
   { reportCode: string },
-  BuiltReport,
+  ReportOutput,
   ReportRouteBody | Record<string, never>,
   ReportRouteQuery
 >;

--- a/packages/report-server/src/routes/TestReportRoute.ts
+++ b/packages/report-server/src/routes/TestReportRoute.ts
@@ -9,13 +9,14 @@ import { createAggregator } from '@tupaia/aggregator';
 import { Route } from '@tupaia/server-boilerplate';
 
 import { Aggregator } from '../aggregator';
-import { ReportBuilder, Row, BuiltReport } from '../reportBuilder';
+import { ReportBuilder, Row } from '../reportBuilder';
+import { ReportOutput } from '../reportBuilder/output';
 import { ReportRouteQuery, ReportRouteBody } from './types';
 import { getRequestedOrgUnitObjects, getAccessibleOrgUnitCodes } from './helpers';
 
 export type TestReportRequest = Request<
   Record<string, never>,
-  BuiltReport,
+  ReportOutput,
   {
     testData?: Row[];
     testConfig: Record<string, unknown>;

--- a/packages/utils/src/__tests__/object.test.js
+++ b/packages/utils/src/__tests__/object.test.js
@@ -17,6 +17,7 @@ import {
   reduceToDictionary,
   reduceToSet,
   stripFields,
+  isNullishOrEmptyObject,
 } from '../object';
 
 describe('object', () => {
@@ -601,5 +602,24 @@ describe('object', () => {
         expect(haveSameFields(objectCollection, fields)).toBe(false);
       });
     });
+  });
+
+  describe('isNullishOrEmptyObject', () => {
+    it('returns `true` for null or undefined', () => {
+      expect(isNullishOrEmptyObject(null)).toBe(true);
+      expect(isNullishOrEmptyObject(undefined)).toBe(true);
+    });
+
+    it('returns `false` for other falsey values', () => {
+      expect(isNullishOrEmptyObject(false)).toBe(false);
+      expect(isNullishOrEmptyObject('')).toBe(false);
+      expect(isNullishOrEmptyObject(0)).toBe(false);
+    });
+
+    it('returns `true` for object with no entries', () =>
+      expect(isNullishOrEmptyObject({})).toBe(true));
+
+    it('returns `false` for object with entries', () =>
+      expect(isNullishOrEmptyObject({ key: 'value' })).toBe(false));
   });
 });

--- a/packages/utils/src/object.js
+++ b/packages/utils/src/object.js
@@ -264,3 +264,6 @@ export const camelKeys = object =>
 
 export const snakeKeys = object =>
   Object.fromEntries(Object.entries(object).map(([key, value]) => [snake(key), value]));
+
+export const isNullishOrEmptyObject = obj =>
+  obj === null || obj === undefined || (typeof obj === 'object' && Object.keys(obj).length < 1);

--- a/packages/web-frontend/src/components/View/MatrixWrapper/MatrixWrapper.js
+++ b/packages/web-frontend/src/components/View/MatrixWrapper/MatrixWrapper.js
@@ -67,7 +67,7 @@ import { DateRangePicker } from '../../DateRangePicker';
 import { getStyles, DESCRIPTION_CELL_WIDTH, MINIMUM_CELL_WIDTH } from './styles';
 import { Matrix } from './components';
 import { formatDataValue } from '../../../utils';
-import { getLimits } from '../../../utils/periodGranularities';
+import { getDatePickerLimits, getDefaultDatePickerDates } from '../../../utils/periodGranularities';
 import { checkIfApplyDotStyle, getIsUsingDots } from '../utils';
 import { ChartContainer, ChartViewContainer } from '../Layout';
 
@@ -222,7 +222,7 @@ export class MatrixWrapper extends Component {
   };
 
   renderPeriodSelector() {
-    const { viewContent } = this.props;
+    const { viewContent, urlStartDate, urlEndDate } = this.props;
     const { periodGranularity } = viewContent;
     const { isLoading } = this.state;
 
@@ -230,19 +230,37 @@ export class MatrixWrapper extends Component {
       return null; // Not using a period selector
     }
 
-    const datePickerLimits = getLimits(viewContent.periodGranularity, viewContent.datePickerLimits);
+    const { startDate: defaultStartDate, endDate: defaultEndDate } = getDefaultDatePickerDates(
+      viewContent,
+    );
+
+    const startDate = urlStartDate || defaultStartDate;
+    const endDate = urlEndDate || defaultEndDate;
+
+    const datePickerLimits = getDatePickerLimits(
+      viewContent.periodGranularity,
+      viewContent.datePickerLimits,
+    );
 
     return (
       <div style={styles.periodSelector}>
         <DateRangePicker
           granularity={viewContent.periodGranularity}
           onSetDates={this.onSetDateRange}
-          startDate={viewContent.startDate}
-          endDate={viewContent.endDate}
+          startDate={startDate}
+          endDate={endDate}
           min={datePickerLimits.startDate}
           max={datePickerLimits.endDate}
           isLoading={isLoading}
         />
+      </div>
+    );
+  }
+
+  renderLoading() {
+    return (
+      <div style={styles.loadingWrapper}>
+        <CircularProgress />
       </div>
     );
   }
@@ -269,11 +287,7 @@ export class MatrixWrapper extends Component {
     const PeriodSelectorComponent = this.renderPeriodSelector();
 
     if (!columns) {
-      return (
-        <div style={styles.loadingWrapper}>
-          <CircularProgress />
-        </div>
-      );
+      return this.renderLoading();
     }
 
     let numberOfColumnsPerPage = 0;
@@ -390,6 +404,8 @@ MatrixWrapper.propTypes = {
   onChangeConfig: PropTypes.func,
   onSetDateRange: PropTypes.func,
   onItemClick: PropTypes.func,
+  urlStartDate: PropTypes.string,
+  urlEndDate: PropTypes.string,
 };
 
 MatrixWrapper.defaultProps = {
@@ -399,4 +415,6 @@ MatrixWrapper.defaultProps = {
   onChangeConfig: () => {},
   onSetDateRange: () => {},
   onItemClick: () => null,
+  urlStartDate: undefined,
+  urlEndDate: undefined,
 };

--- a/packages/web-frontend/src/containers/EnlargedDialog/EnlargedDialog.js
+++ b/packages/web-frontend/src/containers/EnlargedDialog/EnlargedDialog.js
@@ -8,7 +8,7 @@ import Dialog from '@material-ui/core/Dialog';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { toFilename } from '@tupaia/utils';
+import { toFilename, momentToDateString } from '@tupaia/utils';
 import styled from 'styled-components';
 import { useChartDataExport } from '@tupaia/ui-components/lib/chart';
 import {
@@ -276,6 +276,8 @@ const EnlargedDialogComponent = ({
           isDrillDownContent={false}
           onUnDrillDown={onUnDrillDown}
           isDrilledDown={drillDownState.drillDownLevel > 0}
+          urlStartDate={startDateForTopLevel ? momentToDateString(startDateForTopLevel) : undefined}
+          urlEndDate={endDateForTopLevel ? momentToDateString(endDateForTopLevel) : undefined}
         />
       </Dialog>
       <ExportDialog

--- a/packages/web-frontend/src/containers/EnlargedDialog/EnlargedDialogContent.js
+++ b/packages/web-frontend/src/containers/EnlargedDialog/EnlargedDialogContent.js
@@ -19,7 +19,7 @@ import { DateRangePicker } from '../../components/DateRangePicker';
 import { getIsMatrix, getViewWrapper, VIEW_CONTENT_SHAPE } from '../../components/View';
 import { DARK_BLUE, DIALOG_Z_INDEX, WHITE } from '../../styles';
 import { LoadingIndicator } from '../Form/common';
-import { getLimits } from '../../utils/periodGranularities';
+import { getDatePickerLimits, getDefaultDatePickerDates } from '../../utils/periodGranularities';
 import { DialogTitleWrapper } from '../../components/DialogTitleWrapper';
 import { transformDataForViewType } from '../../components/View/utils';
 
@@ -140,7 +140,14 @@ export class EnlargedDialogContent extends PureComponent {
   }
 
   renderBodyContent() {
-    const { viewContent, onCloseOverlay, organisationUnitName, isExporting } = this.props;
+    const {
+      viewContent,
+      onCloseOverlay,
+      organisationUnitName,
+      isExporting,
+      urlStartDate,
+      urlEndDate,
+    } = this.props;
     const ViewWrapper = getViewWrapper(viewContent);
     const newViewContent = transformDataForViewType(viewContent);
     const viewProps = {
@@ -148,6 +155,8 @@ export class EnlargedDialogContent extends PureComponent {
       isEnlarged: true,
       onClose: onCloseOverlay,
       onItemClick: this.onItemClick,
+      urlStartDate,
+      urlEndDate,
     };
     if (getIsMatrix(viewContent)) {
       viewProps.organisationUnitName = organisationUnitName;
@@ -217,10 +226,27 @@ export class EnlargedDialogContent extends PureComponent {
   }
 
   renderPeriodSelector() {
-    const { onSetDateRange, isLoading, viewContent, isExporting } = this.props;
-    const { periodGranularity, startDate, endDate } = viewContent;
+    const {
+      onSetDateRange,
+      isLoading,
+      viewContent,
+      isExporting,
+      urlStartDate,
+      urlEndDate,
+    } = this.props;
+    const { periodGranularity } = viewContent;
 
-    const datePickerLimits = getLimits(viewContent.periodGranularity, viewContent.datePickerLimits);
+    const { startDate: defaultStartDate, endDate: defaultEndDate } = getDefaultDatePickerDates(
+      viewContent,
+    );
+
+    const startDate = urlStartDate || defaultStartDate;
+    const endDate = urlEndDate || defaultEndDate;
+
+    const datePickerLimits = getDatePickerLimits(
+      viewContent.periodGranularity,
+      viewContent.datePickerLimits,
+    );
 
     return (
       <div style={styles.periodSelector(isExporting)}>
@@ -408,6 +434,8 @@ EnlargedDialogContent.propTypes = {
   isDrilledDown: PropTypes.bool,
   isDrillDownContent: PropTypes.bool,
   onUnDrillDown: PropTypes.func,
+  urlStartDate: PropTypes.string,
+  urlEndDate: PropTypes.func,
 };
 
 EnlargedDialogContent.defaultProps = {
@@ -424,4 +452,6 @@ EnlargedDialogContent.defaultProps = {
   exportRef: null,
   isDrilledDown: false,
   isDrillDownContent: false,
+  urlStartDate: undefined,
+  urlEndDate: undefined,
 };

--- a/packages/web-frontend/src/containers/MapOverlayBar/Control.js
+++ b/packages/web-frontend/src/containers/MapOverlayBar/Control.js
@@ -9,7 +9,11 @@ import CircularProgress from '@material-ui/core/CircularProgress';
 import LastUpdated from './LastUpdated';
 import { DateRangePicker } from '../../components/DateRangePicker';
 import { CONTROL_BAR_WIDTH, TUPAIA_ORANGE, MAP_OVERLAY_SELECTOR } from '../../styles';
-import { getDefaultDates, getLimits, GRANULARITY_CONFIG } from '../../utils/periodGranularities';
+import {
+  getDefaultDateRangeToFetch,
+  getDatePickerLimits,
+  GRANULARITY_CONFIG,
+} from '../../utils/periodGranularities';
 import { MapTableModal } from '../MapTableModal';
 
 const Container = styled.div`
@@ -118,8 +122,8 @@ export const Control = ({
   const [isExpanded, setIsExpanded] = useState(false);
   const mapOverlay = selectedMapOverlay || {};
   const { periodGranularity, isTimePeriodEditable = true, name } = mapOverlay;
-  const defaultDates = getDefaultDates(mapOverlay);
-  const datePickerLimits = getLimits(periodGranularity, mapOverlay.datePickerLimits);
+  const defaultDates = getDefaultDateRangeToFetch(mapOverlay);
+  const datePickerLimits = getDatePickerLimits(periodGranularity, mapOverlay.datePickerLimits);
   const showDatePicker = !!(isTimePeriodEditable && periodGranularity);
   const isMeasureSelected = !!name;
   const toggleMeasures = useCallback(() => {

--- a/packages/web-frontend/src/sagas.js
+++ b/packages/web-frontend/src/sagas.js
@@ -139,7 +139,7 @@ import {
   getInfoFromInfoViewKey,
   getBrowserTimeZone,
 } from './utils';
-import { getDefaultDates, getDefaultDrillDownDates } from './utils/periodGranularities';
+import { getDefaultDateRangeToFetch, getDefaultDrillDownDates } from './utils/periodGranularities';
 import { fetchProjectData } from './projects/sagas';
 import { clearLocation } from './historyNavigation/historyNavigation';
 import { decodeLocation } from './historyNavigation/utils';
@@ -740,7 +740,9 @@ function* fetchViewData(parameters, errorHandler) {
   const viewConfig = selectViewConfig(state, infoViewKey);
   // If the view should be constrained to a date range and isn't, constrain it
   const { startDate, endDate } =
-    parameters.startDate || parameters.endDate ? parameters : getDefaultDates(viewConfig);
+    parameters.startDate || parameters.endDate
+      ? parameters
+      : getDefaultDateRangeToFetch(viewConfig);
 
   // Build the request url
   const {
@@ -883,7 +885,7 @@ function* fetchMeasureInfo(mapOverlayId) {
   const { startDate, endDate } =
     measureParams.startDate || measureParams.endDate
       ? measureParams
-      : getDefaultDates(measureParams);
+      : getDefaultDateRangeToFetch(measureParams);
 
   const urlParameters = {
     mapOverlayId,

--- a/packages/web-frontend/src/selectors/dashboardSelectors.js
+++ b/packages/web-frontend/src/selectors/dashboardSelectors.js
@@ -7,7 +7,7 @@ import {
   getLocationComponentValue,
   URL_COMPONENTS,
 } from '../historyNavigation';
-import { getDefaultDates } from '../utils/periodGranularities';
+import { getDefaultDatePickerDates } from '../utils/periodGranularities';
 import { selectCurrentOrgUnitCode } from './orgUnitSelectors';
 import { selectLocation } from './utils';
 
@@ -85,25 +85,21 @@ export const selectIsEnlargedDialogVisible = createSelector(
 );
 
 export const selectShouldUseDashboardData = createSelector(
-  [selectCurrentInfoViewKey, selectCurrentExpandedViewContent, (_, options) => options],
-  (candidateInfoViewKey, candidateViewContent, options) => {
+  [selectCurrentInfoViewKey, selectCurrentExpandedViewConfig, (_, options) => options],
+  (candidateInfoViewKey, candidateViewConfig, options) => {
     const { startDate, endDate, infoViewKey, drillDownLevel } = options;
 
     if (drillDownLevel > 0) return false;
     if (candidateInfoViewKey !== infoViewKey) return false;
-    if (!candidateViewContent || candidateViewContent.type === 'matrix') return false;
+    if (!candidateViewConfig || candidateViewConfig.type === 'matrix') return false;
 
-    const { startDate: defaultStartDate, endDate: defaultEndDate } = getDefaultDates(
-      candidateViewContent,
+    const { startDate: defaultStartDate, endDate: defaultEndDate } = getDefaultDatePickerDates(
+      candidateViewConfig,
     );
-    const {
-      startDate: candidateStartDate = defaultStartDate,
-      endDate: candidateEndDate = defaultEndDate,
-    } = candidateViewContent;
 
     if (!startDate && !endDate) return true;
-    if (!moment(candidateStartDate).isSame(moment(startDate), 'day')) return false;
-    if (!moment(candidateEndDate).isSame(moment(endDate), 'day')) return false;
+    if (!moment(defaultStartDate).isSame(moment(startDate), 'day')) return false;
+    if (!moment(defaultEndDate).isSame(moment(endDate), 'day')) return false;
 
     return true;
   },

--- a/packages/web-frontend/src/tests/utils/periodGranularities.test.js
+++ b/packages/web-frontend/src/tests/utils/periodGranularities.test.js
@@ -9,6 +9,7 @@ import {
   roundStartEndDates,
   getDefaultDateRangeToFetch,
   getDatePickerLimits,
+  getDefaultDatePickerDates,
 } from '../../utils/periodGranularities';
 
 describe('periodGranularities', () => {
@@ -145,6 +146,45 @@ describe('periodGranularities', () => {
         expect(endDate.format()).toEqual('2019-02-08T23:59:59+11:00');
       });
     });
+
+    describe('defaultTimePeriod with useDatesOfData', () => {
+      it('uses the default date range for empty config', () => {
+        const { startDate, endDate } = getDefaultDateRangeToFetch({
+          periodGranularity: 'day',
+          defaultTimePeriod: {
+            useDatesOfData: true,
+          },
+        });
+        expect(startDate.format()).toEqual('2015-01-01T00:00:00+11:00');
+        expect(endDate.format()).toEqual('2019-02-05T21:00:00+11:00');
+      });
+
+      it('uses the specified range for range config', () => {
+        const { startDate, endDate } = getDefaultDateRangeToFetch({
+          periodGranularity: 'day',
+          defaultTimePeriod: {
+            useDatesOfData: true,
+            start: { unit: 'day', offset: -1 },
+            end: { unit: 'day', offset: 3 },
+          },
+        });
+        expect(startDate.format()).toEqual('2019-02-04T00:00:00+11:00');
+        expect(endDate.format()).toEqual('2019-02-08T23:59:59+11:00');
+      });
+
+      it('uses range for single period granularity config', () => {
+        const { startDate, endDate } = getDefaultDateRangeToFetch({
+          periodGranularity: 'one_day_at_a_time',
+          defaultTimePeriod: {
+            useDatesOfData: true,
+            start: { unit: 'day', offset: -1 },
+            end: { unit: 'day', offset: 3 },
+          },
+        });
+        expect(startDate.format()).toEqual('2019-02-04T00:00:00+11:00');
+        expect(endDate.format()).toEqual('2019-02-08T23:59:59+11:00');
+      });
+    });
   });
 
   describe('getDatePickerLimits', () => {
@@ -169,6 +209,50 @@ describe('periodGranularities', () => {
       });
       expect(startDate.format()).toEqual('2019-02-02T00:00:00+11:00'); // rounded
       expect(endDate.format()).toEqual('2019-02-05T23:59:59+11:00'); // rounded
+    });
+  });
+
+  describe('getDefaultDatePickerDates', () => {
+    it('gives nothing if no config', () => {
+      const { startDate, endDate } = getDefaultDatePickerDates({});
+      expect(startDate).toBeNull();
+      expect(endDate).toBeNull();
+    });
+
+    it('gives startDate and endDate', () => {
+      const { startDate, endDate } = getDefaultDatePickerDates({
+        defaultTimePeriod: {
+          useDatesOfData: false,
+          start: {
+            start: { unit: 'day', offset: -1 },
+            end: { unit: 'day', offset: 3 },
+          },
+        },
+        startDate: '2021-01-01',
+        endDate: '2021-01-05',
+        dataStartDate: '2021-01-02',
+        dataEndDate: '2021-01-04',
+      });
+      expect(startDate).toEqual('2021-01-01');
+      expect(endDate).toEqual('2021-01-05');
+    });
+
+    it('gives dataStartDate and dataEndDate if using dates of data', () => {
+      const { startDate, endDate } = getDefaultDatePickerDates({
+        defaultTimePeriod: {
+          useDatesOfData: true,
+          start: {
+            start: { unit: 'day', offset: -1 },
+            end: { unit: 'day', offset: 3 },
+          },
+        },
+        startDate: '2021-01-01',
+        endDate: '2021-01-05',
+        dataStartDate: '2021-01-02',
+        dataEndDate: '2021-01-04',
+      });
+      expect(startDate).toEqual('2021-01-02');
+      expect(endDate).toEqual('2021-01-04');
     });
   });
 });

--- a/packages/web-frontend/src/tests/utils/periodGranularities.test.js
+++ b/packages/web-frontend/src/tests/utils/periodGranularities.test.js
@@ -5,7 +5,11 @@
 
 import moment from 'moment';
 import { mockNow, resetMocks } from '../testutil';
-import { roundStartEndDates, getDefaultDates, getLimits } from '../../utils/periodGranularities';
+import {
+  roundStartEndDates,
+  getDefaultDateRangeToFetch,
+  getDatePickerLimits,
+} from '../../utils/periodGranularities';
 
 describe('periodGranularities', () => {
   beforeEach(() => {
@@ -34,15 +38,15 @@ describe('periodGranularities', () => {
     });
   });
 
-  describe('getDefaultDates', () => {
+  describe('getDefaultDateRangeToFetch', () => {
     it('gives nothing if no period granularity set', () => {
-      const result = getDefaultDates({});
+      const result = getDefaultDateRangeToFetch({});
       expect(result).toEqual({});
     });
 
     describe('defaultTimePeriod with single period', () => {
       it('gives today by default', () => {
-        const { startDate, endDate } = getDefaultDates({
+        const { startDate, endDate } = getDefaultDateRangeToFetch({
           periodGranularity: 'one_day_at_a_time',
           defaultTimePeriod: null,
         });
@@ -51,7 +55,7 @@ describe('periodGranularities', () => {
       });
 
       it('basic config works', () => {
-        const { startDate, endDate } = getDefaultDates({
+        const { startDate, endDate } = getDefaultDateRangeToFetch({
           periodGranularity: 'one_day_at_a_time',
           defaultTimePeriod: {
             start: { unit: 'day', offset: -1 },
@@ -66,7 +70,7 @@ describe('periodGranularities', () => {
         // E.g. if periodGranularity is one_month_at_a_time, and offset is +5 days, it will not take
         // effect, the start date will be rounded to the start of the month.
         const functionCall = () =>
-          getDefaultDates({
+          getDefaultDateRangeToFetch({
             periodGranularity: 'one_month_at_a_time',
             defaultTimePeriod: {
               start: { unit: 'day', offset: -3 },
@@ -78,7 +82,7 @@ describe('periodGranularities', () => {
       it('ignores end offset if both provided', () => {
         // Because we are one_day_at_a_time, end date is restricted to the end of that period (in this case, the day),
         // so is ignored when specified alongside start.
-        const { startDate, endDate } = getDefaultDates({
+        const { startDate, endDate } = getDefaultDateRangeToFetch({
           periodGranularity: 'one_day_at_a_time',
           defaultTimePeriod: {
             start: { unit: 'day', offset: -1 },
@@ -90,7 +94,7 @@ describe('periodGranularities', () => {
       });
 
       it('works when only end date provided', () => {
-        const { startDate, endDate } = getDefaultDates({
+        const { startDate, endDate } = getDefaultDateRangeToFetch({
           periodGranularity: 'one_day_at_a_time',
           defaultTimePeriod: {
             end: { unit: 'day', offset: -2 },
@@ -107,7 +111,7 @@ describe('periodGranularities', () => {
          *     start: { unit: 'day', offset: -1 },
          *   }
          */
-        const { startDate, endDate } = getDefaultDates({
+        const { startDate, endDate } = getDefaultDateRangeToFetch({
           periodGranularity: 'one_day_at_a_time',
           defaultTimePeriod: {
             unit: 'day',
@@ -121,7 +125,7 @@ describe('periodGranularities', () => {
 
     describe('defaultTimePeriod with a date range', () => {
       it('uses the default date range for empty config', () => {
-        const { startDate, endDate } = getDefaultDates({
+        const { startDate, endDate } = getDefaultDateRangeToFetch({
           periodGranularity: 'day',
           defaultTimePeriod: null,
         });
@@ -130,7 +134,7 @@ describe('periodGranularities', () => {
       });
 
       it('basic config works', () => {
-        const { startDate, endDate } = getDefaultDates({
+        const { startDate, endDate } = getDefaultDateRangeToFetch({
           periodGranularity: 'day',
           defaultTimePeriod: {
             start: { unit: 'day', offset: -1 },
@@ -143,9 +147,9 @@ describe('periodGranularities', () => {
     });
   });
 
-  describe('getLimits', () => {
+  describe('getDatePickerLimits', () => {
     it('gives nothing if no config', () => {
-      const { startDate, endDate } = getLimits('day');
+      const { startDate, endDate } = getDatePickerLimits('day');
       expect(startDate).toBeNull();
       expect(endDate).toBeNull();
     });
@@ -155,12 +159,14 @@ describe('periodGranularities', () => {
       // E.g. if periodGranularity is one_month_at_a_time, and offset is +5 days, it will not take
       // effect, the start date will be rounded to the start of the month.
       const functionCall = () =>
-        getLimits('one_month_at_a_time', { start: { unit: 'day', offset: -3 } });
+        getDatePickerLimits('one_month_at_a_time', { start: { unit: 'day', offset: -3 } });
       expect(functionCall).toThrow('limit unit must match periodGranularity');
     });
 
     it('calculates limits', () => {
-      const { startDate, endDate } = getLimits('day', { start: { unit: 'day', offset: -3 } });
+      const { startDate, endDate } = getDatePickerLimits('day', {
+        start: { unit: 'day', offset: -3 },
+      });
       expect(startDate.format()).toEqual('2019-02-02T00:00:00+11:00'); // rounded
       expect(endDate.format()).toEqual('2019-02-05T23:59:59+11:00'); // rounded
     });

--- a/packages/web-frontend/src/utils/periodGranularities.js
+++ b/packages/web-frontend/src/utils/periodGranularities.js
@@ -8,6 +8,8 @@
 import PropTypes from 'prop-types';
 import moment from 'moment';
 
+import { isNullishOrEmptyObject } from '@tupaia/utils';
+
 export const DEFAULT_MIN_DATE = '20150101';
 
 const DAY = 'day';
@@ -137,8 +139,6 @@ export const momentToDateString = (date, granularity, format) =>
     ? date.clone().startOf('W').format(format)
     : date.clone().format(format);
 
-const isEmpty = obj => !(obj && Object.keys(obj).length > 0);
-
 const getOffsetDate = (offset, unit, modifier, modifierUnit = null) => {
   // We need a valid unit to proceed.
   if (!CONFIG[unit]) {
@@ -198,7 +198,7 @@ const getDefaultDatesForSingleDateGranularities = (periodGranularity, defaultTim
   let startDate = moment();
   let endDate = startDate;
 
-  if (!isEmpty(defaultTimePeriod)) {
+  if (!isNullishOrEmptyObject(defaultTimePeriod)) {
     let singleDateConfig;
 
     // If defaultTimePeriod has either start or end,
@@ -241,7 +241,7 @@ const getDefaultDatesForSingleDateGranularities = (periodGranularity, defaultTim
  * @param {*} defaultTimePeriod
  */
 const getDefaultDatesForRangeGranularities = (periodGranularity, defaultTimePeriod) => {
-  if (!isEmpty(defaultTimePeriod)) {
+  if (!isNullishOrEmptyObject(defaultTimePeriod)) {
     let startDate = moment();
     let endDate = startDate;
 
@@ -283,6 +283,10 @@ export function getDefaultDateRangeToFetch(viewConfig) {
 }
 
 export function getDefaultDatePickerDates(viewConfig) {
+  if (isNullishOrEmptyObject(viewConfig)) {
+    return { startDate: null, endDate: null };
+  }
+
   const {
     defaultTimePeriod,
     startDate: requestedStartDate,


### PR DESCRIPTION
### Issue RN-28:

Bit of a roundabout implementation here. For RN-27, we want to be able to automatically detect the latest available data and to show that in the dashboard. In order to do this we will perform the following steps:
1. Fetch data for all time
2. Aggregate data to the MOST_RECENT and then only return records that are match the highest value in their batch
3. Attach metadata to the response stating the period the data is for (this must be done as we don't wish to show the period in the response data itself)
4. Have the frontend determine how to set the date for the date picker based on the metadata in the response

Changes were made in the frontend to support (1), and (4). Changes were made in the report-server to support (3). (2) will be done in the report itself for this dashboard.

Some of the decisions made for the report-server changes I'm not entirely happy with, so would appreciate feedback if the reviewer is also uneasy with them.

**Note:** Couple bugs in the latest merge conflicts so this may not run locally atm. Will fix asap but wanted to get review up!