### PR TITLE
Fix viz export

### DIFF
--- a/packages/admin-panel-server/src/viz-builder/mapOverlayVisualisation/combineMapOverlayVisualisation.ts
+++ b/packages/admin-panel-server/src/viz-builder/mapOverlayVisualisation/combineMapOverlayVisualisation.ts
@@ -42,6 +42,7 @@ export function combineMapOverlayVisualisation(visualisationResource: MapOverlay
     mapOverlayPermissionGroup,
     data,
     presentation,
+    reportPermissionGroup: (report as Report).permissionGroup,
     ...rest,
   };
 

--- a/packages/admin-panel/package.json
+++ b/packages/admin-panel/package.json
@@ -19,7 +19,7 @@
     "eject": "react-scripts eject",
     "lint": "eslint --ignore-path ../../.gitignore .",
     "lint:fix": "yarn lint --fix",
-    "start": "react-scripts start",
+    "start": "SKIP_PREFLIGHT_CHECK=true react-scripts start",
     "start-dev": "npm run start",
     "test": "react-scripts test --env=jsdom --passWithNoTests"
   },

--- a/packages/lesmis/package.json
+++ b/packages/lesmis/package.json
@@ -15,7 +15,7 @@
     "eject": "react-scripts eject",
     "lint": "eslint --ignore-path ../../.gitignore .",
     "lint:fix": "yarn lint --fix",
-    "start-dev": "PORT=3003 react-scripts start",
+    "start-dev": "SKIP_PREFLIGHT_CHECK=true PORT=3003 react-scripts start",
     "start-fullstack": "npm-run-all -c -l -p start-meditrak-server start-web-config-server start-dev",
     "start-meditrak-server": "yarn workspace @tupaia/meditrak-server start-dev -s",
     "start-web-config-server": "yarn workspace @tupaia/web-config-server start-dev -s",

--- a/packages/psss/package.json
+++ b/packages/psss/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint --ignore-path ../../.gitignore .",
     "lint:fix": "yarn lint --fix",
     "pretest:test:cypress:run": "npm run build",
-    "start-dev": "react-scripts start",
+    "start-dev": "SKIP_PREFLIGHT_CHECK=true react-scripts start",
     "start-fullstack": "npm-run-all -c -l -p start-psss-server start-entity-server start-meditrak-server start-report-server  start-dev",
     "start-psss-server": "yarn workspace @tupaia/psss-server start-dev -s",
     "start-entity-server": "yarn workspace @tupaia/entity-server start-dev -s",

--- a/packages/web-frontend/package.json
+++ b/packages/web-frontend/package.json
@@ -22,7 +22,7 @@
     "lint": "eslint --ignore-path ../../.gitignore .",
     "lint:fix": "yarn lint --fix",
     "run:babel": "babel-node --config-file \"../../babel.config.json\"",
-    "start": "PORT=8088 react-scripts start",
+    "start": "SKIP_PREFLIGHT_CHECK=true PORT=8088 react-scripts start",
     "start-dev": "npm run start",
     "start-fullstack": "npm-run-all -c -l -p start-server start",
     "start-mobile": "REACT_APP_APP_TYPE=mobile PORT=8089 PORT=8088 react-scripts start",


### PR DESCRIPTION
Fixes issue where admin-panel was exporting map overlay vizes without `reportPermissionGroup`, which would then fail validation on import.

I broke this accidentally in https://github.com/beyondessential/tupaia/pull/3589. Also adds in some flags for local dev.