### PR TITLE
WAI-1083: Fix preaggregations not running overnight

### DIFF
--- a/packages/devops/scripts/lambda/resources/startup.sh
+++ b/packages/devops/scripts/lambda/resources/startup.sh
@@ -25,7 +25,7 @@ BRANCH=$(${DEPLOYMENT_SCRIPTS}/../utility/getEC2TagValue.sh Branch)
 echo "Starting up ${DEPLOYMENT_NAME} (${BRANCH})"
 
 # Create a directory for logs to go
-mkdir -p $LOGS_DIR
+mkdir -m 777 -p $LOGS_DIR
 
 # Turn on cloudwatch agent for prod and dev (can be turned on manually if needed on feature instances)
 # TODO currently broken

--- a/packages/devops/scripts/lambda/resources/startup.sh
+++ b/packages/devops/scripts/lambda/resources/startup.sh
@@ -36,7 +36,7 @@ mkdir -p $LOGS_DIR
 # Add preaggregation cron job if production
 if [[ $DEPLOYMENT_NAME == "production" ]]; then
   set +e # Temporarily allow non 0 exit, as crontab probably doesn't exist yet
-  (crontab -l ; echo "10 13 * * * /home/ubuntu/tupaia/packages/web-config-server/run_preaggregation.sh |& while IFS= read -r line; do printf '\%s \%s\n' "$(date)" "$line"; done > /home/ubuntu/logs/preaggregation.txt") | crontab -
+  (crontab -l ; echo "10 13 * * * /home/ubuntu/tupaia/packages/web-config-server/run_preaggregation.sh |& while IFS= read -r line; do printf '\%s \%s\\\\n' \"\$(date)\" \"\$line\"; done > /home/ubuntu/logs/preaggregation.txt") | crontab -
   set -e
 fi
 

--- a/packages/devops/scripts/lambda/resources/startup.sh
+++ b/packages/devops/scripts/lambda/resources/startup.sh
@@ -36,7 +36,10 @@ mkdir -p $LOGS_DIR
 # Add preaggregation cron job if production
 if [[ $DEPLOYMENT_NAME == "test-crontab" ]]; then
   set +e # Temporarily allow non 0 exit, as crontab probably doesn't exist yet
+  echo "running"
   sudo -Hu ubuntu (crontab -l ; echo "10 13 * * * /home/ubuntu/tupaia/packages/web-config-server/run_preaggregation.sh |& while IFS= read -r line; do printf '\%s \%s\\n' \"\$(date)\" \"\$line\"; done > /home/ubuntu/logs/preaggregation.txt") | crontab -
+  echo $?
+  echo "done"
   set -e
 fi
 

--- a/packages/devops/scripts/lambda/resources/startup.sh
+++ b/packages/devops/scripts/lambda/resources/startup.sh
@@ -34,12 +34,9 @@ mkdir -m 777 -p $LOGS_DIR
 # fi
 
 # Add preaggregation cron job if production
-if [[ $DEPLOYMENT_NAME == "test-crontab-2" ]]; then
+if [[ $DEPLOYMENT_NAME == "production" ]]; then
   set +e # Temporarily allow non 0 exit, as crontab probably doesn't exist yet
-  echo "running"
   (sudo -u ubuntu crontab -l ; echo "10 13 * * * /home/ubuntu/tupaia/packages/web-config-server/run_preaggregation.sh |& while IFS= read -r line; do printf '\%s \%s\\n' \"\$(date)\" \"\$line\"; done > /home/ubuntu/logs/preaggregation.txt") | sudo -u ubuntu crontab -
-  echo $?
-  echo "done"
   set -e
 fi
 

--- a/packages/devops/scripts/lambda/resources/startup.sh
+++ b/packages/devops/scripts/lambda/resources/startup.sh
@@ -36,7 +36,7 @@ mkdir -p $LOGS_DIR
 # Add preaggregation cron job if production
 if [[ $DEPLOYMENT_NAME == "test-crontab" ]]; then
   set +e # Temporarily allow non 0 exit, as crontab probably doesn't exist yet
-  sudo -Hu ubuntu (crontab -l ; echo "10 13 * * * /home/ubuntu/tupaia/packages/web-config-server/run_preaggregation.sh |& while IFS= read -r line; do printf '\%s \%s\\\\n' \"\$(date)\" \"\$line\"; done > /home/ubuntu/logs/preaggregation.txt") | crontab -
+  sudo -Hu ubuntu (crontab -l ; echo "10 13 * * * /home/ubuntu/tupaia/packages/web-config-server/run_preaggregation.sh |& while IFS= read -r line; do printf '\%s \%s\\n' \"\$(date)\" \"\$line\"; done > /home/ubuntu/logs/preaggregation.txt") | crontab -
   set -e
 fi
 

--- a/packages/devops/scripts/lambda/resources/startup.sh
+++ b/packages/devops/scripts/lambda/resources/startup.sh
@@ -34,7 +34,7 @@ mkdir -p $LOGS_DIR
 # fi
 
 # Add preaggregation cron job if production
-if [[ $DEPLOYMENT_NAME == "production" ]]; then
+if [[ $DEPLOYMENT_NAME == "test-crontab" ]]; then
   set +e # Temporarily allow non 0 exit, as crontab probably doesn't exist yet
   sudo -Hu ubuntu (crontab -l ; echo "10 13 * * * /home/ubuntu/tupaia/packages/web-config-server/run_preaggregation.sh |& while IFS= read -r line; do printf '\%s \%s\\\\n' \"\$(date)\" \"\$line\"; done > /home/ubuntu/logs/preaggregation.txt") | crontab -
   set -e

--- a/packages/devops/scripts/lambda/resources/startup.sh
+++ b/packages/devops/scripts/lambda/resources/startup.sh
@@ -34,10 +34,10 @@ mkdir -p $LOGS_DIR
 # fi
 
 # Add preaggregation cron job if production
-if [[ $DEPLOYMENT_NAME == "test-crontab" ]]; then
+if [[ $DEPLOYMENT_NAME == "test-crontab-2" ]]; then
   set +e # Temporarily allow non 0 exit, as crontab probably doesn't exist yet
   echo "running"
-  sudo -Hu ubuntu (crontab -l ; echo "10 13 * * * /home/ubuntu/tupaia/packages/web-config-server/run_preaggregation.sh |& while IFS= read -r line; do printf '\%s \%s\\n' \"\$(date)\" \"\$line\"; done > /home/ubuntu/logs/preaggregation.txt") | crontab -
+  (sudo -u ubuntu crontab -l ; echo "10 13 * * * /home/ubuntu/tupaia/packages/web-config-server/run_preaggregation.sh |& while IFS= read -r line; do printf '\%s \%s\\n' \"\$(date)\" \"\$line\"; done > /home/ubuntu/logs/preaggregation.txt") | sudo -u ubuntu crontab -
   echo $?
   echo "done"
   set -e

--- a/packages/devops/scripts/lambda/resources/startup.sh
+++ b/packages/devops/scripts/lambda/resources/startup.sh
@@ -36,7 +36,7 @@ mkdir -p $LOGS_DIR
 # Add preaggregation cron job if production
 if [[ $DEPLOYMENT_NAME == "production" ]]; then
   set +e # Temporarily allow non 0 exit, as crontab probably doesn't exist yet
-  (crontab -l ; echo "10 13 * * * /home/ubuntu/tupaia/packages/web-config-server/run_preaggregation.sh |& while IFS= read -r line; do printf '\%s \%s\\\\n' \"\$(date)\" \"\$line\"; done > /home/ubuntu/logs/preaggregation.txt") | crontab -
+  sudo -Hu ubuntu (crontab -l ; echo "10 13 * * * /home/ubuntu/tupaia/packages/web-config-server/run_preaggregation.sh |& while IFS= read -r line; do printf '\%s \%s\\\\n' \"\$(date)\" \"\$line\"; done > /home/ubuntu/logs/preaggregation.txt") | crontab -
   set -e
 fi
 

--- a/packages/devops/scripts/lambda/resources/startup.sh
+++ b/packages/devops/scripts/lambda/resources/startup.sh
@@ -35,8 +35,7 @@ mkdir -m 777 -p $LOGS_DIR
 
 # Add preaggregation cron job if production
 if [[ $DEPLOYMENT_NAME == "production" ]]; then
-  echo PATH=$PATH > tmp.cron
-  echo "10 13 * * * /home/ubuntu/tupaia/packages/web-config-server/run_preaggregation.sh | while IFS= read -r line; do printf '\%s \%s\\n' \"\$(date)\" \"\$line\"; done > /home/ubuntu/logs/preaggregation.txt" >> tmp.cron
+  echo "10 13 * * * PATH=$PATH /home/ubuntu/tupaia/packages/web-config-server/run_preaggregation.sh | while IFS= read -r line; do printf '\%s \%s\\n' \"\$(date)\" \"\$line\"; done > /home/ubuntu/logs/preaggregation.txt" > tmp.cron
   sudo -u ubuntu crontab -l >> tmp.cron || echo "" >> tmp.cron
   sudo -u ubuntu crontab tmp.cron
   rm tmp.cron

--- a/packages/devops/scripts/lambda/resources/startup.sh
+++ b/packages/devops/scripts/lambda/resources/startup.sh
@@ -35,9 +35,11 @@ mkdir -m 777 -p $LOGS_DIR
 
 # Add preaggregation cron job if production
 if [[ $DEPLOYMENT_NAME == "production" ]]; then
-  set +e # Temporarily allow non 0 exit, as crontab probably doesn't exist yet
-  (sudo -u ubuntu crontab -l ; echo "10 13 * * * /home/ubuntu/tupaia/packages/web-config-server/run_preaggregation.sh |& while IFS= read -r line; do printf '\%s \%s\\n' \"\$(date)\" \"\$line\"; done > /home/ubuntu/logs/preaggregation.txt") | sudo -u ubuntu crontab -
-  set -e
+  echo PATH=$PATH > tmp.cron
+  echo "10 13 * * * /home/ubuntu/tupaia/packages/web-config-server/run_preaggregation.sh | while IFS= read -r line; do printf '\%s \%s\\n' \"\$(date)\" \"\$line\"; done > /home/ubuntu/logs/preaggregation.txt" >> tmp.cron
+  sudo -u ubuntu crontab -l >> tmp.cron || echo "" >> tmp.cron
+  sudo -u ubuntu crontab tmp.cron
+  rm tmp.cron
 fi
 
 # Fetch the latest code


### PR DESCRIPTION
### Issue #:
WAI-1083

### Changes:
- Allow cron job to write to the logs folder, which was write protected and preventing the script from running
- Fix date handling in cron job output pipeline, which was being evaluated early 
- Store cron job under ubuntu user so it is easier to find, and not running as root
- Use same PATH as regular bash scripts so `yarn` is available, etc.