### PR TITLE
Hotfix: Update regex in map overlay e2e to use mapOverlayCode

### DIFF
--- a/packages/web-frontend/cypress/e2e/mapOverlays.spec.js
+++ b/packages/web-frontend/cypress/e2e/mapOverlays.spec.js
@@ -30,12 +30,12 @@ const assertUrlResponseHasData = (url, response) => {
 
 const urlToRouteRegex = url => {
   const queryParams = url.split('?').slice(1).join('');
-  const mapOverlayId = new URLSearchParams(queryParams).get('overlay');
-  if (!mapOverlayId) {
+  const mapOverlayCode = new URLSearchParams(queryParams).get('overlay');
+  if (!mapOverlayCode) {
     throw new Error(`'${url}' is not a valid report url: it must contain a 'report' query param`);
   }
 
-  return new RegExp(`measureData\\?(.*&|)mapOverlayId=${mapOverlayId}(&|$)`);
+  return new RegExp(`measureData\\?(.*&|)mapOverlayCode=${mapOverlayCode}(&|$)`);
 };
 
 describe('Map overlays', () => {


### PR DESCRIPTION
### Issue #: No Issue

### Changes:

- Swap the regex replace in `mapOverlays.spec.js` to use `mapOverlayCode`
