### PR TITLE
WAI-1054: Fix timeouts when processing access requests

### DIFF
--- a/packages/admin-panel/src/autocomplete/Autocomplete.js
+++ b/packages/admin-panel/src/autocomplete/Autocomplete.js
@@ -153,6 +153,7 @@ const mapDispatchToProps = (
     onChange,
     parentRecord = {},
     allowMultipleValues,
+    baseFilter,
   },
 ) => ({
   onChangeSelection: (event, newSelection, reason) => {
@@ -186,6 +187,7 @@ const mapDispatchToProps = (
         optionValueKey,
         newSearchTerm,
         parentRecord,
+        baseFilter,
       ),
     ),
   onClearState: () => dispatch(clearState(reduxId)),

--- a/packages/admin-panel/src/autocomplete/actions.js
+++ b/packages/admin-panel/src/autocomplete/actions.js
@@ -27,6 +27,7 @@ export const changeSearchTerm = (
   valueColumn,
   searchTerm,
   parentRecord,
+  baseFilter = {},
 ) => async (dispatch, getState, { api }) => {
   const fetchId = generateId();
   dispatch({
@@ -36,7 +37,7 @@ export const changeSearchTerm = (
     fetchId,
   });
   try {
-    const filter = convertSearchTermToFilter({ [labelColumn]: searchTerm });
+    const filter = convertSearchTermToFilter({ ...baseFilter, [labelColumn]: searchTerm });
     const response = await api.get(makeSubstitutionsInString(endpoint, parentRecord), {
       filter: JSON.stringify(filter),
       pageSize: MAX_AUTOCOMPLETE_RESULTS,

--- a/packages/admin-panel/src/pages/resources/AccessRequestsPage.js
+++ b/packages/admin-panel/src/pages/resources/AccessRequestsPage.js
@@ -16,7 +16,7 @@ const FIELDS = [
   {
     Header: 'Entity',
     source: 'entity.name',
-    editConfig: { optionsEndpoint: 'entities' },
+    editConfig: { optionsEndpoint: 'entities', baseFilter: { type: 'country' } },
   },
   {
     Header: 'Message',

--- a/packages/admin-panel/src/pages/resources/PermissionsPage.js
+++ b/packages/admin-panel/src/pages/resources/PermissionsPage.js
@@ -15,6 +15,7 @@ export const PERMISSIONS_COLUMNS = [
     source: 'entity.name',
     editConfig: {
       optionsEndpoint: 'entities',
+      baseFilter: { type: 'country' },
     },
   },
   {

--- a/packages/admin-panel/src/widgets/InputField/registerInputFields.js
+++ b/packages/admin-panel/src/widgets/InputField/registerInputFields.js
@@ -53,6 +53,7 @@ export const registerInputFields = () => {
       disabled={props.disabled}
       allowMultipleValues={props.allowMultipleValues}
       parentRecord={props.parentRecord}
+      baseFilter={props.baseFilter}
     />
   ));
   registerInputField('json', props => (


### PR DESCRIPTION
### Issue #:
Was caused by a build up of queries against the entity table, which is huge and possibly poorly indexed, so the queries were taking a long time to return. Filtering by country is both a UX improvement, and means the query returns very quickly.

### Changes:
-  Only show countries when granting access requests or permissions
