### PR TITLE
RN-493: Add AuthRoute to meditrak-app-server

### DIFF
--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/api-client",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "API client for connecting to Tupaia APIs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/api-client/src/TupaiaApiClient.ts
+++ b/packages/api-client/src/TupaiaApiClient.ts
@@ -5,15 +5,16 @@
  */
 
 import { AuthHandler } from './types';
-import { ApiConnection, EntityApi, CentralApi } from './connections';
+import { ApiConnection, AuthApi, EntityApi, CentralApi } from './connections';
 import { PRODUCTION_BASE_URLS, ServiceBaseUrlSet } from './constants';
 
 export class TupaiaApiClient {
   public readonly entity: EntityApi;
-
   public readonly central: CentralApi;
+  public readonly auth: AuthApi;
 
   public constructor(authHandler: AuthHandler, baseUrls: ServiceBaseUrlSet = PRODUCTION_BASE_URLS) {
+    this.auth = new AuthApi(new ApiConnection(authHandler, baseUrls.auth));
     this.entity = new EntityApi(new ApiConnection(authHandler, baseUrls.entity));
     this.central = new CentralApi(new ApiConnection(authHandler, baseUrls.central));
   }

--- a/packages/api-client/src/connections/AuthApi.ts
+++ b/packages/api-client/src/connections/AuthApi.ts
@@ -1,0 +1,54 @@
+/*
+ * Tupaia
+ * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
+ *
+ */
+
+import { AccessPolicyObject } from '../types';
+import { BaseApi } from './BaseApi';
+
+type ServerAuthResponse = {
+  accessToken?: string;
+  refreshToken?: string;
+  user?: {
+    email: string;
+    accessPolicy: AccessPolicyObject;
+  };
+};
+
+type AuthDetails = {
+  emailAddress: string;
+  password: string;
+  deviceName: string;
+  devicePlatform?: string;
+  installId?: string;
+};
+
+export class AuthApi extends BaseApi {
+  public async login(authDetails: AuthDetails) {
+    const response = await this.connection.post('auth', { grantType: 'password' }, authDetails);
+    return this.parseServerResponse(response);
+  }
+
+  public async refreshAccessToken(refreshToken: string) {
+    const response = await this.connection.post(
+      'auth',
+      {
+        grantType: 'refresh_token',
+      },
+      {
+        refreshToken,
+      },
+    );
+    return this.parseServerResponse(response);
+  }
+
+  private parseServerResponse(response: ServerAuthResponse) {
+    const { accessToken, refreshToken, user } = response;
+    if (!accessToken || !refreshToken || !user) {
+      throw new Error('Invalid response from auth server');
+    }
+    const { accessPolicy, email } = user;
+    return { accessToken, refreshToken, accessPolicy, email, user };
+  }
+}

--- a/packages/api-client/src/connections/index.ts
+++ b/packages/api-client/src/connections/index.ts
@@ -5,5 +5,6 @@
  */
 
 export { ApiConnection } from './ApiConnection';
+export { AuthApi } from './AuthApi';
 export { EntityApi } from './EntityApi';
 export { CentralApi } from './CentralApi';

--- a/packages/api-client/src/constants.ts
+++ b/packages/api-client/src/constants.ts
@@ -5,7 +5,7 @@
 
 export const DATA_TIME_FORMAT = 'YYYY-MM-DD HH:mm:ss';
 
-type ServiceName = 'entity' | 'central' | 'report';
+type ServiceName = 'auth' | 'entity' | 'central' | 'report';
 export type ServiceBaseUrlSet = Record<ServiceName, string>;
 
 const productionSubdomains = [
@@ -15,6 +15,7 @@ const productionSubdomains = [
   'lesmis',
   'lesmis-api',
   'mobile',
+  'meditrak-api',
   'psss',
   'psss-api',
   'report-api',
@@ -26,6 +27,11 @@ const productionSubdomains = [
 const productionSubdomainSet = new Set(productionSubdomains);
 
 const SERVICES = {
+  auth: {
+    subdomain: 'api',
+    version: 'v2',
+    localPort: '8090',
+  },
   entity: {
     subdomain: 'entity-api',
     version: 'v1',
@@ -46,6 +52,7 @@ const SERVICES = {
 const getLocalUrl = (service: ServiceName): string =>
   `http://localhost:${SERVICES[service].localPort}/${SERVICES[service].version}`;
 export const LOCALHOST_BASE_URLS: ServiceBaseUrlSet = {
+  auth: getLocalUrl('auth'),
   entity: getLocalUrl('entity'),
   central: getLocalUrl('central'),
   report: getLocalUrl('report'),
@@ -58,12 +65,14 @@ const getServiceUrl = (service: ServiceName, subdomainPrefix?: string): string =
 };
 
 export const DEV_BASE_URLS: ServiceBaseUrlSet = {
+  auth: getServiceUrl('auth', 'dev'),
   entity: getServiceUrl('entity', 'dev'),
   central: getServiceUrl('central', 'dev'),
   report: getServiceUrl('report', 'dev'),
 };
 
 export const PRODUCTION_BASE_URLS: ServiceBaseUrlSet = {
+  auth: getServiceUrl('auth'),
   entity: getServiceUrl('entity'),
   central: getServiceUrl('central'),
   report: getServiceUrl('report'),
@@ -100,6 +109,7 @@ const getDefaultBaseUrls = (hostname: string): ServiceBaseUrlSet => {
 
   // any other subdomain should prepend that same subdomain
   return {
+    auth: getServiceUrlForSubdomain('auth', subdomain),
     entity: getServiceUrlForSubdomain('entity', subdomain),
     central: getServiceUrlForSubdomain('central', subdomain),
     report: getServiceUrlForSubdomain('report', subdomain),
@@ -107,8 +117,9 @@ const getDefaultBaseUrls = (hostname: string): ServiceBaseUrlSet => {
 };
 
 export const getBaseUrlsForHost = (hostname: string): ServiceBaseUrlSet => {
-  const { entity, central, report } = getDefaultBaseUrls(hostname);
+  const { auth, entity, central, report } = getDefaultBaseUrls(hostname);
   return {
+    auth: process.env.AUTH_API_URL || auth,
     entity: process.env.ENTITY_API_URL || entity,
     central: process.env.CENTRAL_API_URL || central,
     report: process.env.REPORT_API_URL || report,

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -13,5 +13,3 @@ export { AuthHandler } from './types';
 export * from './auth';
 
 export * from './constants';
-
-

--- a/packages/devops/scripts/ci/validateBranchName.sh
+++ b/packages/devops/scripts/ci/validateBranchName.sh
@@ -4,7 +4,7 @@ DIR=$(dirname "$0")
 . ${DIR}/utils.sh
 
 INVALID_CHARS=('/' '\' '.' '&' '?' '_')
-SUBDOMAIN_SUFFIXES=(admin admin-api aggregation api config db export lesmis lesmis-api mobile psss psss-api report report-api ssh entity entity-api tonga-aggregation www)
+SUBDOMAIN_SUFFIXES=(admin admin-api aggregation api config db export lesmis lesmis-api mobile psss psss-api report report-api ssh entity entity-api meditrak-api tonga-aggregation www)
 
 # Branch names are used in AWS EC2 deployments. They are combined with standard suffixes
 # to create deployment urls, eg {{branchName}}-tonga-aggregation.tupaia.org

--- a/packages/devops/scripts/lambda/helpers/create_from_image.py
+++ b/packages/devops/scripts/lambda/helpers/create_from_image.py
@@ -68,7 +68,7 @@ def create_tupaia_instance_from_image(
 ):
     deployment_type = 'tupaia'
     tupaia_server_iam_role_arn = 'arn:aws:iam::843218180240:instance-profile/TupaiaServerRole'
-    tupaia_subdomains = ['','admin','admin-api','api','config','export','mobile','psss','report-api','psss-api','entity-api','lesmis-api','lesmis'] if setup_gateway else None
+    tupaia_subdomains = ['','admin','admin-api','api','config','export','mobile','psss','report-api','psss-api','entity-api','lesmis-api','lesmis', 'meditrak-api'] if setup_gateway else None
     tupaia_volume_size = 20 # 20GB
     startup_script = Path('./resources/startup.sh').read_text()
 

--- a/packages/entity-server/package.json
+++ b/packages/entity-server/package.json
@@ -32,6 +32,7 @@
     "@tupaia/auth": "1.0.0",
     "@tupaia/database": "1.0.0",
     "@tupaia/server-boilerplate": "1.0.0",
+    "@tupaia/tsutils": "1.0.0",
     "@tupaia/utils": "1.0.0",
     "dotenv": "^8.2.0",
     "express": "^4.16.2",

--- a/packages/entity-server/src/routes/hierarchy/types.ts
+++ b/packages/entity-server/src/routes/hierarchy/types.ts
@@ -4,9 +4,9 @@
  */
 
 import { Request } from 'express';
+import { Resolved } from '@tupaia/tsutils';
 import { EntityFields, EntityType, EntityFilter } from '../../models';
 import { extendedFieldFunctions } from './extendedFieldFunctions';
-import { Resolved } from '../../types';
 
 export interface SingleEntityRequestParams {
   hierarchyName: string;

--- a/packages/entity-server/src/types.ts
+++ b/packages/entity-server/src/types.ts
@@ -12,9 +12,6 @@ export interface EntityServerModelRegistry extends ModelRegistry {
   readonly entityHierarchy: EntityHierarchyModel;
 }
 
-// Returns resolved type if type is promise
-export type Resolved<T> = T extends Promise<infer R> ? R : T;
-
 // Extracts keys that have object-like values from type T
 export type ObjectLikeKeys<T> = {
   [K in keyof T]: T[K] extends Record<string, unknown> ? K : never;

--- a/packages/meditrak-app-server/examples.http
+++ b/packages/meditrak-app-server/examples.http
@@ -28,7 +28,7 @@ Authorization: {{authorization}}
 
 ### /auth (refresh token)
 
-POST http://{{host}}/{{version}}/auth HTTP/2.0
+POST http://{{host}}/{{version}}/auth?grantType=refresh_token HTTP/2.0
 content-type: {{contentType}}
 Authorization: {{authorization}}
 

--- a/packages/meditrak-app-server/examples.http
+++ b/packages/meditrak-app-server/examples.http
@@ -2,8 +2,36 @@
 @port = 8020
 @host = {{hostname}}:{{port}}
 @version = v1
+
+@authorization  = Basic meditrak_client:{{meditrak-client-password}}
+
 @contentType = application/json
 
 ### /test
 GET http://{{host}}/{{version}}/test HTTP/2.0
+content-type: {{contentType}}
+Authorization: {{authorization}}
 
+### /auth (login)
+
+POST http://{{host}}/{{version}}/auth HTTP/2.0
+content-type: {{contentType}}
+Authorization: {{authorization}}
+
+{
+    "emailAddress": "{{email}}",
+    "password": "{{password}}",
+    "deviceName": "test",
+    "devicePlatform": "android",
+    "installId": "1234"
+}
+
+### /auth (refresh token)
+
+POST http://{{host}}/{{version}}/auth HTTP/2.0
+content-type: {{contentType}}
+Authorization: {{authorization}}
+
+{
+    "refreshToken": "1234"
+}

--- a/packages/meditrak-app-server/package.json
+++ b/packages/meditrak-app-server/package.json
@@ -31,7 +31,9 @@
     "@tupaia/api-client": "3.1.0",
     "@tupaia/database": "1.0.0",
     "@tupaia/server-boilerplate": "1.0.0",
+    "@tupaia/tsutils": "1.0.0",
     "dotenv": "^8.2.0",
+    "express": "^4.16.2",
     "winston": "^3.2.1"
   }
 }

--- a/packages/meditrak-app-server/package.json
+++ b/packages/meditrak-app-server/package.json
@@ -28,6 +28,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
+    "@tupaia/api-client": "3.1.0",
     "@tupaia/database": "1.0.0",
     "@tupaia/server-boilerplate": "1.0.0",
     "dotenv": "^8.2.0",

--- a/packages/meditrak-app-server/package.json
+++ b/packages/meditrak-app-server/package.json
@@ -32,6 +32,7 @@
     "@tupaia/database": "1.0.0",
     "@tupaia/server-boilerplate": "1.0.0",
     "@tupaia/tsutils": "1.0.0",
+    "@tupaia/utils": "1.0.0",
     "dotenv": "^8.2.0",
     "express": "^4.16.2",
     "winston": "^3.2.1"

--- a/packages/meditrak-app-server/src/@types/express/index.d.ts
+++ b/packages/meditrak-app-server/src/@types/express/index.d.ts
@@ -1,0 +1,17 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+import { RequestContext } from '../../types';
+
+declare global {
+  namespace Express {
+    export interface Request {
+      ctx: RequestContext;
+    }
+
+    export interface Response {
+      ctx: RequestContext;
+    }
+  }
+}

--- a/packages/meditrak-app-server/src/app/createApp.ts
+++ b/packages/meditrak-app-server/src/app/createApp.ts
@@ -3,13 +3,14 @@
  * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
  */
 import { TupaiaDatabase } from '@tupaia/database';
-import { MicroServiceApiBuilder } from '@tupaia/server-boilerplate';
+import { handleWith, MicroServiceApiBuilder } from '@tupaia/server-boilerplate';
 import {
   ForwardingAuthHandler,
   getBaseUrlsForHost,
   LOCALHOST_BASE_URLS,
   TupaiaApiClient,
 } from '@tupaia/api-client';
+import { AuthRequest, AuthRoute } from '../routes';
 
 /**
  * Set up express server with middleware,
@@ -29,6 +30,7 @@ export function createApp() {
       res.ctx = context;
       next();
     })
+    .post<AuthRequest>('auth', handleWith(AuthRoute))
     .build();
 
   return app;

--- a/packages/meditrak-app-server/src/app/createApp.ts
+++ b/packages/meditrak-app-server/src/app/createApp.ts
@@ -4,12 +4,32 @@
  */
 import { TupaiaDatabase } from '@tupaia/database';
 import { MicroServiceApiBuilder } from '@tupaia/server-boilerplate';
+import {
+  ForwardingAuthHandler,
+  getBaseUrlsForHost,
+  LOCALHOST_BASE_URLS,
+  TupaiaApiClient,
+} from '@tupaia/api-client';
 
 /**
  * Set up express server with middleware,
  */
 export function createApp() {
-  const app = new MicroServiceApiBuilder(new TupaiaDatabase()).build();
+  const app = new MicroServiceApiBuilder(new TupaiaDatabase())
+    .middleware((req, res, next) => {
+      const baseUrls =
+        process.env.NODE_ENV === 'test' ? LOCALHOST_BASE_URLS : getBaseUrlsForHost(req.hostname);
+      const context = {
+        services: new TupaiaApiClient(
+          new ForwardingAuthHandler(req.headers.authorization),
+          baseUrls,
+        ),
+      };
+      req.ctx = context;
+      res.ctx = context;
+      next();
+    })
+    .build();
 
   return app;
 }

--- a/packages/meditrak-app-server/src/routes/AuthRoute.ts
+++ b/packages/meditrak-app-server/src/routes/AuthRoute.ts
@@ -1,0 +1,46 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import { Request } from 'express';
+
+import { Route } from '@tupaia/server-boilerplate';
+import { Resolved } from '@tupaia/tsutils';
+import { TupaiaApiClient } from '@tupaia/api-client';
+
+type RefreshTokenBody = {
+  refreshToken: string;
+};
+
+type ReAuthenticateBody = {
+  emailAddress: string;
+  password: string;
+  deviceName: string;
+  devicePlatform: string;
+  installId: string;
+};
+
+export type AuthRequest = Request<
+  {
+    grantType?: 'refresh_token';
+  },
+  | Resolved<ReturnType<TupaiaApiClient['auth']['login']>>
+  | Resolved<ReturnType<TupaiaApiClient['auth']['refreshAccessToken']>>,
+  ReAuthenticateBody | RefreshTokenBody
+>;
+
+const hasRefreshToken = (body: ReAuthenticateBody | RefreshTokenBody): body is RefreshTokenBody =>
+  'refreshToken' in body;
+
+export class AuthRoute extends Route<AuthRequest> {
+  public async buildResponse() {
+    const { body } = this.req;
+    if (hasRefreshToken(body)) {
+      const { refreshToken } = body;
+      return this.req.ctx.services.auth.refreshAccessToken(refreshToken);
+    }
+
+    return this.req.ctx.services.auth.login(body);
+  }
+}

--- a/packages/meditrak-app-server/src/routes/AuthRoute.ts
+++ b/packages/meditrak-app-server/src/routes/AuthRoute.ts
@@ -11,12 +11,13 @@ import { yup } from '@tupaia/utils';
 import { TupaiaApiClient } from '@tupaia/api-client';
 
 export type AuthRequest = Request<
-  {
-    grantType?: 'refresh_token';
-  },
+  Record<string, never>,
   | Resolved<ReturnType<TupaiaApiClient['auth']['login']>>
   | Resolved<ReturnType<TupaiaApiClient['auth']['refreshAccessToken']>>,
-  Record<string, unknown>
+  Record<string, never>,
+  {
+    grantType?: 'refresh_token';
+  }
 >;
 
 const reAuthValidator = yup.object().shape({

--- a/packages/meditrak-app-server/src/routes/index.ts
+++ b/packages/meditrak-app-server/src/routes/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+export { AuthRequest, AuthRoute } from './AuthRoute';

--- a/packages/meditrak-app-server/src/types.ts
+++ b/packages/meditrak-app-server/src/types.ts
@@ -1,0 +1,10 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import { TupaiaApiClient } from '@tupaia/api-client';
+
+export type RequestContext = {
+  services: TupaiaApiClient;
+};

--- a/packages/report-server/package.json
+++ b/packages/report-server/package.json
@@ -34,7 +34,7 @@
     "@tupaia/database": "1.0.0",
     "@tupaia/expression-parser": "1.0.0",
     "@tupaia/server-boilerplate": "1.0.0",
-    "@tupaia/api-client": "3.0.0",
+    "@tupaia/api-client": "3.1.0",
     "@tupaia/utils": "1.0.0",
     "@tupaia/tsutils": "1.0.0",
     "api-error-handler": "^1.0.0",

--- a/packages/tsutils/src/index.ts
+++ b/packages/tsutils/src/index.ts
@@ -1,1 +1,2 @@
 export * from './validation';
+export * from './types';

--- a/packages/tsutils/src/types.ts
+++ b/packages/tsutils/src/types.ts
@@ -1,0 +1,7 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+// TODO: Switch to 'Awaited' when upgrading to typescript 4.5+
+export type Resolved<T> = T extends Promise<infer R> ? R : T;


### PR DESCRIPTION
### Issue RN-493:

Added `AuthRoute` to `meditrak-app-server`. First by adding an `AuthApi` to the `api-client` so that we didn't need to explicitly request from the the `central-server`. I like this move, as we've been wondering about moving the auth logic into its own server, and by wrapping it in the `api-client` like this it will make the refactor simpler.

After that we just had to add the `api-client` to the request context in the `meditrak-app-server` and then implement a simple route class that uses it.

#### Merge tasks:
- [ ] Add `AUTH_API_URL` .env vars