### PR TITLE
NOT-903 fix dataset autocompletion

### DIFF
--- a/packages/dhis-api/src/DhisApi.js
+++ b/packages/dhis-api/src/DhisApi.js
@@ -184,9 +184,15 @@ export class DhisApi {
   }
 
   async postDataSetCompletion(data) {
-    const response = await this.postData(DATA_SET_COMPLETION, {
-      completeDataSetRegistrations: [data],
-    });
+    const response = await this.postData(
+      DATA_SET_COMPLETION,
+      {
+        completeDataSetRegistrations: [data],
+      },
+      {
+        idScheme: 'id',
+      },
+    );
     return getDiagnosticsFromResponse(response);
   }
 


### PR DESCRIPTION
Issue: https://linear.app/bes/issue/NOT-903/dhis2-data-sets-no-longer-completing-automatically

Basically this PR makes it so that data submitted against data sets is "completed" automatically when the data syncs to DHIS2
- "Completed" basically just means added to the `completedatasetregistration` table

For context - this used to happen automatically but stopped working in mid December (coincidentally right after we patched DHIS2 as mentioned in the issue linked above). This PR seems to make it work again