### PR TITLE
RN-124: Fix error that appears in console when opening viz-builder

### DIFF
--- a/packages/admin-panel/src/VizBuilderApp/api/queries/useLocations.js
+++ b/packages/admin-panel/src/VizBuilderApp/api/queries/useLocations.js
@@ -9,7 +9,10 @@ import { DEFAULT_REACT_QUERY_OPTIONS } from '../constants';
 export const useLocations = (project, search) =>
   useQuery(
     ['hierarchy', project, search],
-    () => get(`hierarchy/${project}/${project}`, { params: { search, fields: 'name,code' } }),
+    () =>
+      project
+        ? get(`hierarchy/${project}/${project}`, { params: { search, fields: 'name,code' } })
+        : [],
     {
       ...DEFAULT_REACT_QUERY_OPTIONS,
     },


### PR DESCRIPTION
Bug occurred due to attempting to fetch available locations before selecting a hierarchy.

### Changes:
- Added handler for when project is undefined

---

### Screenshots:
