### PR TITLE
RN-387: Improve entity hierarchy desktop styles

### DIFF
--- a/packages/web-frontend/src/components/ControlBar.js
+++ b/packages/web-frontend/src/components/ControlBar.js
@@ -27,7 +27,7 @@ import OpenIcon from 'material-ui/svg-icons/navigation/arrow-drop-down';
 import CloseIcon from 'material-ui/svg-icons/navigation/arrow-drop-up';
 import SearchIcon from 'material-ui/svg-icons/action/search';
 import TextField from 'material-ui/TextField';
-import { TRANS_BLACK, CONTROL_BAR_WIDTH, WHITE } from '../styles';
+import { TRANS_BLACK_MORE, CONTROL_BAR_WIDTH, WHITE } from '../styles';
 
 const wrapperPadding = 14;
 
@@ -36,7 +36,7 @@ const Container = styled.div`
   flex-grow: ${props => (props.expanded ? 1 : 0)};
   flex-shrink: ${props => (props.expanded ? 1 : 0)};
   flex-basis: ${props => (props.expanded ? '160px' : '50px')};
-  background-color: ${TRANS_BLACK};
+  background-color: ${TRANS_BLACK_MORE};
   border-radius: 8px;
   width: ${CONTROL_BAR_WIDTH}px;
   flex-direction: column;

--- a/packages/web-frontend/src/components/SearchBarItem.js
+++ b/packages/web-frontend/src/components/SearchBarItem.js
@@ -29,7 +29,6 @@ const Row = styled.div`
   justify-content: space-between;
   align-items: center;
   padding: 0px 15px;
-  background: black;
   border-bottom: ${p => (p.$hideBottomBorder ? 'none' : `1px solid ${DARK_BLUE}`)};
 `;
 

--- a/packages/web-frontend/src/containers/SearchBar/index.js
+++ b/packages/web-frontend/src/containers/SearchBar/index.js
@@ -5,9 +5,6 @@
  * found in the LICENSE file in the root directory of this source tree.
  */
 
-/**
- * SearchBar
- */
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { isNull } from 'lodash';
@@ -49,7 +46,7 @@ const styles = {
     flexShrink: 1,
     flexBasis: '0%',
     overflowY: 'auto',
-    maxHeight: '200px',
+    maxHeight: '350px',
   },
   searchResultItem: {
     display: 'flex',

--- a/packages/web-frontend/src/containers/mobile/EntityHierarchy.js
+++ b/packages/web-frontend/src/containers/mobile/EntityHierarchy.js
@@ -18,7 +18,7 @@ import { SearchBarItem } from '../../components/SearchBarItem';
 
 const StyledList = styled(List)`
   background: black;
-  height: 100%;
+  min-height: 100%;
   padding: 0;
 `;
 

--- a/packages/web-frontend/src/styles/index.js
+++ b/packages/web-frontend/src/styles/index.js
@@ -31,6 +31,7 @@ export const WHITE = '#ffffff';
 export const OFF_WHITE = '#eeeeee';
 export const TRANS_BLACK = 'rgba(43, 45, 56, 0.94)';
 export const TRANS_BLACK_LESS = 'rgba(43, 45, 56, 0.8)';
+export const TRANS_BLACK_MORE = 'rgba(43, 45, 56, 0.97)';
 export const DARK_BLUE = '#262834';
 export const LIGHTENED_DARK_BLUE = '#2e3040';
 export const TRANSPARENT = 'rgba(0,0,0,0)';


### PR DESCRIPTION
I noticed that the change to a full black entity hierarchy looked a bit wrong on desktop, so this changes it to have a more subtle background.