### PR TITLE
WAI-963: Wait a full minute for the database to become available

### DIFF
--- a/packages/database/src/DatabaseChangeChannel.js
+++ b/packages/database/src/DatabaseChangeChannel.js
@@ -43,9 +43,9 @@ export class DatabaseChangeChannel extends PGPubSub {
   /**
    * Sends a ping request out to the database and listens for a response
    * @param {number} timeout - default 250ms
-   * @param {number} retries - default 4
+   * @param {number} retries - default 240 (i.e. 1 minute total wait time)
    */
-  async ping(timeout = 250, retries = 4) {
+  async ping(timeout = 250, retries = 240) {
     return new Promise((resolve, reject) => {
       let tries = 0;
       let nextRequest;


### PR DESCRIPTION
If the database instance and server instance are started at the same time, sometimes the pm2 processes will start up before the database is available. This means the servers will be a little more patient before giving up