### PR TITLE
Hotfix: Release 2022-9 - Fix report-server not responding to requests

### DIFF
--- a/packages/report-server/examples.http
+++ b/packages/report-server/examples.http
@@ -6,6 +6,12 @@
 # see: https://marketplace.visualstudio.com/items?itemName=humao.rest-client#environment-variables
 @authorization  = Basic {{email}}:{{password}}
 
+
+### Test
+GET {{baseUrl}}/test HTTP/1.1
+content-type: {{contentType}}
+Authorization: {{authorization}}
+
 ### Fetch PSSS Weekly Report
 GET {{baseUrl}}/fetchReport/PSSS_Weekly_Report?organisationUnitCodes=TO&hierarchy=psss&period=2020 HTTP/1.1
 content-type: {{contentType}}

--- a/packages/report-server/src/app/createApp.ts
+++ b/packages/report-server/src/app/createApp.ts
@@ -6,13 +6,18 @@
 import { MicroServiceApiBuilder, handleWith } from '@tupaia/server-boilerplate';
 import { TupaiaDatabase } from '@tupaia/database';
 import {
+  ForwardingAuthHandler,
+  getBaseUrlsForHost,
+  LOCALHOST_BASE_URLS,
+  TupaiaApiClient,
+} from '@tupaia/api-client';
+import {
   FetchReportRequest,
   FetchReportRoute,
   TestReportRequest,
   TestReportRoute,
 } from '../routes';
 import { RequestContext } from '../types';
-import { ForwardingAuthHandler, getBaseUrlsForHost, LOCALHOST_BASE_URLS, TupaiaApiClient } from '@tupaia/api-client';
 
 /**
  * Set up express server
@@ -31,6 +36,7 @@ export function createApp() {
       };
       req.ctx = context;
       res.ctx = context;
+      next();
     })
     .get<FetchReportRequest>('fetchReport/:reportCode', handleWith(FetchReportRoute))
     .post<FetchReportRequest>('fetchReport/:reportCode', handleWith(FetchReportRoute))


### PR DESCRIPTION
The issue here is that the `next()` function was never being called when the middleware was appended to the request. As a result requests were never actually being handled.