### PR TITLE
Fix viz builder after data source split

### DIFF
--- a/packages/admin-panel/src/VizBuilderApp/api/queries/index.js
+++ b/packages/admin-panel/src/VizBuilderApp/api/queries/index.js
@@ -10,6 +10,7 @@ export * from './useUser';
 export * from './useDashboardVisualisation';
 export * from './useMapOverlays';
 export * from './useCountries';
-export * from './useSearchDataSources';
+export * from './useSearchDataElements';
+export * from './useSearchDataGroups';
 export * from './useSearchAggregationOptions';
 export * from './useSearchTransformSchemas';

--- a/packages/admin-panel/src/VizBuilderApp/api/queries/useSearchDataElements.js
+++ b/packages/admin-panel/src/VizBuilderApp/api/queries/useSearchDataElements.js
@@ -7,19 +7,19 @@ import { useQuery } from 'react-query';
 import { get } from '../api';
 import { DEFAULT_REACT_QUERY_OPTIONS } from '../constants';
 
-export const useSearchDataSources = ({ search, type = 'dataElement', maxResults = 100 }) =>
+export const useSearchDataElements = ({ search, maxResults = 100 }) =>
   useQuery(
-    ['dataSources', type, search],
+    ['dataElements', search],
     async () => {
-      const endpoint = stringifyQuery(undefined, 'dataSources', {
-        columns: JSON.stringify(['code', 'type']),
+      const endpoint = stringifyQuery(undefined, 'dataElements', {
+        columns: JSON.stringify(['code']),
         filter: JSON.stringify({
-          type,
           code: { comparator: 'ilike', comparisonValue: `${search}%`, castAs: 'text' },
         }),
         pageSize: maxResults,
       });
-      return get(endpoint);
+      const response = await get(endpoint);
+      return response.map(item => ({ ...item, type: 'dataElement' }));
     },
     {
       ...DEFAULT_REACT_QUERY_OPTIONS,

--- a/packages/admin-panel/src/VizBuilderApp/api/queries/useSearchDataGroups.js
+++ b/packages/admin-panel/src/VizBuilderApp/api/queries/useSearchDataGroups.js
@@ -1,0 +1,28 @@
+/*
+ * Tupaia
+ *  Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+import { stringifyQuery } from '@tupaia/utils';
+import { useQuery } from 'react-query';
+import { get } from '../api';
+import { DEFAULT_REACT_QUERY_OPTIONS } from '../constants';
+
+export const useSearchDataGroups = ({ search, maxResults = 100 }) =>
+  useQuery(
+    ['dataGroups', search],
+    async () => {
+      const endpoint = stringifyQuery(undefined, 'dataGroups', {
+        columns: JSON.stringify(['code']),
+        filter: JSON.stringify({
+          code: { comparator: 'ilike', comparisonValue: `${search}%`, castAs: 'text' },
+        }),
+        pageSize: maxResults,
+      });
+      const response = await get(endpoint);
+      return response.map(item => ({ ...item, type: 'dataGroup' }));
+    },
+    {
+      ...DEFAULT_REACT_QUERY_OPTIONS,
+      keepPreviousData: true,
+    },
+  );

--- a/packages/admin-panel/src/VizBuilderApp/components/DataLibrary/DataElementDataLibrary.js
+++ b/packages/admin-panel/src/VizBuilderApp/components/DataLibrary/DataElementDataLibrary.js
@@ -7,7 +7,7 @@ import React, { useState } from 'react';
 import generateId from 'uuid/v1';
 import { BaseSelectedOption, DataLibrary } from '@tupaia/ui-components';
 import PropTypes from 'prop-types';
-import { useSearchDataSources } from '../../api';
+import { useSearchDataElements, useSearchDataGroups } from '../../api';
 import { useDebounce } from '../../../utilities';
 
 const DATA_TYPES = {
@@ -74,17 +74,15 @@ export const DataElementDataLibrary = ({ fetch, onFetchChange }) => {
   const {
     data: dataElementSearchResults = [],
     isFetching: isFetchingDataElements,
-  } = useSearchDataSources({
+  } = useSearchDataElements({
     search: debouncedInputValue,
-    type: 'dataElement',
     maxResults: MAX_RESULTS,
   });
   const {
     data: dataGroupSearchResults = [],
     isFetching: isFetchingDataGroups,
-  } = useSearchDataSources({
+  } = useSearchDataGroups({
     search: debouncedInputValue,
-    type: 'dataGroup',
     maxResults: MAX_RESULTS,
   });
 


### PR DESCRIPTION
Fix fetch data elements and data groups in viz builder after split. Was fetching from 'dataSources' endpoint still.

<img width="1433" alt="Screen Shot 2022-06-09 at 10 54 53 am" src="https://user-images.githubusercontent.com/667652/172741654-cf1267e0-d13c-4e67-b2ae-8dca6065e318.png">

