### PR TITLE
Switched to building frontend modules in serial rather than parallel …

### DIFF
--- a/packages/web-frontend/package.json
+++ b/packages/web-frontend/package.json
@@ -12,7 +12,7 @@
   "main": "dist/index.js",
   "scripts": {
     "analyze": "source-map-explorer build/static/js/main.*",
-    "build": "rm -rf dist && run-p \"build:* {@}\" --",
+    "build": "rm -rf dist && run-s \"build:* {@}\" --",
     "build:desktop": "SKIP_PREFLIGHT_CHECK=true BUILD_PATH='./build/desktop/' GENERATE_SOURCEMAP=false react-scripts build",
     "build:mobile": "SKIP_PREFLIGHT_CHECK=true BUILD_PATH='./build/mobile/' GENERATE_SOURCEMAP=false REACT_APP_APP_TYPE=mobile react-scripts build",
     "cypress:config": "yarn run:babel cypress/scripts/generateConfig",

--- a/scripts/bash/getDeployablePackages.sh
+++ b/scripts/bash/getDeployablePackages.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -e
 
-echo "admin-panel" "lesmis" "psss" "web-frontend" "admin-panel-server" "entity-server" "lesmis-server" "meditrak-server" "psss-server" "report-server" "web-config-server"
+echo "admin-panel" "lesmis" "psss" "web-frontend" "report-server" "admin-panel-server" "entity-server" "lesmis-server" "meditrak-server" "psss-server" "web-config-server"
 exit 0


### PR DESCRIPTION
…(#3751)

* Switched from building frontend modules in serial rather than parallel

* Re-ordered how server packages are built so that dependencies resolve correctly
- admin-panel-server depends on report-server, so it must be build first

### Issue #:

### Changes:

- Example

---

### Screenshots:
