### PR TITLE
WAI-963: Additional tweaks

### DIFF
--- a/packages/devops/scripts/lambda/actions/backup_instances.py
+++ b/packages/devops/scripts/lambda/actions/backup_instances.py
@@ -52,6 +52,7 @@ def backup_instances(event):
     for instance in instances:
 
         instance_name = get_tag(instance, 'Name')
+        deployment_type = get_tag(instance, 'DeploymentType')
         deployment_name = get_tag(instance, 'DeploymentName')
         retention_days = get_tag(instance, 'Retention')
 
@@ -75,12 +76,9 @@ def backup_instances(event):
 
             snapshot_tags = [
                 {'Key': 'DeleteOn', 'Value': delete_fmt},
-                {'Key': 'DeploymentName', 'Value': deployment_name}
+                {'Key': 'DeploymentType', 'Value': deployment_type},
+                {'Key': 'DeploymentName', 'Value': deployment_name},
             ]
-
-            deployment_name = get_tag(instance, 'DeploymentName')
-            if deployment_name != '':
-                snapshot_tags.append({'Key': 'DeploymentName', 'Value': deployment_name})
 
             ec.create_tags(
                 Resources=[snap['SnapshotId']],

--- a/packages/devops/scripts/lambda/actions/redeploy_tupaia_server.py
+++ b/packages/devops/scripts/lambda/actions/redeploy_tupaia_server.py
@@ -55,7 +55,7 @@ def redeploy_tupaia_server(event):
     if deployment_name:
         instance_filters.append({ 'Name': 'tag:DeploymentName', 'Values': [deployment_name] })
 
-    # find current instance
+    # find current instances
     existing_instances = find_instances(instance_filters)
 
     if len(existing_instances) == 0:

--- a/packages/devops/scripts/lambda/actions/refresh_cloned_instances.py
+++ b/packages/devops/scripts/lambda/actions/refresh_cloned_instances.py
@@ -60,7 +60,7 @@ def refresh_cloned_instances(event):
 
     clone_tasks = sum(
     [
-        [asyncio.ensure_future(clone_volume_into_instance(instance, get_tag(instance, 'ClonedFrom'))) for instance in instances]
+        [asyncio.ensure_future(clone_volume_into_instance(instance, get_tag(instance, 'DeploymentType'), get_tag(instance, 'ClonedFrom'))) for instance in instances]
     ], [])
     loop.run_until_complete(asyncio.wait(clone_tasks))
 

--- a/packages/devops/scripts/lambda/actions/spin_up_dhis_deployment.py
+++ b/packages/devops/scripts/lambda/actions/spin_up_dhis_deployment.py
@@ -27,8 +27,6 @@ def spin_up_dhis_deployment(event):
         raise Exception('You must include the key "InstanceType" in the lambda config. We recommend "t3a.medium" unless you need more speed.')
     instance_type = event['InstanceType']
 
-    instance_name_prefix = 'Clone of ' + from_deployment + ': '
-
     extra_tags = [{ 'Key': 'DeployedBy', 'Value': event['User'] }]
 
     if 'StartAtUTC' in event:
@@ -37,6 +35,6 @@ def spin_up_dhis_deployment(event):
     if 'StopAtUTC' in event:
         extra_tags.append({ 'Key': 'StopAtUTC', 'Value': event['StopAtUTC'] })
 
-    clone_instance(from_deployment, deployment_name, instance_type, extra_tags=extra_tags, instance_name_prefix=instance_name_prefix)
+    clone_instance(from_deployment, deployment_name, instance_type, extra_tags=extra_tags)
 
     print('Deployment cloned')

--- a/packages/devops/scripts/lambda/actions/spin_up_dhis_deployment.py
+++ b/packages/devops/scripts/lambda/actions/spin_up_dhis_deployment.py
@@ -6,16 +6,18 @@
 # {
 #   "Action": "spin_up_dhis_deployment",
 #   "User": "edwin",
+#   "DeploymentType": "tonga-dhis2",
 #   "DeploymentName": "tonga-for-testing",
-#   "FromDeployment": "production-tonga-aggregation"
+#   "FromDeployment": "production"
 # }
 #
 # 2. Spin up a new deployment of the regional DHIS2, with a custom instance size and security group
 # {
 #   "Action": "spin_up_dhis_deployment",
 #   "User": "edwin",
+#   "DeploymentType": "tonga-dhis2",
 #   "DeploymentName": "fast-regional-agg",
-#   "FromDeployment": "production-aggregation",
+#   "FromDeployment": "production",
 #   "InstanceType": "t3a.2xlarge",
 #   "SecurityGroupCode": "tupaia-prod-sg"
 # }
@@ -24,6 +26,10 @@ from helpers.clone import clone_instance
 
 def spin_up_dhis_deployment(event):
     # validate input config
+    if 'DeploymentType' not in event:
+        raise Exception('You must include the key "DeploymentType" in the lambda config to indicate whether this is for regional-dhis2, tonga-dhis2, etc.')
+    deployment_type = event['DeploymentType']
+
     if 'FromDeployment' not in event:
         raise Exception('You must include the key "FromDeployment" in the lambda config to indicate which database snapshot to use.')
     from_deployment = event['FromDeployment']
@@ -46,6 +52,6 @@ def spin_up_dhis_deployment(event):
     if 'StopAtUTC' in event:
         extra_tags.append({ 'Key': 'StopAtUTC', 'Value': event['StopAtUTC'] })
 
-    clone_instance(from_deployment, deployment_name, instance_type, extra_tags=extra_tags, security_group_code=security_group_code)
+    clone_instance(deployment_type, from_deployment, deployment_name, instance_type, extra_tags=extra_tags, security_group_code=security_group_code)
 
     print('Deployment cloned')

--- a/packages/devops/scripts/lambda/actions/spin_up_dhis_deployment.py
+++ b/packages/devops/scripts/lambda/actions/spin_up_dhis_deployment.py
@@ -7,8 +7,17 @@
 #   "Action": "spin_up_dhis_deployment",
 #   "User": "edwin",
 #   "DeploymentName": "tonga-for-testing",
-#   "InstanceType": "t3a.medium",
-#   "FromDeployment": "tonga"
+#   "FromDeployment": "production-tonga-aggregation"
+# }
+#
+# 2. Spin up a new deployment of the regional DHIS2, with a custom instance size and security group
+# {
+#   "Action": "spin_up_dhis_deployment",
+#   "User": "edwin",
+#   "DeploymentName": "fast-regional-agg",
+#   "FromDeployment": "production-aggregation",
+#   "InstanceType": "t3a.2xlarge",
+#   "SecurityGroupCode": "tupaia-prod-sg"
 # }
 
 from helpers.clone import clone_instance
@@ -27,6 +36,8 @@ def spin_up_dhis_deployment(event):
         raise Exception('You must include the key "InstanceType" in the lambda config. We recommend "t3a.medium" unless you need more speed.')
     instance_type = event['InstanceType']
 
+    security_group_code = event.get('SecurityGroupCode', 'tupaia-dev-sg') # Use security group tagged with code
+
     extra_tags = [{ 'Key': 'DeployedBy', 'Value': event['User'] }]
 
     if 'StartAtUTC' in event:
@@ -35,6 +46,6 @@ def spin_up_dhis_deployment(event):
     if 'StopAtUTC' in event:
         extra_tags.append({ 'Key': 'StopAtUTC', 'Value': event['StopAtUTC'] })
 
-    clone_instance(from_deployment, deployment_name, instance_type, extra_tags=extra_tags)
+    clone_instance(from_deployment, deployment_name, instance_type, extra_tags=extra_tags, security_group_code=security_group_code)
 
     print('Deployment cloned')

--- a/packages/devops/scripts/lambda/actions/spin_up_tupaia_deployment.py
+++ b/packages/devops/scripts/lambda/actions/spin_up_tupaia_deployment.py
@@ -91,7 +91,9 @@ def spin_up_tupaia_deployment(event):
     # do this after the server has started because it will take a while to run its startup script, so
     # we might as well be cloning the db instance at the same time, so long is it is available before
     # the server first tries to connect
+    deployment_type='tupaia'
     clone_instance(
+        deployment_type,
         clone_db_from,
         deployment_name,
         instance_type,

--- a/packages/devops/scripts/lambda/actions/spin_up_tupaia_deployment.py
+++ b/packages/devops/scripts/lambda/actions/spin_up_tupaia_deployment.py
@@ -7,7 +7,7 @@
 #   "Action": "spin_up_tupaia_deployment",
 #   "User": "edwin",
 #   "Branch": "wai-965",
-#   "HoursOfLife": "8"
+#   "HoursOfLife": 8
 # }
 #
 # 2. Spin up a new deployment of Tupaia, but with the db cloned from dev and a different branch

--- a/packages/devops/scripts/lambda/actions/spin_up_tupaia_deployment.py
+++ b/packages/devops/scripts/lambda/actions/spin_up_tupaia_deployment.py
@@ -91,7 +91,7 @@ def spin_up_tupaia_deployment(event):
         deployment_name,
         branch,
         instance_type,
-        extra_tags=extra_tags,
+        extra_tags=extra_tags + [{ 'Key': 'DeploymentComponent', 'Value': 'app-server' }],
         image_code=image_code,
         security_group_code=security_group_code,
     )
@@ -106,7 +106,7 @@ def spin_up_tupaia_deployment(event):
         clone_db_from,
         deployment_name,
         instance_type,
-        extra_tags=extra_tags,
+        extra_tags=extra_tags + [{ 'Key': 'DeploymentComponent', 'Value': 'db' }],
         security_group_code=security_group_code,
     )
 

--- a/packages/devops/scripts/lambda/actions/swap_out_tupaia_server.py
+++ b/packages/devops/scripts/lambda/actions/swap_out_tupaia_server.py
@@ -20,12 +20,12 @@ def swap_out_tupaia_server(event):
     if not new_instance:
         raise Exception('Could not find new instance to swap in')
 
-    old_instance = get_instance_behind_gateway(deployment_name)
+    old_instance = get_instance_behind_gateway('tupaia', deployment_name)
     if not old_instance:
       raise Exception('Could not find old instance to swap out')
 
     # set up ELB from the old instance to point at the new one
-    swap_gateway_instance(deployment_name, old_instance['InstanceId'], new_instance_id)
+    swap_gateway_instance('tupaia', deployment_name, old_instance['InstanceId'], new_instance_id)
 
     # add the subdomain tags that now relate to the new instance
     add_tag(new_instance_id, 'SubdomainsViaGateway', get_tag(old_instance, 'SubdomainsViaGateway'))

--- a/packages/devops/scripts/lambda/actions/tear_down_dhis_deployment.py
+++ b/packages/devops/scripts/lambda/actions/tear_down_dhis_deployment.py
@@ -4,7 +4,8 @@
 # {
 #   "Action": "tear_down_dhis_deployment",
 #   "User": "edwin",
-#   "DeploymentName": "tonga: wai-965"
+#   "DeploymentName": "wai-965",
+#   "DeploymentType": "tonga-dhis2"
 # }
 
 from helpers.teardown import teardown_instance
@@ -14,8 +15,12 @@ def tear_down_dhis_deployment(event):
     if 'DeploymentName' not in event:
       raise Exception('Must provide DeploymentName when tearing down an instance')
 
+    if 'DeploymentType' not in event:
+      raise Exception('Must provide DeploymentType when tearing down an instance')
+
     filters = [
       { 'Name': 'tag:DeploymentName', 'Values': [event['DeploymentName']] },
+      { 'Name': 'tag:DeploymentType', 'Values': [event['DeploymentType']] },
       { 'Name': 'instance-state-name', 'Values': ['running', 'stopped'] }, # ignore terminated instances
     ]
     instance = get_instance(filters)

--- a/packages/devops/scripts/lambda/actions/tear_down_tupaia_deployment.py
+++ b/packages/devops/scripts/lambda/actions/tear_down_tupaia_deployment.py
@@ -21,19 +21,13 @@ from helpers.teardown import teardown_instance
 from helpers.utilities import find_instances, get_tag
 
 def tear_down_tupaia_deployment(event):
+    if 'DeploymentName' not in event:
+        raise Exception('You must include "DeploymentName" in the lambda config, which is the subdomain of tupaia.org you want to tear down (e.g. "dev").')
+
     instance_filters = [
+      { 'Name': 'tag:DeploymentName', 'Values': [event['DeploymentName']] },
       { 'Name': 'instance-state-name', 'Values': ['running', 'stopped']} # ignore terminated instances
     ]
-
-    if 'Branch' not in event and 'DeploymentName' not in event:
-        raise Exception('You must include either "DeploymentName" or "Branch" in the lambda config, e.g. "dev".')
-
-    if 'Branch' in event:
-        instance_filters.append({ 'Name': 'tag:Branch', 'Values': [event['Branch']] })
-
-    if 'DeploymentName' in event:
-        instance_filters.append({ 'Name': 'tag:DeploymentName', 'Values': [event['DeploymentName']] })
-
     instances = find_instances(instance_filters)
 
     if len(instances) == 0:

--- a/packages/devops/scripts/lambda/helpers/clone.py
+++ b/packages/devops/scripts/lambda/helpers/clone.py
@@ -78,7 +78,6 @@ def clone_instance(
     instance_type,
     extra_tags=None,
     security_group_code=None,
-    instance_name_prefix=None,
 ):
     print('Creating ' + instance_type + ' clone of ' + from_deployment + ' as ' + to_deployment)
     base_instance_filters = [
@@ -86,9 +85,12 @@ def clone_instance(
         { 'Name': 'instance-state-name', 'Values': ['running', 'stopped']} # ignore terminated instances
     ]
     base_instance = get_instance(base_instance_filters)
-    if not instance_name_prefix:
-        base_instance_name = get_tag(base_instance, 'Name')
-        instance_name_prefix = base_instance_name.replace(from_deployment, '')
+
+    if not base_instance:
+        raise Exception('No instance to clone from for ' + from_deployment)
+
+    base_instance_name = get_tag(base_instance, 'Name')
+    instance_name_prefix = base_instance_name.replace(from_deployment, '')
 
     subdomains_via_dns = None
     subdomains_via_dns_string = get_tag(base_instance, 'SubdomainsViaDns')

--- a/packages/devops/scripts/lambda/helpers/clone.py
+++ b/packages/devops/scripts/lambda/helpers/clone.py
@@ -73,24 +73,23 @@ async def clone_volume_into_instance(instance, deployment_name='production'):
 
 
 def clone_instance(
+    deployment_type,
     from_deployment,
     to_deployment,
     instance_type,
     extra_tags=None,
     security_group_code=None,
 ):
-    print('Creating ' + instance_type + ' clone of ' + from_deployment + ' as ' + to_deployment)
+    print('Creating ' + instance_type + ' clone of ' + deployment_type + ': ' + from_deployment + ' as ' + to_deployment)
     base_instance_filters = [
+        { 'Name': 'tag:DeploymentType', 'Values': [deployment_type] },
         { 'Name': 'tag:DeploymentName', 'Values': [from_deployment] },
         { 'Name': 'instance-state-name', 'Values': ['running', 'stopped']} # ignore terminated instances
     ]
     base_instance = get_instance(base_instance_filters)
 
     if not base_instance:
-        raise Exception('No instance to clone from for ' + from_deployment)
-
-    base_instance_name = get_tag(base_instance, 'Name')
-    instance_name_prefix = base_instance_name.replace(from_deployment, '')
+        raise Exception('No instance to clone from for ' + deployment_type + ': ' + from_deployment)
 
     subdomains_via_dns = None
     subdomains_via_dns_string = get_tag(base_instance, 'SubdomainsViaDns')
@@ -109,7 +108,7 @@ def clone_instance(
 
     new_instance = create_instance(
         to_deployment,
-        instance_name_prefix,
+        deployment_type,
         instance_type,
         cloned_from=from_deployment,
         extra_tags=extra_tags,

--- a/packages/devops/scripts/lambda/helpers/create_from_image.py
+++ b/packages/devops/scripts/lambda/helpers/create_from_image.py
@@ -20,7 +20,7 @@ def get_latest_image_id(code):
 
 def create_instance_from_image(
     deployment_name,
-    instance_name_prefix,
+    deployment_type,
     instance_type,
     branch=None,
     extra_tags=None,
@@ -44,7 +44,7 @@ def create_instance_from_image(
 
     instance_object = create_instance(
         deployment_name,
-        instance_name_prefix,
+        deployment_type,
         instance_type,
         branch=branch,
         extra_tags=extra_tags,
@@ -71,7 +71,7 @@ def create_tupaia_instance_from_image(
     security_group_id=None,
     setup_gateway=True,
 ):
-    instance_name_prefix = 'tupaia: '
+    deployment_type = 'tupaia'
     tupaia_server_iam_role_arn = 'arn:aws:iam::843218180240:instance-profile/TupaiaServerRole'
     tupaia_subdomains = ['','admin','admin-api','api','config','export','mobile','psss','report-api','psss-api','entity-api','lesmis-api','lesmis'] if setup_gateway else None
     tupaia_volume_size = 20 # 20GB
@@ -79,7 +79,7 @@ def create_tupaia_instance_from_image(
 
     return create_instance_from_image(
         deployment_name,
-        instance_name_prefix,
+        deployment_type,
         instance_type,
         branch=branch,
         extra_tags=extra_tags,

--- a/packages/devops/scripts/lambda/helpers/creation.py
+++ b/packages/devops/scripts/lambda/helpers/creation.py
@@ -44,12 +44,21 @@ def get_instance_creation_config(
 
     instance_name = deployment_type + ': ' + deployment_name
 
+    # TODO delete deployment component stuff after db on RDS
+    if extra_tags:
+      try:
+        deployment_component = [
+            t.get('Value') for t in extra_tags
+            if t['Key'] == 'DeploymentComponent'][0]
+        instance_name = deployment_type + '-' + deployment_component + ': ' + deployment_name
+      except IndexError:
+        pass # no deployment component to add to instance name
+
     tags = [
       { 'Key': 'Name', 'Value': instance_name },
       { 'Key': 'DeploymentName', 'Value': deployment_name },
       { 'Key': 'DeploymentType', 'Value': deployment_type },
     ]
-
 
     if branch:
       tags.append({ 'Key': 'Branch', 'Value': branch })
@@ -64,10 +73,8 @@ def get_instance_creation_config(
     if cloned_from:
       tags.append({ 'Key': 'ClonedFrom', 'Value': cloned_from })
 
-    extra_tag_keys = []
     if extra_tags:
       tags = tags + extra_tags
-      extra_tag_keys = [extra_tag['Key'] for extra_tag in extra_tags]
 
     instance_creation_config = {
       'ImageId' : image_id,

--- a/packages/devops/scripts/lambda/helpers/creation.py
+++ b/packages/devops/scripts/lambda/helpers/creation.py
@@ -13,7 +13,7 @@ def allocate_elastic_ip(instance_id):
 
 def get_instance_creation_config(
   deployment_name,
-  instance_name_prefix,
+  deployment_type,
   instance_type,
   branch=None,
   cloned_from=None,
@@ -42,11 +42,12 @@ def get_instance_creation_config(
     else:
       security_group_ids = [security_group_id]
 
-    instance_name = instance_name_prefix + deployment_name
+    instance_name = deployment_type + ': ' + deployment_name
 
     tags = [
       { 'Key': 'Name', 'Value': instance_name },
-      { 'Key': 'DeploymentName', 'Value': deployment_name }
+      { 'Key': 'DeploymentName', 'Value': deployment_name },
+      { 'Key': 'DeploymentType', 'Value': deployment_type },
     ]
 
 
@@ -105,7 +106,7 @@ def get_instance_creation_config(
 
 def create_instance(
   deployment_name,
-  instance_name_prefix,
+  deployment_type,
   instance_type,
   branch=None,
   cloned_from=None,
@@ -121,7 +122,7 @@ def create_instance(
 ):
     instance_creation_config = get_instance_creation_config(
       deployment_name,
-      instance_name_prefix,
+      deployment_type,
       instance_type,
       branch=branch,
       cloned_from=cloned_from,
@@ -152,6 +153,6 @@ def create_instance(
     if subdomains_via_dns:
         setup_subdomains_via_dns(new_instance_object, subdomains_via_dns, deployment_name)
     if subdomains_via_gateway:
-        setup_subdomains_via_gateway(new_instance_object, subdomains_via_gateway, deployment_name)
+        setup_subdomains_via_gateway(deployment_type, new_instance_object, subdomains_via_gateway, deployment_name)
 
     return new_instance_object

--- a/packages/devops/scripts/lambda/helpers/networking.py
+++ b/packages/devops/scripts/lambda/helpers/networking.py
@@ -22,53 +22,53 @@ def get_cert(type_tag):
 
 elbv2 = boto3.client('elbv2')
 
-def get_gateway_elb(deployment_name):
+def get_gateway_elb(deployment_type, deployment_name):
     elbs = elbv2.describe_load_balancers(PageSize=400)
     for elb in elbs['LoadBalancers']:
         tag_descriptions = elbv2.describe_tags(
             ResourceArns=[elb['LoadBalancerArn']]
         )
-        matching_arns = list(filter(lambda x: tags_contains(x['Tags'], 'Type', 'Tupaia-Gateway') and tags_contains(x['Tags'], 'DeploymentName', deployment_name), tag_descriptions['TagDescriptions']))
+        matching_arns = list(filter(lambda x: tags_contains(x['Tags'], 'DeploymentType', deployment_type) and tags_contains(x['Tags'], 'DeploymentName', deployment_name), tag_descriptions['TagDescriptions']))
         if len(matching_arns) > 1:
-            raise Exception('Multiple gateway elbs found tagged with tupaia deployment name: ' + deployment_name)
+            raise Exception('Multiple ' + deployment_type + ' gateway elbs found tagged with deployment name: ' + deployment_name)
         if len(matching_arns) == 1:
             return elb
-    raise Exception('No gateway elb found tagged with tupaia deployment name: ' + deployment_name)
+    raise Exception('No ' + deployment_type + ' gateway elb found tagged with deployment name: ' + deployment_name)
 
 
-def get_gateway_target_group(deployment_name):
+def get_gateway_target_group(deployment_type, deployment_name):
     target_groups = elbv2.describe_target_groups(PageSize=400)
     for target_group in target_groups['TargetGroups']:
         tag_descriptions = elbv2.describe_tags(
             ResourceArns=[target_group['TargetGroupArn']]
         )
-        matching_arns = list(filter(lambda x: tags_contains(x['Tags'], 'Type', 'Tupaia-Gateway') and tags_contains(x['Tags'], 'DeploymentName', deployment_name), tag_descriptions['TagDescriptions']))
+        matching_arns = list(filter(lambda x: tags_contains(x['Tags'], 'DeploymentType', deployment_type) and tags_contains(x['Tags'], 'DeploymentName', deployment_name), tag_descriptions['TagDescriptions']))
         if len(matching_arns) > 1:
-            raise Exception('Multiple target groups found tagged with tupaia deployment name: ' + deployment_name)
+            raise Exception('Multiple ' + deployment_type + ' target groups found tagged with deployment name: ' + deployment_name)
         if len(matching_arns) == 1:
             return target_group
 
-    raise Exception('No gateway target group found tagged with tupaia deployment name: ' + deployment_name)
+    raise Exception('No ' + deployment_type + ' gateway target group found tagged with deployment name: ' + deployment_name)
 
 
-def get_gateway_listeners(deployment_name):
-    elb = get_gateway_elb(deployment_name)
+def get_gateway_listeners(deployment_type, deployment_name):
+    elb = get_gateway_elb(deployment_type, deployment_name)
     return elbv2.describe_listeners(
         LoadBalancerArn=elb['LoadBalancerArn'],
         PageSize=100
     )['Listeners']
 
 
-def create_gateway_elb(deployment_name, tupaia_instance_id, config):
+def create_gateway_elb(deployment_type, deployment_name, config):
     response = elbv2.create_load_balancer(
-        Name='gateway-elb-' + tupaia_instance_id,
+        Name=deployment_type + ': ' + deployment_name,
         Subnets=list(map(lambda x: x['SubnetId'], config['AvailabilityZones'])),
         SecurityGroups=config['SecurityGroups'],
         Scheme=config['Scheme'],
         Tags=[
             {
-                'Key': 'Type',
-                'Value': 'Tupaia-Gateway'
+                'Key': 'DeploymentType',
+                'Value': deployment_type
             },
             {
                 'Key': 'DeploymentName',
@@ -81,9 +81,9 @@ def create_gateway_elb(deployment_name, tupaia_instance_id, config):
     return response['LoadBalancers'][0]
 
 
-def create_gateway_target_group(deployment_name, tupaia_instance_id, config):
+def create_gateway_target_group(deployment_type, deployment_name, config):
     response = elbv2.create_target_group(
-        Name='gateway-tg-' + tupaia_instance_id,
+        Name=deployment_type + ': ' + deployment_name,
         Protocol=config['Protocol'],
         ProtocolVersion=config['ProtocolVersion'],
         Port=config['Port'],
@@ -100,8 +100,8 @@ def create_gateway_target_group(deployment_name, tupaia_instance_id, config):
         TargetType=config['TargetType'],
         Tags=[
             {
-                'Key': 'Type',
-                'Value': 'Tupaia-Gateway'
+                'Key': 'DeploymentType',
+                'Value': deployment_type
             },
             {
                 'Key': 'DeploymentName',
@@ -250,16 +250,16 @@ def add_subdomains_to_route53(domain, subdomains, deployment_name, gateway=None,
 
 
 
-def get_instance_behind_gateway(deployment_name):
-    gateway_target_group = get_gateway_target_group(deployment_name)
+def get_instance_behind_gateway(deployment_type, deployment_name):
+    gateway_target_group = get_gateway_target_group(deployment_type, deployment_name)
 
     targets = elbv2.describe_target_health(TargetGroupArn=gateway_target_group['TargetGroupArn'])['TargetHealthDescriptions']
 
     if not targets or len(targets) == 0:
-        raise Exception('Could not find any targets behind the gateway for ' + deployment_name)
+        raise Exception('Could not find any targets behind the ' + deployment_type + ' gateway for ' + deployment_name)
 
     if len(targets) > 1:
-        raise Exception('Too many targets for ' + deployment_name)
+        raise Exception('Too many targets for ' + deployment_type + ': ' + deployment_name)
 
     instance_id = targets[0]['Target']['Id']
 
@@ -270,21 +270,21 @@ def get_instance_behind_gateway(deployment_name):
 # Putting it all together
 # --------------
 
-def create_tupaia_gateway(deployment_name, tupaia_instance_id, ssl_certificate_arn):
+def create_tupaia_gateway(deployment_type, deployment_name, tupaia_instance_id, ssl_certificate_arn):
     # 1. Create ELB
-    prod_gateway_elb = get_gateway_elb('production')
+    prod_gateway_elb = get_gateway_elb(deployment_type, 'production')
     new_gateway_elb = create_gateway_elb(
+        deployment_type=deployment_type,
         deployment_name=deployment_name,
-        tupaia_instance_id=tupaia_instance_id,
         config=prod_gateway_elb,
     )
     new_gateway_elb_arn = new_gateway_elb['LoadBalancerArn']
 
     # 2. Create Target Group
-    prod_gateway_target_group = get_gateway_target_group('production')
+    prod_gateway_target_group = get_gateway_target_group(deployment_type, 'production')
     new_gateway_target_group_arn = create_gateway_target_group(
+        deployment_type=deployment_type,
         deployment_name=deployment_name,
-        tupaia_instance_id=tupaia_instance_id,
         config=prod_gateway_target_group,
     )
 
@@ -303,12 +303,12 @@ def create_tupaia_gateway(deployment_name, tupaia_instance_id, ssl_certificate_a
 
     return new_gateway_elb
 
-def delete_gateway(deployment_name):
-    gateway_elb = get_gateway_elb(deployment_name)
+def delete_gateway(deployment_type, deployment_name):
+    gateway_elb = get_gateway_elb(deployment_type, deployment_name)
 
     # (order matters)
     # 1. Delete listeners
-    listeners = get_gateway_listeners(deployment_name)
+    listeners = get_gateway_listeners(deployment_type, deployment_name)
     for listener in listeners:
         elbv2.delete_listener(
             ListenerArn=listener['ListenerArn']
@@ -320,13 +320,13 @@ def delete_gateway(deployment_name):
     )
 
     # 3. Delete Target Group
-    gateway_target_group = get_gateway_target_group(deployment_name)
+    gateway_target_group = get_gateway_target_group(deployment_type, deployment_name)
     elbv2.delete_target_group(
         TargetGroupArn=gateway_target_group['TargetGroupArn']
     )
 
-def swap_gateway_instance(deployment_name, old_instance_id, new_instance_id):
-    gateway_target_group = get_gateway_target_group(deployment_name)
+def swap_gateway_instance(deployment_type, deployment_name, old_instance_id, new_instance_id):
+    gateway_target_group = get_gateway_target_group(deployment_type, deployment_name)
 
     register_gateway_target(
         target_group_arn=gateway_target_group['TargetGroupArn'],
@@ -339,13 +339,14 @@ def swap_gateway_instance(deployment_name, old_instance_id, new_instance_id):
     )
 
 
-def setup_subdomains_via_gateway(instance_object, subdomains, deployment_name):
+def setup_subdomains_via_gateway(deployment_type, instance_object, subdomains, deployment_name):
     # Fetch *.tupaia.org certificate
     ssl_certificate = get_cert('TupaiaWildcard')
 
     # Create a gateway for the server instance
     print('Creating gateway')
     gateway_elb = create_tupaia_gateway(
+        deployment_type=deployment_type,
         deployment_name=deployment_name,
         tupaia_instance_id=instance_object['InstanceId'],
         ssl_certificate_arn=ssl_certificate['CertificateArn']

--- a/packages/devops/scripts/lambda/helpers/networking.py
+++ b/packages/devops/scripts/lambda/helpers/networking.py
@@ -61,7 +61,7 @@ def get_gateway_listeners(deployment_type, deployment_name):
 
 def create_gateway_elb(deployment_type, deployment_name, config):
     response = elbv2.create_load_balancer(
-        Name=deployment_type + ': ' + deployment_name,
+        Name=deployment_type + '-' + deployment_name,
         Subnets=list(map(lambda x: x['SubnetId'], config['AvailabilityZones'])),
         SecurityGroups=config['SecurityGroups'],
         Scheme=config['Scheme'],
@@ -83,7 +83,7 @@ def create_gateway_elb(deployment_type, deployment_name, config):
 
 def create_gateway_target_group(deployment_type, deployment_name, config):
     response = elbv2.create_target_group(
-        Name=deployment_type + ': ' + deployment_name,
+        Name=deployment_type + '-' + deployment_name,
         Protocol=config['Protocol'],
         ProtocolVersion=config['ProtocolVersion'],
         Port=config['Port'],

--- a/packages/devops/scripts/lambda/helpers/teardown.py
+++ b/packages/devops/scripts/lambda/helpers/teardown.py
@@ -22,6 +22,7 @@ def teardown_instance(instance):
         raise Exception('The instance ' + get_tag(instance, 'Name') + ' is protected and cannot be deleted')
 
     # Get tagged details of instance
+    deployment_type = get_tag(instance, 'DeploymentType')
     deployment_name = get_tag(instance, 'DeploymentName')
 
     # Delete DNS subdomains
@@ -32,7 +33,7 @@ def teardown_instance(instance):
     # Delete gateway subdomains
     subdomains_via_gateway = get_tag(instance, 'SubdomainsViaGateway')
     if subdomains_via_gateway != '':
-      gateway_elb = get_gateway_elb(deployment_name)
+      gateway_elb = get_gateway_elb(deployment_type, deployment_name)
       record_set_deletions = record_set_deletions + [build_record_set_deletion('tupaia.org', subdomain, deployment_name, gateway=gateway_elb) for subdomain in subdomains_via_gateway.split(',')]
 
     # Filter out deletions for record sets that don't actually exist
@@ -53,6 +54,6 @@ def teardown_instance(instance):
 
     # Delete gateway
     if subdomains_via_gateway != '':
-      delete_gateway(deployment_name)
+      delete_gateway(deployment_type, deployment_name)
 
     terminate_instance(instance)


### PR DESCRIPTION
### Issue #:
WAI-963 (already released, these are tweaks only)

### Changes:
Commit names show the changes. The main change is the final commit, which adds a "DeploymentType" tag on instances, gateways, etc. so that we can distinguish between tupaia, regional-dhis2, and tonga-dhis2 deployments. Currently there are some that share a DeploymentName (e.g. dev, e2e) so you can unintentionally tear down instances you don't mean to.