### PR TITLE
RN-347 enable aggregate tab to use transfer

### DIFF
--- a/packages/admin-panel/src/VizBuilderApp/api/queries/index.js
+++ b/packages/admin-panel/src/VizBuilderApp/api/queries/index.js
@@ -11,3 +11,4 @@ export * from './useDashboardVisualisation';
 export * from './useMapOverlays';
 export * from './useCountries';
 export * from './useSearchDataSources';
+export * from './useSearchAggregationOptions';

--- a/packages/admin-panel/src/VizBuilderApp/api/queries/useSearchAggregationOptions.js
+++ b/packages/admin-panel/src/VizBuilderApp/api/queries/useSearchAggregationOptions.js
@@ -1,0 +1,21 @@
+/*
+ * Tupaia
+ *  Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+import { stringifyQuery } from '@tupaia/utils';
+import { useQuery } from 'react-query';
+import { get } from '../api';
+import { DEFAULT_REACT_QUERY_OPTIONS } from '../constants';
+
+export const useSearchAggregationOptions = ({ search }) =>
+  useQuery(
+    ['aggregationOptions', search],
+    async () => {
+      const endpoint = stringifyQuery(undefined, 'fetchAggregationOptions', {});
+      return get(endpoint);
+    },
+    {
+      ...DEFAULT_REACT_QUERY_OPTIONS,
+      keepPreviousData: true,
+    },
+  );

--- a/packages/admin-panel/src/VizBuilderApp/api/queries/useSearchDataSources.js
+++ b/packages/admin-panel/src/VizBuilderApp/api/queries/useSearchDataSources.js
@@ -7,22 +7,31 @@ import { get } from '../api';
 import { DEFAULT_REACT_QUERY_OPTIONS } from '../constants';
 import { stringifyQuery } from '@tupaia/utils';
 
-export const useSearchDataSources = ({ search, type = 'dataElement', maxResults = 100 }) =>
-  useQuery(
-    ['dataSources', type, search],
-    async () => {
-      const endpoint = stringifyQuery(undefined, 'dataSources', {
-        columns: JSON.stringify(['code', 'type']),
-        filter: JSON.stringify({
-          type,
-          code: { comparator: 'ilike', comparisonValue: `${search}%`, castAs: 'text' },
-        }),
-        pageSize: maxResults,
-      });
-      return get(endpoint);
-    },
-    {
-      ...DEFAULT_REACT_QUERY_OPTIONS,
-      keepPreviousData: true,
-    },
-  );
+export const useSearchDataSources = ({
+  getQueryFn,
+  search,
+  type = 'dataElement',
+  maxResults = 100,
+}) =>
+  useQuery(['dataSources', type, search], getQueryFn({ type, search, maxResults }), {
+    ...DEFAULT_REACT_QUERY_OPTIONS,
+    keepPreviousData: true,
+  });
+
+export const getQueryFnFromDatabase = ({ type, search, maxResults }) => async () => {
+  const endpoint = stringifyQuery(undefined, 'dataSources', {
+    columns: JSON.stringify(['code', 'type']),
+    filter: JSON.stringify({
+      type,
+      code: { comparator: 'ilike', comparisonValue: `${search}%`, castAs: 'text' },
+    }),
+    pageSize: maxResults,
+  });
+  return get(endpoint);
+};
+
+export const getQueryFnFromReportServer = ({ search }) => async () => {
+  const endpoint = stringifyQuery(undefined, 'fetchAggregationOptions', {});
+  const result = await get(endpoint);
+  return result.filter(({ code }) => code.toLowerCase().includes(search.toLowerCase()));
+};

--- a/packages/admin-panel/src/VizBuilderApp/api/queries/useSearchDataSources.js
+++ b/packages/admin-panel/src/VizBuilderApp/api/queries/useSearchDataSources.js
@@ -2,36 +2,40 @@
  * Tupaia
  *  Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
  */
+import { stringifyQuery } from '@tupaia/utils';
 import { useQuery } from 'react-query';
 import { get } from '../api';
 import { DEFAULT_REACT_QUERY_OPTIONS } from '../constants';
-import { stringifyQuery } from '@tupaia/utils';
 
-export const useSearchDataSources = ({
-  getQueryFn,
-  search,
-  type = 'dataElement',
-  maxResults = 100,
-}) =>
-  useQuery(['dataSources', type, search], getQueryFn({ type, search, maxResults }), {
-    ...DEFAULT_REACT_QUERY_OPTIONS,
-    keepPreviousData: true,
-  });
+export const useSearchDataSources = ({ search, type = 'dataElement', maxResults = 100 }) =>
+  useQuery(
+    ['dataSources', type, search],
+    async () => {
+      const endpoint = stringifyQuery(undefined, 'dataSources', {
+        columns: JSON.stringify(['code', 'type']),
+        filter: JSON.stringify({
+          type,
+          code: { comparator: 'ilike', comparisonValue: `${search}%`, castAs: 'text' },
+        }),
+        pageSize: maxResults,
+      });
+      return get(endpoint);
+    },
+    {
+      ...DEFAULT_REACT_QUERY_OPTIONS,
+      keepPreviousData: true,
+    },
+  );
 
-export const getQueryFnFromDatabase = ({ type, search, maxResults }) => async () => {
-  const endpoint = stringifyQuery(undefined, 'dataSources', {
-    columns: JSON.stringify(['code', 'type']),
-    filter: JSON.stringify({
-      type,
-      code: { comparator: 'ilike', comparisonValue: `${search}%`, castAs: 'text' },
-    }),
-    pageSize: maxResults,
-  });
-  return get(endpoint);
-};
-
-export const getQueryFnFromReportServer = ({ search }) => async () => {
-  const endpoint = stringifyQuery(undefined, 'fetchAggregationOptions', {});
-  const result = await get(endpoint);
-  return result.filter(({ code }) => code.toLowerCase().includes(search.toLowerCase()));
-};
+export const useSearchAggregationOptions = ({ search }) =>
+  useQuery(
+    ['aggregationOptions', search],
+    async () => {
+      const endpoint = stringifyQuery(undefined, 'fetchAggregationOptions', {});
+      return get(endpoint);
+    },
+    {
+      ...DEFAULT_REACT_QUERY_OPTIONS,
+      keepPreviousData: true,
+    },
+  );

--- a/packages/admin-panel/src/VizBuilderApp/api/queries/useSearchDataSources.js
+++ b/packages/admin-panel/src/VizBuilderApp/api/queries/useSearchDataSources.js
@@ -26,16 +26,3 @@ export const useSearchDataSources = ({ search, type = 'dataElement', maxResults 
       keepPreviousData: true,
     },
   );
-
-export const useSearchAggregationOptions = ({ search }) =>
-  useQuery(
-    ['aggregationOptions', search],
-    async () => {
-      const endpoint = stringifyQuery(undefined, 'fetchAggregationOptions', {});
-      return get(endpoint);
-    },
-    {
-      ...DEFAULT_REACT_QUERY_OPTIONS,
-      keepPreviousData: true,
-    },
-  );

--- a/packages/admin-panel/src/VizBuilderApp/components/DataLibrary/AggregationDataLibrary.js
+++ b/packages/admin-panel/src/VizBuilderApp/components/DataLibrary/AggregationDataLibrary.js
@@ -4,36 +4,33 @@
  */
 
 import React, { useState } from 'react';
-import { useSearchDataSources, getQueryFnFromReportServer } from '../../api';
-import { DataLibrary } from '@tupaia/ui-components';
 import PropTypes from 'prop-types';
+import { DataLibrary } from '@tupaia/ui-components';
+import { useSearchAggregationOptions } from '../../api';
 import { useDebounce } from '../../../utilities';
 
 const MAX_RESULTS = 10;
 
+// Converts internal value array to Viz config.aggregate data structure
 const aggregateToValue = aggregate =>
   aggregate.map(({ type, config }) => ({ code: type, type: 'aggregationOption', config }));
 
 const valueToAggregate = value => value.map(({ code, config }) => ({ type: code, config }));
 
-export const AggregationDataLibrary = ({ aggregate, onAggregatchange }) => {
+export const AggregationDataLibrary = ({ aggregate, onAggregateChange }) => {
   const [inputValue, setInputValue] = useState('');
-  const value = aggregateToValue(aggregate);
   const debouncedInputValue = useDebounce(inputValue, 200);
-
-  const { data: aggregationOptionSearchResults, isFetching } = useSearchDataSources({
-    getQueryFn: getQueryFnFromReportServer,
+  const value = aggregateToValue(aggregate);
+  const { data: aggregationOptionSearchResults, isFetching } = useSearchAggregationOptions({
     search: debouncedInputValue,
-    type: 'aggregateOption',
   });
-
   const options = inputValue ? aggregationOptionSearchResults : [];
 
   return (
     <DataLibrary
       options={options}
       value={value}
-      onChange={(event, newValue) => onAggregatchange(valueToAggregate(newValue))}
+      onChange={(event, newValue) => onAggregateChange(valueToAggregate(newValue))}
       inputValue={inputValue}
       onInputChange={(event, newInputValue) => (event ? setInputValue(newInputValue) : false)}
       isLoading={isFetching}
@@ -52,5 +49,5 @@ AggregationDataLibrary.propTypes = {
     ),
     PropTypes.string,
   ]).isRequired,
-  onAggregatchange: PropTypes.func.isRequired,
+  onAggregateChange: PropTypes.func.isRequired,
 };

--- a/packages/admin-panel/src/VizBuilderApp/components/DataLibrary/AggregationDataLibrary.js
+++ b/packages/admin-panel/src/VizBuilderApp/components/DataLibrary/AggregationDataLibrary.js
@@ -16,7 +16,7 @@ const aggregateToValue = aggregate =>
 
 const valueToAggregate = value => value.map(({ code, config }) => ({ type: code, config }));
 
-export const AggregationDataLibrary = ({ aggregate, onAggregatehange }) => {
+export const AggregationDataLibrary = ({ aggregate, onAggregatchange }) => {
   const [inputValue, setInputValue] = useState('');
   const value = aggregateToValue(aggregate);
   const debouncedInputValue = useDebounce(inputValue, 200);
@@ -33,7 +33,7 @@ export const AggregationDataLibrary = ({ aggregate, onAggregatehange }) => {
     <DataLibrary
       options={options}
       value={value}
-      onChange={(event, newValue) => onAggregatehange(valueToAggregate(newValue))}
+      onChange={(event, newValue) => onAggregatchange(valueToAggregate(newValue))}
       inputValue={inputValue}
       onInputChange={(event, newInputValue) => (event ? setInputValue(newInputValue) : false)}
       isLoading={isFetching}
@@ -52,5 +52,5 @@ AggregationDataLibrary.propTypes = {
     ),
     PropTypes.string,
   ]).isRequired,
-  onAggregatehange: PropTypes.func.isRequired,
+  onAggregatchange: PropTypes.func.isRequired,
 };

--- a/packages/admin-panel/src/VizBuilderApp/components/DataLibrary/AggregationDataLibrary.js
+++ b/packages/admin-panel/src/VizBuilderApp/components/DataLibrary/AggregationDataLibrary.js
@@ -1,0 +1,56 @@
+/*
+ * Tupaia
+ *  Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import React, { useState } from 'react';
+import { useSearchDataSources, getQueryFnFromReportServer } from '../../api';
+import { DataLibrary } from '@tupaia/ui-components';
+import PropTypes from 'prop-types';
+import { useDebounce } from '../../../utilities';
+
+const MAX_RESULTS = 10;
+
+const aggregateToValue = aggregate =>
+  aggregate.map(({ type, config }) => ({ code: type, type: 'aggregationOption', config }));
+
+const valueToAggregate = value => value.map(({ code, config }) => ({ type: code, config }));
+
+export const AggregationDataLibrary = ({ aggregate, onAggregatehange }) => {
+  const [inputValue, setInputValue] = useState('');
+  const value = aggregateToValue(aggregate);
+  const debouncedInputValue = useDebounce(inputValue, 200);
+
+  const { data: aggregationOptionSearchResults, isFetching } = useSearchDataSources({
+    getQueryFn: getQueryFnFromReportServer,
+    search: debouncedInputValue,
+    type: 'aggregateOption',
+  });
+
+  const options = inputValue ? aggregationOptionSearchResults : [];
+
+  return (
+    <DataLibrary
+      options={options}
+      value={value}
+      onChange={(event, newValue) => onAggregatehange(valueToAggregate(newValue))}
+      inputValue={inputValue}
+      onInputChange={(event, newInputValue) => (event ? setInputValue(newInputValue) : false)}
+      isLoading={isFetching}
+      searchPageSize={MAX_RESULTS}
+    />
+  );
+};
+
+AggregationDataLibrary.propTypes = {
+  aggregate: PropTypes.oneOfType([
+    PropTypes.arrayOf(
+      PropTypes.shape({
+        type: PropTypes.string.isRequired,
+        config: PropTypes.object,
+      }),
+    ),
+    PropTypes.string,
+  ]).isRequired,
+  onAggregatehange: PropTypes.func.isRequired,
+};

--- a/packages/admin-panel/src/VizBuilderApp/components/DataLibrary/DataElementDataLibrary.js
+++ b/packages/admin-panel/src/VizBuilderApp/components/DataLibrary/DataElementDataLibrary.js
@@ -4,9 +4,9 @@
  */
 
 import React, { useState } from 'react';
-import { useSearchDataSources } from '../../api';
 import { DataLibrary } from '@tupaia/ui-components';
 import PropTypes from 'prop-types';
+import { useSearchDataSources, getQueryFnFromDatabase } from '../../api';
 import { useDebounce } from '../../../utilities';
 
 const DATA_TYPES = {
@@ -66,6 +66,7 @@ export const DataElementDataLibrary = ({ fetch, onFetchChange }) => {
     data: dataElementSearchResults = [],
     isFetching: isFetchingDataElements,
   } = useSearchDataSources({
+    getQueryFn: getQueryFnFromDatabase,
     search: debouncedInputValue,
     type: 'dataElement',
     maxResults: MAX_RESULTS,
@@ -74,6 +75,7 @@ export const DataElementDataLibrary = ({ fetch, onFetchChange }) => {
     data: dataGroupSearchResults = [],
     isFetching: isFetchingDataGroups,
   } = useSearchDataSources({
+    getQueryFn: getQueryFnFromDatabase,
     search: debouncedInputValue,
     type: 'dataGroup',
     maxResults: MAX_RESULTS,
@@ -103,7 +105,7 @@ export const DataElementDataLibrary = ({ fetch, onFetchChange }) => {
 DataElementDataLibrary.propTypes = {
   fetch: PropTypes.shape({
     dataElements: PropTypes.arrayOf(PropTypes.string).isRequired,
-    dataGroups: PropTypes.arrayOf(PropTypes.string).isRequired,
+    dataGroups: PropTypes.arrayOf(PropTypes.string),
   }).isRequired,
   onFetchChange: PropTypes.func.isRequired,
 };

--- a/packages/admin-panel/src/VizBuilderApp/components/DataLibrary/DataElementDataLibrary.js
+++ b/packages/admin-panel/src/VizBuilderApp/components/DataLibrary/DataElementDataLibrary.js
@@ -6,7 +6,7 @@
 import React, { useState } from 'react';
 import { DataLibrary } from '@tupaia/ui-components';
 import PropTypes from 'prop-types';
-import { useSearchDataSources, getQueryFnFromDatabase } from '../../api';
+import { useSearchDataSources } from '../../api';
 import { useDebounce } from '../../../utilities';
 
 const DATA_TYPES = {
@@ -66,7 +66,6 @@ export const DataElementDataLibrary = ({ fetch, onFetchChange }) => {
     data: dataElementSearchResults = [],
     isFetching: isFetchingDataElements,
   } = useSearchDataSources({
-    getQueryFn: getQueryFnFromDatabase,
     search: debouncedInputValue,
     type: 'dataElement',
     maxResults: MAX_RESULTS,
@@ -75,7 +74,6 @@ export const DataElementDataLibrary = ({ fetch, onFetchChange }) => {
     data: dataGroupSearchResults = [],
     isFetching: isFetchingDataGroups,
   } = useSearchDataSources({
-    getQueryFn: getQueryFnFromDatabase,
     search: debouncedInputValue,
     type: 'dataGroup',
     maxResults: MAX_RESULTS,

--- a/packages/admin-panel/src/VizBuilderApp/components/DataLibrary/index.js
+++ b/packages/admin-panel/src/VizBuilderApp/components/DataLibrary/index.js
@@ -4,3 +4,4 @@
  */
 
 export * from './DataElementDataLibrary';
+export * from './AggregationDataLibrary';

--- a/packages/admin-panel/src/VizBuilderApp/components/Panel.js
+++ b/packages/admin-panel/src/VizBuilderApp/components/Panel.js
@@ -13,7 +13,7 @@ import { JsonEditor } from './JsonEditor';
 import { PlayButton } from './PlayButton';
 import { JsonToggleButton } from './JsonToggleButton';
 import { useTabPanel, useVizConfig, useVizConfigError } from '../context';
-import { DataElementDataLibrary } from './DataLibrary';
+import { DataElementDataLibrary, AggregationDataLibrary } from './DataLibrary';
 
 const Container = styled(FlexColumn)`
   position: relative;
@@ -140,11 +140,21 @@ export const Panel = () => {
         )}
       </TabPanel>
       <TabPanel isSelected={tab === 1} Panel={PanelTabPanel}>
-        <JsonEditor
-          value={aggregate}
-          onChange={value => setTabValue('aggregate', value)}
-          onInvalidChange={handleInvalidChange}
-        />
+        {jsonToggleEnabled ? (
+          <JsonEditor
+            value={aggregate}
+            onChange={value => setTabValue('aggregate', value)}
+            onInvalidChange={handleInvalidChange}
+          />
+        ) : (
+          <AggregationDataLibrary
+            aggregate={aggregate}
+            onAggregatehange={value => {
+              setTabValue('aggregate', value);
+              setFetchJsonEditorKey(fetchJsonEditorKey + 2);
+            }}
+          />
+        )}
       </TabPanel>
       <TabPanel isSelected={tab === 2} Panel={PanelTabPanel}>
         <JsonEditor

--- a/packages/admin-panel/src/VizBuilderApp/components/Panel.js
+++ b/packages/admin-panel/src/VizBuilderApp/components/Panel.js
@@ -102,8 +102,6 @@ export const Panel = () => {
     return tab !== tabId && hasDataError;
   };
 
-  const [fetchJsonEditorKey, setFetchJsonEditorKey] = useState(0);
-
   return (
     <Container>
       <PanelNav>
@@ -124,7 +122,6 @@ export const Panel = () => {
       <TabPanel isSelected={tab === 0} Panel={PanelTabPanel}>
         {jsonToggleEnabled ? (
           <JsonEditor
-            key={fetchJsonEditorKey}
             value={fetch}
             onChange={value => setTabValue('fetch', value)}
             onInvalidChange={handleInvalidChange}
@@ -134,7 +131,6 @@ export const Panel = () => {
             fetch={fetch}
             onFetchChange={value => {
               setTabValue('fetch', value);
-              setFetchJsonEditorKey(fetchJsonEditorKey + 1);
             }}
           />
         )}
@@ -149,9 +145,8 @@ export const Panel = () => {
         ) : (
           <AggregationDataLibrary
             aggregate={aggregate}
-            onAggregatchange={value => {
+            onAggregateChange={value => {
               setTabValue('aggregate', value);
-              setFetchJsonEditorKey(fetchJsonEditorKey + 2);
             }}
           />
         )}

--- a/packages/admin-panel/src/VizBuilderApp/components/Panel.js
+++ b/packages/admin-panel/src/VizBuilderApp/components/Panel.js
@@ -149,7 +149,7 @@ export const Panel = () => {
         ) : (
           <AggregationDataLibrary
             aggregate={aggregate}
-            onAggregatehange={value => {
+            onAggregatchange={value => {
               setTabValue('aggregate', value);
               setFetchJsonEditorKey(fetchJsonEditorKey + 2);
             }}

--- a/packages/ui-components/src/components/DataLibrary/DataLibrary.js
+++ b/packages/ui-components/src/components/DataLibrary/DataLibrary.js
@@ -88,7 +88,7 @@ export const DataLibrary = ({
     multiple: true,
     freeSolo: true,
     value,
-    getOptionLabel: option => `${option.code} ${option.name}`, // filter on both code and name
+    getOptionLabel: option => `${option.code} ${option.description}`, // filter on both code and description
     onChange,
     inputValue,
     onInputChange,

--- a/packages/ui-components/src/components/DataLibrary/DataLibrary.js
+++ b/packages/ui-components/src/components/DataLibrary/DataLibrary.js
@@ -157,11 +157,11 @@ export const DataLibrary = ({
   );
 };
 
-// FIXME: del id, name not needed
+// FIXME: del id not needed
 const optionPropType = PropTypes.shape({
   id: PropTypes.string,
   code: PropTypes.string,
-  name: PropTypes.string,
+  description: PropTypes.string,
 });
 
 DataLibrary.defaultProps = {

--- a/packages/ui-components/src/components/DataLibrary/options.js
+++ b/packages/ui-components/src/components/DataLibrary/options.js
@@ -113,6 +113,8 @@ const OptionTextWithTooltips = ({ option }) => {
           {description}
         </>
       }
+      enterDelay="700"
+      enterNextDelay="700"
     >
       <OptionText>
         <OptionCode>{code}</OptionCode>

--- a/packages/ui-components/src/components/DataLibrary/options.js
+++ b/packages/ui-components/src/components/DataLibrary/options.js
@@ -8,6 +8,7 @@ import styled from 'styled-components';
 import { Done, Close, ChevronRight } from '@material-ui/icons';
 import { Draggable } from 'react-beautiful-dnd';
 import { ALICE_BLUE } from './constant';
+import { Tooltip } from '../Tooltip';
 
 const StyledOption = styled.div`
   border-radius: 3px;
@@ -73,7 +74,13 @@ const OptionCode = styled.div`
   min-width: 0;
 `;
 
-const OptionName = styled.div`
+const OptionTitle = styled.div`
+  font-size: 14px;
+  color: white;
+  line-height: 140%;
+`;
+
+const OptionDescription = styled.div`
   font-size: 12px;
   line-height: 140%;
   color: #5d676c;
@@ -81,7 +88,7 @@ const OptionName = styled.div`
   overflow: hidden;
   text-overflow: ellipsis;
   display: -webkit-box;
-  -webkit-line-clamp: 2; /* number of lines to show */
+  -webkit-line-clamp: 1; /* number of lines to show */
   line-clamp: 2;
   -webkit-box-orient: vertical;
 `;
@@ -95,16 +102,33 @@ const IconWrapper = styled.div`
   }
 `;
 
+const OptionTextWithTooltips = ({ option }) => {
+  const { code, description } = option;
+
+  return (
+    <Tooltip
+      title={
+        <>
+          <OptionTitle>{code}</OptionTitle>
+          {description}
+        </>
+      }
+    >
+      <OptionText>
+        <OptionCode>{code}</OptionCode>
+        <OptionDescription>{description}</OptionDescription>
+      </OptionText>
+    </Tooltip>
+  );
+};
+
 export const SelectableOption = ({ option, isSelected, onSelect, ...restProps }) => (
   <StyledSelectableOption
     onClick={onSelect}
     className={isSelected ? 'selected' : ''}
     {...restProps}
   >
-    <OptionText>
-      <OptionCode>{option.code}</OptionCode>
-      <OptionName>{option.name}</OptionName>
-    </OptionText>
+    <OptionTextWithTooltips option={option} />
     <IconWrapper>
       <Done />
     </IconWrapper>
@@ -113,10 +137,7 @@ export const SelectableOption = ({ option, isSelected, onSelect, ...restProps })
 
 export const SelectableMultipleTimesOption = ({ option, onSelect }) => (
   <StyledSelectableMultipleTimesOption onClick={onSelect}>
-    <OptionText>
-      <OptionCode>{option.code}</OptionCode>
-      <OptionName>{option.name}</OptionName>
-    </OptionText>
+    <OptionTextWithTooltips option={option} />
     <IconWrapper>
       <ChevronRight />
     </IconWrapper>
@@ -137,10 +158,7 @@ export const SelectedDataCard = ({ option, onRemove, index }) => {
           onMouseOver={() => setIsDragging(true)}
           onMouseLeave={() => setIsDragging(false)}
         >
-          <OptionText>
-            <OptionCode>{option.code}</OptionCode>
-            <OptionName>{option.name}</OptionName>
-          </OptionText>
+          <OptionTextWithTooltips option={option} />
           <IconWrapper onClick={event => onRemove(event, option)} className="icon-wrapper">
             <Close />
           </IconWrapper>

--- a/packages/ui-components/stories/dataLibrary.stories.js
+++ b/packages/ui-components/stories/dataLibrary.stories.js
@@ -23,26 +23,35 @@ const Container = styled.div`
 `;
 
 const options = [
-  { id: '1', code: 'ABC_1', name: 'Sentinel Site One' },
-  { id: '2', code: 'ABC_2', name: 'Sentinel Site Two' },
-  { id: '3', code: 'ABC_3', name: 'Sentinel Site Three' },
-  { id: '4', code: 'ABC_4', name: 'Sentinel Site Four' },
-  { id: '5', code: 'ABC_5', name: 'Sentinel Site Five' },
-  { id: '6', code: 'ABC_6', name: 'Sentinel Site Six' },
-  { id: '7', code: 'ABC_7', name: 'Sentinel Site Seven' },
-  { id: '8', code: 'ABC_8', name: 'Sentinel Site Eight' },
-  { id: '9', code: 'ABC_9', name: 'Sentinel Site Nine' },
-  { id: '10', code: 'ABC_10_LONG_CODE_HOW_NOW_BROWN_COW_HEY_HEY', name: 'Sentinel Site Ten' },
+  {
+    id: '1',
+    code: 'ABC_1',
+    description:
+      'Count the number of data in child entities within selected period, then sum and group by ancestor entities (aggregationEntityType)',
+  },
+  { id: '2', code: 'ABC_2', description: 'Sentinel Site Two' },
+  { id: '3', code: 'ABC_3', description: 'Sentinel Site Three' },
+  { id: '4', code: 'ABC_4', description: 'Sentinel Site Four' },
+  { id: '5', code: 'ABC_5', description: 'Sentinel Site Five' },
+  { id: '6', code: 'ABC_6', description: 'Sentinel Site Six' },
+  { id: '7', code: 'ABC_7', description: 'Sentinel Site Seven' },
+  { id: '8', code: 'ABC_8', description: 'Sentinel Site Eight' },
+  { id: '9', code: 'ABC_9', description: 'Sentinel Site Nine' },
+  {
+    id: '10',
+    code: 'ABC_10_LONG_CODE_HOW_NOW_BROWN_COW_HEY_HEY',
+    description: 'Sentinel Site Ten',
+  },
   {
     id: '11',
     code: 'ABC_11',
-    name:
+    description:
       'Sentinel Site Eleven long name how now brown cow and the quick brown fox as well jumped over the lazy dog',
   },
   {
     id: '12',
     code: 'ABC_12',
-    name:
+    description:
       'Sentinel Site Twelve long name how now brown cow and the quick brown fox as well jumped over the lazy dog',
   },
 ];


### PR DESCRIPTION
### Issue #:
RN-347 

### Changes:
1. Enable aggregate tab to use transfer
2. Extend `useSearchDataSources` to fetch `aggregationTypes` from `report-server` 
3. Add a tooltip to show description when hover on result list

### Screenshot:
https://linear.app/bes/issue/RN-347#comment-232e5cf7