### PR TITLE
PHX-231 Can't change date in map overlay

### DIFF
--- a/packages/web-frontend/src/reducers.js
+++ b/packages/web-frontend/src/reducers.js
@@ -24,7 +24,6 @@ import { isMobile, getUniqueViewId } from './utils';
 import { LANDING } from './containers/OverlayDiv/constants';
 import { EMAIL_VERIFIED_STATUS } from './containers/EmailVerification';
 import { getInitialLocation } from './historyNavigation';
-import { selectMapOverlayGroupByCode } from './selectors';
 
 // Import Action Types
 import {
@@ -102,6 +101,7 @@ import {
   SET_OVERLAY_CONFIGS,
 } from './actions';
 import { LOGIN_TYPES } from './constants';
+import { selectMapOverlayGroupByCode } from './utils/mapOverlays';
 
 function authentication(
   state = {
@@ -601,17 +601,13 @@ function mapOverlayBar(
       };
     case SET_OVERLAY_CONFIGS:
     case UPDATE_OVERLAY_CONFIGS: {
-      const mapOverlayHierarchy = [...state.mapOverlayHierarchy];
+      let mapOverlayHierarchy;
       Object.entries(action.overlayConfigs).forEach(([mapOverlayCode, overlayConfig]) => {
-        const { groupIndex, mapOverlay, mapOverlayGroupIndex } = selectMapOverlayGroupByCode(
-          { mapOverlayBar: state },
+        mapOverlayHierarchy = selectMapOverlayGroupByCode(
+          state.mapOverlayHierarchy,
           mapOverlayCode,
+          overlayConfig,
         );
-
-        mapOverlayHierarchy[groupIndex].children[mapOverlayGroupIndex] = {
-          ...mapOverlay,
-          ...overlayConfig,
-        };
       });
 
       return {

--- a/packages/web-frontend/src/reducers.js
+++ b/packages/web-frontend/src/reducers.js
@@ -101,7 +101,7 @@ import {
   SET_OVERLAY_CONFIGS,
 } from './actions';
 import { LOGIN_TYPES } from './constants';
-import { selectMapOverlayGroupByCode } from './utils/mapOverlays';
+import { updatedMapOverlayHierarchyConfig } from './utils/mapOverlays';
 
 function authentication(
   state = {
@@ -603,7 +603,7 @@ function mapOverlayBar(
     case UPDATE_OVERLAY_CONFIGS: {
       let mapOverlayHierarchy;
       Object.entries(action.overlayConfigs).forEach(([mapOverlayCode, overlayConfig]) => {
-        mapOverlayHierarchy = selectMapOverlayGroupByCode(
+        mapOverlayHierarchy = updatedMapOverlayHierarchyConfig(
           state.mapOverlayHierarchy,
           mapOverlayCode,
           overlayConfig,

--- a/packages/web-frontend/src/sagas.js
+++ b/packages/web-frontend/src/sagas.js
@@ -865,7 +865,7 @@ function* watchFetchMoreSearchResults() {
  * Fetches data for a measure and write it to map state by calling fetchMeasureSuccess.
  *
  */
-function* fetchMeasureInfo(mapOverlayCodes, displayedMapOverlays) {
+function* fetchMeasureInfo({ mapOverlayCodes, displayedMapOverlays, overlayConfigs }) {
   const state = yield select();
   const organisationUnitCode = selectCurrentOrgUnitCode(state);
   const country = selectOrgUnitCountry(state, organisationUnitCode);
@@ -883,12 +883,15 @@ function* fetchMeasureInfo(mapOverlayCodes, displayedMapOverlays) {
       yield put(cancelFetchMeasureData());
       return;
     }
-
+    const overlayConfig = overlayConfigs && overlayConfigs[mapOverlayCode];
     // If the view should be constrained to a date range and isn't, constrain it
-    const { startDate, endDate } =
-      mapOverlayParams.startDate || mapOverlayParams.endDate
-        ? mapOverlayParams
-        : getDefaultDates(mapOverlayParams);
+    let { startDate, endDate } = overlayConfig || mapOverlayParams;
+    if (!startDate || !endDate) {
+      const defaultDates = getDefaultDates(mapOverlayParams);
+      startDate = defaultDates.startDate;
+      endDate = defaultDates.endDate;
+    }
+
     const urlParameters = {
       mapOverlayCode,
       organisationUnitCode,
@@ -925,18 +928,18 @@ function* watchSetMapOverlayChange() {
     );
     const newSelectedMapOverlays = mapOverlayCodes.filter(code => !measureInfo[code]);
 
-    yield fetchMeasureInfo(mapOverlayCodes, [
-      ...previousDisplayedOverlays,
-      ...newSelectedMapOverlays,
-    ]);
+    yield fetchMeasureInfo({
+      mapOverlayCodes,
+      displayedMapOverlays: [...previousDisplayedOverlays, ...newSelectedMapOverlays],
+    });
   });
 }
 
 function* watchOverlayPeriodChange() {
-  yield takeLatest(UPDATE_OVERLAY_CONFIGS, function* _() {
+  yield takeLatest(UPDATE_OVERLAY_CONFIGS, function* _(action) {
     const state = yield select();
     const mapOverlayCodes = selectCurrentMapOverlayCodes(state);
-    yield fetchMeasureInfo(mapOverlayCodes);
+    yield fetchMeasureInfo({ mapOverlayCodes, overlayConfigs: action.overlayConfigs });
   });
 }
 
@@ -966,7 +969,10 @@ function* watchSetMapOverlaysOnceHierarchyLoads() {
     }
 
     yield put(setOverlayConfigs(overlayConfigs));
-    yield fetchMeasureInfo(currentOverlayCodes, currentOverlayCodes);
+    yield fetchMeasureInfo({
+      mapOverlayCodes: currentOverlayCodes,
+      displayedMapOverlays: currentOverlayCodes,
+    });
   });
 }
 

--- a/packages/web-frontend/src/selectors/index.js
+++ b/packages/web-frontend/src/selectors/index.js
@@ -72,5 +72,4 @@ export {
   selectDefaultMapOverlayCode,
   selectDefaultMapOverlay,
   selectPeriodGranularityByCode,
-  selectMapOverlayGroupByCode,
 } from './mapOverlaySelectors';

--- a/packages/web-frontend/src/selectors/mapOverlaySelectors.js
+++ b/packages/web-frontend/src/selectors/mapOverlaySelectors.js
@@ -74,26 +74,3 @@ export const selectPeriodGranularityByCode = createSelector(
   [selectMapOverlayByCode],
   mapOverlay => mapOverlay?.periodGranularity,
 );
-
-export const selectMapOverlayGroupByCode = createSelector(
-  [state => state.mapOverlayBar.mapOverlayHierarchy, (_, code) => code],
-  (mapOverlayHierarchy, code) => {
-    let mapOverlayGroup = {};
-
-    mapOverlayHierarchy.forEach(({ name, children }, groupIndex) => {
-      const selectedMapOverlayIndex = children.findIndex(
-        mapOverlay => mapOverlay.mapOverlayCode === code,
-      );
-      if (selectedMapOverlayIndex > -1) {
-        mapOverlayGroup = {
-          name,
-          groupIndex,
-          mapOverlayGroupIndex: selectedMapOverlayIndex,
-          mapOverlay: children[selectedMapOverlayIndex],
-        };
-      }
-    });
-
-    return mapOverlayGroup;
-  },
-);

--- a/packages/web-frontend/src/utils/mapOverlays.js
+++ b/packages/web-frontend/src/utils/mapOverlays.js
@@ -59,3 +59,47 @@ export function flattenMapOverlayHierarchy(mapOverlayHierarchy) {
 
 export const isMapOverlayHierarchyEmpty = mapOverlayHierarchy =>
   flattenMapOverlayHierarchy(mapOverlayHierarchy).length === 0;
+
+const updateMeasureConfigs = (mapOverlayHierarchy, code, overlayConfig) => {
+  const updatedMapOverlayHierarchy = mapOverlayHierarchy;
+  let updated = false;
+
+  mapOverlayHierarchy.forEach((mapOverlay, index) => {
+    if (updated) {
+      return;
+    }
+    const { mapOverlayCode, children } = mapOverlay;
+    if (mapOverlayCode === code) {
+      updatedMapOverlayHierarchy[index] = {
+        ...mapOverlay,
+        ...overlayConfig,
+      };
+      updated = true;
+    }
+
+    if (!updated && children) {
+      const {
+        updated: newUpdated,
+        updatedMapOverlayHierarchy: newMapOverlayHierarchy,
+      } = updateMeasureConfigs(children, code, overlayConfig);
+      if (newUpdated) {
+        updated = newUpdated;
+        updatedMapOverlayHierarchy[index] = {
+          ...mapOverlayHierarchy[index],
+          children: newMapOverlayHierarchy,
+        };
+      }
+    }
+  });
+
+  return { updated, updatedMapOverlayHierarchy };
+};
+
+export const selectMapOverlayGroupByCode = (mapOverlayHierarchy, code, overlayConfig) => {
+  const { updatedMapOverlayHierarchy } = updateMeasureConfigs(
+    mapOverlayHierarchy,
+    code,
+    overlayConfig,
+  );
+  return updatedMapOverlayHierarchy;
+};

--- a/packages/web-frontend/src/utils/mapOverlays.js
+++ b/packages/web-frontend/src/utils/mapOverlays.js
@@ -95,7 +95,7 @@ const updateMeasureConfigs = (mapOverlayHierarchy, code, overlayConfig) => {
   return { updated, updatedMapOverlayHierarchy };
 };
 
-export const selectMapOverlayGroupByCode = (mapOverlayHierarchy, code, overlayConfig) => {
+export const updatedMapOverlayHierarchyConfig = (mapOverlayHierarchy, code, overlayConfig) => {
   const { updatedMapOverlayHierarchy } = updateMeasureConfigs(
     mapOverlayHierarchy,
     code,


### PR DESCRIPTION
### Issue #:
PHX-231

### Changes:
 - sagas cannot perform a fetch using latest date that updated by reducer. I believe it is designed for a reason. So we need to use the latest date from `UPDATE_MAP_OVERLAY_CONFIG` action.
 - `selectMapOverlayGroupByCode ` -> `updatedMapOverlayHierarchyConfig` and it becomes a recursive function to add map overlay config for updated date.

- Example

---

### Screenshots:
