### PR TITLE
Hotfix: Release 2022-9 - Fixed login failing on PSSS due to poorly loaded .env vars

### DIFF
--- a/packages/psss-server/package.json
+++ b/packages/psss-server/package.json
@@ -37,6 +37,7 @@
     "body-parser": "^1.18.3",
     "client-sessions": "^0.8.0",
     "cors": "^2.8.5",
+    "dotenv": "^8.2.0",
     "express": "^4.16.2",
     "winston": "^3.2.1"
   }

--- a/packages/server-boilerplate/src/orchestrator/auth/AuthConnection.ts
+++ b/packages/server-boilerplate/src/orchestrator/auth/AuthConnection.ts
@@ -8,15 +8,12 @@ import { AccessPolicyObject } from '../../types';
 import { Credentials } from '../types';
 import { ApiConnection } from '../../connections';
 
-const {
-  MEDITRAK_API_CLIENT_NAME,
-  MEDITRAK_API_CLIENT_PASSWORD,
-  MEDITRAK_API_URL = 'http://localhost:8090/v2',
-} = process.env;
-const MEDITRAK_API_CREDENTIALS = `${MEDITRAK_API_CLIENT_NAME}:${MEDITRAK_API_CLIENT_PASSWORD}`;
-const BASIC_AUTH_HEADER = `Basic ${Buffer.from(MEDITRAK_API_CREDENTIALS).toString('base64')}`;
 const basicAuthHandler = {
-  getAuthHeader: async () => BASIC_AUTH_HEADER,
+  getAuthHeader: async () => {
+    const { MEDITRAK_API_CLIENT_NAME, MEDITRAK_API_CLIENT_PASSWORD } = process.env;
+    const MEDITRAK_API_CREDENTIALS = `${MEDITRAK_API_CLIENT_NAME}:${MEDITRAK_API_CLIENT_PASSWORD}`;
+    return `Basic ${Buffer.from(MEDITRAK_API_CREDENTIALS).toString('base64')}`;
+  },
 };
 
 export interface AuthResponse {
@@ -29,7 +26,7 @@ export interface AuthResponse {
 }
 
 export class AuthConnection extends ApiConnection {
-  baseUrl = MEDITRAK_API_URL; // auth server is actually just meditrak server
+  baseUrl = process.env.MEDITRAK_API_URL || 'http://localhost:8090/v2'; // auth server is actually just meditrak server
 
   constructor() {
     super(basicAuthHandler);


### PR DESCRIPTION
This was a very strange issue and tbh I still don't quite understand why this was happening.

Whenever we attempted to login to PSSS, we'd send across an auth header of `Basic dW5kZWZpbmVkOnVuZGVmaW5lZA==` which decodes to username and password as `undefined`. This would fail to authenticate and the user couldn't log in.

The auth header is meant to be defined by 2 .env vars:
`MEDITRAK_API_CLIENT_NAME` and `MEDITRAK_API_CLIENT_PASSWORD`

Both of these .env vars are present in the PSSS .env file, with correct values. PSSS is loading its .env vars _**exactly**_ the same as how lesmis does. When logging out the .env vars with a console log they had the correct values.

So I'm pretty stumped, but applying these changes fixed the issue:
1. Correctly listing `dotenv` in psss-server's `package.json`
2. Restructuring the code a little so that we rebuild the auth header at request time rather than when the server first starts. This is slightly inefficient, but it's fine and feels a little safer anyway