### PR TITLE
RN-466: Meditrak entity load performance improvement

### DIFF
--- a/packages/meditrak-app/app/assessment/actions/actions.js
+++ b/packages/meditrak-app/app/assessment/actions/actions.js
@@ -60,7 +60,7 @@ export const initialiseSurveys = () => (dispatch, getState, { database }) => {
   const currentUser = database.getCurrentUser();
   const country = database.getCountry(countryId);
   surveyList
-    .filter(survey => currentUser.hasAccessToSurveyInEntity(survey, country))
+    .filter(survey => currentUser.hasAccessToSurveyInCountry(survey, country))
     .forEach(survey => {
       surveys[survey.id] = survey.getReduxStoreData();
     });

--- a/packages/meditrak-app/app/assessment/specificQuestions/EntityQuestion.js
+++ b/packages/meditrak-app/app/assessment/specificQuestions/EntityQuestion.js
@@ -36,10 +36,10 @@ DumbEntityQuestion.defaultProps = {
 // speaks directly to redux and is sent as part of the metadata of the request.
 export const PrimaryEntityQuestion = connect(
   (state, { id: questionId, answer: selectedEntityId }) => {
-    const { filteredEntities = [] } = getEntityQuestionState(state, questionId);
+    const { entities = [] } = getEntityQuestionState(state, questionId);
 
     return {
-      filteredEntities,
+      entities,
       selectedEntityId,
       hasScrollControl: state.assessment.isChildScrolling,
     };
@@ -55,10 +55,10 @@ export const PrimaryEntityQuestion = connect(
 
 export const EntityQuestion = connect(
   (state, { id: questionId, answer: selectedEntityId }) => {
-    const { filteredEntities } = getEntityQuestionState(state, questionId);
+    const { entities } = getEntityQuestionState(state, questionId);
 
     return {
-      filteredEntities,
+      entities,
       selectedEntityId,
     };
   },

--- a/packages/meditrak-app/app/database/types/Entity.js
+++ b/packages/meditrak-app/app/database/types/Entity.js
@@ -13,7 +13,6 @@ export class Entity extends RealmObject {
       code,
       id,
       type,
-      parent: '',
       parentName: parent && parent.name,
       countryCode,
       attributes: attributes ? JSON.parse(attributes) : {},

--- a/packages/meditrak-app/app/database/types/User.js
+++ b/packages/meditrak-app/app/database/types/User.js
@@ -22,24 +22,12 @@ export class User extends RealmObject {
 
   /**
    * Whether this survey is available to the given user. Checks whether that user has access to the
-   * permission group required by this survey.
+   * permission group required by this survey, in the selected country.
    */
-  hasAccessToSurveyInEntity(survey, entity) {
+  hasAccessToSurveyInCountry(survey, country) {
     const { permissionGroup } = survey;
     if (!permissionGroup) return false; // this survey is not fully synced yet, don't show it
-    return this.hasEntityAccess(entity, permissionGroup.name);
-  }
-
-  // User has access if they have access to the entity itself, or some ancestor entity
-  hasEntityAccess(entity, permissionGroupName = '') {
-    const entities = [];
-    let currentEntity = entity;
-    while (currentEntity && currentEntity.type !== 'world') {
-      entities.push(currentEntity.code);
-      currentEntity = currentEntity.parent;
-    }
-
-    return this.accessPolicy.allowsSome(entities, permissionGroupName);
+    return this.accessPolicy.allows(country.code, permissionGroup.name);
   }
 }
 

--- a/packages/meditrak-app/app/entityMenu/EntityList.js
+++ b/packages/meditrak-app/app/entityMenu/EntityList.js
@@ -91,10 +91,10 @@ export class EntityList extends PureComponent {
       return;
     }
 
-    const { filteredEntities } = this.props;
+    const { entities } = this.props;
     const lowerCaseSearchTerm = searchTerm.toLowerCase();
 
-    const searchResults = filteredEntities
+    const searchResults = entities
       .filter(
         ({ name, parentName }) =>
           name.toLowerCase().includes(lowerCaseSearchTerm) ||
@@ -130,16 +130,16 @@ export class EntityList extends PureComponent {
   };
 
   renderResults() {
-    const { filteredEntities } = this.props;
+    const { entities } = this.props;
     const { searchTerm, searchResults, isOpen } = this.state;
 
-    // while filteredEntities is null, we're still loading from the database
-    if (!filteredEntities) {
+    // while entities is null, we're still loading from the database
+    if (!entities) {
       return <Text style={localStyles.noResultsText}>Loading...</Text>;
     }
 
-    // if filteredEntities is not null, but empty, the survey is probably misconfigured
-    if (filteredEntities.length === 0) {
+    // if entities is not null, but empty, the survey is probably misconfigured
+    if (entities.length === 0) {
       return (
         <Text style={localStyles.noResultsText}>
           No valid entities for this question, please contact your survey administrator.
@@ -157,7 +157,7 @@ export class EntityList extends PureComponent {
     if (isOpen) {
       return (
         <FlatList
-          data={searchResults || filteredEntities}
+          data={searchResults || entities}
           renderItem={this.renderEntityCell}
           keyExtractor={item => item.id}
           keyboardShouldPersistTaps="always"
@@ -184,11 +184,11 @@ export class EntityList extends PureComponent {
   }
 
   render() {
-    const { filteredEntities, selectedEntityId } = this.props;
+    const { entities, selectedEntityId } = this.props;
     const { searchTerm } = this.state;
 
-    if (filteredEntities && selectedEntityId) {
-      const selectedEntity = filteredEntities.find(i => i.id === selectedEntityId);
+    if (entities && selectedEntityId) {
+      const selectedEntity = entities.find(i => i.id === selectedEntityId);
       return (
         <View style={localStyles.container}>
           {this.renderEntityCell({ item: selectedEntity, onDeselect: this.deselectRow })}
@@ -231,7 +231,7 @@ export class EntityList extends PureComponent {
 }
 
 EntityList.propTypes = {
-  filteredEntities: PropTypes.array,
+  entities: PropTypes.array,
   selectedEntityId: PropTypes.string,
   onRowPress: PropTypes.func.isRequired,
   onClear: PropTypes.func.isRequired,
@@ -242,7 +242,7 @@ EntityList.propTypes = {
 };
 
 EntityList.defaultProps = {
-  filteredEntities: null,
+  entities: null,
   selectedEntityId: '',
   onMount: null,
 };

--- a/packages/meditrak-app/app/entityMenu/actions.js
+++ b/packages/meditrak-app/app/entityMenu/actions.js
@@ -6,14 +6,10 @@
 import { ENTITY_RECEIVE_PRIMARY_ENTITIES, ENTITY_RECEIVE_ENTITIES } from './constants';
 import { getAnswerForQuestion, getQuestion } from '../assessment/selectors';
 
-const getPermsCheckFunction = (database, surveyId) => {
-  const currentUser = database.getCurrentUser();
-  const survey = database.findOne('Survey', surveyId);
-
-  return entity => currentUser.hasAccessToSurveyInEntity(survey, entity);
-};
-
 const getEntityDatabaseFilters = (state, database, questionId) => {
+  // filtering for entities within the currently selected country also has the byproduct
+  // of only including entities for which the user has permission - to be filling in a survey in a
+  // country, they must have the associated permission group in that country
   const { code: countryCode } = database.getCountry(state.country.selectedCountryId);
   const filters = { countryCode };
 
@@ -56,19 +52,13 @@ export const loadEntitiesFromDatabase = (isPrimaryEntity, questionId) => (
   { database },
 ) => {
   const state = getState();
-  const { assessment } = state;
 
   const filters = getEntityDatabaseFilters(state, database, questionId);
   const entities = database.getEntities(filters);
 
-  // check permissions - only for the PrimaryEntity questions
-  const { surveyId } = assessment;
-  const permsCheck = isPrimaryEntity ? getPermsCheckFunction(database, surveyId) : () => true;
-  const allowedEntities = entities.filter(permsCheck);
-
   // filter on attributes
   const checkMatchesAttributeFilters = getEntityAttributeFilters(state, questionId);
-  const filteredEntities = allowedEntities.filter(checkMatchesAttributeFilters);
+  const filteredEntities = entities.filter(checkMatchesAttributeFilters);
 
   dispatch({
     type: isPrimaryEntity ? ENTITY_RECEIVE_PRIMARY_ENTITIES : ENTITY_RECEIVE_ENTITIES,

--- a/packages/meditrak-app/app/entityMenu/actions.js
+++ b/packages/meditrak-app/app/entityMenu/actions.js
@@ -58,22 +58,21 @@ export const loadEntitiesFromDatabase = (isPrimaryEntity, questionId) => (
   const state = getState();
   const { assessment } = state;
 
-  // check permissions - only for the PrimaryEntity questions
-  const { surveyId } = assessment;
-  const permsCheck = isPrimaryEntity ? getPermsCheckFunction(database, surveyId) : () => true;
-  const checkMatchesAttributeFilters = getEntityAttributeFilters(state, questionId);
-
   const filters = getEntityDatabaseFilters(state, database, questionId);
   const entities = database.getEntities(filters);
 
-  const filteredEntities = entities
-    .filter(permsCheck)
-    .filter(checkMatchesAttributeFilters)
-    .map(thisEntity => thisEntity.getReduxStoreData());
+  // check permissions - only for the PrimaryEntity questions
+  const { surveyId } = assessment;
+  const permsCheck = isPrimaryEntity ? getPermsCheckFunction(database, surveyId) : () => true;
+  const allowedEntities = entities.filter(permsCheck);
+
+  // filter on attributes
+  const checkMatchesAttributeFilters = getEntityAttributeFilters(state, questionId);
+  const filteredEntities = allowedEntities.filter(checkMatchesAttributeFilters);
 
   dispatch({
     type: isPrimaryEntity ? ENTITY_RECEIVE_PRIMARY_ENTITIES : ENTITY_RECEIVE_ENTITIES,
-    filteredEntities,
+    entities: filteredEntities.map(thisEntity => thisEntity.getReduxStoreData()),
     questionId,
   });
 };

--- a/packages/meditrak-app/app/entityMenu/reducer.js
+++ b/packages/meditrak-app/app/entityMenu/reducer.js
@@ -13,14 +13,14 @@ const defaultState = {
   questions: {},
 };
 
-function updateEntities({ filteredEntities, questionId }, { questions }) {
+function updateEntities({ entities, questionId }, { questions }) {
   const question = questions[questionId] || {};
   return {
     questions: {
       ...questions,
       [questionId]: {
         ...question,
-        filteredEntities,
+        entities,
       },
     },
   };
@@ -30,8 +30,8 @@ const stateChanges = {
   [ENTITY_RECEIVE_ENTITIES]: updateEntities,
   [ENTITY_RECEIVE_PRIMARY_ENTITIES]: updateEntities,
   // reset all questions but not primary entity
-  [SURVEY_SELECT]: (payload, { filteredEntities }) => ({
-    filteredEntities,
+  [SURVEY_SELECT]: (payload, { entities }) => ({
+    entities,
     questions: {},
   }),
   // complete reset


### PR DESCRIPTION
### Issue #:
RN-466

### Changes:
Most of the time spent loading the entities from the db was in running a permissions check. After optimising that permissions check, I realised we actually didn't need it at all!

I would recommend looking at commit 7d4a6e0 on its own before reviewing this as a whole - that's the (very simple) meat and potatoes of the PR. The rest is just nice-to-have simplifications (mainly renaming filteredEntities to entities, because I always found it confusing that the full list of entities handed to the search component was called filteredEntities)