### PR TITLE
RN-458: Take scroll control when autocomplete in use

### DIFF
--- a/packages/meditrak-app/app/assessment/specificQuestions/AutocompleteQuestion.js
+++ b/packages/meditrak-app/app/assessment/specificQuestions/AutocompleteQuestion.js
@@ -113,7 +113,7 @@ export class AutocompleteQuestionComponent extends React.Component {
 
   render() {
     const { optionList } = this.state;
-    const { answer, onChangeAnswer } = this.props;
+    const { answer, onChangeAnswer, scrollIntoFocus } = this.props;
     return (
       <View>
         <Autocomplete
@@ -123,6 +123,7 @@ export class AutocompleteQuestionComponent extends React.Component {
           options={optionList}
           handleEndReached={this.fetchMoreResults}
           handleChangeInput={this.filterOptionList}
+          scrollIntoFocus={scrollIntoFocus}
           endReachedOffset={0.3}
         />
       </View>
@@ -137,6 +138,7 @@ AutocompleteQuestionComponent.propTypes = {
   onChangeAnswer: PropTypes.func.isRequired,
   optionSetId: PropTypes.string.isRequired,
   realmDatabase: PropTypes.any.isRequired,
+  scrollIntoFocus: PropTypes.func.isRequired,
 };
 
 AutocompleteQuestionComponent.defaultProps = {

--- a/packages/meditrak-app/app/widgets/Autocomplete/Autocomplete.js
+++ b/packages/meditrak-app/app/widgets/Autocomplete/Autocomplete.js
@@ -80,21 +80,26 @@ class AutocompleteComponent extends PureComponent {
     if (handleEndReached) handleEndReached();
   };
 
-  renderRightButton = () => {
+  getRightButtonProps = () => {
+    // use an "x" to represent clear if an option is selected or a search term entered
     if (this.props.selectedOption || this.state.searchTerm) {
-      return (
-        <Icon name="times" size={20} style={localStyles.clearIcon} onPress={this.clearSelection} />
-      );
+      return {
+        name: 'times',
+        onPress: this.clearSelection,
+      };
     }
 
+    // otherwise show up/down arrows to open/close the full set of results
     if (this.state.isOpen) {
-      return (
-        <Icon name="caret-up" size={20} style={localStyles.clearIcon} onPress={this.closeResults} />
-      );
+      return {
+        name: 'caret-up',
+        onPress: this.closeResults,
+      };
     }
-    return (
-      <Icon name="caret-down" size={20} style={localStyles.clearIcon} onPress={this.openResults} />
-    );
+    return {
+      name: 'caret-down',
+      onPress: this.openResults,
+    };
   };
 
   render() {
@@ -127,7 +132,7 @@ class AutocompleteComponent extends PureComponent {
             isFocused ? localStyles.textInputFocussed : {},
           ]}
         />
-        {this.renderRightButton()}
+        <Icon size={20} style={localStyles.rightButton} {...this.getRightButtonProps()} />
         {!selectedOption && options.length > 0 && isOpen && (
           <View style={{ flex: 1 }}>
             <FlatList
@@ -209,7 +214,7 @@ const localStyles = StyleSheet.create({
     height: Dimensions.get('window').height, // fixed height so FlatList optimisations work within the outer ScrollView
     flex: 1,
   },
-  clearIcon: {
+  rightButton: {
     position: 'absolute',
     padding: 10,
     right: 0,


### PR DESCRIPTION
### Issue #:
RN-458

### Changes:
A UX change was required here, as we can only have either the autocomplete results _or_ the surrounding screen scrollable. 
See [here](https://linear.app/bes/issue/RN-458#comment-19a2299a) for a description with screenshots, but in brief:
- The autocomplete will now start "closed"
- Pressing the "down" arrow on the right, or just tapping in the searchbox will open the full set of options
- If you start typing, it filters the options and replaces the open/close arrow with a clear button
- Whenever the full list of options is open, it will be scrollable (but the screen around won't be)
- If you select an option or click the "up" button on the right, it will close and hand scroll control back to the surrounding screen
