### PR TITLE
Fix yarn install during deployment

### DIFF
--- a/packages/devops/scripts/deployment/buildDeployablePackages.sh
+++ b/packages/devops/scripts/deployment/buildDeployablePackages.sh
@@ -12,7 +12,7 @@ PACKAGES=$(${TUPAIA_DIR}/scripts/bash/getDeployablePackages.sh)
 
 # Install external dependencies and build internal dependencies
 cd ${TUPAIA_DIR}
-yarn install
+yarn install --non-interactive --frozen-lockfile
 
 # Inject environment variables from LastPass
 LASTPASS_EMAIL=$($DIR/fetchParameterStoreValue.sh LASTPASS_EMAIL)

--- a/packages/devops/scripts/deployment/setupGoldMaster.sh
+++ b/packages/devops/scripts/deployment/setupGoldMaster.sh
@@ -51,7 +51,7 @@ mkdir -p /home/ubuntu/.local/share/lpass
 
 # clone our repo
 cd /home/ubuntu
-git clone https://github.com/beyondessential/tupaia.git
+sudo -Hu ubuntu git clone https://github.com/beyondessential/tupaia.git
 
 # build all packages once using dev to speed up future branch-specific builds
-/home/ubuntu/tupaia/packages/devops/scripts/deployment/buildDeployablePackages.sh gold-master-image-builder
+sudo -Hu ubuntu /home/ubuntu/tupaia/packages/devops/scripts/deployment/buildDeployablePackages.sh gold-master-image-builder

--- a/packages/devops/scripts/lambda/actions/spin_up_tupaia_deployment.py
+++ b/packages/devops/scripts/lambda/actions/spin_up_tupaia_deployment.py
@@ -45,7 +45,7 @@ def spin_up_tupaia_deployment(event):
     if 'DeploymentName' not in event:
         raise Exception('You must include the key "DeploymentName" in the lambda config, e.g. "dev".')
     deployment_name = event['DeploymentName']
-    branch = event.get('Branch', deployment_name) # default to branch if no deployment code set
+    branch = event.get('Branch', deployment_name) # branch defaults to deployment name if not specified
     if deployment_name == 'production' and branch != 'master':
         raise Exception('The production deployment needs to check out master, not ' + branch)
 

--- a/packages/devops/scripts/lambda/resources/startup.sh
+++ b/packages/devops/scripts/lambda/resources/startup.sh
@@ -16,7 +16,7 @@ BRANCH=$(${DEPLOYMENT_SCRIPTS}/../utility/getEC2TagValue.sh Branch)
 echo "Starting up ${DEPLOYMENT_NAME} (${BRANCH})"
 
 # Create a directory for logs to go
-mkdir $LOGS_DIR
+mkdir -p $LOGS_DIR
 
 # Turn on cloudwatch agent for prod and dev (can be turned on manually if needed on feature instances)
 if [[ $DEPLOYMENT_NAME == "production" || $DEPLOYMENT_NAME == "dev" ]]; then

--- a/yarn.lock
+++ b/yarn.lock
@@ -5223,17 +5223,7 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@^2.25.0":
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.34.0.tgz#6f8ce8a46c7dea4a6f1d171d2bb8fbae6dac2be9"
-  integrity sha512-4zY3Z88rEE99+CNvTbXSyovv2z9PNOVffTWD2W8QF5s2prBQtwN2zadqERcrHpcR7O/+KMI3fcTAmUUhK/iQcQ==
-  dependencies:
-    "@typescript-eslint/experimental-utils" "2.34.0"
-    functional-red-black-tree "^1.0.1"
-    regexpp "^3.0.0"
-    tsutils "^3.17.1"
-
-"@typescript-eslint/eslint-plugin@^4.18.0", "@typescript-eslint/eslint-plugin@^4.5.0":
+"@typescript-eslint/eslint-plugin@^2.25.0", "@typescript-eslint/eslint-plugin@^4.18.0", "@typescript-eslint/eslint-plugin@^4.5.0":
   version "4.18.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.18.0.tgz#50fbce93211b5b690895d20ebec6fe8db48af1f6"
   integrity sha512-Lzkc/2+7EoH7+NjIWLS2lVuKKqbEmJhtXe3rmfA8cyiKnZm3IfLf51irnBcmow8Q/AptVV0XBZmBJKuUJTe6cQ==


### PR DESCRIPTION
### Issue #:
Deployments have been failing because:
- The `yarn.lock` file in dev is out of date with the actual dependencies required
- At the end of `yarn install` during startup, yarn tries to update that `yarn.lock` to reflect the current status
- The `tupaia` repo is owned by the root user on the gold master

This PR fixes all three of those issues, as well as two unrelated nits that I came across during debugging.