### PR TITLE
Use date-fns to manipulate date in transform

### DIFF
--- a/packages/expression-parser/package.json
+++ b/packages/expression-parser/package.json
@@ -21,6 +21,7 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "mathjs": "^9.4.0"
+    "mathjs": "^9.4.0",
+    "date-fns": "^2.12.0"
   }
 }

--- a/packages/expression-parser/package.json
+++ b/packages/expression-parser/package.json
@@ -22,6 +22,6 @@
   },
   "dependencies": {
     "mathjs": "^9.4.0",
-    "date-fns": "^2.12.0"
+    "date-fns": "^2.16.1"
   }
 }

--- a/packages/expression-parser/src/__tests__/expression-parser/ExpressionParser.test.js
+++ b/packages/expression-parser/src/__tests__/expression-parser/ExpressionParser.test.js
@@ -37,12 +37,12 @@ describe('ExpressionParser', () => {
       ["firstExistingValue - ignores `'undefined'`", "firstExistingValue('undefined', 1)", 1],
       [
         'dateUtils - differenceInYears',
-        `dateUtils().differenceInYears(date(), date('1993-12-18'))`,
+        `dateUtils.differenceInYears(date(), date('1993-12-18'))`,
         26,
       ],
       [
         'dateUtils - differenceInCalendarYears',
-        `dateUtils().differenceInCalendarYears(date(), date('1993-12-18'))`,
+        `dateUtils.differenceInCalendarYears(date(), date('1993-12-18'))`,
         27,
       ], // More dateUtils functions from https://date-fns.org/v2.16.1/docs/Getting-Started
     ];

--- a/packages/expression-parser/src/__tests__/expression-parser/ExpressionParser.test.js
+++ b/packages/expression-parser/src/__tests__/expression-parser/ExpressionParser.test.js
@@ -35,6 +35,16 @@ describe('ExpressionParser', () => {
       ['firstExistingValue - includes zero', 'firstExistingValue(0, 1)', 0],
       ['firstExistingValue - ignores `undefined`', 'firstExistingValue(undefined, 1)', 1],
       ["firstExistingValue - ignores `'undefined'`", "firstExistingValue('undefined', 1)", 1],
+      [
+        'dateUtils - differenceInYears',
+        `dateUtils().differenceInYears(date(), date('1993-12-18'))`,
+        26,
+      ],
+      [
+        'dateUtils - differenceInCalendarYears',
+        `dateUtils().differenceInCalendarYears(date(), date('1993-12-18'))`,
+        27,
+      ], // More dateUtils functions from https://date-fns.org/v2.16.1/docs/Getting-Started
     ];
 
     const parser = new ExpressionParser();

--- a/packages/expression-parser/src/expression-parser/ExpressionParser.js
+++ b/packages/expression-parser/src/expression-parser/ExpressionParser.js
@@ -4,6 +4,7 @@
  */
 
 import { create, all } from 'mathjs';
+import * as fns from 'date-fns';
 
 import { customFunctions } from './customFunctions';
 
@@ -49,6 +50,7 @@ export class ExpressionParser {
     this.math.import(this.getFunctionExtensions());
     this.math.import(this.getFunctionOverrides(), { wrap: true, override: true });
     this.validExpressionCache = new Set();
+    this.set('dateUtils', fns); // Support all FNS date modification functions. https://date-fns.org/v2.16.1/docs/Getting-Started
   }
 
   /**

--- a/packages/expression-parser/src/expression-parser/ExpressionParser.js
+++ b/packages/expression-parser/src/expression-parser/ExpressionParser.js
@@ -4,9 +4,9 @@
  */
 
 import { create, all } from 'mathjs';
-import * as fns from 'date-fns';
 
 import { customFunctions } from './customFunctions';
+import { customNamespaces } from './customNamespaces';
 
 /**
  * @typedef {Object} Scope
@@ -50,7 +50,7 @@ export class ExpressionParser {
     this.math.import(this.getFunctionExtensions());
     this.math.import(this.getFunctionOverrides(), { wrap: true, override: true });
     this.validExpressionCache = new Set();
-    this.set('dateUtils', fns); // Support all FNS date modification functions. https://date-fns.org/v2.16.1/docs/Getting-Started
+    this.setAll(customNamespaces);
   }
 
   /**

--- a/packages/expression-parser/src/expression-parser/customFunctions.js
+++ b/packages/expression-parser/src/expression-parser/customFunctions.js
@@ -3,6 +3,8 @@
  * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
  */
 
+import * as fns from 'date-fns';
+
 // We use the `'undefined'` string to indicate a missing value in cases where the
 // actual `undefined` JS type cannot be used, e.g. in json config persisted in the DB
 const isUndefined = value => value !== undefined && value !== 'undefined';
@@ -30,9 +32,12 @@ const translate = (value, translations) => {
 
 const date = (...argumentList) => new Date(...argumentList);
 
+const dateUtils = () => fns;
+
 export const customFunctions = {
   avg: average,
   firstExistingValue,
   translate,
   date,
+  dateUtils,
 };

--- a/packages/expression-parser/src/expression-parser/customFunctions.js
+++ b/packages/expression-parser/src/expression-parser/customFunctions.js
@@ -3,8 +3,6 @@
  * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
  */
 
-import * as fns from 'date-fns';
-
 // We use the `'undefined'` string to indicate a missing value in cases where the
 // actual `undefined` JS type cannot be used, e.g. in json config persisted in the DB
 const isUndefined = value => value !== undefined && value !== 'undefined';
@@ -32,12 +30,9 @@ const translate = (value, translations) => {
 
 const date = (...argumentList) => new Date(...argumentList);
 
-const dateUtils = () => fns; // Support all FNS date modification functions. https://date-fns.org/v2.16.1/docs/Getting-Started
-
 export const customFunctions = {
   avg: average,
   firstExistingValue,
   translate,
   date,
-  dateUtils,
 };

--- a/packages/expression-parser/src/expression-parser/customFunctions.js
+++ b/packages/expression-parser/src/expression-parser/customFunctions.js
@@ -32,7 +32,7 @@ const translate = (value, translations) => {
 
 const date = (...argumentList) => new Date(...argumentList);
 
-const dateUtils = () => fns;
+const dateUtils = () => fns; // Support all FNS date modification functions. https://date-fns.org/v2.16.1/docs/Getting-Started
 
 export const customFunctions = {
   avg: average,

--- a/packages/expression-parser/src/expression-parser/customNamespaces.js
+++ b/packages/expression-parser/src/expression-parser/customNamespaces.js
@@ -1,0 +1,10 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import * as fns from 'date-fns';
+
+export const customNamespaces = {
+  dateUtils: fns, // Support all FNS date modification functions. https://date-fns.org/v2.16.1/docs/Getting-Started
+};


### PR DESCRIPTION
### Issue #:
RN-447

### Changes:
- `date-fns` has been used in other places in codebase, it would be great to have it for data transforming. 
- Use `date-fns` to manipulate date in transform, there are plenty handy functions that we can use: https://date-fns.org/docs/Getting-Started

### Example:
- For calculating age 
-- Before:
`age = string(floor((date($currentDate.substring(0,10)).getTime() - date(string($DOB).substring(0,10)).getTime())/(1000 * 3600 * 24* 365)))`
-- Now:
`age = dateUtils().differenceInYears(date($currentDate), date($DOB))`
---
