### PR TITLE
offset from start date instead of end date

### DIFF
--- a/packages/report-server/src/__tests__/reportBuilder/query/QueryBuilder.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/query/QueryBuilder.test.ts
@@ -239,13 +239,13 @@ describe('QueryBuilder', () => {
           {
             config: { fetch: { startDate: { unit: 'year', offset: '-2' } } },
             query: inputQuery({
-              startDate: '2020-05-06', // will be ignored - (offset is applied on top of endDate)
+              startDate: '2020-05-01',
               endDate: '2020-10-01',
             }),
           },
           outputQuery({
-            period: `${getPeriodString([2018, 10], [2020, 9])};20201001`,
-            startDate: '2018-10-01',
+            period: `${getPeriodString([2018, 5], [2020, 9])};20201001`,
+            startDate: '2018-05-01',
             endDate: '2020-10-01',
           }),
         ],

--- a/packages/report-server/src/__tests__/reportBuilder/query/QueryBuilder.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/query/QueryBuilder.test.ts
@@ -235,7 +235,7 @@ describe('QueryBuilder', () => {
           }),
         ],
         [
-          'startDate object specs - applies offset to endDate to calculate startDate',
+          'startDate object specs - applies offset to startDate to calculate startDate',
           {
             config: { fetch: { startDate: { unit: 'year', offset: '-2' } } },
             query: inputQuery({
@@ -281,13 +281,13 @@ describe('QueryBuilder', () => {
               },
             },
             query: inputQuery({
-              startDate: '2020-05-06', // will be ignored - (offset is applied on top of endDate)
+              startDate: '2019-05-06',
               endDate: '2020-10-01',
             }),
           },
           outputQuery({
-            period: `${getPeriodString([2018, 1], [2019, 12])}`,
-            startDate: '2018-01-01',
+            period: `${getPeriodString([2017, 1], [2019, 12])}`,
+            startDate: '2017-01-01',
             endDate: '2019-12-31',
           }),
         ],

--- a/packages/report-server/src/reportBuilder/query/buildPeriodParams.ts
+++ b/packages/report-server/src/reportBuilder/query/buildPeriodParams.ts
@@ -58,7 +58,7 @@ export const buildPeriodParams = (
 
   // Apply date offset if date specs is object
   if (typeof startDateSpecs === 'object') {
-    startDate = buildDateUsingSpecs(endDate, startDateSpecs);
+    startDate = buildDateUsingSpecs(startDate, startDateSpecs);
   }
   if (typeof endDateSpecs === 'object') {
     endDate = buildDateUsingSpecs(endDate, endDateSpecs);


### PR DESCRIPTION
### Issue #:
Currently in `report-server`, `offset` config in `fetch's startDate` will be applied on `endDate` instead of `startDate`.

1. I've checked we are lucky to have only one visual at the moment(`PG_Strive_PNG_Prev_7_Days_Reported_Cases`) to use this config, and it didn't break anything after the changes.

2. From `periodGranularities.test.js` we can tell that it always put start date and end date in query, so there is no way we have a `null` start date.

3. It will be also consistent to the frontend offset config `defaultTimePeriod`:

>    {
         start: { unit: 'day', offset: -1 },
         end: { unit: 'day', offset: 3 },
       } 
  