### PR TITLE
RN-368: Added overnight shutdown for RDS

### DIFF
--- a/packages/devops/scripts/lambda/actions/start_tagged_databases.py
+++ b/packages/devops/scripts/lambda/actions/start_tagged_databases.py
@@ -17,7 +17,8 @@ loop = asyncio.get_event_loop()
 def start_tagged_databases(event):
   hour = time.strftime("%H:00")
   tagged_instances = find_db_instances([
-      { 'Key': 'StartAtUTC', 'Values': [hour] }
+      { 'Key': 'StartAtUTC', 'Values': [hour] },
+      { 'Key': 'DeploymentType', 'Values': ['tupaia'] }
   ])
 
   stopped_instances = list(filter(lambda x: x['DBInstanceStatus'] == 'stopped', tagged_instances))

--- a/packages/devops/scripts/lambda/actions/start_tagged_databases.py
+++ b/packages/devops/scripts/lambda/actions/start_tagged_databases.py
@@ -1,0 +1,38 @@
+# Starts any database tagged with "StartAtUTC" that is currently stopped, and due to be started
+# within the last hour
+#
+# Example config
+# {
+#   "Action": "start_tagged_databases",
+#   "User": "edwin"
+# }
+
+import asyncio
+import time
+
+from helpers.rds import find_db_instances, start_db_instance, wait_for_db_instance
+
+loop = asyncio.get_event_loop()
+
+def start_tagged_databases(event):
+  hour = time.strftime("%H:00")
+  tagged_instances = find_db_instances([
+      { 'Key': 'StartAtUTC', 'Values': [hour] }
+  ])
+
+  stopped_instances = list(filter(lambda x: x['DBInstanceStatus'] == 'stopped', tagged_instances))
+
+  if len(stopped_instances) > 0:
+    tasks = sum(
+    [
+        [asyncio.ensure_future(start_and_wait_for_db(instance)) for instance in stopped_instances]
+    ], [])
+    loop.run_until_complete(asyncio.wait(tasks))
+    print(str(len(stopped_instances)) + ' previously stopped instances started')
+  else:
+    print('No stopped instances required starting')
+
+async def start_and_wait_for_db(db_instance):
+  db_id = db_instance['DBInstanceIdentifier']
+  start_db_instance(db_id)
+  await wait_for_db_instance(db_id, 'available')

--- a/packages/devops/scripts/lambda/actions/stop_tagged_databases.py
+++ b/packages/devops/scripts/lambda/actions/stop_tagged_databases.py
@@ -1,0 +1,29 @@
+# Stops any database tagged with "StopAtUTC" that is currently available, and due to be stopped
+# within the last hour
+#
+# Example config
+# {
+#   "Action": "stop_tagged_databases",
+#   "User": "edwin"
+# }
+
+import time
+
+from helpers.rds import find_db_instances, stop_db_instance
+
+def stop_tagged_databases(event):
+    hour = time.strftime("%H:00")
+    tagged_instances = find_db_instances([
+        { 'Key': 'StopAtUTC', 'Values': [hour] }
+    ])
+
+    available_instances = list(filter(lambda x: x['DBInstanceStatus'] == 'available', tagged_instances))
+
+    if len(available_instances) > 0:
+      instance_ids = list(map(lambda x: x['DBInstanceIdentifier'], available_instances))
+      for instance_id in instance_ids:
+          stop_db_instance(instance_id)
+      
+      print(str(len(available_instances)) + ' previously available instances stopping')
+    else:
+      print('No available instances required stopping')

--- a/packages/devops/scripts/lambda/actions/stop_tagged_databases.py
+++ b/packages/devops/scripts/lambda/actions/stop_tagged_databases.py
@@ -12,18 +12,19 @@ import time
 from helpers.rds import find_db_instances, stop_db_instance
 
 def stop_tagged_databases(event):
-    hour = time.strftime("%H:00")
-    tagged_instances = find_db_instances([
-        { 'Key': 'StopAtUTC', 'Values': [hour] }
-    ])
+  hour = time.strftime("%H:00")
+  tagged_instances = find_db_instances([
+    { 'Key': 'StopAtUTC', 'Values': [hour] },
+    { 'Key': 'DeploymentType', 'Values': ['tupaia'] }
+  ])
 
-    available_instances = list(filter(lambda x: x['DBInstanceStatus'] == 'available', tagged_instances))
+  available_instances = list(filter(lambda x: x['DBInstanceStatus'] == 'available', tagged_instances))
 
-    if len(available_instances) > 0:
-      instance_ids = list(map(lambda x: x['DBInstanceIdentifier'], available_instances))
-      for instance_id in instance_ids:
-          stop_db_instance(instance_id)
-      
-      print(str(len(available_instances)) + ' previously available instances stopping')
-    else:
-      print('No available instances required stopping')
+  if len(available_instances) > 0:
+    instance_ids = list(map(lambda x: x['DBInstanceIdentifier'], available_instances))
+    for instance_id in instance_ids:
+      stop_db_instance(instance_id)
+    
+    print(str(len(available_instances)) + ' previously available instances stopping')
+  else:
+    print('No available instances required stopping')

--- a/packages/devops/scripts/lambda/helpers/rds.py
+++ b/packages/devops/scripts/lambda/helpers/rds.py
@@ -49,6 +49,16 @@ def rename_db_instance(db_id, new_db_id):
         ApplyImmediately=True
     )
 
+def start_db_instance(db_id):
+    rds.start_db_instance(
+        DBInstanceIdentifier=db_id
+    )
+
+def stop_db_instance(db_id):
+    rds.stop_db_instance(
+        DBInstanceIdentifier=db_id
+    )
+
 def get_latest_db_snapshot(source_db_id):
     snapshots_response = rds.describe_db_snapshots(
         DBInstanceIdentifier=source_db_id

--- a/packages/devops/scripts/lambda/lambda_function.py
+++ b/packages/devops/scripts/lambda/lambda_function.py
@@ -7,7 +7,9 @@ from actions.redeploy_tupaia_server import redeploy_tupaia_server
 from actions.spin_up_dhis_deployment import spin_up_dhis_deployment
 from actions.spin_up_tupaia_deployment import spin_up_tupaia_deployment
 from actions.spin_up_tupaia_database import spin_up_tupaia_database
+from actions.start_tagged_databases import start_tagged_databases
 from actions.start_tagged_servers import start_tagged_servers
+from actions.stop_tagged_databases import stop_tagged_databases
 from actions.stop_tagged_servers import stop_tagged_servers
 from actions.swap_out_tupaia_server import swap_out_tupaia_server
 from actions.tear_down_tupaia_deployment import tear_down_tupaia_deployment
@@ -23,7 +25,9 @@ actions = {
   'spin_up_dhis_deployment': spin_up_dhis_deployment,
   'spin_up_tupaia_deployment': spin_up_tupaia_deployment,
   'spin_up_tupaia_database': spin_up_tupaia_database,
+  'start_tagged_databases': start_tagged_databases,
   'start_tagged_servers': start_tagged_servers,
+  'stop_tagged_databases': stop_tagged_databases,
   'stop_tagged_servers': stop_tagged_servers,
   'swap_out_tupaia_server': swap_out_tupaia_server,
   'tear_down_tupaia_deployment': tear_down_tupaia_deployment,


### PR DESCRIPTION
### Issue RN-368:

Added deployment scripts to stop and start RDS instances based on the `StartAtUTC` and `StopAtUTC` tags.

Will add EventBridge configurations to trigger these automatically