### PR TITLE
Remove db change channel timeout

### DIFF
--- a/packages/database/src/DatabaseChangeChannel.js
+++ b/packages/database/src/DatabaseChangeChannel.js
@@ -43,7 +43,7 @@ export class DatabaseChangeChannel extends PGPubSub {
   /**
    * Sends a ping request out to the database and listens for a response
    * @param {number} timeout - default 250ms
-   * @param {number} retries - default 240 (i.e. 1 minute total wait time)
+   * @param {number} retries - default 240 (i.e. 1 minute total wait time). Set to 0 for unlimited retries
    */
   async ping(timeout = 250, retries = 240) {
     return new Promise((resolve, reject) => {
@@ -58,7 +58,7 @@ export class DatabaseChangeChannel extends PGPubSub {
 
       const pingRequest = () => {
         this.publish('ping', true);
-        if (tries < retries) {
+        if (retries === 0 || tries < retries) {
           nextRequest = setTimeout(pingRequest, timeout);
         } else {
           delete this.pingListeners[id];

--- a/packages/database/src/TupaiaDatabase.js
+++ b/packages/database/src/TupaiaDatabase.js
@@ -99,7 +99,7 @@ export class TupaiaDatabase {
     if (!this.changeChannel) {
       this.changeChannel = new DatabaseChangeChannel();
       this.changeChannel.addDataChangeHandler(this.notifyChangeHandlers);
-      this.changeChannelPromise = this.changeChannel.ping();
+      this.changeChannelPromise = this.changeChannel.ping(undefined, 0);
     }
     return this.changeChannel;
   }


### PR DESCRIPTION
Remove db change channel timeout to fix issue of db being down for ~10 minutes for the overnight sync.

Have tested on my local:
1. start servers with db down and wait 4 minutes (previous timeout), then start db 
2. start servers with db up, take db down for 4 minutes, then start db
...it reconnects and everything seems to work fine.

Not sure what the other implications of this change are.