### PR TITLE
Switched to explicit deinit in mvrefresh installation scripts

### DIFF
--- a/packages/data-api/scripts/installMvRefreshModule.sh
+++ b/packages/data-api/scripts/installMvRefreshModule.sh
@@ -20,7 +20,7 @@ else
     export DB_MV_HOME="$PWD"
     (. runCreateFastRefreshModule.sh)
     cd ../..
-    git submodule deinit --all
+    git submodule deinit scripts/pg-mv-fast-refresh
 fi
 
 export PGPASSWORD=$DB_PG_PASSWORD

--- a/packages/data-api/scripts/uninstallMvRefreshModule.sh
+++ b/packages/data-api/scripts/uninstallMvRefreshModule.sh
@@ -15,7 +15,7 @@ else
     export DB_MV_HOME="$PWD"
     (. dropFastRefreshModule.sh)
     cd ../..
-    git submodule deinit --all
+    git submodule deinit scripts/pg-mv-fast-refresh
     export PGPASSWORD=$DB_PG_PASSWORD
     psql -p $DB_PORT -h $DB_URL -d $DB_NAME -U $DB_PG_USER -tc "REVOKE ALL PRIVILEGES on schema public FROM $DB_MV_USER; DROP ROLE IF EXISTS $DB_MV_USER;"
 fi


### PR DESCRIPTION
`git` on prod/feature instances don't support `--all` flag with `git submodule deinit`

I prefer this anyway as it's cleaner and more explicit
