### PR TITLE
Swap default lesmis date to 2021

### DIFF
--- a/packages/lesmis/src/constants/constants.js
+++ b/packages/lesmis/src/constants/constants.js
@@ -35,7 +35,9 @@ export const SUB_DASHBOARD_OPTIONS = [
 export const SINGLE_YEAR_GRANULARITY = 'one_year_at_a_time';
 export const MIN_DATA_DATE = '20150101';
 export const MIN_DATA_YEAR = '2015';
-export const DEFAULT_DATA_YEAR = `${new Date().getFullYear()}`;
+// TODO: Put this back when requested
+// export const DEFAULT_DATA_YEAR = `${new Date().getFullYear()}`;
+export const DEFAULT_DATA_YEAR = '2021';
 
 // Layout Constants
 export const NAVBAR_HEIGHT_INT = 70;


### PR DESCRIPTION
### Issue #:
Requested by @enunan in slack: https://beyondessential.slack.com/archives/C02E8F08CAU/p1650596299491969


### Changes:

- Swap default date to hard `2021` instead of the current year