### PR TITLE
RN-388: Add map tab to mobile

### DIFF
--- a/packages/web-frontend/src/actions.js
+++ b/packages/web-frontend/src/actions.js
@@ -35,6 +35,7 @@ export const CHANGE_SIDE_BAR_CONTRACTED_WIDTH = 'CHANGE_SIDE_BAR_CONTRACTED_WIDT
 export const CHANGE_SIDE_BAR_EXPANDED_WIDTH = 'CHANGE_SIDE_BAR_EXPANDED_WIDTH';
 export const CLEAR_MAP_OVERLAY_HIERARCHY = 'CLEAR_MAP_OVERLAY_HIERARCHY';
 export const SET_MAP_OVERLAYS = 'SET_MAP_OVERLAYS';
+export const SET_MOBILE_TAB = 'SET_MOBILE_TAB';
 export const SET_DISPLAYED_MAP_OVERLAY = 'SET_DISPLAYED_MAP_OVERLAY';
 export const SET_OVERLAY_CONFIGS = 'SET_OVERLAY_CONFIGS';
 export const UPDATE_OVERLAY_CONFIGS = 'UPDATE_OVERLAY_CONFIGS';
@@ -1112,4 +1113,8 @@ export function updateEnlargedDialogError(errorMessage) {
 
 export function updateHistoryLocation(location) {
   return { type: UPDATE_HISTORY_LOCATION, location };
+}
+
+export function setMobileTab(tab) {
+  return { type: SET_MOBILE_TAB, tab };
 }

--- a/packages/web-frontend/src/historyNavigation/constants.js
+++ b/packages/web-frontend/src/historyNavigation/constants.js
@@ -17,6 +17,7 @@ const PASSWORD_RESET_TOKEN = 'PASSWORD_RESET_TOKEN';
 const VERIFY_EMAIL_TOKEN = 'VERIFY_EMAIL_TOKEN';
 const OVERLAY_PERIOD = 'OVERLAY_PERIOD';
 const REPORT_PERIOD = 'REPORT_PERIOD';
+const MOBILE_TAB = 'MOBILE_TAB';
 
 export const URL_COMPONENTS = {
   // Path components
@@ -31,6 +32,7 @@ export const URL_COMPONENTS = {
   VERIFY_EMAIL_TOKEN,
   OVERLAY_PERIOD,
   REPORT_PERIOD,
+  MOBILE_TAB,
 };
 
 export const PATH_COMPONENTS = [PROJECT, ORG_UNIT, DASHBOARD];
@@ -41,12 +43,14 @@ export const SEARCH_COMPONENTS = [
   VERIFY_EMAIL_TOKEN,
   OVERLAY_PERIOD,
   REPORT_PERIOD,
+  MOBILE_TAB,
 ];
 
 export const LEGACY_PATH_PREFIXES = ['country', 'facility'];
 
 export const SEARCH_PARAM_KEY_MAP = {
   [MAP_OVERLAY]: 'overlay',
+  [MOBILE_TAB]: 'tab',
   [OVERLAY_PERIOD]: 'overlayPeriod',
   [REPORT]: 'report',
   [REPORT_PERIOD]: 'reportPeriod',

--- a/packages/web-frontend/src/historyNavigation/historyMiddleware.js
+++ b/packages/web-frontend/src/historyNavigation/historyMiddleware.js
@@ -18,6 +18,7 @@ import {
   SET_DASHBOARD_GROUP,
   SET_ENLARGED_DIALOG_DATE_RANGE,
   SET_MAP_OVERLAYS,
+  SET_MOBILE_TAB,
   SET_ORG_UNIT,
   SET_PROJECT,
   updateHistoryLocation,
@@ -125,6 +126,12 @@ export const historyMiddleware = store => next => action => {
 
       dispatchLocationUpdate(store, {
         [URL_COMPONENTS.OVERLAY_PERIOD]: currentOverlayPeriods.join(','),
+      });
+      break;
+    }
+    case SET_MOBILE_TAB: {
+      dispatchLocationUpdate(store, {
+        [URL_COMPONENTS.MOBILE_TAB]: action.tab,
       });
       break;
     }

--- a/packages/web-frontend/src/selectors/index.js
+++ b/packages/web-frontend/src/selectors/index.js
@@ -74,3 +74,5 @@ export {
   selectDefaultMapOverlay,
   selectPeriodGranularityByCode,
 } from './mapOverlaySelectors';
+
+export { selectMobileTab } from './navigationSelectors';

--- a/packages/web-frontend/src/selectors/navigationSelectors.js
+++ b/packages/web-frontend/src/selectors/navigationSelectors.js
@@ -1,0 +1,13 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import { createSelector } from 'reselect';
+
+import { getLocationComponentValue, URL_COMPONENTS } from '../historyNavigation';
+import { selectLocation } from './utils';
+
+export const selectMobileTab = createSelector([selectLocation], location =>
+  getLocationComponentValue(location, URL_COMPONENTS.MOBILE_TAB),
+);


### PR DESCRIPTION
### Issue #:
RN-388 (subtask of RN-373)

### Changes:
- Add tabs to navigate between dashboard and map overlay on the root screen
- Deep linked using a query parameter (makes sense to live in the path, but it's already tightly structured and would break things on desktop)

Screenshots on [the ticket](https://linear.app/bes/issue/RN-388#comment-0431fd4f)