### PR TITLE
MAUI-754: Run report-server in cluster mode

### DIFF
--- a/packages/devops/scripts/deployment/startBackEnds.sh
+++ b/packages/devops/scripts/deployment/startBackEnds.sh
@@ -14,7 +14,7 @@ for PACKAGE in ${PACKAGES[@]}; do
         echo "Starting ${PACKAGE}"
         cd ${TUPAIA_DIR}/packages/$PACKAGE
         REPLICATION_PM2_CONFIG=''
-        if [[ $PACKAGE == "web-config-server" ]]; then
+        if [ $PACKAGE == "web-config-server" ] || [ $PACKAGE == "report-server" ]; then
             # as many replicas as cpu cores - 1
             REPLICATION_PM2_CONFIG='-i -1'
         fi


### PR DESCRIPTION
### Issue MAUI-754:

Currently there's just 1 report-server instance, and since node is single threaded, it's a pretty major bottleneck when loading multiple vizes. Usually most of the work is being done in the database which is async, but the transforms are sync, which means that each viz can only be handled one by one.

By running in pm2's cluster mode we can parallelize up to 7 vizes at once, which greatly improves throughput for dashboard with multiple slow vizes.

#### Testing using Tonga Covid-19 Dashboard:
Current (fork mode):
- min: 46ms
- max: 90.18s
- avg: 33.67s

Cluster mode:
- min: 45ms
- max: 16.73s
- avg: 4.59s