### PR TITLE
RN-536: Modified DatabaseModel.findOrCreate to be atomic

### DIFF
--- a/packages/database/src/TupaiaDatabase.js
+++ b/packages/database/src/TupaiaDatabase.js
@@ -47,6 +47,10 @@ export const JOIN_TYPES = {
 // list valid behaviour so we can validate against sql injection
 const VALID_CAST_TYPES = ['text', 'text[]', 'date'];
 const VALID_COMPARISON_TYPES = ['where', 'whereBetween', 'whereIn', 'orWhere'];
+const WHERE_SUBQUERY_CLAUSES = {
+  EXISTS: 'exists',
+  NOT_EXISTS: 'notExists',
+};
 
 // no math here, just hand-tuned to be as low as possible while
 // keeping all the tests passing
@@ -265,8 +269,12 @@ export class TupaiaDatabase {
   }
 
   async findOrCreate(recordType, where, extraFieldsIfCreating = {}) {
-    const record = await this.findOne(recordType, where);
-    return record || this.create(recordType, { ...where, ...extraFieldsIfCreating });
+    await this.create(
+      recordType,
+      { ...where, ...extraFieldsIfCreating },
+      { notExists: { queryMethod: QUERY_METHODS.SELECT, recordType, where } },
+    );
+    return this.findOne(recordType, where);
   }
 
   async count(recordType, where, options) {
@@ -275,15 +283,18 @@ export class TupaiaDatabase {
     return parseInt(result[0].count, 10);
   }
 
-  async create(recordType, record) {
+  async create(recordType, record, where) {
     if (!record.id) {
       record.id = this.generateId();
     }
-    await this.query({
-      recordType,
-      queryMethod: QUERY_METHODS.INSERT,
-      queryMethodParameter: record,
-    });
+    await this.query(
+      {
+        recordType,
+        queryMethod: QUERY_METHODS.INSERT,
+        queryMethodParameter: record,
+      },
+      where,
+    );
 
     return record;
   }
@@ -553,6 +564,16 @@ function addWhereClause(connection, baseQuery, where) {
       const { sql = value, parameters } = value;
       return querySoFar.whereRaw(sql, parameters);
     }
+    if (key === WHERE_SUBQUERY_CLAUSES.EXISTS) {
+      return querySoFar.whereExists(function () {
+        this.query(value);
+      });
+    }
+    if (key === WHERE_SUBQUERY_CLAUSES.NOT_EXISTS) {
+      return querySoFar.whereNotExists(function () {
+        this.query(value);
+      });
+    }
     if (value === undefined) {
       return querySoFar; // Ignore undefined criteria
     }
@@ -572,6 +593,7 @@ function addWhereClause(connection, baseQuery, where) {
       throw new Error(`Cannot compare using ${comparisonType}`);
     }
 
+    // TODO: Replace with knex json where functions, eg. whereJsonPath
     const columnKey = key.includes('->>') ? connection.raw(`??->>?`, key.split('->>')) : key;
     const columnSelector = castAs ? connection.raw(`??::${castAs}`, [columnKey]) : columnKey;
 


### PR DESCRIPTION
### Issue RN-536:

Switched to using [whereNotExists](http://knexjs.org/guide/query-builder.html#wherenotexists) ensure we don't create a record that already exists. Best practice as described here: https://stackoverflow.com/questions/4069718/postgres-insert-if-does-not-exist-already/13342031#13342031

Another option could have been use to use Postgres's `ON CONFLICT` clause (https://www.postgresqltutorial.com/postgresql-tutorial/postgresql-upsert/) however that requires database constraints to be applied to work (something we might wanna consider for the future...)