### PR TITLE
RN-258: Show loading state on admin panel login

### DIFF
--- a/packages/admin-panel/src/authentication/LoginForm.js
+++ b/packages/admin-panel/src/authentication/LoginForm.js
@@ -8,7 +8,13 @@ import styled from 'styled-components';
 import Typography from '@material-ui/core/Typography';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { getEmailAddress, getErrorMessage, getPassword, getRememberMe } from './selectors';
+import {
+  getEmailAddress,
+  getErrorMessage,
+  getIsLoading,
+  getPassword,
+  getRememberMe,
+} from './selectors';
 import { changeEmailAddress, changePassword, login, changeRememberMe } from './actions';
 
 const ErrorMessage = styled.p`
@@ -34,6 +40,7 @@ const LoginFormComponent = ({
   password,
   rememberMe,
   errorMessage,
+  isLoading,
   onChangeEmailAddress,
   onChangePassword,
   onChangeRememberMe,
@@ -64,7 +71,7 @@ const LoginFormComponent = ({
         checked={rememberMe}
         onChange={onChangeRememberMe}
       />
-      <StyledButton type="submit" fullWidth>
+      <StyledButton type="submit" fullWidth isLoading={isLoading}>
         Login to your account
       </StyledButton>
     </form>
@@ -76,6 +83,7 @@ LoginFormComponent.propTypes = {
   password: PropTypes.string.isRequired,
   rememberMe: PropTypes.bool,
   errorMessage: PropTypes.string,
+  isLoading: PropTypes.bool,
   onChangeEmailAddress: PropTypes.func.isRequired,
   onChangePassword: PropTypes.func.isRequired,
   onChangeRememberMe: PropTypes.func.isRequired,
@@ -84,6 +92,7 @@ LoginFormComponent.propTypes = {
 
 LoginFormComponent.defaultProps = {
   errorMessage: null,
+  isLoading: false,
   rememberMe: false,
 };
 
@@ -92,6 +101,7 @@ const mapStateToProps = state => ({
   password: getPassword(state),
   rememberMe: getRememberMe(state),
   errorMessage: getErrorMessage(state),
+  isLoading: getIsLoading(state),
 });
 
 const mergeProps = (stateProps, { dispatch }, ownProps) => ({

--- a/packages/admin-panel/src/authentication/reducer.js
+++ b/packages/admin-panel/src/authentication/reducer.js
@@ -22,7 +22,7 @@ const defaultState = {
   emailAddress: '',
   password: '',
   user: null,
-  isLoggingIn: false,
+  isLoading: false,
   rememberMe: false,
   errorMessage: null,
 };
@@ -61,7 +61,7 @@ const stateChanges = {
       isBESAdmin: isBESAdmin(payload.user.accessPolicy),
     };
   },
-  [LOGIN_REQUEST]: () => ({ isLoggingIn: true }),
+  [LOGIN_REQUEST]: () => ({ isLoading: true }),
   [LOGIN_ERROR]: logoutStateUpdater,
   [LOGOUT]: logoutStateUpdater,
   [PROFILE_SUCCESS]: (user, currentState) => ({

--- a/packages/admin-panel/src/authentication/selectors.js
+++ b/packages/admin-panel/src/authentication/selectors.js
@@ -9,6 +9,7 @@ export const getEmailAddress = state => getAuthenticationState(state).emailAddre
 export const getPassword = state => getAuthenticationState(state).password;
 export const getRememberMe = state => getAuthenticationState(state).rememberMe;
 export const getErrorMessage = state => getAuthenticationState(state).errorMessage;
+export const getIsLoading = state => getAuthenticationState(state).isLoading;
 
 // Authentication details
 export const getIsUserAuthenticated = state => !!getAuthenticationState(state).user;


### PR DESCRIPTION
### Issue #:
- RN-258

### Changes:
Although the ticket says to use a loading spinner, our common ui-component Button uses the "Loading..." text, so I've gone with that here too. That keeps the interface consistent with PSSS, LESMIS, etc.

![image](https://user-images.githubusercontent.com/1274422/154575800-bd48dcdd-ad45-4fa6-9b51-8912d5788d79.png)
