### PR TITLE
wai-1018 update dhisApi default lookback period

### DIFF
--- a/packages/dhis-api/src/DhisApi.js
+++ b/packages/dhis-api/src/DhisApi.js
@@ -36,7 +36,7 @@ const {
   INDICATOR,
 } = DHIS2_RESOURCE_TYPES;
 
-const LATEST_LOOKBACK_PERIOD = '600d';
+const LATEST_LOOKBACK_PERIOD = '3650d';
 
 export class DhisApi {
   constructor(serverName, serverUrl, serverReadOnly = false) {


### PR DESCRIPTION
### Issue #: [WAI-1018](https://linear.app/bes/issue/WAI-1018/dhis2-data-older-than-600d-doesnt-fetch)

This PR changes the default lookback period from 600 days to 3650 days (e.g. 10 years). The reason for this is that we have data on DHIS2 that is older than 600 days now and for databuilders where the default lookback period is used the data doesn't fetch
