### PR TITLE
Allow pulling non-numeric data from the data-lake

### DIFF
--- a/packages/data-lake-api/src/DataLakeAnalyticsFetchQuery.ts
+++ b/packages/data-lake-api/src/DataLakeAnalyticsFetchQuery.ts
@@ -87,7 +87,7 @@ export class DataLakeAnalyticsFetchQuery {
         entity_code AS "entityCode", 
         data_element_code AS "dataElementCode",
         to_char(date, 'YYYYMMDD') as period,
-        'Number' as type,
+        value_type as type,
         value
       FROM analytics
         ${SqlQuery.innerJoin('analytics', 'entity_code', this.entityCodes)}


### PR DESCRIPTION
When we first wrote this code the data-lake didn't have a `value_type` column, so we just assumed all data was numeric. Now it has such a column, so we should respect it.