### PR TITLE
Release 2022-7

### DIFF
--- a/packages/admin-panel/src/pages/resources/PermissionsPage.js
+++ b/packages/admin-panel/src/pages/resources/PermissionsPage.js
@@ -103,8 +103,15 @@ const CREATE_CONFIG = {
   },
 };
 
-// Return an array of records for bulk editing on the server
-const processDataForSave = fieldsToSave => {
+// When creating, return an array of records for bulk editing on the server
+// When editing, just process a single record as normal
+const processDataForSave = (fieldsToSave, recordData) => {
+  const isEditingSingle = Object.keys(recordData).length > 0;
+  if (isEditingSingle) {
+    return fieldsToSave;
+  }
+
+  // Creating new records in bulk
   const records = [];
 
   const getRecordValues = (partialRecord, values) => {

--- a/packages/database/.babelrc
+++ b/packages/database/.babelrc
@@ -1,7 +1,0 @@
-{
-  "env": {
-    "test": {
-      "plugins": ["istanbul"]
-    }
-  }
-}

--- a/packages/database/.babelrc.js
+++ b/packages/database/.babelrc.js
@@ -1,0 +1,52 @@
+const getPlugins = api => {
+  if (api.env(['development', 'test'])) {
+    return ['istanbul'];
+  }
+  return [];
+};
+
+const includedDateOffset = 90 * 24 * 60 * 60 * 1000; // include migrations up to 90 days old
+const includedMigrationsDate = new Date().setTime(Date.now() - includedDateOffset);
+const checkMigrationOutdated = function (migrationName) {
+  const yearPart = migrationName.substring(0, 4);
+  const monthPart = migrationName.substring(4, 6);
+  const dayPart = migrationName.substring(6, 8);
+  const migrationDate = new Date(`${yearPart}-${monthPart}-${dayPart}`);
+  return migrationDate < includedMigrationsDate;
+};
+
+const getIgnore = api => {
+  if (api.caller(caller => caller.name === '@babel/cli')) {
+    // When building @tupaia/database, babel-cli compiles in advance, so we only want it to bother
+    // with the last 90 days of migrations, otherwise it takes too long
+    return [
+      'src/tests/**',
+      function (filepath) {
+        const filepathComponents = filepath.split('/');
+        const filename = filepathComponents.pop();
+        const directory = filepathComponents.pop();
+        const parentDirectory = filepathComponents.pop();
+
+        if (directory === 'migrations' || directory === 'migrationData') {
+          return checkMigrationOutdated(filename);
+        }
+
+        // Some migration data is broken into separate subfiles within a folder named with the
+        // same name as the migration, be sure to ignore that if it's outdated too
+        if (parentDirectory === 'migrationData') {
+          return checkMigrationOutdated(directory);
+        }
+        return false;
+      },
+    ];
+  }
+  // During migrations and testing, we use babel-node and babel-register, and want them to process
+  // all files, so don't ignore anything
+  return [];
+};
+
+module.exports = function (api) {
+  const plugins = getPlugins(api);
+  const ignore = getIgnore(api);
+  return { plugins, ignore };
+};

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -11,7 +11,7 @@
   "author": "Beyond Essential Systems <admin@tupaia.org> (https://beyondessential.com.au)",
   "main": "dist/index.js",
   "scripts": {
-    "build": "babel src --out-dir dist --source-maps --ignore \"**/migrations\",\"src/tests/**\" --config-file \"../../babel.config.json\" && tsc",
+    "build": "babel src --out-dir dist --source-maps --config-file \"../../babel.config.json\" && tsc",
     "dump-database": "./scripts/dumpDatabase.sh",
     "lint": "eslint --ignore-path ../../.gitignore .",
     "lint:fix": "yarn lint --fix",

--- a/packages/database/src/getDbMigrator.js
+++ b/packages/database/src/getDbMigrator.js
@@ -1,0 +1,54 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+
+import DBMigrate from 'db-migrate';
+import { runPostMigration } from './runPostMigration';
+import { getConnectionConfig } from './getConnectionConfig';
+
+const exitWithError = error => {
+  console.error(error.message);
+  process.exit(1);
+};
+
+const cliCallback = async (migrator, internals, originalError, migrationError) => {
+  if (originalError) {
+    exitWithError(new Error(`db-migrate error: ${migrationError.message}`));
+  }
+  if (migrationError) {
+    exitWithError(new Error(`Migration error: ${migrationError.message}`));
+  }
+
+  try {
+    const { driver } = migrator;
+    await runPostMigration(driver);
+  } catch (error) {
+    exitWithError(new Error(`Post migration error: ${error.message}`));
+  }
+};
+
+const appCallback = async (migrator, internals, callback, error) => {
+  if (error) {
+    throw error;
+  }
+
+  const { driver } = migrator;
+  await runPostMigration(driver);
+};
+
+export const getDbMigrator = (forCli = false) =>
+  DBMigrate.getInstance(
+    true,
+    {
+      cwd: __dirname,
+      config: {
+        defaultEnv: 'tupaia',
+        tupaia: {
+          driver: 'pg',
+          ...getConnectionConfig(),
+        },
+      },
+    },
+    forCli ? cliCallback : appCallback,
+  );

--- a/packages/database/src/index.js
+++ b/packages/database/src/index.js
@@ -6,6 +6,7 @@
 export * from './modelClasses';
 export { MaterializedViewLogDatabaseModel } from './analytics';
 export * from './changeHandlers';
+export { getDbMigrator } from './getDbMigrator';
 export {
   generateId,
   getHighestPossibleIdForGivenTime,

--- a/packages/database/src/migrate.js
+++ b/packages/database/src/migrate.js
@@ -2,44 +2,8 @@
  * Tupaia
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
-
-import DBMigrate from 'db-migrate';
 import {} from 'dotenv/config'; // Load the environment variables into process.env
-import { runPostMigration } from './runPostMigration';
-import { getConnectionConfig } from './getConnectionConfig';
+import { getDbMigrator } from './getDbMigrator';
 
-const exitWithError = error => {
-  console.error(error.message);
-  process.exit(1);
-};
-
-const migrationInstance = DBMigrate.getInstance(
-  true,
-  {
-    cwd: `${__dirname}/migrations`,
-    config: {
-      defaultEnv: 'tupaia',
-      tupaia: {
-        driver: 'pg',
-        ...getConnectionConfig(),
-      },
-    },
-  },
-  async (migrator, internals, originalError, migrationError) => {
-    if (originalError) {
-      exitWithError(new Error(`db-migrate error: ${migrationError.message}`));
-    }
-    if (migrationError) {
-      exitWithError(new Error(`Migration error: ${migrationError.message}`));
-    }
-
-    try {
-      const { driver } = migrator;
-      await runPostMigration(driver);
-    } catch (error) {
-      exitWithError(new Error(`Post migration error: ${error.message}`));
-    }
-  },
-);
-
-migrationInstance.run();
+const migrator = getDbMigrator(true);
+migrator.run();

--- a/packages/database/src/migrations/20220210214956-UpdateCovid19SamoaVisualisationPermissions-modifies-data.js
+++ b/packages/database/src/migrations/20220210214956-UpdateCovid19SamoaVisualisationPermissions-modifies-data.js
@@ -1,0 +1,61 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+const reportsToUpdate = [
+  'WS_COVID_Household_Vaccination_Status',
+  'WS_Covid_Samoa_COVID-19_Percent_Of_Population_1st_Vaccine_Dose_Taken_Capped',
+  'WS_Covid_Samoa_COVID-19_Percent_Of_Population_2nd_Vaccine_Dose_Taken_Capped',
+  'WS_COVID_TRACKING_Dose_1_Home_Sub_District_Percentage_Capped_map',
+  'WS_COVID_TRACKING_Dose_2_Home_Sub_District_Percentage_Capped_map',
+  'WS_COVID_TRACKING_Dose_1_Home_Village_Percentage_Capped_map',
+  'WS_COVID_TRACKING_Dose_2_Home_Village_Percentage_Capped_map',
+];
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = async function (db) {
+  const selectNewPermissionId = await db.runSql(`
+    SELECT id FROM permission_group WHERE name = 'COVID-19 Samoa';
+  `);
+  const [newPermission] = selectNewPermissionId.rows;
+  const newPermissionId = newPermission.id;
+
+  reportsToUpdate.forEach(async report => {
+    await db.runSql(`
+      UPDATE report
+      SET permission_group_id = '${newPermissionId}'
+      WHERE code = '${report}';
+    `);
+  });
+};
+
+exports.down = async function (db) {
+  const selectOldPermissionId = await db.runSql(`
+    SELECT id FROM permission_group WHERE name = 'COVID-19';
+  `);
+  const [oldPermission] = selectOldPermissionId.rows;
+  const oldPermissionId = oldPermission.id;
+
+  reportsToUpdate.forEach(async report => {
+    await db.runSql(`
+      UPDATE report
+      SET permission_group_id = '${oldPermissionId}'
+      WHERE code = '${report}';
+    `);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/packages/database/src/migrations/20220210235957-UnfpaMarshallIslandsAddFacilities-modifies-data.js
+++ b/packages/database/src/migrations/20220210235957-UnfpaMarshallIslandsAddFacilities-modifies-data.js
@@ -1,0 +1,57 @@
+'use strict';
+
+import { codeToId, insertObject, generateId, nameToId } from '../utilities';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+const facilities = [
+  { code: 'MH_037', parent: 'MH_Wotje' },
+  { code: 'MH_038', parent: 'MH_Wotje' },
+];
+const hierarchyCode = 'unfpa';
+
+exports.up = async function (db) {
+  const hierarchyId = await nameToId(db, 'entity_hierarchy', hierarchyCode);
+
+  await Promise.all(
+    facilities.map(async facility =>
+      insertObject(db, 'entity_relation', {
+        id: generateId(),
+        parent_id: await codeToId(db, 'entity', facility.parent),
+        child_id: await codeToId(db, 'entity', facility.code),
+        entity_hierarchy_id: hierarchyId,
+      }),
+    ),
+  );
+};
+
+exports.down = async function (db) {
+  const hierarchyId = await nameToId(db, 'entity_hierarchy', hierarchyCode);
+
+  await Promise.all(
+    facilities.map(async facility => {
+      const entityId = await codeToId(db, 'entity', facility.code);
+      return db.runSql(`
+        delete from entity_relation
+        where child_id = '${entityId}' 
+        and entity_hierarchy_id = '${hierarchyId}';
+      `);
+    }),
+  );
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/packages/database/src/migrations/20220218050602-AddCovidKiribatiProject-modifies-data.js
+++ b/packages/database/src/migrations/20220218050602-AddCovidKiribatiProject-modifies-data.js
@@ -1,0 +1,134 @@
+'use strict';
+
+import { insertObject, codeToId, generateId } from '../utilities';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+const PROJECT_NAME = 'COVID-19 Kiribati';
+const PROJECT_CODE = 'covid_kiribati';
+const DASHBOARD_CODE = 'covid_ki';
+const DASHBOARD_NAME = 'COVID-19 Kiribati';
+const MAP_OVERLAY_GROUP_CODE = 'covid_ki';
+const MAP_OVERLAY_GROUP_NAME = 'COVID-19 Kiribati';
+const PROJECT = {
+  code: PROJECT_CODE,
+  description: 'COVID-19 case surveillance and data visualisations in Kiribati',
+  sort_order: 16,
+  image_url:
+    'https://tupaia.s3.ap-southeast-2.amazonaws.com/uploads/covid_kiribati_background.jpeg',
+  default_measure: '126,171',
+  dashboard_group_name: DASHBOARD_NAME,
+  permission_groups: '{COVID-19 Kiribati Admin,COVID-19 Kiribati}',
+  logo_url: 'https://tupaia.s3.ap-southeast-2.amazonaws.com/uploads/covid_kiribati_logo.jpeg',
+};
+const ENTITY = {
+  code: PROJECT_CODE,
+  name: PROJECT_NAME,
+  type: 'project',
+};
+
+const addDashboard = async db => {
+  await insertObject(db, 'dashboard', {
+    id: generateId(),
+    code: DASHBOARD_CODE,
+    name: DASHBOARD_NAME,
+    root_entity_code: PROJECT_CODE,
+  });
+};
+
+const addMapOverlayGroup = async db => {
+  await insertObject(db, 'map_overlay_group', {
+    id: generateId(),
+    code: MAP_OVERLAY_GROUP_CODE,
+    name: MAP_OVERLAY_GROUP_NAME,
+  });
+
+  const mapOverlayGroupId = await codeToId(db, 'map_overlay_group', 'Root');
+  const childId = await codeToId(db, 'map_overlay_group', MAP_OVERLAY_GROUP_CODE);
+
+  await insertObject(db, 'map_overlay_group_relation', {
+    id: generateId(),
+    map_overlay_group_id: mapOverlayGroupId,
+    child_id: childId,
+    child_type: 'mapOverlayGroup',
+  });
+};
+
+const addEntity = async db => {
+  const id = generateId();
+  const parentId = await codeToId(db, 'entity', 'World');
+  await insertObject(db, 'entity', {
+    id,
+    parent_id: parentId,
+    ...ENTITY,
+  });
+};
+
+const addEntityHierarchy = async db => {
+  await insertObject(db, 'entity_hierarchy', {
+    id: generateId(),
+    name: PROJECT_CODE,
+    canonical_types: '{country,district,sub_district,facility}',
+  });
+};
+
+const hierarchyNameToId = async (db, name) => {
+  const record = await db.runSql(`SELECT id FROM entity_hierarchy WHERE name = '${name}'`);
+  return record.rows[0] && record.rows[0].id;
+};
+
+const addEntityRelation = async db => {
+  insertObject(db, 'entity_relation', {
+    id: generateId(),
+    parent_id: await codeToId(db, 'entity', PROJECT_CODE),
+    child_id: await codeToId(db, 'entity', 'KI'),
+    entity_hierarchy_id: await hierarchyNameToId(db, PROJECT_CODE),
+  });
+};
+
+const addProject = async db => {
+  await insertObject(db, 'project', {
+    id: generateId(),
+    entity_id: await codeToId(db, 'entity', PROJECT_CODE),
+    entity_hierarchy_id: await hierarchyNameToId(db, PROJECT_CODE),
+    ...PROJECT,
+  });
+};
+
+exports.up = async function (db) {
+  await addEntity(db);
+  await addDashboard(db);
+  await addMapOverlayGroup(db);
+  await addEntityHierarchy(db);
+  await addEntityRelation(db);
+  await addProject(db);
+};
+
+exports.down = async function (db) {
+  const childId = await codeToId(db, 'map_overlay_group', MAP_OVERLAY_GROUP_CODE);
+  const hierarchyId = await hierarchyNameToId(db, PROJECT_CODE);
+
+  await db.runSql(`DELETE FROM "dashboard" WHERE code = '${DASHBOARD_CODE}'`);
+  await db.runSql(`DELETE FROM "map_overlay_group_relation" WHERE child_id = '${childId}'`);
+  await db.runSql(`DELETE FROM "map_overlay_group" WHERE code = '${MAP_OVERLAY_GROUP_CODE}'`);
+  await db.runSql(`DELETE FROM project WHERE code = '${PROJECT_CODE}'`);
+  await db.runSql(`DELETE FROM entity_relation WHERE entity_hierarchy_id = '${hierarchyId}'`);
+  await db.runSql(`DELETE FROM entity_hierarchy WHERE name = '${PROJECT_CODE}'`);
+  await db.runSql(`DELETE FROM entity WHERE code = '${PROJECT_CODE}'`);
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/packages/devops/scripts/deployment/startBackEnds.sh
+++ b/packages/devops/scripts/deployment/startBackEnds.sh
@@ -29,12 +29,6 @@ for PACKAGE in ${PACKAGES[@]}; do
             yarn workspace @tupaia/data-api install-mv-refresh
             yarn workspace @tupaia/data-api patch-mv-refresh up
             yarn workspace @tupaia/data-api build-analytics-table
-
-            # now that meditrak-server is up and listening for changes, we can run any migrations
-            # if run earlier when meditrak-server isn't listening, changes will be missed from the
-            # sync queues
-            echo "Migrating the database"
-            yarn migrate
         fi
     fi
 done

--- a/packages/devops/scripts/lambda/actions/redeploy_tupaia_server.py
+++ b/packages/devops/scripts/lambda/actions/redeploy_tupaia_server.py
@@ -77,7 +77,15 @@ def redeploy_tupaia_server(event):
         ]
         delete_after = get_tag(existing_instance, 'DeleteAfter')
         if delete_after != '':
-            extra_tags.append({ 'Key': 'DeleteAfter', 'Value': delete_after }),
+            extra_tags.append({ 'Key': 'DeleteAfter', 'Value': delete_after })
+
+        start_at_utc = get_tag(existing_instance, 'StartAtUTC')
+        if start_at_utc != '':
+            extra_tags.append({ 'Key': 'StartAtUTC', 'Value': start_at_utc })
+
+        stop_at_utc = get_tag(existing_instance, 'StopAtUTC')
+        if stop_at_utc != '':
+            extra_tags.append({ 'Key': 'StopAtUTC', 'Value': stop_at_utc })
 
         # launch server instance based on gold master AMI
         # original instance will be deleted by lambda script "swap_out_tupaia_server" once new instance is running

--- a/packages/devops/scripts/lambda/helpers/teardown.py
+++ b/packages/devops/scripts/lambda/helpers/teardown.py
@@ -25,10 +25,14 @@ def teardown_instance(instance):
     deployment_type = get_tag(instance, 'DeploymentType')
     deployment_name = get_tag(instance, 'DeploymentName')
 
+    # Build list of route53 entries to delete
+    record_set_deletions = []
+
     # Delete DNS subdomains
-    subdomains_via_dns = get_tag(instance, 'SubdomainsViaGateway')
-    public_dns_url = instance['PublicDnsName']
-    record_set_deletions = [build_record_set_deletion('tupaia.org', subdomain, deployment_name, dns_url=public_dns_url) for subdomain in subdomains_via_dns.split(',')]
+    subdomains_via_dns = get_tag(instance, 'SubdomainsViaDns')
+    if subdomains_via_dns != '':
+      public_dns_url = instance['PublicDnsName']
+      record_set_deletions = [build_record_set_deletion('tupaia.org', subdomain, deployment_name, dns_url=public_dns_url) for subdomain in subdomains_via_dns.split(',')]
 
     # Delete gateway subdomains
     subdomains_via_gateway = get_tag(instance, 'SubdomainsViaGateway')
@@ -38,7 +42,9 @@ def teardown_instance(instance):
 
     # Filter out deletions for record sets that don't actually exist
     hosted_zone_id = route53.list_hosted_zones_by_name(DNSName='tupaia.org')['HostedZones'][0]['Id']
-    all_record_sets = route53.list_resource_record_sets(HostedZoneId=hosted_zone_id)['ResourceRecordSets']
+    record_set_paginator = route53.get_paginator('list_resource_record_sets')
+    record_set_response = record_set_paginator.paginate(HostedZoneId=hosted_zone_id).build_full_result()
+    all_record_sets = record_set_response['ResourceRecordSets']
     all_record_set_names = [record_set['Name'] for record_set in all_record_sets]
     valid_record_set_deletions = [deletion for deletion in record_set_deletions if deletion['ResourceRecordSet']['Name'] in all_record_set_names]
     print('Generated {} record set changes'.format(len(record_set_deletions)))

--- a/packages/indicators/src/Builder/helpers.ts
+++ b/packages/indicators/src/Builder/helpers.ts
@@ -32,12 +32,12 @@ export const fetchAnalytics = async (
   // Group data elements per aggregationList to minimise aggregator calls
   const aggregationJsonToElements = groupKeysByValueJson(aggregationLisByElement);
 
-  const analytics: Analytic[] = [];
+  let analytics: Analytic[] = [];
   await Promise.all(
     Object.entries(aggregationJsonToElements).map(async ([aggregationJson, elements]) => {
       const aggregations = JSON.parse(aggregationJson);
       const { results } = await aggregator.fetchAnalytics(elements, fetchOptions, { aggregations });
-      analytics.push(...results);
+      analytics = analytics.concat(results);
     }),
   );
 

--- a/packages/meditrak-app/appcenter-post-clone.sh
+++ b/packages/meditrak-app/appcenter-post-clone.sh
@@ -11,11 +11,17 @@ env | grep "USER-DEFINED_.*" | awk -F "USER-DEFINED_" '{print $2}' > .env
 ## To manage that, we here manually install external deps, build internal deps, then redirect the
 ## package.json entries to the internal filesystem
 
+# workaround to override the v8 alias (see https://intercom.help/appcenter/en/articles/1592748-react-native-builds-fail-with-the-engine-node-is-incompatible-with-this-module-expected-version-x-x-x-error-found-incompatible-module)
+npm config delete prefix
+. ~/.bashrc
+nvm install
+nvm use
+
 # move to the root folder
 cd ../..
 
 # install root dependencies
-SKIP_BUILD_INTERNAL_DEPENDENCIES=true yarn install --ignore-engines
+SKIP_BUILD_INTERNAL_DEPENDENCIES=true yarn install
 
 # move to meditrak folder
 cd packages/meditrak-app

--- a/scripts/bash/buildInternalDependencies.sh
+++ b/scripts/bash/buildInternalDependencies.sh
@@ -43,7 +43,7 @@ delete_command="rm -rf"
 # a BUILD_LIBRARY flag is added for packages that have both an app build and a library build
 for PACKAGE in $(${DIR}/getInternalDependencies.sh ${package_path}); do
     delete_command="${delete_command} packages/${PACKAGE}/${OUT_DIR}"
-    build_commands+=("\"BUILD_LIBRARY=true yarn workspace @tupaia/${PACKAGE} build $build_args\"")
+    build_commands+=("\"NODE_ENV=production BUILD_LIBRARY=true yarn workspace @tupaia/${PACKAGE} build $build_args\"")
 done
 
 if [[ $watch == "true" ]]; then


### PR DESCRIPTION
## Manual Release Steps
- [x] Deploy WAITP-1106 changes to lambda (@edmofro done pre-release on 17/02/22)
- [x] Deploy WAITP-1107 changes to lambda (@edmofro done pre-release on 18/02/22)

## Features ⭐

## Tweaks ⚖️ 

## Visualisations 📊 
MAUI-429: Create project Covid-19 Kiribati

## Bug fixes 🐛 
- No issue: Fix maximum call stack size exceeded with array.push
- RN-335 Fix COVID-19 Samoa visualisation permission issues
- WAITP-1105 and WAITP-1103: Include category headers when exporting matrix to excel
- WAITP-1104: Fix single record editing on permissions page
- RN-301: Add new Marshall Island facilities to UNFPA
- RN-229 Work around to override the v8 alias (#3678)

## Automation 🤖

## Infrastructure and maintenance 🛠️
- WAITP-1106: Properly delete route53 entries on teardown
- WAITP-1107: Copy over StartAt/StopAt tags when redeploying
- WAI-1070: Migrate database when meditrak-server starts via pm2