### PR TITLE
Fix cypress not found when running e2e

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "migrate-create": "yarn workspace @tupaia/database migrate-create",
     "migrate-down": "yarn workspace @tupaia/database migrate-down",
     "package-json-lint": "npmPkgJsonLint --configFile .npmpackagejsonlintrc.json .",
+    "postinstall": "test -n \"$SKIP_BUILD_INTERNAL_DEPENDENCIES\" || yarn build:internal-dependencies",
     "refresh-database": "yarn workspace @tupaia/database refresh-database --root ../../",
     "test-all": "node ./scripts/node/testAll --silent",
     "update-codeship-env-vars": "./packages/devops/scripts/ci/updateCiEnvVars.sh",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "migrate-create": "yarn workspace @tupaia/database migrate-create",
     "migrate-down": "yarn workspace @tupaia/database migrate-down",
     "package-json-lint": "npmPkgJsonLint --configFile .npmpackagejsonlintrc.json .",
-    "postinstall": "yarn build:internal-dependencies",
     "refresh-database": "yarn workspace @tupaia/database refresh-database --root ../../",
     "test-all": "node ./scripts/node/testAll --silent",
     "update-codeship-env-vars": "./packages/devops/scripts/ci/updateCiEnvVars.sh",

--- a/packages/devops/ci/e2e.Dockerfile
+++ b/packages/devops/ci/e2e.Dockerfile
@@ -23,7 +23,7 @@ COPY packages/ui-components/package.json ./packages/ui-components
 RUN mkdir -p ./packages/utils
 COPY packages/utils/package.json ./packages/utils
 
-RUN yarn install
+RUN SKIP_BUILD_INTERNAL_DEPENDENCIES=true yarn install
 
 # Copy TS config used in internal dependencies
 COPY tsconfig-js.json ./

--- a/packages/devops/ci/e2e.Dockerfile
+++ b/packages/devops/ci/e2e.Dockerfile
@@ -23,7 +23,7 @@ COPY packages/ui-components/package.json ./packages/ui-components
 RUN mkdir -p ./packages/utils
 COPY packages/utils/package.json ./packages/utils
 
-RUN yarn install --ignore-scripts
+RUN yarn install
 
 # Copy TS config used in internal dependencies
 COPY tsconfig-js.json ./

--- a/packages/devops/ci/tupaia-ci-cd.Dockerfile
+++ b/packages/devops/ci/tupaia-ci-cd.Dockerfile
@@ -77,7 +77,7 @@ RUN mkdir -p ./packages/web-frontend
 COPY packages/web-frontend/package.json ./packages/web-frontend
 
 ## run yarn without building, so we can cache node_modules without code changes invalidating this layer
-RUN yarn install --non-interactive --frozen-lockfile
+RUN SKIP_BUILD_INTERNAL_DEPENDENCIES=true yarn install --non-interactive --frozen-lockfile
 
 ## add content of all internal dependency packages ready for internal dependencies to be built
 COPY packages/access-policy/. ./packages/access-policy

--- a/packages/devops/ci/tupaia-ci-cd.Dockerfile
+++ b/packages/devops/ci/tupaia-ci-cd.Dockerfile
@@ -77,7 +77,7 @@ RUN mkdir -p ./packages/web-frontend
 COPY packages/web-frontend/package.json ./packages/web-frontend
 
 ## run yarn without building, so we can cache node_modules without code changes invalidating this layer
-RUN yarn install --ignore-scripts --non-interactive --frozen-lockfile
+RUN yarn install --non-interactive --frozen-lockfile
 
 ## add content of all internal dependency packages ready for internal dependencies to be built
 COPY packages/access-policy/. ./packages/access-policy

--- a/packages/meditrak-app/appcenter-post-clone.sh
+++ b/packages/meditrak-app/appcenter-post-clone.sh
@@ -21,7 +21,7 @@ nvm use
 cd ../..
 
 # install root dependencies
-yarn install
+SKIP_BUILD_INTERNAL_DEPENDENCIES=true yarn install
 
 # move to meditrak folder
 cd packages/meditrak-app

--- a/packages/meditrak-app/appcenter-post-clone.sh
+++ b/packages/meditrak-app/appcenter-post-clone.sh
@@ -21,7 +21,7 @@ nvm use
 cd ../..
 
 # install root dependencies
-yarn install --ignore-scripts
+yarn install
 
 # move to meditrak folder
 cd packages/meditrak-app


### PR DESCRIPTION
Cypress installation requires postinstall hook to run

This fixes cypress being installed correctly. ~But it also removes the convenience behaviour for local development of rebuilding internal dependancies after running yarn install.~