### PR TITLE
RN-501: Move sync logic to meditrak-app-server (PushChangesRoute)

### DIFF
--- a/packages/api-client/src/connections/CentralApi.ts
+++ b/packages/api-client/src/connections/CentralApi.ts
@@ -36,4 +36,12 @@ export class CentralApi extends BaseApi {
       await this.connection.post('surveyResponse', null, chunk);
     }
   }
+
+  /**
+   * Solely for use by meditrak-app-server. Should be deprecated once RN-556 is implemented
+   * @param changes Changes from the meditrak-app sync
+   */
+  public async meditrak_only_pushChanges(changes: unknown[]): Promise<{ message: string }> {
+    return this.connection.post('changes', null, changes as any[]);
+  }
 }

--- a/packages/meditrak-app-server/examples.http
+++ b/packages/meditrak-app-server/examples.http
@@ -105,3 +105,25 @@ Authorization: {{user-authorization}}
 GET http://{{host}}/{{version}}/changes?since=1503986686475.5&appVersion={{appVersion}} HTTP/2.0
 content-type: {{contentType}}
 Authorization: {{user-authorization}}
+
+### Push changes
+
+POST http://{{host}}/{{version}}/changes?appVersion={{appVersion}} HTTP/2.0
+content-type: {{contentType}}
+Authorization: {{user-authorization}}
+
+[
+    {
+        "action": "SubmitSurveyResponse",
+        "payload": {
+            "id": "1234",
+            "assessor_name": "Tim",
+            "entity_id": "5678",
+            "start_time": "2010-01-01",
+            "end_time": "2010-01-02",
+            "survey_id": "qwer",
+            "user_id": "tyui",
+            "answers": []
+        }
+    }
+]

--- a/packages/meditrak-app-server/src/__tests__/__integration__/sync/PushChangesRoute.test.ts
+++ b/packages/meditrak-app-server/src/__tests__/__integration__/sync/PushChangesRoute.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import { constructAccessToken } from '@tupaia/auth';
+import { TestableServer } from '@tupaia/server-boilerplate';
+import { createBearerHeader } from '@tupaia/utils';
+import { setupTestApp, setupTestUser } from '../../utilities';
+import { CAT_USER_SESSION } from '../fixtures';
+
+const mockResponseMsg = (numberOfChanges: number) =>
+  `Successfully pushed ${numberOfChanges} changes`;
+
+describe('changes (POST)', () => {
+  let app: TestableServer;
+  let authHeader: string;
+
+  beforeAll(async () => {
+    app = await setupTestApp({
+      central: {
+        async meditrak_only_pushChanges(changes: unknown[]) {
+          return { message: mockResponseMsg(changes.length) };
+        },
+      },
+    });
+
+    const user = await setupTestUser();
+    authHeader = createBearerHeader(
+      constructAccessToken({
+        userId: user.id,
+        refreshToken: CAT_USER_SESSION.refresh_token,
+        apiClientUserId: undefined,
+      }),
+    );
+  });
+
+  it('throws an error if no auth header provided', async () => {
+    const response = await app.post('changes');
+    expect(response.statusCode).toEqual(500);
+    expect(response.body.error).toMatch(/.*Authorization header required/);
+  });
+
+  it('it invokes meditrak_only_pushChanges() on the CentralApi', async () => {
+    const changes = [
+      {
+        action: 'SubmitSurveyResponse',
+        payload: {
+          id: '1234',
+          assessor_name: 'Tim',
+          entity_id: '5678',
+          start_time: '2010-01-01',
+          end_time: '2010-01-02',
+          survey_id: 'qwer',
+          user_id: 'tyui',
+          answers: [],
+        },
+      },
+    ];
+
+    const response = await app.post('changes', {
+      headers: {
+        Authorization: authHeader,
+      },
+      body: changes,
+    });
+    expect(response.statusCode).toEqual(200);
+    expect(response.body).toEqual({ message: mockResponseMsg(changes.length) });
+  });
+});

--- a/packages/meditrak-app-server/src/app/createApp.ts
+++ b/packages/meditrak-app-server/src/app/createApp.ts
@@ -13,6 +13,8 @@ import {
   CountChangesRoute,
   PullChangesRequest,
   PullChangesRoute,
+  PushChangesRequest,
+  PushChangesRoute,
   RegisterUserRequest,
   RegisterUserRoute,
   SocialFeedRequest,
@@ -42,6 +44,7 @@ export function createApp(database = new TupaiaDatabase()) {
     )
     .get<CountChangesRequest>('changes/count', authMiddleware, handleWith(CountChangesRoute))
     .get<PullChangesRequest>('changes', authMiddleware, handleWith(PullChangesRoute))
+    .post<PushChangesRequest>('changes', authMiddleware, handleWith(PushChangesRoute))
     .build();
 
   return app;

--- a/packages/meditrak-app-server/src/routes/index.ts
+++ b/packages/meditrak-app-server/src/routes/index.ts
@@ -12,5 +12,7 @@ export {
   CountChangesRoute,
   PullChangesRequest,
   PullChangesRoute,
+  PushChangesRequest,
+  PushChangesRoute,
 } from './sync';
 export { UserRewardsRequest, UserRewardsRoute } from './UserRewardsRoute';

--- a/packages/meditrak-app-server/src/routes/sync/PushChangesRoute.ts
+++ b/packages/meditrak-app-server/src/routes/sync/PushChangesRoute.ts
@@ -1,0 +1,29 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import { Request } from 'express';
+
+import { TupaiaApiClient } from '@tupaia/api-client';
+import { Route } from '@tupaia/server-boilerplate';
+import { Resolved } from '@tupaia/tsutils';
+
+export type PushChangesRequest = Request<
+  Record<string, never>,
+  Resolved<ReturnType<TupaiaApiClient['central']['meditrak_only_pushChanges']>>,
+  unknown[]
+>;
+
+/**
+ * Currently this route just re-directs the request to the central-server
+ * where the logic is handled by `postChanges.js`
+ *
+ * We should not be doing this, rather it should be handled by this route itself.
+ * RN-556 has been created to complete this work
+ */
+export class PushChangesRoute extends Route<PushChangesRequest> {
+  public async buildResponse() {
+    return this.req.ctx.services.central.meditrak_only_pushChanges(this.req.body);
+  }
+}

--- a/packages/meditrak-app-server/src/routes/sync/index.ts
+++ b/packages/meditrak-app-server/src/routes/sync/index.ts
@@ -5,3 +5,4 @@
 
 export { CountChangesRequest, CountChangesRoute } from './CountChangesRoute';
 export { PullChangesRequest, PullChangesRoute } from './PullChangesRoute';
+export { PushChangesRequest, PushChangesRoute } from './PushChangesRoute';


### PR DESCRIPTION
### Issue RN-501:

Part 4 of 4.

I know when I am beat. I put a real effort into implementing this route properly in the `meditrak-app-server`. However, there were a few too many complexities (permissions, validation, translation, etc.) and given that this ticket has been going on for some time I decided to just implement this in the simplest way possible.

That simple implementation is just to directly re-route the request to the central-server, and let it handle everything.

I've created RN-556 to capture properly completing this route, and pushed [my branch](https://github.com/beyondessential/tupaia/tree/rn-556-finish-push-changes-route) with the progress I've made so far.