### PR TITLE
WAITP-990: add question permission filter

### DIFF
--- a/packages/meditrak-server/src/apiV2/questions/GETQuestions.js
+++ b/packages/meditrak-server/src/apiV2/questions/GETQuestions.js
@@ -5,9 +5,16 @@
 
 import { GETHandler } from '../GETHandler';
 import { assertAdminPanelAccess } from '../../permissions';
+import { createQuestionDBFilter } from './assertQuestionPermissions';
 
 export class GETQuestions extends GETHandler {
+  permissionsFilteredInternally = true;
+
   async assertUserHasAccess() {
     await this.assertPermissions(assertAdminPanelAccess);
+  }
+
+  async getPermissionsFilter(criteria, options) {
+    return createQuestionDBFilter(this.accessPolicy, this.models, criteria, options);
   }
 }

--- a/packages/meditrak-server/src/apiV2/questions/assertQuestionPermissions.js
+++ b/packages/meditrak-server/src/apiV2/questions/assertQuestionPermissions.js
@@ -2,8 +2,12 @@
  * Tupaia
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
-
+import { QUERY_CONJUNCTIONS, TYPES } from '@tupaia/database';
 import { assertSurveyEditPermissions } from '../surveys';
+import { hasBESAdminAccess } from '../../permissions';
+import { fetchCountryIdsByPermissionGroupId, mergeMultiJoin } from '../utilities';
+
+const { RAW } = QUERY_CONJUNCTIONS;
 
 export const assertQuestionEditPermissions = async (accessPolicy, models, questionId) => {
   const question = await models.question.findById(questionId);
@@ -22,4 +26,50 @@ export const assertQuestionEditPermissions = async (accessPolicy, models, questi
   }
 
   return true;
+};
+
+export const createQuestionDBFilter = async (accessPolicy, models, criteria, options) => {
+  const dbConditions = { ...criteria };
+  const dbOptions = { ...options };
+
+  if (hasBESAdminAccess(accessPolicy)) {
+    return { dbConditions, dbOptions };
+  }
+
+  const countryIdsByPermissionGroupId = await fetchCountryIdsByPermissionGroupId(
+    accessPolicy,
+    models,
+  );
+
+  dbOptions.multiJoin = mergeMultiJoin(
+    [
+      {
+        joinWith: TYPES.SURVEY_SCREEN_COMPONENT,
+        joinCondition: [`${TYPES.SURVEY_SCREEN_COMPONENT}.question_id`, `${TYPES.QUESTION}.id`],
+      },
+      {
+        joinWith: TYPES.SURVEY_SCREEN,
+        joinCondition: [`${TYPES.SURVEY_SCREEN}.id`, `${TYPES.SURVEY_SCREEN_COMPONENT}.screen_id`],
+      },
+      {
+        joinWith: TYPES.SURVEY,
+        joinCondition: [`${TYPES.SURVEY}.id`, `${TYPES.SURVEY_SCREEN}.survey_id`],
+      },
+    ],
+    dbOptions.multiJoin,
+  );
+
+  dbConditions[RAW] = {
+    sql: `
+    (
+      survey.country_ids
+      &&
+      ARRAY(
+        SELECT TRIM('"' FROM JSON_ARRAY_ELEMENTS(?::JSON->survey.permission_group_id)::TEXT)
+      )
+    )`,
+    parameters: JSON.stringify(countryIdsByPermissionGroupId),
+  };
+
+  return { dbConditions, dbOptions };
 };


### PR DESCRIPTION
### Issue #: WAITP-990: add question permission filter

### Changes:

- add filter for questions based on survey permission group and country access

---

