### PR TITLE
Fix maximum call stack size exceeded with array.push

### DIFF
--- a/packages/indicators/src/Builder/helpers.ts
+++ b/packages/indicators/src/Builder/helpers.ts
@@ -32,12 +32,12 @@ export const fetchAnalytics = async (
   // Group data elements per aggregationList to minimise aggregator calls
   const aggregationJsonToElements = groupKeysByValueJson(aggregationLisByElement);
 
-  const analytics: Analytic[] = [];
+  let analytics: Analytic[] = [];
   await Promise.all(
     Object.entries(aggregationJsonToElements).map(async ([aggregationJson, elements]) => {
       const aggregations = JSON.parse(aggregationJson);
       const { results } = await aggregator.fetchAnalytics(elements, fetchOptions, { aggregations });
-      analytics.push(...results);
+      analytics = [...analytics, ...results];
     }),
   );
 

--- a/packages/indicators/src/Builder/helpers.ts
+++ b/packages/indicators/src/Builder/helpers.ts
@@ -37,7 +37,7 @@ export const fetchAnalytics = async (
     Object.entries(aggregationJsonToElements).map(async ([aggregationJson, elements]) => {
       const aggregations = JSON.parse(aggregationJson);
       const { results } = await aggregator.fetchAnalytics(elements, fetchOptions, { aggregations });
-      analytics = [...analytics, ...results];
+      analytics = analytics.concat(results);
     }),
   );
 


### PR DESCRIPTION
### Issue #:
[Issue from slack](https://beyondessential.slack.com/archives/C02HES8HFQF/p1644452399914279)

We were doing an `arrray.push` over a large number of values. It will put a large amount of number (number > ~135000) as function arguments on the stack, which will cause maximum call stack size exceeded error.

### Changes:
Using spread `...` can fix this.