### PR TITLE
RN-557: Add logging in api_request_log table for all apis

### DIFF
--- a/packages/admin-panel-server/src/app/createApp.ts
+++ b/packages/admin-panel-server/src/app/createApp.ts
@@ -48,95 +48,95 @@ const { CENTRAL_API_URL = 'http://localhost:8090/v2' } = process.env;
  * Set up express server with middleware,
  */
 export function createApp() {
-  const app = new OrchestratorApiBuilder(new TupaiaDatabase())
+  const app = new OrchestratorApiBuilder(new TupaiaDatabase(), 'admin-panel')
     .useSessionModel(AdminPanelSessionModel)
     .verifyLogin(hasTupaiaAdminPanelAccess)
-    .get('/v1/user', handleWith(UserRoute))
+    .get('user', handleWith(UserRoute))
     .get<FetchHierarchyEntitiesRequest>(
-      '/v1/hierarchy/:hierarchyName/:entityCode',
+      'hierarchy/:hierarchyName/:entityCode',
       verifyBESAdminAccess,
       handleWith(FetchHierarchyEntitiesRoute),
     )
     .post<FetchReportPreviewDataRequest>(
-      '/v1/fetchReportPreviewData',
+      'fetchReportPreviewData',
       verifyBESAdminAccess,
       handleWith(FetchReportPreviewDataRoute),
     )
     .post<SaveDashboardVisualisationRequest>(
-      '/v1/dashboardVisualisation',
+      'dashboardVisualisation',
       verifyBESAdminAccess,
       handleWith(SaveDashboardVisualisationRoute),
     )
     .put<SaveDashboardVisualisationRequest>(
-      '/v1/dashboardVisualisation/:dashboardVisualisationId',
+      'dashboardVisualisation/:dashboardVisualisationId',
       verifyBESAdminAccess,
       handleWith(SaveDashboardVisualisationRoute),
     )
     .post<SaveMapOverlayVisualisationRequest>(
-      '/v1/mapOverlayVisualisation',
+      'mapOverlayVisualisation',
       verifyBESAdminAccess,
       handleWith(SaveMapOverlayVisualisationRoute),
     )
     .put<SaveMapOverlayVisualisationRequest>(
-      '/v1/mapOverlayVisualisation/:mapOverlayVisualisationId',
+      'mapOverlayVisualisation/:mapOverlayVisualisationId',
       verifyBESAdminAccess,
       handleWith(SaveMapOverlayVisualisationRoute),
     )
     .get<FetchDashboardVisualisationRequest>(
-      '/v1/dashboardVisualisation/:dashboardVisualisationId',
+      'dashboardVisualisation/:dashboardVisualisationId',
       verifyBESAdminAccess,
       handleWith(FetchDashboardVisualisationRoute),
     )
     .get(
-      '/v1/export/dashboardVisualisation/:dashboardVisualisationId',
+      'export/dashboardVisualisation/:dashboardVisualisationId',
       verifyBESAdminAccess,
       handleWith(ExportDashboardVisualisationRoute),
     )
     .get(
-      '/v1/export/mapOverlayVisualisation/:mapOverlayVisualisationId',
+      'export/mapOverlayVisualisation/:mapOverlayVisualisationId',
       verifyBESAdminAccess,
       handleWith(ExportMapOverlayVisualisationRoute),
     )
     .post<ExportDashboardVisualisationRequest>(
-      '/v1/export/dashboardVisualisation',
+      'export/dashboardVisualisation',
       verifyBESAdminAccess,
       handleWith(ExportDashboardVisualisationRoute),
     )
     .post<ExportMapOverlayVisualisationRequest>(
-      '/v1/export/mapOverlayVisualisation',
+      'export/mapOverlayVisualisation',
       verifyBESAdminAccess,
       handleWith(ExportMapOverlayVisualisationRoute),
     )
     .post<ImportDashboardVisualisationRequest>(
-      '/v1/import/dashboardVisualisations',
+      'import/dashboardVisualisations',
       verifyBESAdminAccess,
       upload.array('dashboardVisualisations'),
       handleWith(ImportDashboardVisualisationRoute),
     )
     .post<ImportMapOverlayVisualisationRequest>(
-      '/v1/import/mapOverlayVisualisations',
+      'import/mapOverlayVisualisations',
       verifyBESAdminAccess,
       upload.array('mapOverlayVisualisations'),
       handleWith(ImportMapOverlayVisualisationRoute),
     )
     .post<UploadTestDataRequest>(
-      '/v1/uploadTestData',
+      'uploadTestData',
       verifyBESAdminAccess,
       upload.single('testData'),
       handleWith(UploadTestDataRoute),
     )
     .get<FetchMapOverlayVisualisationRequest>(
-      '/v1/mapOverlayVisualisation/:mapOverlayVisualisationId',
+      'mapOverlayVisualisation/:mapOverlayVisualisationId',
       verifyBESAdminAccess,
       handleWith(FetchMapOverlayVisualisationRoute),
     )
     .get<FetchAggregationOptionsRequest>(
-      '/v1/fetchAggregationOptions',
+      'fetchAggregationOptions',
       verifyBESAdminAccess,
       handleWith(FetchAggregationOptionsRoute),
     )
     .get<FetchTransformSchemasRequest>(
-      '/v1/fetchTransformSchemas',
+      'fetchTransformSchemas',
       verifyBESAdminAccess,
       handleWith(FetchTransformSchemasRoute),
     )

--- a/packages/central-server/src/apiV2/middleware/logApiRequest.js
+++ b/packages/central-server/src/apiV2/middleware/logApiRequest.js
@@ -8,6 +8,8 @@ export const logApiRequest = async (req, res, next) => {
   const refreshToken = await extractRefreshTokenFromReq(req);
   const { id: apiRequestLogId } = await req.models.apiRequestLog.create({
     version: 2, // only version that can get through current route handling
+    api: 'central',
+    method: req.method,
     endpoint: req.path,
     user_id: req.userId,
     query: req.query,

--- a/packages/central-server/src/database/models/index.js
+++ b/packages/central-server/src/database/models/index.js
@@ -5,7 +5,6 @@
 
 export { AccessRequestModel as AccessRequest } from './AccessRequest';
 export { AnswerModel as Answer } from './Answer';
-export { ApiRequestLogModel as ApiRequestLog } from './ApiRequestLog';
 export { CountryModel as Country } from './Country';
 export { DataElementModel as DataElement } from './DataElement';
 export { DhisSyncLogModel as DhisSyncLog } from './DhisSyncLog';

--- a/packages/database/src/migrations/20220614225441-AddLoggingForAllServicesApiRequestLog-modifies-schema.js
+++ b/packages/database/src/migrations/20220614225441-AddLoggingForAllServicesApiRequestLog-modifies-schema.js
@@ -1,0 +1,40 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+/**
+ * Add 'api' and 'method' columns to api_request_log
+ *  api: the api that we're logging for (eg. 'central', 'meditrak', 'entity' etc.)
+ *  method: the request method (eg. GET, POST, etc.), useful when multiple routes share the same endpoint
+ */
+exports.up = function (db) {
+  return db.runSql(`
+    ALTER TABLE api_request_log ADD COLUMN api TEXT;
+    UPDATE api_request_log SET api = 'central';
+    ALTER TABLE api_request_log ALTER COLUMN api SET NOT NULL;
+    ALTER TABLE api_request_log ADD COLUMN method TEXT;
+  `);
+};
+
+exports.down = function (db) {
+  return db.runSql(`
+    ALTER TABLE api_request_log DROP COLUMN api;
+    ALTER TABLE api_request_log DROP COLUMN method;
+  `);
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/packages/database/src/modelClasses/ApiRequestLog.js
+++ b/packages/database/src/modelClasses/ApiRequestLog.js
@@ -3,7 +3,9 @@
  * Copyright (c) 2019 Beyond Essential Systems Pty Ltd
  */
 
-import { DatabaseModel, DatabaseType, TYPES } from '@tupaia/database';
+import { DatabaseModel } from '../DatabaseModel';
+import { DatabaseType } from '../DatabaseType';
+import { TYPES } from '../types';
 
 export class ApiRequestLogType extends DatabaseType {
   static databaseType = TYPES.API_REQUEST_LOG;

--- a/packages/database/src/modelClasses/index.js
+++ b/packages/database/src/modelClasses/index.js
@@ -8,6 +8,7 @@ import { AccessRequestModel } from './AccessRequest';
 import { AncestorDescendantRelationModel } from './AncestorDescendantRelation';
 import { AnswerModel } from './Answer';
 import { APIClientModel } from './APIClient';
+import { ApiRequestLogModel } from './ApiRequestLog';
 import { CommentModel } from './Comment';
 import { CountryModel } from './Country';
 import { DashboardModel } from './Dashboard';
@@ -56,6 +57,7 @@ export const modelClasses = {
   AncestorDescendantRelation: AncestorDescendantRelationModel,
   Answer: AnswerModel,
   ApiClient: APIClientModel,
+  ApiRequestLog: ApiRequestLogModel,
   Comment: CommentModel,
   Country: CountryModel,
   Dashboard: DashboardModel,
@@ -104,6 +106,7 @@ export {
   AncestorDescendantRelationModel,
   AncestorDescendantRelationType,
 } from './AncestorDescendantRelation';
+export { ApiRequestLogModel } from './ApiRequestLog';
 export { CommentModel } from './Comment';
 export { CountryModel } from './Country';
 export { DataElementModel, DataElementType } from './DataElement';

--- a/packages/entity-server/src/app/createApp.ts
+++ b/packages/entity-server/src/app/createApp.ts
@@ -35,8 +35,8 @@ import { attachRelationshipsContext } from '../routes/hierarchy/relationships/mi
  */
 export function createApp(db = new TupaiaDatabase()) {
   return (
-    new MicroServiceApiBuilder(db)
-      .useBasicBearerAuth('entity-server')
+    new MicroServiceApiBuilder(db, 'entity')
+      .useBasicBearerAuth()
 
       // MultiEntity routes
       .post<MultiEntityRequest>(

--- a/packages/lesmis-server/src/app/createApp.ts
+++ b/packages/lesmis-server/src/app/createApp.ts
@@ -41,7 +41,7 @@ const path = require('path');
  * Set up express server with middleware,
  */
 export function createApp() {
-  const app = new OrchestratorApiBuilder(new TupaiaDatabase())
+  const app = new OrchestratorApiBuilder(new TupaiaDatabase(), 'lesmis')
     .useSessionModel(LesmisSessionModel)
     .useAttachSession(attachSession)
     .verifyLogin(hasLesmisAccess)
@@ -50,28 +50,25 @@ export function createApp() {
     /**
      * GET
      */
-    .get<DashboardRequest>('/v1/dashboard/:entityCode', handleWith(DashboardRoute))
-    .get<UserRequest>('/v1/user', handleWith(UserRoute))
-    .get<EntitiesRequest>('/v1/entities/:entityCode', handleWith(EntitiesRoute))
-    .get<MapOverlaysRequest>('/v1/map-overlays/:entityCode', handleWith(MapOverlaysRoute))
-    .get<EntityRequest>('/v1/entity/:entityCode', handleWith(EntityRoute))
-    .get<ReportRequest>('/v1/report/:entityCode/:reportCode', handleWith(ReportRoute))
-    .get<VerifyEmailRequest>('/v1/verify/:emailToken', handleWith(VerifyEmailRoute))
+    .get<DashboardRequest>('dashboard/:entityCode', handleWith(DashboardRoute))
+    .get<UserRequest>('user', handleWith(UserRoute))
+    .get<EntitiesRequest>('entities/:entityCode', handleWith(EntitiesRoute))
+    .get<MapOverlaysRequest>('map-overlays/:entityCode', handleWith(MapOverlaysRoute))
+    .get<EntityRequest>('entity/:entityCode', handleWith(EntityRoute))
+    .get<ReportRequest>('report/:entityCode/:reportCode', handleWith(ReportRoute))
+    .get<VerifyEmailRequest>('verify/:emailToken', handleWith(VerifyEmailRoute))
 
     /**
      * POST
      */
 
-    .post<RegisterRequest>('/v1/register', handleWith(RegisterRoute))
-    .post<ReportRequest>('/v1/report/:entityCode/:reportCode', handleWith(ReportRoute))
+    .post<RegisterRequest>('register', handleWith(RegisterRoute))
+    .post<ReportRequest>('report/:entityCode/:reportCode', handleWith(ReportRoute))
 
     /**
      * PUT
      */
-    .put<UpdateSurveyResponseRequest>(
-      '/v1/survey-response/:id',
-      handleWith(UpdateSurveyResponseRoute),
-    )
+    .put<UpdateSurveyResponseRequest>('survey-response/:id', handleWith(UpdateSurveyResponseRoute))
 
     .build();
 

--- a/packages/meditrak-app-server/src/app/createApp.ts
+++ b/packages/meditrak-app-server/src/app/createApp.ts
@@ -23,7 +23,7 @@ import { authHandlerProvider, buildAuthMiddleware } from '../auth';
  */
 export function createApp(database = new TupaiaDatabase()) {
   const authMiddleware = buildAuthMiddleware(database);
-  const app = new MicroServiceApiBuilder(database)
+  const app = new MicroServiceApiBuilder(database, 'meditrak')
     .attachApiClientToContext(authHandlerProvider)
     .post<AuthRequest>('auth', handleWith(AuthRoute))
     .post<RegisterUserRequest>('user', handleWith(RegisterUserRoute))

--- a/packages/psss-server/src/app/createApp.ts
+++ b/packages/psss-server/src/app/createApp.ts
@@ -35,29 +35,26 @@ import { hasPSSSAccess } from '../utils';
  */
 export function createApp(db = new TupaiaDatabase()) {
   return (
-    new OrchestratorApiBuilder(db)
+    new OrchestratorApiBuilder(db, 'psss')
       .useSessionModel(PsssSessionModel)
       .verifyLogin(hasPSSSAccess)
 
       /**
        * GET routes
        */
-      .get<FetchAlertsRequest>('/v1/alerts/:category', handleWith(FetchAlertsRoute))
+      .get<FetchAlertsRequest>('alerts/:category', handleWith(FetchAlertsRoute))
       .get<FetchConfirmedWeeklyReportRequest>(
-        '/v1/confirmedWeeklyReport/:countryCode?',
+        'confirmedWeeklyReport/:countryCode?',
         handleWith(FetchConfirmedWeeklyReportRoute),
       )
-      .get<FetchCountriesRequest>('/v1/country', handleWith(FetchCountries))
-      .get<FetchCountrySitesRequest>(
-        '/v1/country/:countryCode/sites',
-        handleWith(FetchCountrySites),
-      )
+      .get<FetchCountriesRequest>('country', handleWith(FetchCountries))
+      .get<FetchCountrySitesRequest>('country/:countryCode/sites', handleWith(FetchCountrySites))
       .get<FetchWeeklyReportRequest>(
-        '/v1/weeklyReport/:countryCode',
+        'weeklyReport/:countryCode',
         handleWith(FetchWeeklyReportRoute),
       )
       .get<FetchWeeklyReportRequest>(
-        '/v1/weeklyReport/:countryCode/:sites?',
+        'weeklyReport/:countryCode/:sites?',
         handleWith(FetchWeeklyReportRoute),
       )
 
@@ -65,7 +62,7 @@ export function createApp(db = new TupaiaDatabase()) {
        * POST routes
        */
       .post<ConfirmWeeklyReportRequest>(
-        '/v1/confirmedWeeklyReport/:countryCode',
+        'confirmedWeeklyReport/:countryCode',
         handleWith(ConfirmWeeklyReportRoute),
       )
 
@@ -73,11 +70,11 @@ export function createApp(db = new TupaiaDatabase()) {
        * PUT routes
        */
       .put<SaveWeeklyReportRequest>(
-        '/v1/weeklyReport/:countryCode/:siteCode?',
+        'weeklyReport/:countryCode/:siteCode?',
         handleWith(SaveWeeklyReportRoute),
       )
       .put<ProcessAlertActionRequest>(
-        '/v1/alerts/:alertId/:action',
+        'alerts/:alertId/:action',
         handleWith(ProcessAlertActionRoute),
       )
 
@@ -85,10 +82,10 @@ export function createApp(db = new TupaiaDatabase()) {
        * DELETE routes
        */
       .delete<DeleteWeeklyReportRequest>(
-        '/v1/weeklyReport/:countryCode/:siteCode?',
+        'weeklyReport/:countryCode/:siteCode?',
         handleWith(DeleteWeeklyReportRoute),
       )
-      .delete<DeleteAlertRequest>('/v1/alerts/:alertId', handleWith(DeleteAlertRoute))
+      .delete<DeleteAlertRequest>('alerts/:alertId', handleWith(DeleteAlertRoute))
 
       .build()
   );

--- a/packages/report-server/src/app/createApp.ts
+++ b/packages/report-server/src/app/createApp.ts
@@ -21,8 +21,8 @@ import { FetchTransformSchemaRequest } from '../routes/FetchTransformSchemaRoute
  * Set up express server
  */
 export function createApp() {
-  return new MicroServiceApiBuilder(new TupaiaDatabase())
-    .useBasicBearerAuth('report-server')
+  return new MicroServiceApiBuilder(new TupaiaDatabase(), 'report')
+    .useBasicBearerAuth()
     .attachApiClientToContext(req => new ForwardingAuthHandler(req.headers.authorization))
     .get<FetchReportRequest>('fetchReport/:reportCode', handleWith(FetchReportRoute))
     .get<FetchAggregationOptionsRequest>(

--- a/packages/server-boilerplate/README.md
+++ b/packages/server-boilerplate/README.md
@@ -23,10 +23,10 @@ Instantiate an api for a server by using either the `MicroServiceApiBuilder` or 
 #### Adding routes to the app
 
 - Routes: Add routes to the api via the get/post/etc. methods. When adding the routes to the app, you will need to wrap the routes with the `handleWith` util for the routes to work properly.
-  eg. `new MicroServiceApiBuilder().get('/v1/test', handleWith(TestRoute)).build();`
+  eg. `new MicroServiceApiBuilder(db, apiName).get('/v1/test', handleWith(TestRoute)).build();`
 
 - Middleware: Add middleware to the api via the use method.
-  eg. `new OrchestratorApiBuilder().use('/v1', attachContext).build();`
+  eg. `new OrchestratorApiBuilder(db, apiName).use('/v1', attachContext).build();`
 
 ## Defining new Routes
 

--- a/packages/server-boilerplate/src/microService/@types/express/index.d.ts
+++ b/packages/server-boilerplate/src/microService/@types/express/index.d.ts
@@ -12,6 +12,7 @@ declare global {
       user: UserType;
       accessPolicy: AccessPolicy;
       models: ModelRegistry;
+      apiRequestLogId: string;
     }
   }
 }

--- a/packages/server-boilerplate/src/microService/utils/index.ts
+++ b/packages/server-boilerplate/src/microService/utils/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+export { logApiRequest } from './logApiRequest';

--- a/packages/server-boilerplate/src/microService/utils/logApiRequest.ts
+++ b/packages/server-boilerplate/src/microService/utils/logApiRequest.ts
@@ -1,0 +1,26 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import { NextFunction, Request, Response } from 'express';
+import { ServerBoilerplateModelRegistry } from '../../types';
+
+export const logApiRequest = (
+  models: ServerBoilerplateModelRegistry,
+  apiName: string,
+  version: number,
+) => async (req: Request, res: Response, next: NextFunction) => {
+  const { user } = req;
+  const userId = user?.id;
+  const { id: apiRequestLogId } = await models.apiRequestLog.create({
+    version,
+    api: apiName,
+    method: req.method,
+    endpoint: req.path,
+    query: req.query,
+    user_id: userId,
+  });
+  req.apiRequestLogId = apiRequestLogId;
+  next();
+};

--- a/packages/server-boilerplate/src/orchestrator/@types/express/index.d.ts
+++ b/packages/server-boilerplate/src/orchestrator/@types/express/index.d.ts
@@ -11,6 +11,7 @@ declare global {
       sessionModel: SessionModel;
       sessionCookie?: SessionCookie;
       session?: SessionType;
+      apiRequestLogId?: string;
     }
   }
 }

--- a/packages/server-boilerplate/src/orchestrator/api/ApiBuilder.ts
+++ b/packages/server-boilerplate/src/orchestrator/api/ApiBuilder.ts
@@ -8,7 +8,7 @@ import cors from 'cors';
 import bodyParser from 'body-parser';
 import errorHandler from 'api-error-handler';
 
-import { TupaiaDatabase } from '@tupaia/database';
+import { ModelRegistry, TupaiaDatabase } from '@tupaia/database';
 import { AccessPolicy } from '@tupaia/access-policy';
 import { UnauthenticatedError } from '@tupaia/utils';
 
@@ -19,26 +19,34 @@ import { attachSession as defaultAttachSession } from '../session';
 import { ExpressRequest, Params, ReqBody, ResBody, Query } from '../../routes/Route';
 import { sessionCookie } from './sessionCookie';
 import { SessionModel } from '../models';
+import { logApiRequest } from '../utils';
+import { ServerBoilerplateModelRegistry } from '../../types';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const i18n = require('i18n');
 
-type Middleware = (req: Request, res: Response, next: NextFunction) => void;
-
 export class ApiBuilder {
   private readonly app: Express;
   private readonly database: TupaiaDatabase;
+  private readonly models: ServerBoilerplateModelRegistry;
+  private readonly apiName: string;
 
-  private attachSession: Middleware;
+  private attachSession: RequestHandler;
+  private logApiRequestMiddleware: RequestHandler;
   private attachVerifyLogin?: (req: LoginRequest, res: Response, next: NextFunction) => void;
-  private verifyAuthMiddleware?: Middleware;
+  private verifyAuthMiddleware?: RequestHandler;
+  private version: number;
 
   private translatorConfigured = false;
 
-  public constructor(transactingConnection: TupaiaDatabase) {
+  public constructor(transactingConnection: TupaiaDatabase, apiName: string) {
     this.database = transactingConnection;
+    this.models = new ModelRegistry(this.database) as ServerBoilerplateModelRegistry;
+    this.apiName = apiName;
+    this.version = 1; // Default version
     this.app = express();
     this.attachSession = defaultAttachSession;
+    this.logApiRequestMiddleware = logApiRequest(this.models, this.apiName, this.version);
 
     /**
      * Add middleware
@@ -68,10 +76,24 @@ export class ApiBuilder {
     /**
      * Test Route
      */
-    this.app.get('/v1/test', handleWith(TestRoute));
+    this.app.get(this.formatPath('test'), handleWith(TestRoute));
   }
 
-  public useAttachSession(attachSession: Middleware) {
+  public setVersion(version: number) {
+    this.version = version;
+    this.logApiRequestMiddleware = logApiRequest(this.models, this.apiName, this.version);
+    return this;
+  }
+
+  public logApiRequests() {
+    if (!this.apiName) {
+      throw new Error('Must set apiName in order to log api requests');
+    }
+    this.logApiRequestMiddleware = logApiRequest(this.models, this.apiName, this.version);
+    return this;
+  }
+
+  public useAttachSession(attachSession: RequestHandler) {
     this.attachSession = attachSession;
     return this;
   }
@@ -137,7 +159,11 @@ export class ApiBuilder {
     path: string,
     middleware: RequestHandler<Params<T>, ResBody<T>, ReqBody<T>, Query<T>>,
   ) {
-    this.app.use(path, this.attachSession, middleware);
+    this.app.use(
+      this.formatPath(path),
+      this.attachSession as RequestHandler<Params<T>, ResBody<T>, ReqBody<T>, Query<T>>,
+      middleware,
+    );
     return this;
   }
 
@@ -147,9 +173,20 @@ export class ApiBuilder {
     ...handlers: RequestHandler<Params<T>, ResBody<T>, ReqBody<T>, Query<T>>[]
   ) {
     if (this.verifyAuthMiddleware) {
-      this.app[method](path, this.attachSession, this.verifyAuthMiddleware, ...handlers);
+      this.app[method](
+        this.formatPath(path),
+        this.attachSession as RequestHandler<Params<T>, ResBody<T>, ReqBody<T>, Query<T>>,
+        this.verifyAuthMiddleware as RequestHandler<Params<T>, ResBody<T>, ReqBody<T>, Query<T>>,
+        this.logApiRequestMiddleware as RequestHandler<Params<T>, ResBody<T>, ReqBody<T>, Query<T>>,
+        ...handlers,
+      );
     } else {
-      this.app[method](path, this.attachSession, ...handlers);
+      this.app[method](
+        this.formatPath(path),
+        this.attachSession as RequestHandler<Params<T>, ResBody<T>, ReqBody<T>, Query<T>>,
+        this.logApiRequestMiddleware as RequestHandler<Params<T>, ResBody<T>, ReqBody<T>, Query<T>>,
+        ...handlers,
+      );
     }
     return this;
   }
@@ -184,13 +221,22 @@ export class ApiBuilder {
 
   public build() {
     if (this.attachVerifyLogin) {
-      this.app.post('/v1/login', this.attachVerifyLogin, handleWith(LoginRoute));
+      this.app.post(
+        this.formatPath('login'),
+        this.attachVerifyLogin,
+        this.logApiRequestMiddleware,
+        handleWith(LoginRoute),
+      );
     } else {
-      this.app.post('/v1/login', handleWith(LoginRoute));
+      this.app.post(this.formatPath('login'), this.logApiRequestMiddleware, handleWith(LoginRoute));
     }
-    this.app.post('/v1/logout', handleWith(LogoutRoute));
+    this.app.post(this.formatPath('logout'), this.logApiRequestMiddleware, handleWith(LogoutRoute));
 
     this.app.use(handleError);
     return this.app;
+  }
+
+  private formatPath(path: string) {
+    return `/v${this.version}/${path}`;
   }
 }

--- a/packages/server-boilerplate/src/orchestrator/models/Session.ts
+++ b/packages/server-boilerplate/src/orchestrator/models/Session.ts
@@ -30,13 +30,13 @@ export class SessionType extends DatabaseType {
   public static databaseType = 'session';
   public readonly id: string;
   public email: string;
+  public refresh_token: string;
 
   private readonly authConnection: AuthConnection;
 
   private access_policy: AccessPolicyObject;
   private access_token: string;
   private access_token_expiry: number;
-  private refresh_token: string;
 
   private refreshAccessTokenPromise: Promise<void> | null;
 

--- a/packages/server-boilerplate/src/orchestrator/utils/index.ts
+++ b/packages/server-boilerplate/src/orchestrator/utils/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+export { logApiRequest } from './logApiRequest';

--- a/packages/server-boilerplate/src/orchestrator/utils/logApiRequest.ts
+++ b/packages/server-boilerplate/src/orchestrator/utils/logApiRequest.ts
@@ -1,0 +1,28 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import { NextFunction, Request, Response } from 'express';
+import { ServerBoilerplateModelRegistry } from '../../types';
+
+export const logApiRequest = (
+  models: ServerBoilerplateModelRegistry,
+  apiName: string,
+  version: number,
+) => async (req: Request, res: Response, next: NextFunction) => {
+  const { session } = req;
+  const refreshToken = session?.refresh_token;
+  const userId = session ? (await models.user.findOne({ email: session.email })).id : undefined;
+  const { id: apiRequestLogId } = await models.apiRequestLog.create({
+    version,
+    api: apiName,
+    method: req.method,
+    endpoint: req.path,
+    query: req.query,
+    user_id: userId,
+    refresh_token: refreshToken,
+  });
+  req.apiRequestLogId = apiRequestLogId;
+  next();
+};

--- a/packages/server-boilerplate/src/types.ts
+++ b/packages/server-boilerplate/src/types.ts
@@ -3,6 +3,9 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
+import { ModelRegistry, ApiRequestLogModel } from '@tupaia/database';
+import { UserModel } from './models';
+
 export type AccessPolicyObject = Record<string, string[]>;
 
 export type EmptyObject = Record<string, never>;
@@ -13,3 +16,8 @@ export type EmptyObject = Record<string, never>;
 export type QueryParameters = Record<string, string>;
 
 export type RequestBody = Record<string, unknown> | Record<string, unknown>[];
+
+export interface ServerBoilerplateModelRegistry extends ModelRegistry {
+  readonly apiRequestLog: ApiRequestLogModel;
+  readonly user: UserModel;
+}


### PR DESCRIPTION
### Issue RN-557:

Currently we just log the requests for the `central-server` to the `api_request_log` table. This table can be quite useful when debugging issues with meditrak-app. However, once we've moved the routes out to the `meditrak-app-server` we'll lose the logs. So this ticket to get logging happening for that server, and it proved easy enough to add support for all our other apis built off `server-boilerplate` as well.
