### PR TITLE
Use the latest image, even on redeploy

### DIFF
--- a/packages/devops/scripts/lambda/actions/redeploy_tupaia_server.py
+++ b/packages/devops/scripts/lambda/actions/redeploy_tupaia_server.py
@@ -93,7 +93,7 @@ def redeploy_tupaia_server(event):
             deployment_name=get_tag(existing_instance, 'DeploymentName'),
             branch=get_tag(existing_instance, 'Branch'),
             instance_type=event.get('InstanceType', existing_instance['InstanceType']),
-            image_code=event.get('ImageCode', None), # will use id below if not defined in the event
+            image_code=event.get('ImageCode', 'tupaia-gold-master'), # will use tupaia-gold-master by default if not defined in the event
             extra_tags=extra_tags,
             security_group_code=event.get('SecurityGroupCode', None), # will use id below if not defined in the event
             security_group_id=existing_instance['SecurityGroups'][0]['GroupId'],

--- a/packages/devops/scripts/lambda/actions/redeploy_tupaia_server.py
+++ b/packages/devops/scripts/lambda/actions/redeploy_tupaia_server.py
@@ -95,7 +95,6 @@ def redeploy_tupaia_server(event):
             instance_type=event.get('InstanceType', existing_instance['InstanceType']),
             image_code=event.get('ImageCode', None), # will use id below if not defined in the event
             extra_tags=extra_tags,
-            image_id=existing_instance['ImageId'],
             security_group_code=event.get('SecurityGroupCode', None), # will use id below if not defined in the event
             security_group_id=existing_instance['SecurityGroups'][0]['GroupId'],
             setup_gateway=False,

--- a/packages/devops/scripts/lambda/actions/spin_up_tupaia_deployment.py
+++ b/packages/devops/scripts/lambda/actions/spin_up_tupaia_deployment.py
@@ -76,8 +76,8 @@ def spin_up_tupaia_deployment(event):
         deployment_name,
         branch,
         instance_type,
+        image_code,
         extra_tags=server_extra_tags,
-        image_code=image_code,
         security_group_code=security_group_code,
     )
 

--- a/packages/devops/scripts/lambda/helpers/create_from_image.py
+++ b/packages/devops/scripts/lambda/helpers/create_from_image.py
@@ -22,11 +22,10 @@ def create_instance_from_image(
     deployment_name,
     deployment_type,
     instance_type,
+    image_code,
     branch=None,
     extra_tags=None,
     iam_role_arn=None,
-    image_code=None,
-    image_id=None,
     security_group_code=None,
     security_group_id=None,
     subdomains_via_dns=None,
@@ -37,10 +36,7 @@ def create_instance_from_image(
     print('Creating ' + deployment_name + ' as ' + instance_type)
 
     # get ami to create instance from
-    if image_code:
-        image_id = get_latest_image_id(image_code)
-    else:
-        image_id = image_id
+    image_id = get_latest_image_id(image_code)
 
     instance_object = create_instance(
         deployment_name,
@@ -64,9 +60,8 @@ def create_tupaia_instance_from_image(
     deployment_name,
     branch,
     instance_type,
+    image_code,
     extra_tags=None,
-    image_code=None,
-    image_id=None,
     security_group_code=None,
     security_group_id=None,
     setup_gateway=True,
@@ -81,11 +76,10 @@ def create_tupaia_instance_from_image(
         deployment_name,
         deployment_type,
         instance_type,
+        image_code,
         branch=branch,
         extra_tags=extra_tags,
         iam_role_arn=tupaia_server_iam_role_arn,
-        image_code=image_code,
-        image_id=image_id,
         security_group_code=security_group_code,
         security_group_id=security_group_id,
         subdomains_via_gateway=tupaia_subdomains,


### PR DESCRIPTION
This not only meant that if we deleted old images, we couldn't redeploy to servers based on those images, but _we weren't actually including the latest security patches on production_ 🤦 