### PR TITLE
MAUI-530: Remove invalid Kiribati entities

### DIFF
--- a/packages/admin-panel/src/pages/resources/DashboardRelationsPage.js
+++ b/packages/admin-panel/src/pages/resources/DashboardRelationsPage.js
@@ -6,6 +6,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { ResourcePage } from './ResourcePage';
+import { prettyArray } from '../../utilities';
+import { ArrayFilter } from '../../table/columnTypes/columnFilters';
 
 // export for use on users page
 export const DASHBOARD_RELATION_ENDPOINT = 'dashboardRelations';
@@ -33,6 +35,8 @@ export const DASHBOARD_RELATION_COLUMNS = [
   {
     Header: 'Permission Groups',
     source: 'permission_groups',
+    Filter: ArrayFilter,
+    Cell: ({ value }) => prettyArray(value),
     editConfig: {
       optionsEndpoint: 'permissionGroups',
       optionLabelKey: 'name',
@@ -44,6 +48,8 @@ export const DASHBOARD_RELATION_COLUMNS = [
   {
     Header: 'Entity Types',
     source: 'entity_types',
+    Filter: ArrayFilter,
+    Cell: ({ value }) => prettyArray(value),
     editConfig: {
       type: 'autocomplete',
       allowMultipleValues: true,
@@ -56,6 +62,8 @@ export const DASHBOARD_RELATION_COLUMNS = [
   {
     Header: 'Project Codes',
     source: 'project_codes',
+    Filter: ArrayFilter,
+    Cell: ({ value }) => prettyArray(value),
     editConfig: {
       optionsEndpoint: 'projects',
       optionLabelKey: 'code',

--- a/packages/admin-panel/src/pages/resources/MapOverlaysPage.js
+++ b/packages/admin-panel/src/pages/resources/MapOverlaysPage.js
@@ -11,6 +11,7 @@ import { prettyArray } from '../../utilities';
 import { LightOutlinedButton } from '@tupaia/ui-components';
 import AddCircleIcon from '@material-ui/icons/AddCircle';
 import { Link } from 'react-router-dom';
+import { ArrayFilter } from '../../table/columnTypes/columnFilters';
 
 const StyledLink = styled(Link)`
   text-decoration: none;
@@ -53,6 +54,7 @@ const FIELDS = [
     source: 'linked_measures',
     width: 160,
     Cell: ({ value }) => prettyArray(value),
+    Filter: ArrayFilter,
     editConfig: {
       optionsEndpoint: MAP_OVERLAYS_ENDPOINT,
       optionLabelKey: 'id',
@@ -72,6 +74,7 @@ const FIELDS = [
     source: 'country_codes',
     width: 140,
     Cell: ({ value }) => prettyArray(value),
+    Filter: ArrayFilter,
     editConfig: {
       optionsEndpoint: 'entities',
       optionLabelKey: 'code',
@@ -85,6 +88,7 @@ const FIELDS = [
     source: 'project_codes',
     width: 140,
     Cell: ({ value }) => prettyArray(value),
+    Filter: ArrayFilter,
     editConfig: {
       optionsEndpoint: 'projects',
       optionLabelKey: 'code',

--- a/packages/admin-panel/src/table/columnTypes/columnFilters.js
+++ b/packages/admin-panel/src/table/columnTypes/columnFilters.js
@@ -2,9 +2,13 @@
  * Tupaia MediTrak
  * Copyright (c) 2017 Beyond Essential Systems Pty Ltd
  */
+
 import React from 'react';
-import { Select } from '@tupaia/ui-components';
+import styled from 'styled-components';
 import PropTypes from 'prop-types';
+import MuiChip from '@material-ui/core/Chip';
+import { Autocomplete, Select } from '@tupaia/ui-components';
+
 /*
  * Makes boolean fields work with the database filter
  * https://github.com/tannerlinsley/react-table/tree/v6/examples/custom-filtering
@@ -67,4 +71,59 @@ VerifiedFilter.defaultProps = {
   filter: null,
   onChange: null,
   column: {},
+};
+
+const Chip = styled(MuiChip)`
+  &:first-child {
+    margin-left: 6px;
+  }
+`;
+
+const StyledAutocomplete = styled(Autocomplete)`
+  flex: 1;
+`;
+
+export const ArrayFilter = React.memo(({ onChange }) => {
+  const [searchTerm, setSearchTerm] = React.useState('');
+  const [selection, setSelection] = React.useState([]);
+
+  const onChangeSelection = (event, newSelection) => {
+    setSelection(newSelection);
+    onChange(
+      newSelection === null
+        ? undefined
+        : {
+            comparator: '@>',
+            comparisonValue: `{${newSelection.join(',')}}`,
+            castAs: 'text[]',
+          },
+    );
+  };
+
+  return (
+    <StyledAutocomplete
+      value={selection || []}
+      inputValue={searchTerm}
+      onInputChange={(event, newSearchTerm) => setSearchTerm(newSearchTerm)}
+      options={searchTerm.length > 0 ? [searchTerm] : []}
+      getOptionSelected={(option, selected) => option === selected}
+      onChange={onChangeSelection}
+      placeholder={selection.length === 0 ? 'Enter values' : ''}
+      muiProps={{
+        freeSolo: true,
+        multiple: true,
+        selectOnFocus: true,
+        clearOnBlur: true,
+        handleHomeEndKeys: true,
+        renderTags: (values, getTagProps) =>
+          values.map((option, index) => (
+            <Chip color="primary" label={option} {...getTagProps({ index })} />
+          )),
+      }}
+    />
+  );
+});
+
+ArrayFilter.propTypes = {
+  onChange: PropTypes.func.isRequired,
 };

--- a/packages/database/src/migrations/20220223052221-DeleteInvalidKiribatiEntities-modifies-data.js
+++ b/packages/database/src/migrations/20220223052221-DeleteInvalidKiribatiEntities-modifies-data.js
@@ -29,7 +29,6 @@ exports.up = async function (db) {
   for (const code of ENTITY_CODES) {
     const entityId = await codeToId(db, 'entity', code);
     await deleteObject(db, 'entity_relation', { child_id: entityId });
-    await deleteObject(db, 'survey_response', { entity_id: entityId });
     await deleteObject(db, 'entity', { id: entityId });
   }
 };

--- a/packages/database/src/migrations/20220223052221-DeleteInvalidKiribatiEntities-modifies-data.js
+++ b/packages/database/src/migrations/20220223052221-DeleteInvalidKiribatiEntities-modifies-data.js
@@ -1,0 +1,43 @@
+'use strict';
+
+import { codeToId, deleteObject, updateValues } from '../utilities';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+// note the invalid codes have the letter L after the G in Gilbert
+const ENTITY_CODES = ['KI_Glibert Islands_Abaiang', 'KI_Glibert Islands'];
+const VALID_DISTRICT_CODE = 'KI_Gilbert Islands_Abaiang';
+const FACILITY_CODE = 'KI_ABRD21';
+
+exports.up = async function (db) {
+  const parentId = await codeToId(db, 'entity', VALID_DISTRICT_CODE);
+  const facilityId = await codeToId(db, 'entity', FACILITY_CODE);
+  await updateValues(db, 'entity', { parent_id: parentId }, { id: facilityId });
+
+  for (const code of ENTITY_CODES) {
+    const entityId = await codeToId(db, 'entity', code);
+    await deleteObject(db, 'entity_relation', { child_id: entityId });
+    await deleteObject(db, 'survey_response', { entity_id: entityId });
+    await deleteObject(db, 'entity', { id: entityId });
+  }
+};
+
+exports.down = function (db) {
+  return null;
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/packages/database/src/modelClasses/Entity.js
+++ b/packages/database/src/modelClasses/Entity.js
@@ -31,8 +31,8 @@ const PROJECT = 'project';
 const CITY = 'city';
 const POSTCODE = 'postcode';
 
-// Note: if a new type is not included in `ORG_UNIT_ENTITY_TYPES`,
-// a corresponding tracked entity type must be created in DHIS
+// Note: if a new type is not included in `ORG_UNIT_ENTITY_TYPES`, but data is to be stored against
+// it on DHIS2, a corresponding tracked entity type must be created in DHIS2
 const ENTITY_TYPES = {
   CASE,
   CASE_CONTACT,

--- a/packages/meditrak-server/src/apiV2/GETHandler/GETHandler.js
+++ b/packages/meditrak-server/src/apiV2/GETHandler/GETHandler.js
@@ -7,8 +7,8 @@ import { respond } from '@tupaia/utils';
 import { CRUDHandler } from '../CRUDHandler';
 import {
   getQueryOptionsForColumns,
+  fullyQualifyColumnSelector,
   processColumns,
-  processColumnSelector,
   processColumnSelectorKeys,
   generateLinkHeader,
 } from './helpers';
@@ -79,7 +79,7 @@ export class GETHandler extends CRUDHandler {
     if (sortString) {
       const sortKeys = JSON.parse(sortString);
       const fullyQualifiedSortKeys = sortKeys.map(sortKey =>
-        processColumnSelector(this.models, sortKey, this.recordType),
+        fullyQualifyColumnSelector(this.models, sortKey, this.recordType),
       );
       // if 'distinct', we can't order by any columns that aren't included in the distinct selection
       if (distinct) {


### PR DESCRIPTION
### Issue MAUI-530:
(cherry-picked commits from previous PR: https://github.com/beyondessential/tupaia/pull/3715)
### Changes:
Create database migration that will:

- Remove invalid district and sub_district entity records
- Reassign a valid parent id to an orphan facility entity