### PR TITLE
RN-221: Log deployment errors to deployment.log file

### DIFF
--- a/packages/devops/scripts/lambda/resources/startup.sh
+++ b/packages/devops/scripts/lambda/resources/startup.sh
@@ -30,13 +30,13 @@ mkdir -p $LOGS_DIR
 # Turn on cloudwatch agent for prod and dev (can be turned on manually if needed on feature instances)
 # TODO currently broken
 # if [[ $DEPLOYMENT_NAME == "production" || $DEPLOYMENT_NAME == "dev" ]]; then
-#     $DEPLOYMENT_SCRIPTS/startCloudwatchAgent.sh | while IFS= read -r line; do printf '\%s \%s\n' "$(date)" "$line"; done  >> $LOGS_DIR/deployment_log.txt
+#     $DEPLOYMENT_SCRIPTS/startCloudwatchAgent.sh |& while IFS= read -r line; do printf '\%s \%s\n' "$(date)" "$line"; done  >> $LOGS_DIR/deployment_log.txt
 # fi
 
 # Add preaggregation cron job if production
 if [[ $DEPLOYMENT_NAME == "production" ]]; then
   set +e # Temporarily allow non 0 exit, as crontab probably doesn't exist yet
-  (crontab -l ; echo "10 13 * * * /home/ubuntu/tupaia/packages/web-config-server/run_preaggregation.sh | while IFS= read -r line; do printf '\%s \%s\n' "$(date)" "$line"; done > /home/ubuntu/logs/preaggregation.txt") | crontab -
+  (crontab -l ; echo "10 13 * * * /home/ubuntu/tupaia/packages/web-config-server/run_preaggregation.sh |& while IFS= read -r line; do printf '\%s \%s\n' "$(date)" "$line"; done > /home/ubuntu/logs/preaggregation.txt") | crontab -
   set -e
 fi
 
@@ -57,11 +57,11 @@ git checkout ${BRANCH_TO_USE}
 git reset --hard origin/${BRANCH_TO_USE}
 
 # Deploy each package, including injecting environment variables from LastPass
-sudo -Hu ubuntu $DEPLOYMENT_SCRIPTS/buildDeployablePackages.sh $DEPLOYMENT_NAME | while IFS= read -r line; do printf '\%s \%s\n' "$(date)" "$line"; done  >> $LOGS_DIR/deployment_log.txt
-sudo -Hu ubuntu $DEPLOYMENT_SCRIPTS/startBackEnds.sh | while IFS= read -r line; do printf '\%s \%s\n' "$(date)" "$line"; done  >> $LOGS_DIR/deployment_log.txt
+sudo -Hu ubuntu $DEPLOYMENT_SCRIPTS/buildDeployablePackages.sh $DEPLOYMENT_NAME |& while IFS= read -r line; do printf '\%s \%s\n' "$(date)" "$line"; done  >> $LOGS_DIR/deployment_log.txt
+sudo -Hu ubuntu $DEPLOYMENT_SCRIPTS/startBackEnds.sh |& while IFS= read -r line; do printf '\%s \%s\n' "$(date)" "$line"; done  >> $LOGS_DIR/deployment_log.txt
 
 # Set nginx config and start the service running
-$DEPLOYMENT_SCRIPTS/configureNginx.sh | while IFS= read -r line; do printf '\%s \%s\n' "$(date)" "$line"; done  >> $LOGS_DIR/deployment_log.txt
+$DEPLOYMENT_SCRIPTS/configureNginx.sh |& while IFS= read -r line; do printf '\%s \%s\n' "$(date)" "$line"; done  >> $LOGS_DIR/deployment_log.txt
 
 # Tag as complete so CI/CD system can use the tag as a health check
 aws ec2 create-tags --resources ${INSTANCE_ID} --tags Key=StartupBuildProgress,Value=complete


### PR DESCRIPTION
### Issue RN-221

Currently we don't see the error message if the deployment fails, which can make debugging tricky.

### Changes:
-  Added `&` to pipe to log stderr as well as stdout (https://www.gnu.org/software/bash/manual/bash.html#Pipelines)