### PR TITLE
RN-439: Show recently used entities in entity selection questions

### DIFF
--- a/packages/meditrak-app/app/assessment/actions/actions.js
+++ b/packages/meditrak-app/app/assessment/actions/actions.js
@@ -29,11 +29,7 @@ import {
 import { openSurvey, openSurveyGroup } from '../../navigation/actions';
 import { watchUserLocation, stopWatchingUserLocation } from '../../utilities/userLocation';
 import { validateAnswer } from '../validation';
-import {
-  doesScreenHaveValidationErrors,
-  getDefaultEntitySettingKey,
-  getEntityCreationQuestions,
-} from '../helpers';
+import { doesScreenHaveValidationErrors, getEntityCreationQuestions } from '../helpers';
 
 const DEFAULT_PRIMARY_QUESTION_ID = 'selected-entity';
 const DEFAULT_PRIMARY_ENTITY_QUESTION = {
@@ -155,22 +151,15 @@ export const selectSurvey = (surveyId, isRepeating = false) => (
   };
 
   const answers = {};
-  // If the user has previously submitted a survey for the same primary entity type, default to that
   const userId = database.getCurrentUser().id;
-  const entityTypes = questions[primaryEntityQuestionId].config.entity.type;
-  const state = getState();
-  const defaultEntityId = database.getSetting(
-    getDefaultEntitySettingKey(userId, entityTypes, state.country.selectedCountryId),
-  );
-  if (defaultEntityId) {
-    answers[primaryEntityQuestionId] = defaultEntityId;
-  }
+
   const entityCreationQuestionIds = getEntityCreationQuestions(Object.values(questions)).map(
     ({ id }) => id,
   );
   entityCreationQuestionIds.forEach(questionId => {
     answers[questionId] = generateUUID().toString();
   });
+
   dispatch({
     type: SURVEY_SELECT,
     assessorId: userId,
@@ -180,6 +169,7 @@ export const selectSurvey = (surveyId, isRepeating = false) => (
     hasCustomEntitySelector: !!customPrimaryEntityQuestion,
     startTime: new Date().toISOString(),
     answers,
+    primaryEntityQuestionId,
   });
 
   if (!isRepeating) {

--- a/packages/meditrak-app/app/assessment/actions/submitSurvey.js
+++ b/packages/meditrak-app/app/assessment/actions/submitSurvey.js
@@ -17,7 +17,7 @@ import { getAnswers, getScreens, getValidQuestions } from '../selectors';
 import { changeAnswer, selectSurvey, validateScreen } from './actions';
 import {
   doesScreenHaveValidationErrors,
-  getDefaultEntitySettingKey,
+  addRecentEntityId,
   getEntityCreationQuestions,
   getOptionCreationAutocompleteQuestions,
 } from '../helpers';
@@ -108,13 +108,11 @@ const processQuestions = async (dispatch, getState, database, userId, questions)
       case 'DateOfData':
         responseFields.dataTime = moment(answer).toISOString();
         break;
-      case 'PrimaryEntity': {
+      case 'PrimaryEntity':
+      case 'Entity': {
         const { type } = question.config.entity;
         responseFields.entityId = answer;
-        database.setSetting(
-          getDefaultEntitySettingKey(userId, type, getState().country.selectedCountryId),
-          answer,
-        );
+        addRecentEntityId(database, userId, type, getState().country.selectedCountryId, answer);
         break;
       }
       default:

--- a/packages/meditrak-app/app/assessment/actions/submitSurvey.js
+++ b/packages/meditrak-app/app/assessment/actions/submitSurvey.js
@@ -110,9 +110,15 @@ const processQuestions = async (dispatch, getState, database, userId, questions)
         break;
       case 'PrimaryEntity':
       case 'Entity': {
-        const { type } = question.config.entity;
+        const { type: entityTypes } = question.config.entity;
         responseFields.entityId = answer;
-        addRecentEntityId(database, userId, type, getState().country.selectedCountryId, answer);
+        addRecentEntityId(
+          database,
+          userId,
+          entityTypes,
+          getState().country.selectedCountryId,
+          answer,
+        );
         break;
       }
       default:

--- a/packages/meditrak-app/app/assessment/helpers.js
+++ b/packages/meditrak-app/app/assessment/helpers.js
@@ -46,7 +46,7 @@ export const getRecentEntityIds = (database, userId, entityTypes, countryId) =>
   JSON.parse(
     database.getSetting(getRecentEntitiesSettingKey(userId, entityTypes, countryId)) || '[]',
   );
-const MAX_RECENT_ENTITIES = 5;
+const MAX_RECENT_ENTITIES = 3;
 export const addRecentEntityId = (database, userId, entityTypes, countryId, entityId) => {
   const recentEntityIds = getRecentEntityIds(database, userId, entityTypes, countryId);
   const updatedRecentEntityIds = [entityId, ...recentEntityIds.filter(id => id !== entityId)].slice(

--- a/packages/meditrak-app/app/assessment/helpers.js
+++ b/packages/meditrak-app/app/assessment/helpers.js
@@ -39,8 +39,25 @@ export const checkAnswerPreconditionsAreMet = (answers, visibilityCriteria) => {
 export const doesScreenHaveValidationErrors = screen =>
   screen && screen.components.some(({ validationErrorMessage }) => !!validationErrorMessage);
 
-export const getDefaultEntitySettingKey = (userId, entityTypes, countryId) =>
-  `DEFAULT_ENTITY_${userId}_${countryId}_${entityTypes.join('_')}`;
+export const getRecentEntitiesSettingKey = (userId, entityTypes, countryId) =>
+  `RECENT_ENTITIES_${userId}_${countryId}_${entityTypes.join('_')}`;
+
+export const getRecentEntityIds = (database, userId, entityTypes, countryId) =>
+  JSON.parse(
+    database.getSetting(getRecentEntitiesSettingKey(userId, entityTypes, countryId)) || '[]',
+  );
+const MAX_RECENT_ENTITIES = 5;
+export const addRecentEntityId = (database, userId, entityTypes, countryId, entityId) => {
+  const recentEntityIds = getRecentEntityIds(database, userId, entityTypes, countryId);
+  const updatedRecentEntityIds = [entityId, ...recentEntityIds.filter(id => id !== entityId)].slice(
+    0,
+    MAX_RECENT_ENTITIES,
+  );
+  database.setSetting(
+    getRecentEntitiesSettingKey(userId, entityTypes, countryId),
+    JSON.stringify(updatedRecentEntityIds),
+  );
+};
 
 export const getEntityCreationQuestions = questions =>
   questions.filter(({ config }) => config.entity && config.entity.createNew);

--- a/packages/meditrak-app/app/assessment/reducer.js
+++ b/packages/meditrak-app/app/assessment/reducer.js
@@ -26,6 +26,7 @@ const defaultState = {
   screens: null,
   isSubmitting: false,
   isSurveyInProgress: false,
+  primaryEntityQuestionId: null,
   questions: {},
   answers: {},
   isChildScrolling: false, // question controlling scroll as opposed to DumbSurveyScreen
@@ -66,11 +67,20 @@ const stateChanges = {
     screens[screenIndex].errorMessage = message;
     return { screens };
   },
-  [SURVEY_SELECT]: ({ answers, assessorId, surveyId, screens, startTime, questions }) => ({
+  [SURVEY_SELECT]: ({
+    answers,
+    assessorId,
+    primaryEntityQuestionId,
+    surveyId,
+    screens,
+    startTime,
+    questions,
+  }) => ({
     answers,
     assessorId,
     surveyId,
     screens,
+    primaryEntityQuestionId,
     questions,
     startTime,
     isSubmitting: false,

--- a/packages/meditrak-app/app/assessment/specificQuestions/EntityQuestion.js
+++ b/packages/meditrak-app/app/assessment/specificQuestions/EntityQuestion.js
@@ -36,10 +36,11 @@ DumbEntityQuestion.defaultProps = {
 // speaks directly to redux and is sent as part of the metadata of the request.
 export const PrimaryEntityQuestion = connect(
   (state, { id: questionId, answer: selectedEntityId }) => {
-    const { entities = [] } = getEntityQuestionState(state, questionId);
+    const { entities = [], recentEntities = [] } = getEntityQuestionState(state, questionId);
 
     return {
       entities,
+      recentEntities,
       selectedEntityId,
       hasScrollControl: state.assessment.isChildScrolling,
     };

--- a/packages/meditrak-app/app/entityMenu/EntityList.js
+++ b/packages/meditrak-app/app/entityMenu/EntityList.js
@@ -128,7 +128,7 @@ export class EntityList extends PureComponent {
     }
 
     const { entities, recentEntities } = this.props;
-    if (recentEntities && recentEntities.length > 0) {
+    if (recentEntities?.length > 0) {
       return [
         { title: 'Recently used', data: recentEntities },
         { title: 'All entities', data: entities },

--- a/packages/meditrak-app/app/entityMenu/actions.js
+++ b/packages/meditrak-app/app/entityMenu/actions.js
@@ -73,10 +73,13 @@ export const loadEntitiesFromDatabase = (isPrimaryEntity, questionId) => (
   recentEntityIds.forEach((id, index) => {
     recentEntityIdToIndex[id] = index;
   });
-  const recentEntities = database
-    .getEntities({ ...filters, id: recentEntityIds })
-    .slice()
-    .sort((a, b) => recentEntityIdToIndex[a.id] - recentEntityIdToIndex[b.id]);
+  const recentEntities =
+    recentEntityIds.length === 0
+      ? []
+      : database
+          .getEntities({ ...filters, id: recentEntityIds })
+          .slice()
+          .sort((a, b) => recentEntityIdToIndex[a.id] - recentEntityIdToIndex[b.id]);
 
   dispatch({
     type: isPrimaryEntity ? ENTITY_RECEIVE_PRIMARY_ENTITIES : ENTITY_RECEIVE_ENTITIES,

--- a/packages/meditrak-app/app/entityMenu/reducer.js
+++ b/packages/meditrak-app/app/entityMenu/reducer.js
@@ -13,7 +13,7 @@ const defaultState = {
   questions: {},
 };
 
-function updateEntities({ entities, questionId }, { questions }) {
+function updateEntities({ entities, recentEntities, questionId }, { questions }) {
   const question = questions[questionId] || {};
   return {
     questions: {
@@ -21,6 +21,7 @@ function updateEntities({ entities, questionId }, { questions }) {
       [questionId]: {
         ...question,
         entities,
+        recentEntities,
       },
     },
   };


### PR DESCRIPTION
### Issue #:
Fixes the awkward UX Sima mentions [here](https://linear.app/bes/issue/RN-439#comment-e61bc161)

### Changes:
- Show a list of recently used entities, rather than pre-selecting the last used entity when starting a new survey

See the screenshot [here](https://linear.app/bes/issue/RN-439#comment-a332a845)