### PR TITLE
RN-411: Use new entity as primary entity in same sync batch

### DIFF
--- a/packages/meditrak-server/src/apiV2/import/importSurveyResponses/assertCanImportSurveyResponses.js
+++ b/packages/meditrak-server/src/apiV2/import/importSurveyResponses/assertCanImportSurveyResponses.js
@@ -58,23 +58,20 @@ export const assertCanImportSurveyResponses = async (
   return true;
 };
 
-const getEntityCodeFromSurveyResponseChange = async (models, surveyResponse) => {
-  // If we're creating a new entity we don't have a currently valid entity_code
-  // So instead, check our permissions against the new entity's parent
-  if (surveyResponse.entities_created) {
-    const newEntity = surveyResponse.entities_created.find(e => e.id === surveyResponse.entity_id);
-    if (newEntity) {
-      const parentEntity = await models.entity.findById(newEntity.parent_id);
-      return parentEntity.code;
-    }
-  }
-
+const getEntityCodeFromSurveyResponseChange = async (models, surveyResponse, entitiesCreated) => {
   // There are three valid ways to refer to the entity in a batch change:
   // entity_code, entity_id, clinic_id
   if (surveyResponse.entity_code) {
     return surveyResponse.entity_code;
   }
   if (surveyResponse.entity_id) {
+    // If we're submitting a response against a new entity, it won't yet have a valid entity_code in
+    // the server db. Instead, check our permissions against the new entity's parent
+    const newEntity = entitiesCreated.find(e => e.id === surveyResponse.entity_id);
+    if (newEntity) {
+      const parentEntity = await models.entity.findById(newEntity.parent_id);
+      return parentEntity.code;
+    }
     const entity = await models.entity.findById(surveyResponse.entity_id);
     return entity.code;
   }
@@ -95,8 +92,17 @@ export const assertCanSubmitSurveyResponses = async (accessPolicy, models, surve
   const surveys = await models.survey.findManyById(surveyIds);
   const surveyNamesById = reduceToDictionary(surveys, 'id', 'name');
 
+  const entitiesCreated = surveyResponses
+    .filter(sr => !!sr.entities_created)
+    .map(sr => sr.entities_created)
+    .flat();
+
   for (const response of surveyResponses) {
-    const entityCode = await getEntityCodeFromSurveyResponseChange(models, response);
+    const entityCode = await getEntityCodeFromSurveyResponseChange(
+      models,
+      response,
+      entitiesCreated,
+    );
     const surveyName = surveyNamesById[response.survey_id];
 
     if (!entitiesBySurveyName[surveyName]) {

--- a/packages/meditrak-server/src/tests/apiV2/postChanges.test.js
+++ b/packages/meditrak-server/src/tests/apiV2/postChanges.test.js
@@ -12,6 +12,7 @@ import {
   generateValueOfType,
   TYPES,
   buildAndInsertSurveys,
+  upsertDummyRecord,
 } from '@tupaia/database';
 
 import { TEST_IMAGE_DATA } from '../testData';
@@ -64,6 +65,16 @@ const generateDummyAnswer = questionNumber => ({
   question_id: getQuestionId(questionNumber),
 });
 
+const generateDummyEntityDetails = () => ({
+  id: generateTestId(),
+  name: generateValueOfType('text'),
+  country_code: 'DL',
+  parent_id: entityId,
+  code: generateValueOfType('text'),
+  type: 'case',
+  attributes: {},
+});
+
 const BUCKET_URL = 'https://s3-ap-southeast-2.amazonaws.com';
 
 const PSQL_DATE_FORMAT = 'YYYY-MM-DD HH:mm:ss';
@@ -91,13 +102,18 @@ describe('POST /changes', async () => {
 
   describe('SubmitSurveyResponse', () => {
     before(async () => {
-      await app.grantFullAccess();
+      await app.grantAccess({ DL: ['TEST_PERMISSION_GROUP'] });
 
       for (let i = 0; i < 20; i++) {
         await upsertQuestion({ id: getQuestionId(i), code: `TEST_QUESTION_${i}` });
       }
 
-      await buildAndInsertSurveys(models, [{ id: surveyId, code: 'TEST_SURVEY' }]);
+      const permissionGroup = await upsertDummyRecord(models.permissionGroup, {
+        name: 'TEST_PERMISSION_GROUP',
+      });
+      await buildAndInsertSurveys(models, [
+        { id: surveyId, code: 'TEST_SURVEY', permission_group_id: permissionGroup.id },
+      ]);
       await upsertEntity({ id: entityId, code: 'TEST_ENTITY' });
 
       const user = await models.user.findOne();
@@ -445,6 +461,69 @@ describe('POST /changes', async () => {
         const imageBuffer = await imageResponse.buffer();
         const imageString = imageBuffer.toString('base64');
         expect(imageString).to.equal(TEST_IMAGE_DATA);
+      });
+    });
+
+    describe('Survey responses creating entities', () => {
+      it('adds created entities to the database', async () => {
+        const entitiesCreated = new Array(5).fill(0).map(() => generateDummyEntityDetails());
+        const surveyResponseObject = generateDummySurveyResponse({
+          entities_created: entitiesCreated,
+        });
+        const syncAction = {
+          action: 'SubmitSurveyResponse',
+          payload: surveyResponseObject,
+        };
+        const syncResponse = await app.post('changes', { body: [syncAction] });
+        expect(syncResponse.statusCode).to.equal(200);
+
+        const entities = await models.entity.find({ id: entitiesCreated.map(e => e.id) });
+        expect(entities.length).to.equal(entitiesCreated.length);
+      });
+
+      it('can use a created entity as the primary entity of the same response', async () => {
+        const entitiesCreated = new Array(5).fill(0).map(() => generateDummyEntityDetails());
+        const primaryEntityId = entitiesCreated[0].id;
+        const surveyResponseObject = generateDummySurveyResponse({
+          entities_created: entitiesCreated,
+          entity_id: primaryEntityId,
+        });
+        const syncAction = {
+          action: 'SubmitSurveyResponse',
+          payload: surveyResponseObject,
+        };
+        const syncResponse = await app.post('changes', { body: [syncAction] });
+        expect(syncResponse.statusCode).to.equal(200);
+
+        const surveyResponse = await models.surveyResponse.findById(surveyResponseObject.id);
+        expect(surveyResponse.entity_id).to.equal(primaryEntityId);
+      });
+
+      it('can use a created entity as the primary entity of a different response in the same batch', async () => {
+        const entitiesCreated = new Array(5).fill(0).map(() => generateDummyEntityDetails());
+        const primaryEntityId = entitiesCreated[0].id;
+        const surveyResponseObjectOne = generateDummySurveyResponse({
+          entities_created: entitiesCreated,
+        });
+        const syncActionOne = {
+          action: 'SubmitSurveyResponse',
+          payload: surveyResponseObjectOne,
+        };
+        const surveyResponseObjectTwo = generateDummySurveyResponse({
+          entity_id: primaryEntityId,
+        });
+        const syncActionTwo = {
+          action: 'SubmitSurveyResponse',
+          payload: surveyResponseObjectTwo,
+        };
+        const syncResponse = await app.post('changes', { body: [syncActionOne, syncActionTwo] });
+        expect(syncResponse.statusCode).to.equal(200);
+
+        const surveyResponseOne = await models.surveyResponse.findById(surveyResponseObjectOne.id);
+        expect(surveyResponseOne.entity_id).to.equal(entityId);
+
+        const surveyResponseTwo = await models.surveyResponse.findById(surveyResponseObjectTwo.id);
+        expect(surveyResponseTwo.entity_id).to.equal(primaryEntityId);
       });
     });
 


### PR DESCRIPTION
### Issue #:
- RN-411

### Changes:
When using Tupaia for recording lab results, you create a `case` entity in the "C19 Test Registration" survey, and then submit a "C19 Test Result" survey against that same case. If both the registration and the result sync up to the server in the same batch of changes, the permissions check for the result will fail, because the `case` won't have been created until the "C19 Test Registration" is fully processed. This PR fixes that, allowing the permissions check for the "C19 Test Result" response to use the case created in the registration response, before it has been saved to the db.