### PR TITLE
phx-148-delete-dashboard-covid19-surveil

### DIFF
--- a/packages/database/src/migrations/20211201223600-DeleteCovid19SurveillanceDashbaord-modifies-data.js
+++ b/packages/database/src/migrations/20211201223600-DeleteCovid19SurveillanceDashbaord-modifies-data.js
@@ -1,0 +1,33 @@
+('use strict');
+
+import { codeToId, deleteObject } from '../utilities';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+const DASHBOARD_CODE = 'PG_COVID_19_Surveillance';
+
+exports.up = async function (db) {
+  const dashboardId = await codeToId(db, 'dashboard', DASHBOARD_CODE);
+  await deleteObject(db, 'dashboard_relation', { dashboard_id: dashboardId });
+  return deleteObject(db, 'dashboard', { id: dashboardId });
+};
+
+exports.down = function (db) {
+  return null;
+};
+
+exports._meta = {
+  version: 1,
+};


### PR DESCRIPTION
### Issue #:
PHX-148: Delete Empty Dashboard Group "COVID 19 Surveillance"
### Changes:
- delete record from dashboard table