### PR TITLE
hotfix-lesmis-shaded-polygons

### DIFF
--- a/packages/ui-components/src/components/Map/MarkerLayer.js
+++ b/packages/ui-components/src/components/Map/MarkerLayer.js
@@ -45,7 +45,15 @@ export const MarkerLayer = ({ measureData, serieses, onChangeOrgUnit }) => {
     <LayerGroup>
       {data.map(measure =>
         measure.region ? (
-          <ShadedPolygon key={measure.organisationUnitCode} positions={measure.region} {...measure}>
+          <ShadedPolygon
+            key={measure.organisationUnitCode}
+            positions={measure.region}
+            pathOptions={{
+              color: measure.color,
+              fillColor: measure.color,
+            }}
+            {...measure}
+          >
             <AreaTooltip text={getTooltipText(measure, serieses)} />
           </ShadedPolygon>
         ) : (


### PR DESCRIPTION
### Issue #: No Issue. hotfix-lesmis-shaded-polygons

### Changes:

Fix issue with shaded polygons where colors don't update. Issue caused by upgrade to new version of react-leaflet. It turns out there is a different prop for colors if it needs to be mutable.

---

