### PR TITLE
Bump version to 1.11.115

### DIFF
--- a/packages/meditrak-app/ios/TupaiaMediTrak/Info.plist
+++ b/packages/meditrak-app/ios/TupaiaMediTrak/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.11.114</string>
+	<string>1.11.115</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>114</string>
+	<string>115</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/packages/meditrak-app/package.json
+++ b/packages/meditrak-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/meditrak-app",
-  "version": "1.11.114",
+  "version": "1.11.115",
   "private": true,
   "description": "Android and iOS app for surveying medical facilities",
   "repository": {


### PR DESCRIPTION
### Issue #: No Issue

### Changes:

- Bump meditrak app version number before publishing an app release