### PR TITLE
RN-396: Remove failed access policies  from the cache if they fail to build

### DIFF
--- a/packages/auth/src/__tests__/AccessPolicyBuilder.test.js
+++ b/packages/auth/src/__tests__/AccessPolicyBuilder.test.js
@@ -9,8 +9,6 @@ import { buildLegacyAccessPolicy } from '../buildLegacyAccessPolicy';
 
 jest.mock('../buildAccessPolicy');
 jest.mock('../buildLegacyAccessPolicy');
-const buildAccessPolicyMock = buildAccessPolicy.mockResolvedValue({});
-const buildLegacyAccessPolicyMock = buildLegacyAccessPolicy.mockResolvedValue({});
 
 describe('AccessPolicyBuilder', () => {
   let notifyPermissionsChange;
@@ -32,6 +30,13 @@ describe('AccessPolicyBuilder', () => {
     },
   };
   const userId = 'xxx';
+  let buildAccessPolicyMock;
+  let buildLegacyAccessPolicyMock;
+
+  beforeAll(() => {
+    buildAccessPolicyMock = buildAccessPolicy.mockResolvedValue({});
+    buildLegacyAccessPolicyMock = buildLegacyAccessPolicy.mockResolvedValue({});
+  });
 
   it('throws error when userId is undefined', () => {
     const builder = new AccessPolicyBuilder(models);
@@ -68,6 +73,32 @@ describe('AccessPolicyBuilder', () => {
   });
 
   describe('handles caching and cache invalidation', () => {
+    beforeEach(() => {
+      buildAccessPolicyMock = buildAccessPolicy.mockResolvedValue({});
+      buildLegacyAccessPolicyMock = buildLegacyAccessPolicy.mockResolvedValue({});
+    });
+
+    it('does not cache the policy if the response throws an error', async () => {
+      buildAccessPolicyMock = buildAccessPolicy.mockRejectedValue(
+        new Error('Could not build access policy'),
+      );
+
+      const builder = new AccessPolicyBuilder(models);
+      try {
+        await builder.getPolicyForUser(userId); // built once
+      } catch (error) {
+        // Error expected
+      }
+
+      try {
+        await builder.getPolicyForUser(userId); // built second time since it fails to build
+      } catch (error) {
+        // Error expected
+      }
+
+      expect(buildAccessPolicyMock).toHaveBeenCalledTimes(2);
+    });
+
     it('avoids rebuilding the policy for the same user', async () => {
       const builder = new AccessPolicyBuilder(models);
       await builder.getPolicyForUser(userId);

--- a/packages/auth/src/__tests__/AccessPolicyBuilder.test.js
+++ b/packages/auth/src/__tests__/AccessPolicyBuilder.test.js
@@ -30,13 +30,8 @@ describe('AccessPolicyBuilder', () => {
     },
   };
   const userId = 'xxx';
-  let buildAccessPolicyMock;
-  let buildLegacyAccessPolicyMock;
-
-  beforeAll(() => {
-    buildAccessPolicyMock = buildAccessPolicy.mockResolvedValue({});
-    buildLegacyAccessPolicyMock = buildLegacyAccessPolicy.mockResolvedValue({});
-  });
+  let buildAccessPolicyMock = buildAccessPolicy.mockResolvedValue({});
+  let buildLegacyAccessPolicyMock = buildLegacyAccessPolicy.mockResolvedValue({});
 
   it('throws error when userId is undefined', () => {
     const builder = new AccessPolicyBuilder(models);


### PR DESCRIPTION
### Issue RN-396:

This is a pretty obvious problem when you look at it. We always cache the first time we try to build the access policy for a user, however if that fails for any reason (eg. database connection timeout) we keep that cached result. That can be seen happening here: https://beyondessential.slack.com/archives/C01JD93J4E6/p1646349708959339

This seems to be a fairly general case problem. In the past, we've made a conscious effort to try and cache promises rather than results (in order to avoid many requests for the same expensive resource). However the natural downside of doing that is that we don't know if the promise resolves successfully or not...

Happy to chat with the reviewer and decide if this should be fixed in other areas (namely `DatabaseModel.js`)