### PR TITLE
Fixed deployment failing when checking if branch exists

### DIFF
--- a/packages/devops/scripts/lambda/resources/startup.sh
+++ b/packages/devops/scripts/lambda/resources/startup.sh
@@ -55,7 +55,7 @@ fi
 
 # Fetch the latest code
 cd $TUPAIA_DIR
-BRANCH_ON_REMOTE=$(git ls-remote --heads origin ${BRANCH})
+BRANCH_ON_REMOTE=$(sudo -Hu ubuntu git ls-remote --heads origin ${BRANCH})
 if [[ $BRANCH_ON_REMOTE == *${BRANCH} ]]; then
   echo "${BRANCH} exists"
   BRANCH_TO_USE=${BRANCH}


### PR DESCRIPTION
Run the `git ls-remote` command as the `ubuntu` user, as the `ssm-agent` user doesn't have access to the `.git` file that describes the directory as a git repo.