### PR TITLE
wai-352: Restrict analytics to production

### DIFF
--- a/packages/web-frontend/public/index.html
+++ b/packages/web-frontend/public/index.html
@@ -14,7 +14,9 @@
     <meta property="og:url" content="https://tupaia.org" />
     <meta property="og:title" content="Tupaia" />
 
-    <% if (process.env.NODE_ENV === 'production') { %>
+    <% if (process.env.REACT_APP_DEPLOYMENT_NAME === 'master'
+    || process.env.REACT_APP_DEPLOYMENT_NAME === 'main'
+    || process.env.REACT_APP_DEPLOYMENT_NAME === 'production') { %>
     <!-- Google Analytics -->
     <script>
       (function(i, s, o, g, r, a, m) {


### PR DESCRIPTION
### Issue #: WAI-352: Restrict analytics to production

### Changes:

- Use REACT_APP_DEPLOYMENT_NAME value to only run analytics on live deployments

---

