### PR TITLE
RN-226: Fixed error where location search wasn't working as intended

### DIFF
--- a/packages/admin-panel/src/VizBuilderApp/components/PreviewOptions.js
+++ b/packages/admin-panel/src/VizBuilderApp/components/PreviewOptions.js
@@ -102,7 +102,7 @@ const LocationField = ({
     loading={isLoadingLocations}
     onInputChange={debounce(
       (event, newValue) => {
-        setLocationSearch(newValue.name);
+        setLocationSearch(newValue);
       },
       [200],
     )}


### PR DESCRIPTION
### Issue RN-226:

Not sure how long this has been broken hehe 😅 Basically due incorrectly treating the string input as an object we were never actually searching for values (however the `Autocomplete` component automatically searches through it's known data so it had the appearance of searching...)