### PR TITLE
WAI-963: Fail build when committing to a deployed branch out of hours

### DIFF
--- a/packages/devops/scripts/ci/triggerRedeploy.sh
+++ b/packages/devops/scripts/ci/triggerRedeploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 STOPPED_INSTANCES=$(aws ec2 describe-instances \
-      --filters Name=tag:Branch,Values=${CI_BRANCH} Name=tag-key,Values=SubdomainsViaGateway Name=instance-state-name,Values=stopped \
+      --filters Name=tag:Branch,Values=${CI_BRANCH} Name=tag:DeploymentType,Values=tupaia Name=tag:DeploymentComponent,Values=app-server Name=instance-state-name,Values=stopped \
       --no-cli-pager)
 
 if [[ $STOPPED_INSTANCES == *"Instances"* ]]; then
@@ -11,7 +11,7 @@ fi
 
 
 RUNNING_INSTANCES=$(aws ec2 describe-instances \
-      --filters Name=tag:Branch,Values=${CI_BRANCH} Name=tag-key,Values=SubdomainsViaGateway Name=instance-state-name,Values=running \
+      --filters Name=tag:Branch,Values=${CI_BRANCH} Name=tag:DeploymentType,Values=tupaia Name=tag:DeploymentComponent,Values=app-server Name=instance-state-name,Values=running \
       --no-cli-pager)
 
 if [[ $RUNNING_INSTANCES != *"Instances"* ]]; then

--- a/packages/devops/scripts/ci/triggerRedeploy.sh
+++ b/packages/devops/scripts/ci/triggerRedeploy.sh
@@ -1,15 +1,25 @@
 #!/bin/bash
 
-EXISTING_INSTANCES=$(aws ec2 describe-instances \
-      --filters Name=tag:Branch,Values=${CI_BRANCH} Name=tag-key,Values=SubdomainsViaGateway Name=instance-state-name,Values=running,stopped \
+STOPPED_INSTANCES=$(aws ec2 describe-instances \
+      --filters Name=tag:Branch,Values=${CI_BRANCH} Name=tag-key,Values=SubdomainsViaGateway Name=instance-state-name,Values=stopped \
       --no-cli-pager)
 
-if [[ $EXISTING_INSTANCES != *"Instances"* ]]; then
+if [[ $STOPPED_INSTANCES == *"Instances"* ]]; then
+  echo "Can't redeploy while a deployment for ${CI_BRANCH} is stopped. Try again inside office hours, or start the app server and database then restart the build."
+  exit 1
+fi
+
+
+RUNNING_INSTANCES=$(aws ec2 describe-instances \
+      --filters Name=tag:Branch,Values=${CI_BRANCH} Name=tag-key,Values=SubdomainsViaGateway Name=instance-state-name,Values=running \
+      --no-cli-pager)
+
+if [[ $RUNNING_INSTANCES != *"Instances"* ]]; then
   echo "No deployment running, skipping redeploy"
   exit 0
 fi
 
-echo "At least one existing deployment, triggering redeploy of any tagged with Branch ${CI_BRANCH}"
+echo "At least one running deployment, triggering redeploy of any tagged with Branch ${CI_BRANCH}"
 RESPONSE_FILE=lambda_redeploy_response.json
 aws lambda invoke \
   --function-name deployment \

--- a/packages/devops/scripts/lambda/actions/spin_up_tupaia_deployment.py
+++ b/packages/devops/scripts/lambda/actions/spin_up_tupaia_deployment.py
@@ -42,10 +42,10 @@ from helpers.utilities import find_instances
 
 def spin_up_tupaia_deployment(event):
     # validate input config
-    if 'Branch' not in event:
-        raise Exception('You must include the key "Branch" in the lambda config, e.g. "dev".')
-    branch = event['Branch']
-    deployment_name = event.get('DeploymentName', branch) # default to branch if no deployment code set
+    if 'DeploymentName' not in event:
+        raise Exception('You must include the key "DeploymentName" in the lambda config, e.g. "dev".')
+    deployment_name = event['DeploymentName']
+    branch = event.get('Branch', deployment_name) # default to branch if no deployment code set
     if deployment_name == 'production' and branch != 'master':
         raise Exception('The production deployment needs to check out master, not ' + branch)
 

--- a/packages/devops/scripts/lambda/helpers/networking.py
+++ b/packages/devops/scripts/lambda/helpers/networking.py
@@ -22,6 +22,10 @@ def get_cert(type_tag):
 
 elbv2 = boto3.client('elbv2')
 
+def get_gateway_name(deployment_type, deployment_name):
+    name = deployment_type + '-' + deployment_name
+    return name[0:32] # max 32 chars in an ELB or gateway name
+
 def get_gateway_elb(deployment_type, deployment_name):
     elbs = elbv2.describe_load_balancers(PageSize=400)
     for elb in elbs['LoadBalancers']:
@@ -61,7 +65,7 @@ def get_gateway_listeners(deployment_type, deployment_name):
 
 def create_gateway_elb(deployment_type, deployment_name, config):
     response = elbv2.create_load_balancer(
-        Name=deployment_type + '-' + deployment_name,
+        Name=get_gateway_name(deployment_type, deployment_name),
         Subnets=list(map(lambda x: x['SubnetId'], config['AvailabilityZones'])),
         SecurityGroups=config['SecurityGroups'],
         Scheme=config['Scheme'],
@@ -83,7 +87,7 @@ def create_gateway_elb(deployment_type, deployment_name, config):
 
 def create_gateway_target_group(deployment_type, deployment_name, config):
     response = elbv2.create_target_group(
-        Name=deployment_type + '-' + deployment_name,
+        Name=get_gateway_name(deployment_type, deployment_name),
         Protocol=config['Protocol'],
         ProtocolVersion=config['ProtocolVersion'],
         Port=config['Port'],

--- a/packages/devops/scripts/lambda/helpers/networking.py
+++ b/packages/devops/scripts/lambda/helpers/networking.py
@@ -24,7 +24,10 @@ elbv2 = boto3.client('elbv2')
 
 def get_gateway_name(deployment_type, deployment_name):
     name = deployment_type + '-' + deployment_name
-    return name[0:32] # max 32 chars in an ELB or gateway name
+    name = name[0:32] # max 32 chars in an ELB or gateway name
+    if name.endswith('-'):
+        name = name[:-1] # name cannot end with a hyphen
+    return name
 
 def get_gateway_elb(deployment_type, deployment_name):
     elbs = elbv2.describe_load_balancers(PageSize=400)


### PR DESCRIPTION
### Issue #:
WAI-963 (already released)

### Changes:
If someone pushes to a branch out of hours, the redeploy will fail, but the build will still go green. This is because when the servers try to start up, the db instance will be sleeping. This change doesn't actually make it work (if we want to fix this properly, we should wait until the RDS transition is complete), but does mean that if the deployment is stopped, codeship won't trigger a redeploy, but will mark the build as failed so the dev knows to retry it during office hours.