### PR TITLE
Hotfix RN-568 - fix issue with sync queue breaking

### DIFF
--- a/packages/database/src/migrations/20220623233124-AddHouseholdsToEntityHierarchyCanonicalTypes-modifies-data.js
+++ b/packages/database/src/migrations/20220623233124-AddHouseholdsToEntityHierarchyCanonicalTypes-modifies-data.js
@@ -1,0 +1,42 @@
+'use strict';
+import nameToId from '../utilities';
+
+var dbm;
+var type;
+var seed;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+const PROJECT_CODE = 'olangch_palau';
+
+exports.up = async function (db) {
+  const hierarchyId = await nameToId(db, 'entity_hierarchy', PROJECT_CODE);
+
+  await db.runSql(`
+    UPDATE "entity_hierarchy"
+    SET "canonical_types" = '{country,district,sub_district,facility,village,household}'
+    WHERE "id" = '${hierarchyId}';
+  `);
+};
+
+exports.down = async function (db) {
+  const hierarchyId = await nameToId(db, 'entity_hierarchy', PROJECT_CODE);
+
+  await db.runSql(`
+    UPDATE "entity_hierarchy"
+    SET "canonical_types" = '{}'
+    WHERE "id" = '${hierarchyId}';
+  `);
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/packages/database/src/migrations/20220623233124-AddHouseholdsToEntityHierarchyCanonicalTypes-modifies-data.js
+++ b/packages/database/src/migrations/20220623233124-AddHouseholdsToEntityHierarchyCanonicalTypes-modifies-data.js
@@ -1,5 +1,5 @@
 'use strict';
-import nameToId from '../utilities';
+import { nameToId } from '../utilities';
 
 var dbm;
 var type;


### PR DESCRIPTION
Issue: [RN-568](https://linear.app/bes/issue/RN-568/submitting-an-eh01-survey-response-breaks-the-sync-queue)

This is a hotfix to fix the issue where submitting EH01 survey responses would break the sync queue 

It seems like putting `household` into the `canonical_types` of the `entity_hierarchy` for the Palau project fixes it