### PR TITLE
RN-498: Add RegisterUser route to meditrak-app-server

### DIFF
--- a/packages/api-client/src/connections/CentralApi.ts
+++ b/packages/api-client/src/connections/CentralApi.ts
@@ -17,6 +17,12 @@ export type Answers = {
 };
 
 export class CentralApi extends BaseApi {
+  public async registerUserAccount(
+    userFields: Record<string, unknown>,
+  ): Promise<{ userId: string; message: string }> {
+    return this.connection.post('user', null, userFields);
+  }
+
   public async createSurveyResponses(responses: SurveyResponse[]): Promise<void> {
     const BATCH_SIZE = 500;
     for (let i = 0; i < responses.length; i += BATCH_SIZE) {

--- a/packages/meditrak-app-server/examples.http
+++ b/packages/meditrak-app-server/examples.http
@@ -12,7 +12,7 @@ GET http://{{host}}/{{version}}/test HTTP/2.0
 content-type: {{contentType}}
 Authorization: {{authorization}}
 
-### /auth (login)
+### Login
 
 POST http://{{host}}/{{version}}/auth HTTP/2.0
 content-type: {{contentType}}
@@ -26,7 +26,7 @@ Authorization: {{authorization}}
     "installId": "1234"
 }
 
-### /auth (refresh token)
+### Refresh Token
 
 POST http://{{host}}/{{version}}/auth?grantType=refresh_token HTTP/2.0
 content-type: {{contentType}}
@@ -34,4 +34,21 @@ Authorization: {{authorization}}
 
 {
     "refreshToken": "1234"
+}
+
+### Register User
+
+POST http://{{host}}/{{version}}/user HTTP/2.0
+content-type: {{contentType}}
+Authorization: {{authorization}}
+
+{
+    "firstName": "Bob",
+    "lastName": "Burger",
+    "emailAddress": "bob_burger@test.com",
+    "password": "test_test",
+    "passwordConfirm": "test_test",
+    "contactNumber": "12345678",
+    "employer": "Boss",
+    "position": "Cat"
 }

--- a/packages/meditrak-app-server/src/app/createApp.ts
+++ b/packages/meditrak-app-server/src/app/createApp.ts
@@ -10,7 +10,7 @@ import {
   LOCALHOST_BASE_URLS,
   TupaiaApiClient,
 } from '@tupaia/api-client';
-import { AuthRequest, AuthRoute } from '../routes';
+import { AuthRequest, AuthRoute, RegisterUserRequest, RegisterUserRoute } from '../routes';
 
 /**
  * Set up express server with middleware,
@@ -31,6 +31,7 @@ export function createApp() {
       next();
     })
     .post<AuthRequest>('auth', handleWith(AuthRoute))
+    .post<RegisterUserRequest>('user', handleWith(RegisterUserRoute))
     .build();
 
   return app;

--- a/packages/meditrak-app-server/src/routes/RegisterUserRoute.ts
+++ b/packages/meditrak-app-server/src/routes/RegisterUserRoute.ts
@@ -1,0 +1,24 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import { Request } from 'express';
+
+import { Route } from '@tupaia/server-boilerplate';
+import { Resolved } from '@tupaia/tsutils';
+import { TupaiaApiClient } from '@tupaia/api-client';
+
+export type RegisterUserRequest = Request<
+  Record<string, never>,
+  Resolved<ReturnType<TupaiaApiClient['central']['registerUserAccount']>>,
+  Record<string, unknown>
+>;
+
+export class RegisterUserRoute extends Route<RegisterUserRequest> {
+  public async buildResponse() {
+    const { body } = this.req;
+
+    return this.req.ctx.services.central.registerUserAccount(body);
+  }
+}

--- a/packages/meditrak-app-server/src/routes/index.ts
+++ b/packages/meditrak-app-server/src/routes/index.ts
@@ -4,3 +4,4 @@
  */
 
 export { AuthRequest, AuthRoute } from './AuthRoute';
+export { RegisterUserRequest, RegisterUserRoute } from './RegisterUserRoute';


### PR DESCRIPTION
### Issue RN-498:

Pretty simple route here, just pass user details through to `CentralApi` to register the user