### PR TITLE
Update fields if data element existed

### DIFF
--- a/packages/meditrak-server/src/apiV2/import/importDataSources/createDataSources.js
+++ b/packages/meditrak-server/src/apiV2/import/importDataSources/createDataSources.js
@@ -22,9 +22,9 @@ export async function createDataSources(transactingModels, dataSources) {
 
     const exsitingDataSource = await transactingModels.dataSource.find({ code });
     if (exsitingDataSource.length > 0) {
-      throw new ImportValidationError(`Data source code '${code}' already exists`, excelRowNumber);
+      await transactingModels.dataSource.update({ code }, dataSource);
+    } else {
+      await transactingModels.dataSource.create(dataSource);
     }
-
-    await transactingModels.dataSource.create(dataSource);
   }
 }


### PR DESCRIPTION
Issue #:
RN-419

Changes:
Currently we block the update if code existed. If we can update the existing date elements in bulks, we can reuse the data elements for lesmis in the datalake and the existing reports.