### PR TITLE
hotfix issue with phx-105 for this weeks release

### DIFF
--- a/packages/database/src/migrations/20211011020420-UpdateDashboardRelationsForPermissionGroupNameChange-modifies-data.js
+++ b/packages/database/src/migrations/20211011020420-UpdateDashboardRelationsForPermissionGroupNameChange-modifies-data.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function (db) {
+  return db.runSql(`
+   UPDATE dashboard_relation
+   SET permission_groups = '{"Tonga Community Health Senior"}'
+   WHERE permission_groups = '{"Community Health Senior"}';
+  `);
+};
+
+exports.down = function (db) {
+  return null;
+};
+
+exports._meta = {
+  "version": 1
+};


### PR DESCRIPTION
Fixes up an issue that was found during regression testing where a change to permission group name also had to be addressed in the `dashboard_relation` table

Original issue: https://linear.app/bes/issue/PHX-105/change-name-of-community-health-senior-permission-group