### PR TITLE
rn-344 remove tamanu server from meditrak leaderboard

### DIFF
--- a/packages/meditrak-server/src/social/getLeaderboard.js
+++ b/packages/meditrak-server/src/social/getLeaderboard.js
@@ -14,6 +14,7 @@ const EXCLUDED_USERS = [
   "'geoffreyfisher@hotmail.com'", // Geoff F
   "'josh@sussol.net'", // mSupply API Client
   "'unicef.laos.edu@gmail.com'", // Laos Schools Data Collector
+  "'tamanu-server@tupaia.org'", // Tamanu Server
 ];
 const INTERNAL_EMAIL = '@beyondessential.com.au';
 


### PR DESCRIPTION
Issue: https://linear.app/bes/issue/RN-344/remove-tamanu-server-user-from-meditrak-leaderboard

This (in theory) removes Tamanu Server from the MediTrak leaderboard. I haven't tested it locally but I feel confident it will work