### PR TITLE
wai-1020 export code instead of id for entities

### DIFF
--- a/packages/meditrak-server/src/dataAccessors/findAnswersInSurveyResponse.js
+++ b/packages/meditrak-server/src/dataAccessors/findAnswersInSurveyResponse.js
@@ -28,6 +28,7 @@ export const findAnswersInSurveyResponse = async (
             { [`${TYPES.QUESTION}.id`]: 'question.id' },
             { text: 'answer.text' },
             { [`${TYPES.QUESTION}.text`]: 'question.text' },
+            { type: 'question.type' },
             ...(options.columns ? options.columns : []),
           ],
           sort: ['screen_number', 'component_number', ...options.sort],


### PR DESCRIPTION
Issue: https://linear.app/bes/issue/WAI-1020/export-answers-to-entity-questions-as-codes-rather-than-ids

This exports Entity answers as the Entity code instead of the Entity id