### PR TITLE
Added logging around refresh after migrations

### DIFF
--- a/packages/database/src/runPostMigration.js
+++ b/packages/database/src/runPostMigration.js
@@ -91,6 +91,7 @@ export const runPostMigration = async driver => {
   );
 
   // Refresh analytics in case they've been impacted by migrations
+  console.log(`Migrations complete, refreshing analytics...`);
   const start = Date.now();
   await driver.runSql(`SELECT mv$refreshMaterializedView('analytics', 'public', true);`);
   const end = Date.now();


### PR DESCRIPTION
Once the migrations have run we do an analytics refresh. This can sometimes take a long time, and it's a bit unclear what's taking so long. Just added a simple log message to indicate that the analytics are being refreshed