### PR TITLE
[HOT FIX] Avoid multiple redeploy attempts

### DIFF
--- a/packages/devops/scripts/lambda/actions/redeploy_tupaia_server.py
+++ b/packages/devops/scripts/lambda/actions/redeploy_tupaia_server.py
@@ -85,7 +85,7 @@ def redeploy_tupaia_server(event):
             deployment_name=get_tag(existing_instance, 'DeploymentName'),
             branch=get_tag(existing_instance, 'Branch'),
             instance_type=event.get('InstanceType', existing_instance['InstanceType']),
-            extra_tags=extra_tags,
+            extra_tags=extra_tags + [{ 'Key': 'DeploymentComponent', 'Value': 'app-server' }], # TODO remove deployment component stuff after move to RDS
             image_code=event.get('ImageCode', None), # will use id below if not defined in the event
             image_id=existing_instance['ImageId'],
             security_group_code=event.get('SecurityGroupCode', None), # will use id below if not defined in the event


### PR DESCRIPTION
### Issue #:
Now that we have four deployments all connected to the master branch, the lambda redeploy function was taking longer than the default AWS CLI timeout. The AWS CLI then kicks into "helpful" retry attempts, which resulted in multiple deployments coming online for production, e2e, viz-testing and viz-sandbox.

This change:
- Increases the AWS CLI timeout to match lambda's 15 min max execution time
- Turns off the retry attempt behaviour, lest it try to be helpful again in future