### PR TITLE
remove-dashboard-item-import-export

### DIFF
--- a/packages/admin-panel/src/pages/resources/DashboardItemsPage.js
+++ b/packages/admin-panel/src/pages/resources/DashboardItemsPage.js
@@ -42,7 +42,7 @@ const IMPORT_CONFIG = {
   },
 };
 
-export const DashboardItemsPage = ({ getHeaderEl, isBESAdmin }) => {
+export const DashboardItemsPage = ({ getHeaderEl, isBESAdmin, ...props }) => {
   const extraEditFields = [
     // ID field for constructing viz-builder path only, not for showing or editing
     {
@@ -107,6 +107,7 @@ export const DashboardItemsPage = ({ getHeaderEl, isBESAdmin }) => {
         title: 'Edit Dashboard Item',
       }}
       getHeaderEl={getHeaderEl}
+      {...props}
     />
   );
 };

--- a/packages/lesmis/src/routes/AdminPanelRoutes.js
+++ b/packages/lesmis/src/routes/AdminPanelRoutes.js
@@ -8,7 +8,6 @@ import { Switch, Redirect, Route } from 'react-router-dom';
 import { TabsToolbar } from '@tupaia/ui-components';
 import { Assignment, InsertChart, PeopleAlt } from '@material-ui/icons';
 import {
-  DashboardItemsPage,
   DashboardsPage,
   QuestionsPage,
   SurveysPage,
@@ -27,12 +26,13 @@ import {
 import { LesmisAdminRoute } from './LesmisAdminRoute';
 import { useUser } from '../api/queries';
 import { getApiUrl } from '../utils/getApiUrl';
+import { DashboardItemsView } from '../views/AdminPanel/DashboardItemsView';
 
 /* eslint-disable */
 import {
   ApprovedSurveyResponsesView,
   DraftSurveyResponsesView,
-} from '../views/SurveyResponsesView';
+} from '../views/AdminPanel/SurveyResponsesView';
 
 const ADMIN_URL = '/admin';
 
@@ -91,7 +91,7 @@ export const ROUTES = [
       {
         label: 'Dashboard Items',
         to: '',
-        component: DashboardItemsPage,
+        component: DashboardItemsView,
       },
       {
         label: 'Dashboards',

--- a/packages/lesmis/src/views/AdminPanel/DashboardItemsView.js
+++ b/packages/lesmis/src/views/AdminPanel/DashboardItemsView.js
@@ -1,0 +1,14 @@
+/*
+ * Tupaia
+ *  Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+import React from 'react';
+import { DashboardItemsPage } from '@tupaia/admin-panel/lib';
+
+// Remove import and export buttons from Dashboard Items page because they are handled by
+// admin-panel-server and not meditrak-server
+export const DashboardItemsView = props => {
+  const dashboardItemColumns = DashboardItemsPage(props).props.columns;
+  const columns = dashboardItemColumns.filter(column => column.type !== 'export');
+  return <DashboardItemsPage columns={columns} importConfig={null} {...props} />;
+};

--- a/packages/lesmis/src/views/AdminPanel/SurveyResponsesView.js
+++ b/packages/lesmis/src/views/AdminPanel/SurveyResponsesView.js
@@ -5,7 +5,7 @@
 import React from 'react';
 import { SurveyResponsesPage, SURVEY_RESPONSE_COLUMNS } from '@tupaia/admin-panel/lib';
 import { ConfirmModal } from '@tupaia/ui-components';
-import { ApproveButton } from '../components';
+import { ApproveButton } from '../../components';
 
 // Todo: Replace base filter with real filter @see WAI-832
 export const ApprovedSurveyResponsesView = props => (


### PR DESCRIPTION
### Issue #: WAI-61: lesmis admin panel

Fixes bug found in testing where dashboard item import and export don't work in lesmis admin panel
See testing comment: https://linear.app/bes/issue/WAI-1001#comment-c76db317

### Changes:

- Remove import and export buttons from Dashboard Items page because they are handled by admin-panel-server and not meditrak-server

---
