### PR TITLE
MAUI-390: Base the latest responses on data time rather than end time

### DIFF
--- a/packages/meditrak-server/src/apiV2/export/exportSurveyResponses/exportResponsesToFile.js
+++ b/packages/meditrak-server/src/apiV2/export/exportSurveyResponses/exportResponsesToFile.js
@@ -161,7 +161,7 @@ export async function exportResponsesToFile(
 
     const allEntityIds = entities.map(entity => entity.id);
     const sortAndLimitSurveyResponses =
-      latest === 'true' ? { sort: ['end_time DESC'], limit: 1 } : { sort: ['end_time ASC'] };
+      latest === 'true' ? { sort: ['data_time DESC'], limit: 1 } : { sort: ['data_time ASC'] };
 
     // to support a large number of entities (e.g. all schools in Laos), 'findManyByColumn' will
     // break the query into batches, using a subset of entities each time


### PR DESCRIPTION
### Issue #:
MAUI-390

### Changes:
During a disaster, users are likely more interested in data that relates to the most recent time period rather than the data that was most recently submitted. This changes the raw data download to sort by date of data rather than the time the survey was completed, and fixes a mismatch between the export and the visual, reported **Issue 2** in MAUI-390