### PR TITLE
RN-320 Line sliced off at margins (line chart)

### DIFF
--- a/packages/ui-components/src/components/Chart/XAxis.js
+++ b/packages/ui-components/src/components/Chart/XAxis.js
@@ -124,7 +124,7 @@ export const XAxis = ({ viewContent, isExporting, isEnlarged }) => {
       return { left: padding, right: padding };
     }
 
-    return { left: 0, right: 0 };
+    return { left: 0, right: 10 };
   };
 
   const renderVerticalTick = tickProps => {

--- a/packages/ui-components/src/components/Chart/YAxes.js
+++ b/packages/ui-components/src/components/Chart/YAxes.js
@@ -130,6 +130,7 @@ const YAxis = ({ config = {}, viewContent, chartDataConfig, isExporting, isEnlar
       }
       interval={isExporting ? 0 : 'preserveStartEnd'}
       stroke={fillColor}
+      padding={{ top: 10 }}
     />
   );
 };


### PR DESCRIPTION
### Issue #:
RN-320 Line sliced off at margins (line chart)
### Changes:
Add padding on X and Y axes

---

### Screenshots:
Before:
<img width="738" alt="Screen Shot 2022-01-11 at 3 01 46 pm" src="https://user-images.githubusercontent.com/28696655/148879511-e39ecfa7-dba1-44bb-8e45-2b7680511e0b.png">
After:
<img width="729" alt="Screen Shot 2022-01-11 at 3 02 13 pm" src="https://user-images.githubusercontent.com/28696655/148879522-c9cce8a5-ce8d-4107-a3f6-ee1795cbc2b7.png">

