### PR TITLE
RN-501: Move sync logic to meditrak-app-server (PullChangesRoute)

### DIFF
--- a/packages/database/src/DatabaseModel.js
+++ b/packages/database/src/DatabaseModel.js
@@ -61,6 +61,9 @@ export class DatabaseModel {
     return this.schemaPromise;
   }
 
+  /**
+   * @returns {Promise<string[]>} fields of the model
+   */
   async fetchFieldNames() {
     if (!this.fieldNames) {
       const schema = await this.fetchSchema();

--- a/packages/database/src/ModelRegistry.js
+++ b/packages/database/src/ModelRegistry.js
@@ -55,6 +55,10 @@ export class ModelRegistry {
     });
   }
 
+  /**
+   * @param {string} databaseType
+   * @returns {import('./DatabaseModel').DatabaseModel}
+   */
   getModelForDatabaseType(databaseType) {
     return Object.values(this).find(model => model.databaseType === databaseType);
   }

--- a/packages/database/src/analytics/MaterializedViewLogDatabaseModel.js
+++ b/packages/database/src/analytics/MaterializedViewLogDatabaseModel.js
@@ -7,11 +7,12 @@ import { DatabaseModel } from '../DatabaseModel';
 
 export class MaterializedViewLogDatabaseModel extends DatabaseModel {
   async fetchSchema() {
-    if (!this.schemaPromise) {
-      const realSchemaPromise = await super.fetchSchema();
-      delete realSchemaPromise.m_row$; // Remove the m_row$ field from the schema notation
-      this.schemaPromise = realSchemaPromise;
+    this.schemaPromise = await super.fetchSchema();
+
+    if ('m_row$' in this.schemaPromise) {
+      delete this.schemaPromise.m_row$; // Remove the m_row$ field from the schema notation
     }
+
     return this.schemaPromise;
   }
 }

--- a/packages/meditrak-app-server/examples.http
+++ b/packages/meditrak-app-server/examples.http
@@ -99,3 +99,9 @@ Authorization: {{user-authorization}}
 GET http://{{host}}/{{version}}/changes/count?since=1503986686475.5&appVersion={{appVersion}} HTTP/2.0
 content-type: {{contentType}}
 Authorization: {{user-authorization}}
+
+### Get changes
+
+GET http://{{host}}/{{version}}/changes?since=1503986686475.5&appVersion={{appVersion}} HTTP/2.0
+content-type: {{contentType}}
+Authorization: {{user-authorization}}

--- a/packages/meditrak-app-server/jest.setup.ts
+++ b/packages/meditrak-app-server/jest.setup.ts
@@ -5,6 +5,11 @@
 
 import { getTestDatabase, clearTestData } from '@tupaia/database';
 
+beforeAll(async () => {
+  const database = getTestDatabase();
+  await clearTestData(database);
+});
+
 afterAll(async () => {
   const database = getTestDatabase();
   await clearTestData(database);

--- a/packages/meditrak-app-server/src/__tests__/__integration__/sync/PullChangesRoute.test.ts
+++ b/packages/meditrak-app-server/src/__tests__/__integration__/sync/PullChangesRoute.test.ts
@@ -1,0 +1,446 @@
+/* eslint jest/expect-expect: ["warn", { "assertFunctionNames": ["expect", "expectMatchingChangeRecords"] }] */
+
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import { constructAccessToken } from '@tupaia/auth';
+import {
+  clearTestData,
+  DatabaseModel,
+  getTestDatabase,
+  getTestModels,
+  upsertDummyRecord,
+} from '@tupaia/database';
+import { TestableServer } from '@tupaia/server-boilerplate';
+import { oneSecondSleep, randomIntBetween, createBearerHeader } from '@tupaia/utils';
+import { SyncableChangeEnqueuer, getUnsupportedModelFields } from '../../../sync';
+import { MeditrakAppServerModelRegistry } from '../../../types';
+import { TestModelRegistry } from '../../types';
+import { setupTestApp, setupTestUser } from '../../utilities';
+import { CAT_USER_SESSION } from '../fixtures';
+import { upsertDummyQuestion } from './upsertDummyQuestion';
+
+type ChangeRecord = {
+  recordType: string;
+  record: Record<string, unknown>;
+  action: string;
+  timestamp: number;
+};
+
+const recordToChange = async (
+  recordType: string,
+  record: Record<string, unknown>,
+  changeType: 'update' | 'delete',
+) => {
+  if (changeType === 'delete') {
+    return {
+      action: 'delete',
+      recordType: 'question',
+      record: {
+        id: record.id,
+      },
+    };
+  }
+
+  const fields = await (record.model as DatabaseModel).fetchFieldNames();
+  const unsupportedFields = getUnsupportedModelFields(recordType);
+
+  // Supported fields with non-null values
+  const cleanedRecordForSync = Object.fromEntries(
+    Object.entries(record).filter(
+      ([field, value]) =>
+        fields.includes(field) && !unsupportedFields.includes(field) && value !== null,
+    ),
+  );
+
+  return {
+    recordType,
+    action: 'update',
+    record: cleanedRecordForSync,
+  };
+};
+
+const expectMatchingChangeRecords = (
+  actual: ChangeRecord[],
+  expected: Omit<ChangeRecord, 'timestamp'>[],
+) => {
+  // Can't match timestamp, just just assert the field is there and check it's a number
+  actual.forEach(changeRecord => expect(typeof changeRecord.timestamp).toBe('number'));
+  const timestampFilteredActual = actual.map(changeRecord =>
+    Object.entries(changeRecord).reduce((obj, [fieldName, fieldValue]) => {
+      if (fieldName === 'timestamp') {
+        return obj;
+      }
+
+      return { ...obj, [fieldName]: fieldValue };
+    }, {}),
+  );
+  expect(timestampFilteredActual).toEqual(expected);
+};
+
+describe('changes (GET)', () => {
+  let app: TestableServer;
+  let authHeader: string;
+  const models = getTestModels() as TestModelRegistry;
+  const syncableChangeEnqueuer = new SyncableChangeEnqueuer(
+    getTestModels() as MeditrakAppServerModelRegistry,
+  );
+  syncableChangeEnqueuer.setDebounceTime(50);
+
+  beforeAll(async () => {
+    syncableChangeEnqueuer.listenForChanges();
+    app = await setupTestApp();
+
+    const user = await setupTestUser();
+    authHeader = createBearerHeader(
+      constructAccessToken({
+        userId: user.id,
+        refreshToken: CAT_USER_SESSION.refresh_token,
+        apiClientUserId: undefined,
+      }),
+    );
+  });
+
+  afterAll(async () => {
+    syncableChangeEnqueuer.stopListeningForChanges();
+    await clearTestData(getTestDatabase());
+  });
+
+  it('throws an error if no auth header provided', async () => {
+    const response = await app.get('changes');
+    expect(response.statusCode).toEqual(500);
+    expect(response.body.error).toMatch(/.*Authorization header required/);
+  });
+
+  it('should return the total number of update changes with no "since"', async () => {
+    const questionCreated = await upsertDummyQuestion(models);
+    const questionCreateAndDeleted = await upsertDummyQuestion(models);
+    await models.database.waitForAllChangeHandlers();
+    await models.question.deleteById(questionCreateAndDeleted.id);
+    await models.database.waitForAllChangeHandlers();
+
+    const response = await app.get('changes', {
+      headers: {
+        Authorization: authHeader,
+      },
+    });
+    const expectedResults = await Promise.all([
+      recordToChange('question', questionCreated, 'update'),
+    ]);
+
+    expectMatchingChangeRecords(response.body, expectedResults);
+  });
+
+  it('should return the correct number of changes since "since" if updates are made', async () => {
+    const since = Date.now();
+    const numberOfQuestionsToAdd = 3;
+    const newQuestions = [];
+    await oneSecondSleep();
+    for (let i = 0; i < numberOfQuestionsToAdd; i++) {
+      newQuestions.push(await upsertDummyQuestion(models));
+      await models.database.waitForAllChangeHandlers();
+    }
+
+    const response = await app.get('changes', {
+      headers: {
+        Authorization: authHeader,
+      },
+      query: {
+        since,
+      },
+    });
+
+    const expectedResults = await Promise.all(
+      newQuestions.map(questionCreated => recordToChange('question', questionCreated, 'update')),
+    );
+    expectMatchingChangeRecords(response.body, expectedResults);
+  });
+
+  it('should return the correct number of changes since "since" if updates and deletes are made', async () => {
+    // Note: sync skips redundant deletes, i.e. any 'delete' records that reflect the deletion of a
+    // record that the client has never seen are not synced to that client
+
+    // Note that throughout this test we sleep before and after taking the timestamps as there is
+    // overlap due to ids not being very fine grained
+
+    // Add some questions
+    const timestampBeforeFirstUpdate = Date.now();
+    await oneSecondSleep();
+    const numberOfQuestionsToAddInFirstUpdate = 3;
+    const questionsInFirstUpdate = [];
+    for (let i = 0; i < numberOfQuestionsToAddInFirstUpdate; i++) {
+      questionsInFirstUpdate.push(await upsertDummyQuestion(models));
+      await models.database.waitForAllChangeHandlers();
+    }
+
+    // Add some more questions
+    await oneSecondSleep();
+    const timestampBeforeSecondUpdate = Date.now();
+    await oneSecondSleep();
+    const numberOfQuestionsToAddInSecondUpdate = 4;
+    const questionsInSecondUpdate = [];
+    for (let i = 0; i < numberOfQuestionsToAddInSecondUpdate; i++) {
+      questionsInSecondUpdate.push(await upsertDummyQuestion(models));
+      await models.database.waitForAllChangeHandlers();
+    }
+
+    // Delete some of the questions added in the first update
+    await oneSecondSleep();
+    const timestampBeforeFirstDelete = Date.now();
+    await oneSecondSleep();
+    const numberOfQuestionsToDeleteFromFirstUpdate = randomIntBetween(
+      1,
+      numberOfQuestionsToAddInFirstUpdate,
+    );
+    const questionKeptFromFirstUpdate = questionsInFirstUpdate.slice(
+      numberOfQuestionsToDeleteFromFirstUpdate,
+    );
+    const questionsDeletedFromFirstUpdate = questionsInFirstUpdate.slice(
+      0,
+      numberOfQuestionsToDeleteFromFirstUpdate,
+    );
+    for (let i = 0; i < numberOfQuestionsToDeleteFromFirstUpdate; i++) {
+      await models.question.deleteById(questionsInFirstUpdate[i].id);
+      await models.database.waitForAllChangeHandlers();
+    }
+
+    // Delete some of the questions added in the second update
+    await oneSecondSleep();
+    const timestampBeforeSecondDelete = Date.now();
+    await oneSecondSleep();
+    const numberOfQuestionsToDeleteFromSecondUpdate = randomIntBetween(
+      1,
+      numberOfQuestionsToAddInSecondUpdate,
+    );
+    const questionKeptFromSecondUpdate = questionsInSecondUpdate.slice(
+      numberOfQuestionsToDeleteFromSecondUpdate,
+    );
+    const questionsDeletedFromSecondUpdate = questionsInSecondUpdate.slice(
+      0,
+      numberOfQuestionsToDeleteFromSecondUpdate,
+    );
+    for (let i = 0; i < numberOfQuestionsToDeleteFromSecondUpdate; i++) {
+      await models.question.deleteById(questionsInSecondUpdate[i].id);
+      await models.database.waitForAllChangeHandlers();
+    }
+
+    // If syncing from before the first update, should only need to sync the number of records that
+    // actually need to be added. No need to know about deletes of records we never integrated
+    const keptQuestions = [...questionKeptFromFirstUpdate, ...questionKeptFromSecondUpdate];
+    let expectedResults = await Promise.all(
+      keptQuestions.map(questionCreated => recordToChange('question', questionCreated, 'update')),
+    );
+    let response = await app.get('changes', {
+      headers: {
+        Authorization: authHeader,
+      },
+      query: {
+        since: timestampBeforeFirstUpdate,
+      },
+    });
+    expectMatchingChangeRecords(response.body, expectedResults);
+
+    // If syncing from after both the updates but before the deletes, the changes needed will be all
+    // of the deletes
+    const deletedQuestions = [
+      ...questionsDeletedFromFirstUpdate,
+      ...questionsDeletedFromSecondUpdate,
+    ];
+    expectedResults = await Promise.all(
+      deletedQuestions.map(questionCreated =>
+        recordToChange('question', questionCreated, 'delete'),
+      ),
+    );
+    response = await app.get('changes', {
+      headers: {
+        Authorization: authHeader,
+      },
+      query: {
+        since: timestampBeforeFirstDelete,
+      },
+    });
+    expectMatchingChangeRecords(response.body, expectedResults);
+
+    // If syncing from after the first update, but before the second, need to sync all deletes for
+    // records from the first update, plus the net number of records that need to be added from the
+    // second update
+    expectedResults = await Promise.all(
+      questionKeptFromSecondUpdate
+        .map(questionCreated => recordToChange('question', questionCreated, 'update'))
+        .concat(
+          questionsDeletedFromFirstUpdate.map(questionCreated =>
+            recordToChange('question', questionCreated, 'delete'),
+          ),
+        ),
+    );
+    response = await app.get('changes', {
+      headers: {
+        Authorization: authHeader,
+      },
+      query: {
+        since: timestampBeforeSecondUpdate,
+      },
+    });
+    expectMatchingChangeRecords(response.body, expectedResults);
+
+    // If syncing from after the first delete but before the second, just need to sync all deletes
+    // that happen in the second round of deletes
+    expectedResults = await Promise.all(
+      questionsDeletedFromSecondUpdate.map(questionCreated =>
+        recordToChange('question', questionCreated, 'delete'),
+      ),
+    );
+    response = await app.get('changes', {
+      headers: {
+        Authorization: authHeader,
+      },
+      query: {
+        since: timestampBeforeSecondDelete,
+      },
+    });
+    expectMatchingChangeRecords(response.body, expectedResults);
+  });
+
+  it('should return the correct number of changes based on the models the appVersion supports', async () => {
+    const since = Date.now();
+    await oneSecondSleep();
+
+    const numberOfEntitiesToAdd = 2;
+    const entitySupportedAppVersion = '1.7.102';
+    const entityUnsupportedAppVersion = '1.7.101';
+
+    const newEntities = [];
+    for (let i = 0; i < numberOfEntitiesToAdd; i++) {
+      newEntities.push(await upsertDummyRecord(models.entity, {}));
+      await models.database.waitForAllChangeHandlers();
+    }
+
+    const entitySupportedResponse = await app.get('changes', {
+      headers: {
+        Authorization: authHeader,
+      },
+      query: {
+        since,
+        appVersion: entitySupportedAppVersion,
+      },
+    });
+    const entityUnsupportedResponse = await app.get('changes', {
+      headers: {
+        Authorization: authHeader,
+      },
+      query: {
+        since,
+        appVersion: entityUnsupportedAppVersion,
+      },
+    });
+    const expectedEntitySupportedResults = await Promise.all(
+      newEntities.map(entityCreated => recordToChange('entity', entityCreated, 'update')),
+    );
+    expectMatchingChangeRecords(entitySupportedResponse.body, expectedEntitySupportedResults);
+    expect(entityUnsupportedResponse.body).toEqual([]);
+  });
+
+  it('should return the correct number of changes based on the requested record types', async () => {
+    const since = Date.now();
+    await oneSecondSleep();
+
+    const numberOfEntitiesToAdd = 2;
+    const numberOfQuestionsToAdd = 3;
+
+    const newEntities = [];
+    for (let i = 0; i < numberOfEntitiesToAdd; i++) {
+      newEntities.push(await upsertDummyRecord(models.entity, {}));
+      await models.database.waitForAllChangeHandlers();
+    }
+
+    const newQuestions = [];
+    for (let i = 0; i < numberOfQuestionsToAdd; i++) {
+      newQuestions.push(await upsertDummyQuestion(models));
+      await models.database.waitForAllChangeHandlers();
+    }
+
+    const entityChangesResponse = await app.get('changes', {
+      headers: {
+        Authorization: authHeader,
+      },
+      query: {
+        since,
+        recordTypes: 'entity',
+      },
+    });
+    const questionChangesResponse = await app.get('changes', {
+      headers: {
+        Authorization: authHeader,
+      },
+      query: {
+        since,
+        recordTypes: 'question',
+      },
+    });
+    const entityAndQuestionChangesResponse = await app.get('changes', {
+      headers: {
+        Authorization: authHeader,
+      },
+      query: {
+        since,
+        recordTypes: 'entity,question',
+      },
+    });
+    const expectedEntityChangesResults = await Promise.all(
+      newEntities.map(entityCreated => recordToChange('entity', entityCreated, 'update')),
+    );
+    const expectedQuestionChangesResults = await Promise.all(
+      newQuestions.map(questionCreated => recordToChange('question', questionCreated, 'update')),
+    );
+    const expectedEntityAndQuestionChangesResults = [
+      ...expectedEntityChangesResults,
+      ...expectedQuestionChangesResults,
+    ];
+    expectMatchingChangeRecords(entityChangesResponse.body, expectedEntityChangesResults);
+    expectMatchingChangeRecords(questionChangesResponse.body, expectedQuestionChangesResults);
+    expectMatchingChangeRecords(
+      entityAndQuestionChangesResponse.body,
+      expectedEntityAndQuestionChangesResults,
+    );
+  });
+
+  it('can paginate the results', async () => {
+    const since = Date.now();
+    const pageSize = 2;
+    const numberOfQuestionsToAdd = 5;
+    const newQuestions = [];
+    await oneSecondSleep();
+    for (let i = 0; i < numberOfQuestionsToAdd; i++) {
+      newQuestions.push(await upsertDummyQuestion(models));
+      await models.database.waitForAllChangeHandlers();
+    }
+
+    const expectedResults = await Promise.all(
+      newQuestions.map(questionCreated => recordToChange('question', questionCreated, 'update')),
+    );
+
+    let changesPulled = 0;
+    let pagesPulled = 0;
+    while (changesPulled < numberOfQuestionsToAdd) {
+      const response = await app.get('changes', {
+        headers: {
+          Authorization: authHeader,
+        },
+        query: {
+          since,
+          offset: pagesPulled * pageSize,
+          limit: pageSize,
+        },
+      });
+
+      expectMatchingChangeRecords(
+        response.body,
+        expectedResults.slice(changesPulled, changesPulled + pageSize),
+      );
+      pagesPulled += 1;
+      changesPulled += pageSize;
+    }
+  });
+});

--- a/packages/meditrak-app-server/src/__tests__/__integration__/sync/upsertDummyQuestion.ts
+++ b/packages/meditrak-app-server/src/__tests__/__integration__/sync/upsertDummyQuestion.ts
@@ -1,0 +1,17 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import { upsertDummyRecord } from '@tupaia/database';
+import { TestModelRegistry } from '../../types';
+
+export const upsertDummyQuestion = async (models: TestModelRegistry) => {
+  const dataElement = await upsertDummyRecord(models.dataElement, {
+    service_type: 'tupaia',
+  });
+  return upsertDummyRecord(models.question, {
+    code: dataElement.code,
+    data_element_id: dataElement.id,
+  });
+};

--- a/packages/meditrak-app-server/src/app/createApp.ts
+++ b/packages/meditrak-app-server/src/app/createApp.ts
@@ -11,6 +11,8 @@ import {
   ChangePasswordRoute,
   CountChangesRequest,
   CountChangesRoute,
+  PullChangesRequest,
+  PullChangesRoute,
   RegisterUserRequest,
   RegisterUserRoute,
   SocialFeedRequest,
@@ -39,6 +41,7 @@ export function createApp(database = new TupaiaDatabase()) {
       handleWith(ChangePasswordRoute),
     )
     .get<CountChangesRequest>('changes/count', authMiddleware, handleWith(CountChangesRoute))
+    .get<PullChangesRequest>('changes', authMiddleware, handleWith(PullChangesRoute))
     .build();
 
   return app;

--- a/packages/meditrak-app-server/src/routes/index.ts
+++ b/packages/meditrak-app-server/src/routes/index.ts
@@ -7,5 +7,10 @@ export { AuthRequest, AuthRoute } from './AuthRoute';
 export { ChangePasswordRequest, ChangePasswordRoute } from './ChangePasswordRoute';
 export { RegisterUserRequest, RegisterUserRoute } from './RegisterUserRoute';
 export { SocialFeedRequest, SocialFeedRoute } from './social';
-export { CountChangesRequest, CountChangesRoute } from './sync';
+export {
+  CountChangesRequest,
+  CountChangesRoute,
+  PullChangesRequest,
+  PullChangesRoute,
+} from './sync';
 export { UserRewardsRequest, UserRewardsRoute } from './UserRewardsRoute';

--- a/packages/meditrak-app-server/src/routes/sync/PullChangesRoute.ts
+++ b/packages/meditrak-app-server/src/routes/sync/PullChangesRoute.ts
@@ -1,0 +1,108 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import { Request } from 'express';
+
+import { TYPES } from '@tupaia/database';
+import { Route } from '@tupaia/server-boilerplate';
+import { DatabaseError } from '@tupaia/utils';
+import { getChangesFilter } from './getChangesFilter';
+import { getUnsupportedModelFields } from '../../sync';
+
+type ChangeRecord = {
+  action: 'update' | 'delete';
+  recordType: string;
+  timestamp: number;
+  record?: Record<string, unknown>;
+  error?: { error: string };
+};
+
+export type PullChangesRequest = Request<
+  Record<string, never>,
+  ChangeRecord[],
+  Record<string, unknown>,
+  { appVersion: string; since?: string; recordTypes?: string; limit?: string; offset?: string }
+>;
+
+const MAX_CHANGES_RETURNED = 100;
+
+async function filterNullProperties(record: Record<string, unknown>) {
+  const recordWithoutNulls: Record<string, unknown> = {};
+  // Remove null entries to a) save bandwidth and b) remain consistent with previous mongo based db
+  // which simply had no key for undefined properties, whereas postgres uses null
+  Object.entries(record).forEach(([key, value]) => {
+    if (value !== null) {
+      recordWithoutNulls[key] = value;
+    }
+  });
+  return recordWithoutNulls;
+}
+
+export class PullChangesRoute extends Route<PullChangesRequest> {
+  private async getAppSupportColumns(recordType: string) {
+    const model = this.req.models.getModelForDatabaseType(recordType);
+    const fields = await model.fetchFieldNames();
+    const unsupportedFields = getUnsupportedModelFields(recordType);
+    return fields.filter(field => !unsupportedFields.includes(field));
+  }
+
+  public async buildResponse() {
+    const {
+      appVersion,
+      since,
+      recordTypes,
+      limit = `${MAX_CHANGES_RETURNED}`,
+      offset = '0',
+    } = this.req.query;
+
+    const filter = getChangesFilter(
+      appVersion,
+      since ? parseFloat(since) : undefined,
+      recordTypes ? recordTypes.split(',') : undefined,
+    );
+
+    const changes = await this.req.models.meditrakSyncQueue.find(filter, {
+      sort: ['change_time'],
+      limit: parseInt(limit),
+      offset: parseInt(offset),
+    });
+
+    try {
+      return await Promise.all(
+        changes.map(async change => {
+          const {
+            type: action,
+            record_type: recordType,
+            record_id: recordId,
+            change_time: timestamp,
+          } = change;
+          const columns = await this.getAppSupportColumns(recordType);
+          const changeObject: ChangeRecord = { action, recordType, timestamp };
+          if (action === 'delete') {
+            changeObject.record = { id: recordId };
+            if (recordType === TYPES.GEOGRAPHICAL_AREA) {
+              // TODO LEGACY Deal with this bug on app end for v3 api
+              changeObject.recordType = 'area';
+            }
+          } else {
+            const record = await this.req.models.database.findById(recordType, recordId, {
+              lean: true,
+              columns,
+            });
+            if (!record) {
+              const errorMessage = `Couldn't find record type ${recordType} with id ${recordId}`;
+              changeObject.error = { error: errorMessage };
+            } else {
+              changeObject.record = await filterNullProperties(record);
+            }
+          }
+          return changeObject;
+        }),
+      );
+    } catch (error) {
+      throw new DatabaseError('fetching changes', error);
+    }
+  }
+}

--- a/packages/meditrak-app-server/src/routes/sync/index.ts
+++ b/packages/meditrak-app-server/src/routes/sync/index.ts
@@ -4,3 +4,4 @@
  */
 
 export { CountChangesRequest, CountChangesRoute } from './CountChangesRoute';
+export { PullChangesRequest, PullChangesRoute } from './PullChangesRoute';


### PR DESCRIPTION
### Issue RN-501:

Part 3 of 4.

In this PR we're adding the `PullChangesRoute`, which the meditrak-app calls to get the actual changes. Mostly unit tests this route itself was pretty simple and almost entirely copied from [central-server](https://github.com/beyondessential/tupaia/blob/973ac52ae0381ad668e7f417f664ee7fb63b2927/packages/central-server/src/apiV2/getChanges.js)

