### PR TITLE
MAUI-367: Fully qualify URL for latest data downloads

### DIFF
--- a/packages/web-config-server/README.md
+++ b/packages/web-config-server/README.md
@@ -74,27 +74,6 @@ API connect for Tupaia App server
 
 Deals with oauth2 authentication and request from dhis2
 
-## Exporting charts and Lambda
-
-In order to export charts from a local instance of the config server you'll need to
-get an AWS API access key set up for your user account. Then, in `startConfigServer.sh` you'll need to add the following lines:
-
-```
-AWS_ACCESS_KEY_ID='[YOUR KEY ID]' \
-AWS_SECRET_ACCESS_KEY='[YOUR ACCESS KEY]' \
-```
-
-In order for our Lambda method to export a chart it needs to have access to the front-end it's exporting from. You can't do this locally however you can add the following lines to `startConfigServer.sh` to export charts from the dev server:
-
-```
-EXPORT_URL=https://dev-config.tupaia.org \
-EXPORT_COOKIE_URL=dev-config.tupaia.org \
-```
-
-Note: The `EXPORT_COOKIE_URL` should not contain a http or https prefix.
-
-There's one exception however, authentication cookies will not work so you'll only be able to export publicly accessible charts (though you'll still need to log in in order for the config server to know which email address to send the export to).
-
 ## Debugging
 
 ### Visual Studio Code

--- a/packages/web-frontend/src/components/View/SingleDownloadLinkWrapper.js
+++ b/packages/web-frontend/src/components/View/SingleDownloadLinkWrapper.js
@@ -22,11 +22,15 @@ import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { VIEW_STYLES } from '../../styles';
+import { getAbsoluteApiRequestUri } from '../../utils/request';
 
 class SingleDownloadLinkWrapperComponent extends PureComponent {
   render() {
     const { name, value } = this.props.viewContent;
     const { isUserLoggedIn } = this.props;
+
+    // if url already fully qualified, use it, otherwise fetch against config server api
+    const downloadUrl = value.startsWith('http') ? value : getAbsoluteApiRequestUri(value);
 
     return (
       <div style={VIEW_STYLES.viewContainer}>
@@ -36,7 +40,7 @@ class SingleDownloadLinkWrapperComponent extends PureComponent {
           <a
             style={VIEW_STYLES.downloadLink}
             rel="noreferrer noopener"
-            href={value}
+            href={downloadUrl}
             download
             target="_blank"
           >


### PR DESCRIPTION
### Issue #:
MAUI-367

### Changes:
[This hot fix](https://github.com/beyondessential/tupaia-backlog/issues/3208) worked for standard raw data downloads, but not for latest data downloads. This PR brings the same strategy of fetching against the correct URL for web-config-server to latest data downloads.