### PR TITLE
RN-125: Add 'dataElementCodeToName' function to report-server transforms

### DIFF
--- a/packages/report-server/src/__tests__/reportBuilder/context/buildContext.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/context/buildContext.test.ts
@@ -109,4 +109,53 @@ describe('buildContext', () => {
       expect(context).toStrictEqual(expectedContext);
     });
   });
+
+  describe('dataElementCodeToName', () => {
+    it('includes dataElementCodeToName from fetched data', async () => {
+      const transform = [
+        {
+          insert: {
+            name: '=dataElementCodeToName($dataElement)',
+          },
+          transform: 'updateColumns',
+        },
+      ];
+      const analytics = [
+        { dataElement: 'BCD1', organisationUnit: 'TO', period: '20210101', value: 1 },
+        { dataElement: 'BCD2', organisationUnit: 'FJ', period: '20210101', value: 2 },
+      ];
+      const data = {
+        results: analytics,
+        metadata: {
+          dataElementCodeToName: { BCD1: 'Facility Status', BCD2: 'Reason for closure' },
+        },
+      };
+
+      const context = await buildContext(transform, reqContext, data);
+      const expectedContext = {
+        dataElementCodeToName: { BCD1: 'Facility Status', BCD2: 'Reason for closure' },
+      };
+      expect(context).toStrictEqual(expectedContext);
+    });
+
+    it('builds an empty object when using fetch events', async () => {
+      const transform = [
+        {
+          insert: {
+            name: '=dataElementCodeToName($dataElement)',
+          },
+          transform: 'updateColumns',
+        },
+      ];
+      const events = [
+        { event: 'evId1', eventDate: '2021-01-01T12:00:00', orgUnit: 'TO', orgUnitName: 'Tonga' },
+        { event: 'evId2', eventDate: '2021-01-01T12:00:00', orgUnit: 'FJ', orgUnitName: 'Fiji' },
+      ];
+      const data = { results: events };
+
+      const context = await buildContext(transform, reqContext, data);
+      const expectedContext = { dataElementCodeToName: {} };
+      expect(context).toStrictEqual(expectedContext);
+    });
+  });
 });

--- a/packages/report-server/src/__tests__/reportBuilder/transform/parser/functions.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/transform/parser/functions.test.ts
@@ -94,6 +94,27 @@ describe('functions', () => {
         expect(parser.evaluate("=orgUnitCodeToName('WS')")).toBe(undefined);
       });
     });
+
+    describe('dataElementCodeToName', () => {
+      const context = {
+        dataElementCodeToName: {
+          FijiBCSC93: 'Haloperidol Tablets 5mg',
+          FijiBCSC61: 'Benztropine  Injection 2mg/ml',
+        },
+      };
+
+      it('converts given data element code to name', () => {
+        const parser = new TransformParser(undefined, context);
+        expect(parser.evaluate("=dataElementCodeToName('FijiBCSC93')")).toBe(
+          'Haloperidol Tablets 5mg',
+        );
+      });
+
+      it('returns undefined if the data element code is not found', () => {
+        const parser = new TransformParser(undefined, context);
+        expect(parser.evaluate("=dataElementCodeToName('BCD1')")).toBe(undefined);
+      });
+    });
   });
 
   describe('utils', () => {

--- a/packages/report-server/src/aggregator/Aggregator.ts
+++ b/packages/report-server/src/aggregator/Aggregator.ts
@@ -4,7 +4,11 @@
  */
 
 import { Aggregator as BaseAggregator } from '@tupaia/aggregator';
-import { getDefaultPeriod, convertPeriodStringToDateRange, convertDateRangeToPeriodString } from '@tupaia/utils';
+import {
+  getDefaultPeriod,
+  convertPeriodStringToDateRange,
+  convertDateRangeToPeriodString,
+} from '@tupaia/utils';
 import { Event, AggregationObject } from '../types';
 
 type PeriodParams = {

--- a/packages/report-server/src/reportBuilder/context/extractContextProps.ts
+++ b/packages/report-server/src/reportBuilder/context/extractContextProps.ts
@@ -7,7 +7,7 @@ import isPlainObject from 'lodash.isplainobject';
 
 import { getUniqueEntries } from '@tupaia/utils';
 
-import { contextConfig, TransformParams, TransformParser } from '../transform';
+import { contextFunctionConfigs, TransformParser } from '../transform';
 import { ContextProp } from './types';
 
 const extractContextPropsFromExpressions = (expressions: string[]) => {
@@ -19,7 +19,7 @@ const extractContextPropsFromExpressions = (expressions: string[]) => {
     })
     .flat();
 
-  const contextProps = Object.entries(contextConfig)
+  const contextProps = Object.entries(contextFunctionConfigs)
     .filter(([fnName]) => functions.includes(fnName))
     .map(([, config]) => config.contextProps)
     .flat();
@@ -32,7 +32,7 @@ export const extractContextProps = (transform: unknown): ContextProp[] => {
     return [];
   }
 
-  const expressions = (transform as TransformParams[])
+  const expressions = transform
     .map(transformStep => {
       if (typeof transformStep === 'string' || !isPlainObject(transformStep)) {
         // Skipping aliased transforms
@@ -47,7 +47,15 @@ export const extractContextProps = (transform: unknown): ContextProp[] => {
       } = transformStep;
 
       return Object.values(restOfTransformParams).map(param => {
-        return typeof param !== 'object' ? [param] : Object.entries(param);
+        if (typeof param !== 'object') {
+          return [param];
+        }
+
+        if (param === null) {
+          return [];
+        }
+
+        return Object.entries(param);
       });
     })
     .flat(5)

--- a/packages/report-server/src/reportBuilder/context/index.ts
+++ b/packages/report-server/src/reportBuilder/context/index.ts
@@ -1,2 +1,8 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+
 export { buildContext, ReqContext } from './buildContext';
+
 export { Context, ContextProp } from './types';

--- a/packages/report-server/src/reportBuilder/context/types.ts
+++ b/packages/report-server/src/reportBuilder/context/types.ts
@@ -4,7 +4,8 @@
  */
 
 export interface Context {
-  orgUnits: { code: string; name: string }[];
+  orgUnits?: { code: string; name: string }[];
+  dataElementCodeToName?: Record<string, string>;
 }
 
 export type ContextProp = keyof Context;

--- a/packages/report-server/src/reportBuilder/transform/index.ts
+++ b/packages/report-server/src/reportBuilder/transform/index.ts
@@ -3,5 +3,5 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
-export { contextConfig, TransformParser } from './parser';
-export { buildTransform, TransformParams } from './transform';
+export { buildTransform } from './transform';
+export { contextFunctionConfigs, TransformParser } from './parser';

--- a/packages/report-server/src/reportBuilder/transform/parser/TransformParser.ts
+++ b/packages/report-server/src/reportBuilder/transform/parser/TransformParser.ts
@@ -9,8 +9,8 @@ import { Context } from '../../context';
 import { Row, FieldValue } from '../../types';
 import {
   customFunctions,
-  contextConfig,
-  functionsExtensions,
+  contextFunctionConfigs,
+  functionExtensions,
   functionOverrides,
 } from './functions';
 import { TransformScope } from './TransformScope';
@@ -151,7 +151,7 @@ export class TransformParser extends ExpressionParser {
   }
 
   protected getFunctionExtensions() {
-    return { ...super.getFunctionExtensions(), ...functionsExtensions };
+    return { ...super.getFunctionExtensions(), ...functionExtensions };
   }
 
   protected getFunctionOverrides() {
@@ -164,7 +164,7 @@ export class TransformParser extends ExpressionParser {
     };
 
     const functions = Object.fromEntries(
-      Object.entries(contextConfig).map(([fnName, { create }]) => [
+      Object.entries(contextFunctionConfigs).map(([fnName, { create }]) => [
         fnName,
         this.factory(fnName, ['getContext'], create),
       ]),

--- a/packages/report-server/src/reportBuilder/transform/parser/functions/context.ts
+++ b/packages/report-server/src/reportBuilder/transform/parser/functions/context.ts
@@ -22,7 +22,23 @@ export const orgUnitCodeToName: ContextFunctionConfig = {
   contextProps: ['orgUnits'],
   create: ({ getContext }) => (orgUnitCode: string) => {
     const { orgUnits } = getContext();
+    if (!orgUnits) {
+      throw new Error("Missing dependency 'orgUnits' required by 'orgUnitCodeToName'");
+    }
     const codeToName = reduceToDictionary(orgUnits, 'code', 'name');
     return codeToName[orgUnitCode];
+  },
+};
+
+export const dataElementCodeToName: ContextFunctionConfig = {
+  contextProps: ['dataElementCodeToName'],
+  create: ({ getContext }) => (dataElementCode: string) => {
+    const { dataElementCodeToName: codeToNameMap } = getContext();
+    if (!codeToNameMap) {
+      throw new Error(
+        "Missing dependency 'dataElementCodeToName' required by 'dataElementCodeToName'",
+      );
+    }
+    return codeToNameMap[dataElementCode];
   },
 };

--- a/packages/report-server/src/reportBuilder/transform/parser/functions/index.ts
+++ b/packages/report-server/src/reportBuilder/transform/parser/functions/index.ts
@@ -4,7 +4,7 @@
  */
 
 import { value, last, eq, notEq, exists, notExists, gt, length, any, all } from './basic';
-import { orgUnitCodeToName } from './context';
+import { orgUnitCodeToName, dataElementCodeToName } from './context';
 import {
   convertToPeriod,
   dateStringToPeriod,
@@ -35,14 +35,15 @@ export const customFunctions = {
   all,
 };
 
-export const contextConfig = {
+export const contextFunctionConfigs = {
   orgUnitCodeToName,
+  dataElementCodeToName,
 };
 
 /**
  * Functions to extend existing mathjs functions
  */
-export const functionsExtensions = {
+export const functionExtensions = {
   add,
   divide,
 };

--- a/packages/report-server/src/reportBuilder/transform/parser/index.ts
+++ b/packages/report-server/src/reportBuilder/transform/parser/index.ts
@@ -3,5 +3,5 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
-export { contextConfig } from './functions';
+export { contextFunctionConfigs } from './functions';
 export { TransformParser } from './TransformParser';

--- a/packages/report-server/src/reportBuilder/transform/transform.ts
+++ b/packages/report-server/src/reportBuilder/transform/transform.ts
@@ -10,8 +10,6 @@ import { Context } from '../context';
 import { transformBuilders } from './functions';
 import { aliases } from './aliases';
 
-export type TransformParams = yup.InferType<typeof transformParamsValidator>;
-
 type BuiltTransformParams = {
   title?: string;
   name: string;
@@ -53,7 +51,7 @@ const transform = (rows: Row[], transformSteps: BuiltTransformParams[]): Row[] =
 };
 
 const buildParams = (params: unknown, context: Context): BuiltTransformParams => {
-  const validatedParams: TransformParams = transformParamsValidator.validateSync(params);
+  const validatedParams = transformParamsValidator.validateSync(params);
   if (typeof validatedParams === 'string') {
     return {
       name: validatedParams,
@@ -75,7 +73,7 @@ const buildParams = (params: unknown, context: Context): BuiltTransformParams =>
   };
 };
 
-export const buildTransform = (params: unknown, context: Context) => {
+export const buildTransform = (params: unknown, context: Context = {}) => {
   const validatedParams = paramsValidator.validateSync(params);
 
   const builtParams = validatedParams.map(param => buildParams(param, context));


### PR DESCRIPTION
### Issue RN-125:

Basically just importing the `dataElementCodeToName` from the analytics fetch into the context, and then using a function to reference it from there. I thought about allowing users to directly reference the `metadata` object in the transform itself, and I think that could still have merit, but this method is cleaner and easier for users to work with 👍 

Note: only works with fetch analytics for now. If we want to add support when using fetch events I'd recommend we support that by returning metadata from fetch events also

A couple of cleanups in this PR as well, hopefully they aren't too distracting.
