### PR TITLE
RN-439: Scroll question to top on focus

### DIFF
--- a/packages/meditrak-app/app/assessment/DumbQuestion.js
+++ b/packages/meditrak-app/app/assessment/DumbQuestion.js
@@ -29,6 +29,7 @@ export class DumbQuestion extends React.Component {
       text,
       SpecificQuestion,
       validationErrorMessage,
+      onLayout,
       ...questionProps
     } = this.props;
     return (
@@ -37,6 +38,7 @@ export class DumbQuestion extends React.Component {
           ...localStyles.container,
           display: questionProps.isVisible ? 'flex' : 'none',
         }}
+        onLayout={onLayout}
       >
         {imageData && imageData.length > 0 ? (
           <Image source={getImageSourceFromData(imageData)} style={localStyles.image} />
@@ -63,6 +65,7 @@ DumbQuestion.propTypes = {
   text: PropTypes.string,
   validationErrorMessage: PropTypes.string,
   SpecificQuestion: PropTypes.any.isRequired,
+  onLayout: PropTypes.func.isRequired,
 };
 
 DumbQuestion.defaultProps = {

--- a/packages/meditrak-app/app/assessment/DumbSurveyScreen.js
+++ b/packages/meditrak-app/app/assessment/DumbSurveyScreen.js
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { ActivityIndicator, Animated, ScrollView, StyleSheet, View } from 'react-native';
+import { ActivityIndicator, Animated, StyleSheet, View } from 'react-native';
 import PropTypes from 'prop-types';
 
 import { database } from '../database';
@@ -39,24 +39,14 @@ export class DumbSurveyScreen extends React.Component {
       screenIndexAnimation: new Animated.Value(props.screenIndex),
       lastScreenIndex: null,
     };
-    this.scrollViewRefs = [null, null];
   }
 
   componentDidMount() {
     this.updateHeaderLabel(this.props.surveyName);
   }
 
-  componentWillUnmount() {
-    this.props.releaseScrollControl();
-  }
-
   componentWillReceiveProps(nextProps) {
-    // During transition, make sure the incoming screen is set to the top
     if (nextProps.screenIndex !== this.props.screenIndex) {
-      const scrollViewRef = this.scrollViewRefs[nextProps.screenIndex % 2];
-      if (scrollViewRef) {
-        scrollViewRef.scrollTo({ x: 0, y: 0, animated: false });
-      }
       this.setState({
         lastScreenIndex: this.props.screenIndex,
       });
@@ -80,7 +70,6 @@ export class DumbSurveyScreen extends React.Component {
     if (this.props.screenIndex !== nextProps.screenIndex) return true;
     if (this.props.isSubmitting !== nextProps.isSubmitting) return true;
     if (this.props.errorMessage !== nextProps.errorMessage) return true;
-    if (this.props.isChildScrolling !== nextProps.isChildScrolling) return true;
     if (this.state !== nextState) return true;
     return false;
   }
@@ -141,7 +130,6 @@ export class DumbSurveyScreen extends React.Component {
       surveyName,
       surveyProgress,
       isSubmitting,
-      isChildScrolling,
       surveyScreens,
       screenIndex,
       questions,
@@ -167,20 +155,13 @@ export class DumbSurveyScreen extends React.Component {
               {isCurrentContent && !!errorMessage && (
                 <StatusMessage type={STATUS_MESSAGE_ERROR} message={errorMessage} />
               )}
-              <ScrollView
-                ref={scrollViewRef => {
-                  this.scrollViewRefs[index] = scrollViewRef;
-                }}
-                style={localStyles.scrollView}
-                scrollEnabled={!isChildScrolling}
-                nestedScrollEnabled
-              >
-                {screenIndexForThisContent === surveyScreens.length ? (
-                  <SubmitScreen />
-                ) : (
-                  <QuestionScreen database={database} screenIndex={screenIndexForThisContent} />
-                )}
-                {isSubmitting && <ActivityIndicator color={THEME_COLOR_ONE} size="large" />}
+              {screenIndexForThisContent === surveyScreens.length ? (
+                <SubmitScreen />
+              ) : (
+                <QuestionScreen database={database} screenIndex={screenIndexForThisContent} />
+              )}
+              {isSubmitting && <ActivityIndicator color={THEME_COLOR_ONE} size="large" />}
+              {(onPressSubmit || onPressRepeat) && (
                 <View style={localStyles.buttonContainerContainer}>
                   {isCurrentContent && onPressSubmit !== null && !isSubmitting && (
                     <Button
@@ -197,7 +178,7 @@ export class DumbSurveyScreen extends React.Component {
                     />
                   )}
                 </View>
-              </ScrollView>
+              )}
             </Animated.View>
           );
         })}
@@ -236,11 +217,9 @@ DumbSurveyScreen.propTypes = {
   onPressSubmit: PropTypes.func,
   onPressRepeat: PropTypes.func,
   onSelectSurveyScreen: PropTypes.func,
-  releaseScrollControl: PropTypes.func.isRequired,
   surveyName: PropTypes.string.isRequired,
   surveyProgress: PropTypes.number.isRequired,
   isSubmitting: PropTypes.bool,
-  isChildScrolling: PropTypes.bool,
   surveyScreens: PropTypes.array.isRequired,
   screenIndex: PropTypes.number.isRequired,
 };
@@ -251,7 +230,6 @@ DumbSurveyScreen.defaultProps = {
   onPressSubmit: null,
   onPressRepeat: null,
   isSubmitting: false,
-  isChildScrolling: false,
   onSelectSurveyScreen: null,
 };
 
@@ -266,10 +244,6 @@ const localStyles = StyleSheet.create({
   },
   submitButton: {
     margin: 5,
-  },
-  scrollView: {
-    flex: 1,
-    padding: 15,
   },
   actionBar: {
     position: 'relative',

--- a/packages/meditrak-app/app/assessment/SurveyScreen.js
+++ b/packages/meditrak-app/app/assessment/SurveyScreen.js
@@ -7,12 +7,7 @@ import { connect } from 'react-redux';
 
 import { DumbSurveyScreen } from './DumbSurveyScreen';
 
-import {
-  moveSurveyScreens,
-  moveToSurveyScreen,
-  submitSurvey,
-  releaseScrollControl,
-} from './actions';
+import { moveSurveyScreens, moveToSurveyScreen, submitSurvey } from './actions';
 import {
   getSurveyName,
   getSurveyScreenIndex,
@@ -22,15 +17,7 @@ import {
 
 function mapStateToProps(state) {
   const { assessment } = state;
-  const {
-    assessorId,
-    isSubmitting,
-    screens,
-    questions,
-    startTime,
-    surveyId,
-    isChildScrolling,
-  } = assessment;
+  const { assessorId, isSubmitting, screens, questions, startTime, surveyId } = assessment;
   const screenIndex = getSurveyScreenIndex(state);
   return {
     assessorId,
@@ -43,7 +30,6 @@ function mapStateToProps(state) {
     startTime,
     surveyId,
     surveyName: getSurveyName(state),
-    isChildScrolling,
   };
 }
 
@@ -59,7 +45,6 @@ function mergeProps(stateProps, { dispatch }, ownProps) {
     startTime,
     surveyId,
     surveyName,
-    isChildScrolling,
     ...otherStateProps
   } = stateProps;
   const isSubmitScreen = screenIndex === screens.length;
@@ -77,13 +62,11 @@ function mergeProps(stateProps, { dispatch }, ownProps) {
     onPressRepeat: isSubmitScreen && canRepeat ? () => dispatchSubmitSurvey(true) : null,
     onPressSubmit: isSubmitScreen ? () => dispatchSubmitSurvey(false) : null,
     onSelectSurveyScreen: newScreenIndex => dispatch(moveToSurveyScreen(newScreenIndex)),
-    releaseScrollControl: () => dispatch(releaseScrollControl()),
     screenIndex,
     surveyProgress,
     surveyName,
     surveyScreens: screens,
     questions,
-    isChildScrolling,
   };
 }
 

--- a/packages/meditrak-app/app/entityMenu/EntityList.js
+++ b/packages/meditrak-app/app/entityMenu/EntityList.js
@@ -25,7 +25,7 @@ export class EntityList extends PureComponent {
     this.state = {
       searchTerm: '',
       searchResults: null,
-      isOpen: props.startOpen,
+      isOpen: false,
     };
   }
 
@@ -35,9 +35,8 @@ export class EntityList extends PureComponent {
       onMount(); // E.g. pull database records into the redux store to populate the clinic list
     }
 
-    // if starting open, the user gets to scroll through all possible entities immediately
     if (startOpen) {
-      this.props.takeScrollControl();
+      this.openResults();
     }
   }
 
@@ -57,10 +56,15 @@ export class EntityList extends PureComponent {
 
   openResults = () => {
     // if opening results, take scroll control from outer scroll view
-    this.props.takeScrollControl();
-    this.setState({
-      isOpen: true,
-    });
+    this.setState(
+      {
+        isOpen: true,
+      },
+      () => {
+        this.props.takeScrollControl();
+        this.props.scrollIntoFocus();
+      },
+    );
   };
 
   selectRow = row => {


### PR DESCRIPTION
This is an attempt to fix _**known_issue_1**_ recorded [here](https://linear.app/bes/issue/RN-439#comment-1fe72a8a)

Honestly I'm on the fence about whether this is worth merging. It feels kinda heavy handed and over complicated for solving one minor UX interaction, so I'm interested in the reviewers thoughts.

The current behaviour is that if the entity question is the last one on a screen, when you click to focus it, the results of your search will be entirely hidden by the keyboard
![image](https://user-images.githubusercontent.com/1274422/162351653-e39f6c68-3453-44b8-a938-0ab10583792a.png)

The change here makes the question scroll nearly to the top of the screen, allowing at least one result to be seen (on the screen size I'm emulating anyway) 
![image](https://user-images.githubusercontent.com/1274422/162351757-facaafbc-8ffb-40f5-9323-ac0fbc029bca.png)

This comes at the expense of a large amount of whitespace that can be scrolled into view at the bottom of the screen. I don't think that's a major deal though
![image](https://user-images.githubusercontent.com/1274422/162351712-16c27b73-f609-4cad-93c7-042282a4a97f.png)
