### PR TITLE
MAUI-530: Remove invalid Kiribati entities

### DIFF
--- a/packages/database/src/migrations/20220223052221-DeleteInvalidKiribatiEntities-modifies-data.js
+++ b/packages/database/src/migrations/20220223052221-DeleteInvalidKiribatiEntities-modifies-data.js
@@ -29,7 +29,6 @@ exports.up = async function (db) {
   for (const code of ENTITY_CODES) {
     const entityId = await codeToId(db, 'entity', code);
     await deleteObject(db, 'entity_relation', { child_id: entityId });
-    await deleteObject(db, 'survey_response', { entity_id: entityId });
     await deleteObject(db, 'entity', { id: entityId });
   }
 };

--- a/packages/database/src/migrations/20220223052221-DeleteInvalidKiribatiEntities-modifies-data.js
+++ b/packages/database/src/migrations/20220223052221-DeleteInvalidKiribatiEntities-modifies-data.js
@@ -1,0 +1,43 @@
+'use strict';
+
+import { codeToId, deleteObject, updateValues } from '../utilities';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+// note the invalid codes have the letter L after the G in Gilbert
+const ENTITY_CODES = ['KI_Glibert Islands_Abaiang', 'KI_Glibert Islands'];
+const VALID_DISTRICT_CODE = 'KI_Gilbert Islands_Abaiang';
+const FACILITY_CODE = 'KI_ABRD21';
+
+exports.up = async function (db) {
+  const parentId = await codeToId(db, 'entity', VALID_DISTRICT_CODE);
+  const facilityId = await codeToId(db, 'entity', FACILITY_CODE);
+  await updateValues(db, 'entity', { parent_id: parentId }, { id: facilityId });
+
+  for (const code of ENTITY_CODES) {
+    const entityId = await codeToId(db, 'entity', code);
+    await deleteObject(db, 'entity_relation', { child_id: entityId });
+    await deleteObject(db, 'survey_response', { entity_id: entityId });
+    await deleteObject(db, 'entity', { id: entityId });
+  }
+};
+
+exports.down = function (db) {
+  return null;
+};
+
+exports._meta = {
+  version: 1,
+};


### PR DESCRIPTION
### Issue #:
MAUI-530

### Changes:
Create database migration that will:
- Remove invalid district and sub_district entity records
- Reassign a valid parent id to an orphan facility entity
