### PR TITLE
WAI-5: Fix lesmis map spectrum colors

### DIFF
--- a/packages/lesmis/src/api/queries/useMapOverlayReportData.js
+++ b/packages/lesmis/src/api/queries/useMapOverlayReportData.js
@@ -47,14 +47,10 @@ const getMeasureDataFromResponse = (overlay, measureDataResponse) => {
   };
 };
 
-const processMeasureInfo = ({ serieses, measureData, ...rest }) => {
-  const processedSerieses = serieses.map(series => {
+const processSerieses = (serieses, measureData) =>
+  serieses.map(series => {
     const { values: mapOptionValues, type } = series;
-
-    // assign colors
     const values = autoAssignColors(mapOptionValues);
-
-    // value mapping
     const valueMapping = createValueMapping(values, type);
 
     if (SPECTRUM_MEASURE_TYPES.includes(type)) {
@@ -89,13 +85,6 @@ const processMeasureInfo = ({ serieses, measureData, ...rest }) => {
       valueMapping,
     };
   });
-
-  return {
-    serieses: processedSerieses,
-    measureData,
-    ...rest,
-  };
-};
 
 const processMeasureData = ({
   entityType,
@@ -206,8 +195,10 @@ export const useMapOverlayReportData = ({ entityCode, year }) => {
     [setHiddenValues],
   );
 
-  // processMeasureInfo
-  const processedMeasureInfo = measureData ? processMeasureInfo(measureData) : null;
+  // processSerieses
+  const processedSerieses = measureData
+    ? processSerieses(measureData.serieses, measureData.measureData)
+    : null;
 
   // processMeasureData
   const processedMeasureData =
@@ -217,14 +208,14 @@ export const useMapOverlayReportData = ({ entityCode, year }) => {
           measureLevel: measureData.measureLevel,
           measureData: measureData.measureData,
           entitiesData,
-          serieses: processedMeasureInfo.serieses,
+          serieses: processedSerieses,
           hiddenValues,
         })
       : null;
 
   return {
     isLoading: entitiesLoading || measureDataLoading || overlaysLoading,
-    data: { ...measureData, ...processedMeasureInfo, measureData: processedMeasureData },
+    data: { ...measureData, serieses: processedSerieses, measureData: processedMeasureData },
     entityData,
     hiddenValues,
     setValueHidden,

--- a/packages/lesmis/src/api/queries/useMapOverlayReportData.js
+++ b/packages/lesmis/src/api/queries/useMapOverlayReportData.js
@@ -19,6 +19,7 @@ import { useEntitiesData } from './useEntitiesData';
 import { yearToApiDates } from './utils';
 import { useUrlSearchParam } from '../../utils/useUrlSearchParams';
 import { useMapOverlaysData, findOverlay } from './useMapOverlaysData';
+import { COUNTRY_CODE } from '../../constants';
 import { get } from '../api';
 
 const getMeasureDataFromResponse = (overlay, measureDataResponse) => {
@@ -154,15 +155,15 @@ export const useMapOverlayReportData = ({ entityCode, year }) => {
   };
 
   const { data: measureDataResponse, isLoading: measureDataLoading } = useQuery(
-    ['mapOverlay', entityCode, selectedOverlay, params],
+    ['mapOverlay', COUNTRY_CODE, selectedOverlay, params],
     () =>
-      get(`report/${entityCode}/${reportCode}`, {
+      get(`report/${COUNTRY_CODE}/${reportCode}`, {
         params,
       }),
     {
       staleTime: 60 * 60 * 1000,
       refetchOnWindowFocus: false,
-      enabled: !!entityCode && !!reportCode && !!overlay,
+      enabled: !!reportCode && !!overlay,
     },
   );
 


### PR DESCRIPTION
### Issue #: Relates to all lesmis map overlays but the issue was raised on WAI-5

There are 2 commits on this PR. The first one is a simple refactor which I did as part of debugging the issue. The second one is the actual fix.

### Changes:
Always get measureData for the whole country so that the displayed area has a color relative to the rest of the country.

---

### Screenshots:
See WAI-5 Issue
