### PR TITLE
RN-132: Fixed entity-server not returning any relationships when ancestorType = descendantType

### DIFF
--- a/packages/entity-server/src/__tests__/__integration__/EntityRelationshipsRoutes.test.ts
+++ b/packages/entity-server/src/__tests__/__integration__/EntityRelationshipsRoutes.test.ts
@@ -100,6 +100,21 @@ describe('relationships', () => {
       expect(entities).toEqual({ Kanto: ['Cerulean Cave'] });
     });
 
+    it('can fetch relations where ancestor and descendant have the same type', async () => {
+      const { body: entities } = await app.get('hierarchy/redblue/KANTO/relationships', {
+        query: { ancestor_filter: 'type==facility', descendant_filter: 'type==facility' },
+      });
+
+      expect(entities).toEqual({
+        CELADON_GAME: ['CELADON_GAME'],
+        CERULEAN_CAVE: ['CERULEAN_CAVE'],
+        PKMN_MANSION: ['PKMN_MANSION'],
+        SAFARI: ['SAFARI'],
+        PKMN_TOWER: ['PKMN_TOWER'],
+        SILPH: ['SILPH'],
+      });
+    });
+
     it('can fetch relationships in an alternate hierarchy', async () => {
       const { body: entities } = await app.get('hierarchy/goldsilver/goldsilver/relationships', {
         query: {

--- a/packages/entity-server/src/routes/hierarchy/relationships/ResponseBuilder.ts
+++ b/packages/entity-server/src/routes/hierarchy/relationships/ResponseBuilder.ts
@@ -45,7 +45,17 @@ export class ResponseBuilder {
   private async buildAncestorCodesAndPairs(descendants: EntityType[]): Promise<[string[], Pair[]]> {
     const { hierarchyId, entities } = this.ctx;
     const { type: ancestorType } = this.ctx.ancestor;
+    const { type: descendantType } = this.ctx.descendant;
+
     const descendantCodes = descendants.map(descendant => descendant.code);
+    if (ancestorType === descendantType) {
+      // types match, so just return descendants as mapping to themselves
+      return [
+        descendantCodes,
+        descendantCodes.map(descendant => ({ descendant, ancestor: descendant })),
+      ];
+    }
+
     const descendantAncestorMapping = await this.models.entity.fetchAncestorDetailsByDescendantCode(
       descendantCodes,
       hierarchyId,


### PR DESCRIPTION
### Issue RN-132:

Pretty straightforward bug, was occurring because `models.entity.fetchAncestorDetailsByDescendantCode()` doesn't return values that map to themselves (and it probably shouldn't)

### Changes:

- Example

---

### Screenshots:
