### PR TITLE
WAITM-1111: Fix missing lesmis translation

### DIFF
--- a/packages/lesmis-server/locales/lo.json
+++ b/packages/lesmis-server/locales/lo.json
@@ -397,7 +397,7 @@
     "School has water for use the whole year": "ມີນໍ້າໃຊ້ ສະໜອງໄດ້ຕະຫຼອດປີ",
     "School keeps an accurate and up to date school financial record and assets register": "ໂຮງຮຽນຮັກສາບັນຊີການເງິນ ແລະ ຂຶ້ນທະບຽນຊັບສິນຢ່າງຖືກຕ້ອງ ແລະ ທັນສະພາບການ   (ໃໝ່ຫຼ້າສຸດ)",
     "School offers classes every day of the official school year (165 days as norm)": "ໂຮງຮຽນຈັດການຮຽນ-ການສອນທຸກມື້ຕາມປະຕິທິນການສຶກສາ ( 33 ອາທິດx 5 ມື້ = 165ມື້ຕາມປົກກະຕິ )",
-    "Student teacher ratio: according to the allocation guidelines": "ອັດຕາສ່ວນນັກຮຽນຕໍ່ຄູ ຖືກຕ້ອງຕາມມາດຕະຖານ (ຕາມຄູ່ມືຊັບຊ້ອນຄູ)",
+    "Student teacher ratio according to the allocation guidelines": "ອັດຕາສ່ວນນັກຮຽນຕໍ່ຄູ ຖືກຕ້ອງຕາມມາດຕະຖານ (ຕາມຄູ່ມືຊັບຊ້ອນຄູ)",
     "Students are polite and well behaved": "ນັກຮຽນມີຄວາມສຸພາບຮຽບຮ້ອຍ, ມີມາລະຍາດດີ",
     "Teacher has 1 record book for student naming and scoring per class": "ຄູມີປຶ້ມຮຽກຊື່ ແລະ ໃຫ້ຄະແນນ 1 ເຫຼັ້ມຕໍ່ 1 ຫ້ອງຮຽນ",
     "Teacher has 1 set of materials for teaching and learning for mathematics": "ຄູມີອຸປະກອນການຮຽນ-ການສອນວິຊາ ຄະນິດສາດ 1 ຊຸດຕໍ່ຄູ 1 ຄົນ",


### PR DESCRIPTION
### Issue #: WAITM-1111: Fix missing lesmis translation

The translatable route uses . and : as delimiters of the transition object key and so they don't work in actual translation string keys. There is no easy fix for the delimiters working in the translations but a simple work around is to just remove them from the delimiters translation config keys. The end result is the 100% correct translation.