### PR TITLE
Build admin-panel-server last

### DIFF
--- a/scripts/bash/getDeployablePackages.sh
+++ b/scripts/bash/getDeployablePackages.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -e
 
-echo "admin-panel-server" "central-server" "entity-server" "lesmis-server" "meditrak-app-server" "psss-server" "report-server" "web-config-server" "admin-panel" "lesmis" "psss" "web-frontend"
+echo "admin-panel" "lesmis" "psss" "web-frontend" "central-server" "entity-server" "lesmis-server" "meditrak-app-server" "psss-server" "report-server" "web-config-server" "admin-panel-server" # admin-panel-server last as it depends on report-server
 exit 0

--- a/scripts/bash/getDeployablePackages.sh
+++ b/scripts/bash/getDeployablePackages.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -e
 
-echo "admin-panel" "lesmis" "psss" "web-frontend" "admin-panel-server" "central-server" "entity-server" "lesmis-server" "meditrak-app-server" "psss-server" "report-server" "web-config-server"
+echo "admin-panel-server" "central-server" "entity-server" "lesmis-server" "meditrak-app-server" "psss-server" "report-server" "web-config-server" "admin-panel" "lesmis" "psss" "web-frontend"
 exit 0


### PR DESCRIPTION
This should fix an issue where the Gold Master EC2 Image building process is failing with the following error: 
```
src/viz-builder/types.ts(6,30): error TS2307: Cannot find module '@tupaia/report-server' or its corresponding type declarations.
```

i.e., the report server has not had its types built at the point the admin panel is being built

There's one thing that's confusing me though - the image building process _does_ sometimes succeed (see the screenshot below). Can the reviewer understand why that might be? I would've thought if this was the issue it would deterministically fail?

![image](https://user-images.githubusercontent.com/1274422/173957822-b733212b-b791-4d9b-8379-a799137af45d.png)