### PR TITLE
WAITP-1106: Properly delete route53 entries on teardown

### DIFF
--- a/packages/devops/scripts/lambda/helpers/teardown.py
+++ b/packages/devops/scripts/lambda/helpers/teardown.py
@@ -25,10 +25,14 @@ def teardown_instance(instance):
     deployment_type = get_tag(instance, 'DeploymentType')
     deployment_name = get_tag(instance, 'DeploymentName')
 
+    # Build list of route53 entries to delete
+    record_set_deletions = []
+
     # Delete DNS subdomains
-    subdomains_via_dns = get_tag(instance, 'SubdomainsViaGateway')
-    public_dns_url = instance['PublicDnsName']
-    record_set_deletions = [build_record_set_deletion('tupaia.org', subdomain, deployment_name, dns_url=public_dns_url) for subdomain in subdomains_via_dns.split(',')]
+    subdomains_via_dns = get_tag(instance, 'SubdomainsViaDns')
+    if subdomains_via_dns != '':
+      public_dns_url = instance['PublicDnsName']
+      record_set_deletions = [build_record_set_deletion('tupaia.org', subdomain, deployment_name, dns_url=public_dns_url) for subdomain in subdomains_via_dns.split(',')]
 
     # Delete gateway subdomains
     subdomains_via_gateway = get_tag(instance, 'SubdomainsViaGateway')
@@ -38,7 +42,9 @@ def teardown_instance(instance):
 
     # Filter out deletions for record sets that don't actually exist
     hosted_zone_id = route53.list_hosted_zones_by_name(DNSName='tupaia.org')['HostedZones'][0]['Id']
-    all_record_sets = route53.list_resource_record_sets(HostedZoneId=hosted_zone_id)['ResourceRecordSets']
+    record_set_paginator = route53.get_paginator('list_resource_record_sets')
+    record_set_response = record_set_paginator.paginate(HostedZoneId=hosted_zone_id).build_full_result()
+    all_record_sets = record_set_response['ResourceRecordSets']
     all_record_set_names = [record_set['Name'] for record_set in all_record_sets]
     valid_record_set_deletions = [deletion for deletion in record_set_deletions if deletion['ResourceRecordSet']['Name'] in all_record_set_names]
     print('Generated {} record set changes'.format(len(record_set_deletions)))


### PR DESCRIPTION
### Issue #:
WAITP-1106

### Changes:
- Use boto3's paginator (and undocumented `build_full_result` feature) to get all route53 entries when checking which are appropriate to delete, so we don't just get the first page and miss the ones we're after
- Only delete subdomains via dns if the instance is tagged as having them (which the app server isn't - didn't realise this was buggy because we've never actually been deleting route53 entries due to the pagination issue!)