### PR TITLE
Hot fix importing facilities

### DIFF
--- a/packages/central-server/src/apiV2/import/importEntities/updateCountryEntities.js
+++ b/packages/central-server/src/apiV2/import/importEntities/updateCountryEntities.js
@@ -41,10 +41,12 @@ async function attemptFacilityUpsert(
     country,
   },
 ) {
-  if (!parentGeographicalArea)
+  if (!parentGeographicalArea) {
     console.warn(
       `Parent entity of facility has no geographical area, skipping facility creation for ${code}, parent entity code: ${parentEntity.code}`,
     );
+    return;
+  }
   const defaultTypeDetails = getDefaultTypeDetails(facilityType);
   const facilityToUpsert = {
     type: facilityType,

--- a/packages/database/src/modelClasses/Entity.js
+++ b/packages/database/src/modelClasses/Entity.js
@@ -30,7 +30,7 @@ const WORLD = 'world';
 const PROJECT = 'project';
 const CITY = 'city';
 const POSTCODE = 'postcode';
-const LOCAL_GOV = 'local_gov';
+const LOCAL_GOVERNMENT = 'local_government';
 
 // Note: if a new type is not included in `ORG_UNIT_ENTITY_TYPES`, but data is to be stored against
 // it on DHIS2, a corresponding tracked entity type must be created in DHIS2
@@ -55,7 +55,7 @@ const ENTITY_TYPES = {
   PROJECT,
   CITY,
   POSTCODE,
-  LOCAL_GOV,
+  LOCAL_GOVERNMENT,
 };
 
 export const ORG_UNIT_ENTITY_TYPES = {


### PR DESCRIPTION
### Issue #:
See https://beyondessential.slack.com/archives/C02HES8HFQF/p1652822478304789 (first commit) and https://beyondessential.slack.com/archives/C011G5L1J12/p1652820293767959?thread_ts=1647919038.678739&cid=C011G5L1J12 (second commit)

### Changes:

- Fix missed text change from local_gov -> local_government
- Skip facility record creation if it doesn't have a valid geographical_area parent. `facility` aka `clinic` is a bit of a legacy thing, and is only maintained for people using older versions of MediTrak, meaning that most new `facility` type entities won't need a corresponding entry in the `facility`/`clinic` table