### PR TITLE
[Hot fix]: Include json migrationData files in babel output directory

### DIFF
--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -11,7 +11,7 @@
   "author": "Beyond Essential Systems <admin@tupaia.org> (https://beyondessential.com.au)",
   "main": "dist/index.js",
   "scripts": {
-    "build": "babel src --out-dir dist --source-maps --config-file \"../../babel.config.json\" && tsc",
+    "build": "babel src --out-dir dist --source-maps --config-file \"../../babel.config.json\" --copy-files --no-copy-ignored && tsc",
     "dump-database": "./scripts/dumpDatabase.sh",
     "lint": "eslint --ignore-path ../../.gitignore .",
     "lint:fix": "yarn lint --fix",


### PR DESCRIPTION
In today's release, we changed to running migrations within the meditrak-server process when it starts up. Subsequently, we deployed the first migration since that change as a hot-fix, and it met an edge case: json files were not included in the `dist` folder that meditrak-server reads migrations from. 

See https://beyondessential.slack.com/archives/CT0KTFSHZ/p1645492338632989?thread_ts=1645491301.510779&cid=CT0KTFSHZ