### PR TITLE
Unable to edit survey code on certain surveys

### DIFF
--- a/packages/meditrak-server/src/dataAccessors/editSurvey.js
+++ b/packages/meditrak-server/src/dataAccessors/editSurvey.js
@@ -104,7 +104,9 @@ class SurveyEditor {
       await validateSurveyFields(this.models, {
         code: model.code,
         periodGranularity: model.period_granularity,
-        serviceType: this.updatedFieldsByResource[RESOURCE_TYPES.DATA_GROUP].service_type,
+        serviceType:
+          this.updatedFieldsByResource[RESOURCE_TYPES.DATA_GROUP].service_type ||
+          this.dataGroup.service_type,
       });
     }
 


### PR DESCRIPTION
### Issue #:
RN-253

### Changes:
Reason: `service_type` plays a role in survey update validation. While we only want to change the survey code in admin panel, it doesn't have `service_type` in updated field from front end.

Change: Add `service_type` from `dataGroup` if `service_type` is not set.