### PR TITLE
RN-196: Few fixes for heavy memory usage when fetching /organisationUnits

### DIFF
--- a/packages/database/src/modelClasses/AncestorDescendantRelation.js
+++ b/packages/database/src/modelClasses/AncestorDescendantRelation.js
@@ -25,6 +25,10 @@ export class AncestorDescendantRelationType extends DatabaseType {
       fields: { code: 'ancestor_code' },
     },
   ];
+
+  get cacheDependencies() {
+    return [TYPES.ENTITY_RELATION, TYPES.ENTITY_HIERARCHY];
+  }
 }
 
 export class AncestorDescendantRelationModel extends DatabaseModel {
@@ -41,22 +45,34 @@ export class AncestorDescendantRelationModel extends DatabaseModel {
   }
 
   async getChildIdToParentId(hierarchyId) {
-    const relationRecords = await this.getImmediateRelations(hierarchyId);
-    return reduceToDictionary(relationRecords, 'descendant_id', 'ancestor_id');
+    const cacheKey = this.getCacheKey(this.getChildIdToParentId.name, hierarchyId);
+    return this.runCachedFunction(cacheKey, async () => {
+      const relationRecords = await this.getImmediateRelations(hierarchyId);
+      return reduceToDictionary(relationRecords, 'descendant_id', 'ancestor_id');
+    });
   }
 
   async getChildCodeToParentCode(hierarchyId) {
-    const relationRecords = await this.getImmediateRelations(hierarchyId);
-    return reduceToDictionary(relationRecords, 'descendant_code', 'ancestor_code');
+    const cacheKey = this.getCacheKey(this.getChildCodeToParentCode.name, hierarchyId);
+    return this.runCachedFunction(cacheKey, async () => {
+      const relationRecords = await this.getImmediateRelations(hierarchyId);
+      return reduceToDictionary(relationRecords, 'descendant_code', 'ancestor_code');
+    });
   }
 
   async getParentIdToChildIds(hierarchyId) {
-    const relationRecords = await this.getImmediateRelations(hierarchyId);
-    return reduceToArrayDictionary(relationRecords, 'ancestor_id', 'descendant_id');
+    const cacheKey = this.getCacheKey(this.getParentIdToChildIds.name, hierarchyId);
+    return this.runCachedFunction(cacheKey, async () => {
+      const relationRecords = await this.getImmediateRelations(hierarchyId);
+      return reduceToArrayDictionary(relationRecords, 'ancestor_id', 'descendant_id');
+    });
   }
 
   async getParentCodeToChildCodes(hierarchyId) {
-    const relationRecords = await this.getImmediateRelations(hierarchyId);
-    return reduceToArrayDictionary(relationRecords, 'ancestor_code', 'descendant_code');
+    const cacheKey = this.getCacheKey(this.getParentCodeToChildCodes.name, hierarchyId);
+    return this.runCachedFunction(cacheKey, async () => {
+      const relationRecords = await this.getImmediateRelations(hierarchyId);
+      return reduceToArrayDictionary(relationRecords, 'ancestor_code', 'descendant_code');
+    });
   }
 }

--- a/packages/database/src/modelClasses/Entity.js
+++ b/packages/database/src/modelClasses/Entity.js
@@ -431,7 +431,7 @@ export class EntityModel extends MaterializedViewLogDatabaseModel {
         ? ['ancestor_id', 'descendant_id']
         : ['descendant_id', 'ancestor_id'];
 
-    const relationData = await this.runCachedFunction(cacheKey, async () => {
+    const entityRecords = await this.runCachedFunction(cacheKey, async () => {
       const relations = await this.find(
         {
           ...criteria,
@@ -443,11 +443,11 @@ export class EntityModel extends MaterializedViewLogDatabaseModel {
           sort: ['generational_distance ASC'],
         },
       );
-      return Promise.all(relations.map(async r => r.getData()));
+      const relationData = await Promise.all(relations.map(async r => r.getData()));
+      const uniqueEntities = Object.values(keyBy(relationData, 'id'));
+      return uniqueEntities;
     });
-
-    const uniqueEntities = Object.values(keyBy(relationData, 'id'));
-    return Promise.all(uniqueEntities.map(async r => this.generateInstance(r)));
+    return Promise.all(entityRecords.map(async r => this.generateInstance(r)));
   }
 
   async getAncestorsOfEntities(hierarchyId, entityIds, criteria) {


### PR DESCRIPTION
### Issue RN-196:

This isn't an exhaustive investigation/fix by any means, but addresses a few low hanging fruit.

It seems that memory consumption when loading the /organisationUnits route in a project with a large hierarchy can be very high. During this process the memory usage of the web-config-server can spike to over 1GB. Initially the memory seemed to be leaking as it stayed high and grew on each subsequent request, but it turns out that was just the Node garbage collection not cleaning things up as yet. 

Overall to stop such issues in the future we probably need to tune our max memory limits for the various servers to something more safe given the total RAM of the feature instances is only 4GB.

Actual fixes here:
1. Pushed the filtering for unique entities in Entity.js inside the cached function. This avoid accidentally caching duplicate entities, as removes the need to perform this filter every time
2. Wrapped the the utility functions for getting parent/child relations on AncestorDescendantRelation.js inside cached functions. This saves us some work recalculating these every time
3. Made a few optimisations to the logic of the /organisationUnits route 

Still doing a bit of proper testing on a feature instance to guage just how much difference they make (seemed to make a 40% reduction in peak memory usage on my local), will post results once that's completed
