### PR TITLE
Display latest overlay date in a format

### DIFF
--- a/packages/web-frontend/src/components/View/View.js
+++ b/packages/web-frontend/src/components/View/View.js
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import CircularProgress from 'material-ui/CircularProgress';
-import moment from 'moment';
+import { periodToMoment } from '@tupaia/utils';
 import { CHART_TYPES } from '@tupaia/ui-components/lib/chart';
 import { VIEW_STYLES } from '../../styles';
 import { NoDataMessage } from './NoDataMessage';
@@ -69,7 +69,7 @@ const getContainerStyle = (baseStyle, viewContent) => {
 };
 
 const formatDate = value => {
-  return `Latest available data: ${moment(value).format('DD/MM/YY')}`;
+  return `Latest available data: ${periodToMoment(value).format('DD/MM/YY')}`;
 };
 
 const formatPeriodRange = period => {

--- a/packages/web-frontend/src/containers/EnlargedDialog/EnlargedDialogContent.js
+++ b/packages/web-frontend/src/containers/EnlargedDialog/EnlargedDialogContent.js
@@ -9,6 +9,7 @@ import IconButton from 'material-ui/IconButton';
 import DownloadIcon from 'material-ui/svg-icons/file/file-download';
 import BackIcon from 'material-ui/svg-icons/hardware/keyboard-arrow-left';
 import DefaultCloseIcon from 'material-ui/svg-icons/navigation/close';
+import { periodToMoment } from '@tupaia/utils';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
@@ -251,7 +252,7 @@ export class EnlargedDialogContent extends PureComponent {
     return (
       <DialogContentText style={styles.periodRange}>
         {'Latest available data: '}
-        {moment(period.latestAvailable).format('DD/MM/YY')}
+        {periodToMoment(period.latestAvailable).format('DD/MM/YY')}
       </DialogContentText>
     );
   }

--- a/packages/web-frontend/src/containers/MapOverlayBar/LastUpdated.js
+++ b/packages/web-frontend/src/containers/MapOverlayBar/LastUpdated.js
@@ -8,7 +8,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import moment from 'moment';
+import { periodToDisplayString } from '@tupaia/utils';
 
 import { VIEW_STYLES } from '../../styles';
 import { selectCurrentMapOverlayCodes } from '../../selectors';
@@ -16,7 +16,7 @@ import { selectCurrentMapOverlayCodes } from '../../selectors';
 class LastUpdated extends Component {
   getFormattedDate = () => {
     const { latestAvailable } = this.props;
-    return `Latest overlay data: ${moment(latestAvailable).format('DD/MM/YYYY')}`;
+    return `Latest overlay data: ${periodToDisplayString(latestAvailable)}`;
   };
 
   shouldRender = () => !!this.props.latestAvailable;

--- a/packages/web-frontend/src/containers/MapOverlayBar/LastUpdated.js
+++ b/packages/web-frontend/src/containers/MapOverlayBar/LastUpdated.js
@@ -8,7 +8,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { periodToDisplayString } from '@tupaia/utils';
+import { periodToMoment } from '@tupaia/utils';
 
 import { VIEW_STYLES } from '../../styles';
 import { selectCurrentMapOverlayCodes } from '../../selectors';
@@ -16,7 +16,7 @@ import { selectCurrentMapOverlayCodes } from '../../selectors';
 class LastUpdated extends Component {
   getFormattedDate = () => {
     const { latestAvailable } = this.props;
-    return `Latest overlay data: ${periodToDisplayString(latestAvailable)}`;
+    return `Latest overlay data: ${periodToMoment(latestAvailable).format('DD/MM/YYYY')}`;
   };
 
   shouldRender = () => !!this.props.latestAvailable;


### PR DESCRIPTION
### Issue #:
RN-250

### Changes:
`moment.js` is not able to import date with format 'yyyymm', thus we need to use our customised translate function `periodToMoment` in front end. 
