### PR TITLE
Hotfix: Switched to using translated key for 'Population' in lesmis vitals

### DIFF
--- a/packages/lesmis/src/translations/en.json
+++ b/packages/lesmis/src/translations/en.json
@@ -44,6 +44,7 @@
     "nameOfProvince": "Name of Province",
     "numberOfSchools": "Number of Schools",
     "numberOfStudents": "Number of Students",
+    "Population": "Population",
     "preSchool": "Pre School",
     "primary": "Primary",
     "priorityDistrict": "Priority District",
@@ -119,6 +120,5 @@
     "agreeToTerms": "I agree to the terms and conditions",
     "password": "Password *",
     "confirmPassword": "Confirm Password *"
-
   }
 }

--- a/packages/lesmis/src/translations/lo.json
+++ b/packages/lesmis/src/translations/lo.json
@@ -42,6 +42,7 @@
     "nameOfProvince": "ຊື່ແຂວງ",
     "numberOfSchools": "ຈໍານວນ ໂຮງຮຽນ",
     "numberOfStudents": "ຈໍານວນ ນັກຮຽນ",
+    "Population": "ປະຊາກອນ",
     "preSchool": "ຫ້ອງກຽມ",
     "primary": "ປະຖົມສຶກສາ",
     "priorityDistrict": "ເມືອງບູລິມະສິດ",

--- a/packages/lesmis/src/views/VitalsView.js
+++ b/packages/lesmis/src/views/VitalsView.js
@@ -89,7 +89,7 @@ const ProvinceView = ({ vitals }) => {
         />
         <EntityVitalsItem
           name={<I18n t="dashboards.provincePopulation" />}
-          value={vitals[translate('Population')]?.toLocaleString()}
+          value={vitals[translate('dashboards.Population')]?.toLocaleString()}
           icon="Group"
         />
         <EntityVitalsItem
@@ -123,7 +123,7 @@ const DistrictView = ({ vitals }) => {
         />
         <EntityVitalsItem
           name={<I18n t="dashboards.districtPopulation" />}
-          value={vitals[translate('Population')]?.toLocaleString()}
+          value={vitals[translate('dashboards.Population')]?.toLocaleString()}
           icon="Group"
         />
         <EntityVitalsItem
@@ -160,7 +160,7 @@ const DistrictView = ({ vitals }) => {
           />
           <EntityVitalsItem
             name={<I18n t="dashboards.provincePopulation" />}
-            value={vitals.parentVitals?.[translate('Population')]?.toLocaleString()}
+            value={vitals.parentVitals?.[translate('dashboards.Population')]?.toLocaleString()}
           />
         </FlexStart>
       </MuiBox>
@@ -221,7 +221,7 @@ const SchoolView = ({ vitals }) => {
           />
           <EntityVitalsItem
             name={<I18n t="dashboards.districtPopulation" />}
-            value={vitals.parentVitals?.[translate('Population')]?.toLocaleString()}
+            value={vitals.parentVitals?.[translate('dashboards.Population')]?.toLocaleString()}
             mr={4}
           />
           <EntityVitalsItem

--- a/packages/lesmis/src/views/VitalsView.js
+++ b/packages/lesmis/src/views/VitalsView.js
@@ -12,7 +12,7 @@ import MuiBox from '@material-ui/core/Box';
 import Typography from '@material-ui/core/Typography';
 import { EntityVitalsItem, FlexStart, I18n, MiniMap, VitalsLoader } from '../components';
 import { useVitalsData } from '../api/queries';
-import { useUrlParams } from '../utils';
+import { useI18n, useUrlParams } from '../utils';
 
 const Heading = styled(Typography)`
   font-weight: 600;
@@ -73,154 +73,168 @@ const CountryView = ({ vitals }) => (
   </VitalsContainer>
 );
 
-const ProvinceView = ({ vitals }) => (
-  <VitalsContainer>
-    <Heading variant="h4">
-      <I18n t="dashboards.provinceDetails" />
-    </Heading>
-    <ThreeColGrid>
-      <EntityVitalsItem
-        name={<I18n t="dashboards.provinceCode" />}
-        value={vitals.code}
-        icon="LocationPin"
-      />
-      <EntityVitalsItem
-        name={<I18n t="dashboards.provincePopulation" />}
-        value={vitals.Population?.toLocaleString()}
-        icon="Group"
-      />
-      <EntityVitalsItem
-        name={<I18n t="dashboards.numberOfSchools" />}
-        value={vitals.NumberOfSchools?.toLocaleString()}
-        icon="School"
-      />
-      <EntityVitalsItem
-        name={<I18n t="dashboards.numberOfStudents" />}
-        value={vitals.NumberOfStudents?.toLocaleString()}
-        icon="Study"
-      />
-    </ThreeColGrid>
-  </VitalsContainer>
-);
+const ProvinceView = ({ vitals }) => {
+  const { translate } = useI18n();
 
-const DistrictView = ({ vitals }) => (
-  <VitalsContainer>
-    <Heading variant="h4">
-      <I18n t="dashboards.districtDetails" />
-    </Heading>
-    <ThreeColGrid>
-      <EntityVitalsItem
-        name={<I18n t="dashboards.districtCode" />}
-        value={vitals.code}
-        icon="LocationPin"
-      />
-      <EntityVitalsItem
-        name={<I18n t="dashboards.districtPopulation" />}
-        value={vitals.Population?.toLocaleString()}
-        icon="Group"
-      />
-      <EntityVitalsItem
-        name={<I18n t="dashboards.priorityDistrict" />}
-        value={vitals.attributes?.type === 'LESMIS_Target_District' ? 'Yes' : 'No'}
-        icon="Notepad"
-      />
-      <EntityVitalsItem
-        name={<I18n t="dashboards.numberOfSchools" />}
-        value={vitals.NumberOfSchools?.toLocaleString()}
-        icon="School"
-      />
-      <EntityVitalsItem
-        name={<I18n t="dashboards.numberOfStudents" />}
-        value={vitals.NumberOfStudents?.toLocaleString()}
-        icon="Study"
-      />
-    </ThreeColGrid>
-    <HorizontalDivider />
-    <MuiBox mt={2}>
-      <SubHeading variant="h4">
+  return (
+    <VitalsContainer>
+      <Heading variant="h4">
         <I18n t="dashboards.provinceDetails" />
-      </SubHeading>
-      <FlexStart mt={1} mb={4}>
-        <EntityVitalsItem
-          name={<I18n t="dashboards.nameOfProvince" />}
-          value={vitals.parentVitals?.name}
-          mr={4}
-        />
+      </Heading>
+      <ThreeColGrid>
         <EntityVitalsItem
           name={<I18n t="dashboards.provinceCode" />}
-          value={vitals.parentVitals?.code}
-          mr={4}
+          value={vitals.code}
+          icon="LocationPin"
         />
         <EntityVitalsItem
           name={<I18n t="dashboards.provincePopulation" />}
-          value={vitals.parentVitals?.Population?.toLocaleString()}
+          value={vitals[translate('Population')]?.toLocaleString()}
+          icon="Group"
         />
-      </FlexStart>
-    </MuiBox>
-  </VitalsContainer>
-);
-
-const SchoolView = ({ vitals }) => (
-  <VitalsContainer>
-    <Heading variant="h4">
-      <I18n t="dashboards.schoolDetails" />
-    </Heading>
-    <ThreeColGrid>
-      <EntityVitalsItem
-        name={<I18n t="dashboards.schoolCode" />}
-        value={vitals.code}
-        icon="LocationPin"
-      />
-      <EntityVitalsItem
-        name={<I18n t="dashboards.numberOfStudents" />}
-        value={vitals.NumberOfStudents?.toLocaleString()}
-        icon="Study"
-      />
-      <EntityVitalsItem
-        name={<I18n t="dashboards.completeSchool" />}
-        value={vitals.SchoolComplete ? 'Yes' : 'No'}
-        icon="Notepad"
-      />
-      <EntityVitalsItem
-        name={<I18n t="dashboards.distanceToMainRoad" />}
-        value={vitals.DistanceToMainRoad ? `${vitals.DistanceToMainRoad} km` : '-'}
-        icon="Road"
-      />
-      <EntityVitalsItem
-        name={<I18n t="dashboards.location" />}
-        value={vitals.point?.map(x => x.toFixed(3)).join(', ')}
-        icon="PushPin"
-      />
-      <EntityVitalsItem
-        name={<I18n t="dashboards.schoolType" />}
-        value={vitals.attributes?.type}
-        icon="School"
-      />
-    </ThreeColGrid>
-    <HorizontalDivider />
-    <MuiBox mt={2}>
-      <SubHeading variant="h4">
-        <I18n t="dashboards.districtDetails" />
-      </SubHeading>
-      <FlexStart mt={1} mb={4}>
         <EntityVitalsItem
-          name={<I18n t="dashboards.nameOfDistrict" />}
-          value={vitals.parentVitals?.name}
-          mr={4}
+          name={<I18n t="dashboards.numberOfSchools" />}
+          value={vitals.NumberOfSchools?.toLocaleString()}
+          icon="School"
+        />
+        <EntityVitalsItem
+          name={<I18n t="dashboards.numberOfStudents" />}
+          value={vitals.NumberOfStudents?.toLocaleString()}
+          icon="Study"
+        />
+      </ThreeColGrid>
+    </VitalsContainer>
+  );
+};
+
+const DistrictView = ({ vitals }) => {
+  const { translate } = useI18n();
+
+  return (
+    <VitalsContainer>
+      <Heading variant="h4">
+        <I18n t="dashboards.districtDetails" />
+      </Heading>
+      <ThreeColGrid>
+        <EntityVitalsItem
+          name={<I18n t="dashboards.districtCode" />}
+          value={vitals.code}
+          icon="LocationPin"
         />
         <EntityVitalsItem
           name={<I18n t="dashboards.districtPopulation" />}
-          value={vitals.parentVitals?.Population?.toLocaleString()}
-          mr={4}
+          value={vitals[translate('Population')]?.toLocaleString()}
+          icon="Group"
         />
         <EntityVitalsItem
           name={<I18n t="dashboards.priorityDistrict" />}
-          value={vitals.parentVitals?.attributes?.type === 'LESMIS_Target_District' ? 'Yes' : 'No'}
+          value={vitals.attributes?.type === 'LESMIS_Target_District' ? 'Yes' : 'No'}
+          icon="Notepad"
         />
-      </FlexStart>
-    </MuiBox>
-  </VitalsContainer>
-);
+        <EntityVitalsItem
+          name={<I18n t="dashboards.numberOfSchools" />}
+          value={vitals.NumberOfSchools?.toLocaleString()}
+          icon="School"
+        />
+        <EntityVitalsItem
+          name={<I18n t="dashboards.numberOfStudents" />}
+          value={vitals.NumberOfStudents?.toLocaleString()}
+          icon="Study"
+        />
+      </ThreeColGrid>
+      <HorizontalDivider />
+      <MuiBox mt={2}>
+        <SubHeading variant="h4">
+          <I18n t="dashboards.provinceDetails" />
+        </SubHeading>
+        <FlexStart mt={1} mb={4}>
+          <EntityVitalsItem
+            name={<I18n t="dashboards.nameOfProvince" />}
+            value={vitals.parentVitals?.name}
+            mr={4}
+          />
+          <EntityVitalsItem
+            name={<I18n t="dashboards.provinceCode" />}
+            value={vitals.parentVitals?.code}
+            mr={4}
+          />
+          <EntityVitalsItem
+            name={<I18n t="dashboards.provincePopulation" />}
+            value={vitals.parentVitals?.[translate('Population')]?.toLocaleString()}
+          />
+        </FlexStart>
+      </MuiBox>
+    </VitalsContainer>
+  );
+};
+
+const SchoolView = ({ vitals }) => {
+  const { translate } = useI18n();
+
+  return (
+    <VitalsContainer>
+      <Heading variant="h4">
+        <I18n t="dashboards.schoolDetails" />
+      </Heading>
+      <ThreeColGrid>
+        <EntityVitalsItem
+          name={<I18n t="dashboards.schoolCode" />}
+          value={vitals.code}
+          icon="LocationPin"
+        />
+        <EntityVitalsItem
+          name={<I18n t="dashboards.numberOfStudents" />}
+          value={vitals.NumberOfStudents?.toLocaleString()}
+          icon="Study"
+        />
+        <EntityVitalsItem
+          name={<I18n t="dashboards.completeSchool" />}
+          value={vitals.SchoolComplete ? 'Yes' : 'No'}
+          icon="Notepad"
+        />
+        <EntityVitalsItem
+          name={<I18n t="dashboards.distanceToMainRoad" />}
+          value={vitals.DistanceToMainRoad ? `${vitals.DistanceToMainRoad} km` : '-'}
+          icon="Road"
+        />
+        <EntityVitalsItem
+          name={<I18n t="dashboards.location" />}
+          value={vitals.point?.map(x => x.toFixed(3)).join(', ')}
+          icon="PushPin"
+        />
+        <EntityVitalsItem
+          name={<I18n t="dashboards.schoolType" />}
+          value={vitals.attributes?.type}
+          icon="School"
+        />
+      </ThreeColGrid>
+      <HorizontalDivider />
+      <MuiBox mt={2}>
+        <SubHeading variant="h4">
+          <I18n t="dashboards.districtDetails" />
+        </SubHeading>
+        <FlexStart mt={1} mb={4}>
+          <EntityVitalsItem
+            name={<I18n t="dashboards.nameOfDistrict" />}
+            value={vitals.parentVitals?.name}
+            mr={4}
+          />
+          <EntityVitalsItem
+            name={<I18n t="dashboards.districtPopulation" />}
+            value={vitals.parentVitals?.[translate('Population')]?.toLocaleString()}
+            mr={4}
+          />
+          <EntityVitalsItem
+            name={<I18n t="dashboards.priorityDistrict" />}
+            value={
+              vitals.parentVitals?.attributes?.type === 'LESMIS_Target_District' ? 'Yes' : 'No'
+            }
+          />
+        </FlexStart>
+      </MuiBox>
+    </VitalsContainer>
+  );
+};
 
 const Wrapper = styled.section`
   background: #fbfbfb;


### PR DESCRIPTION
### Issue https://beyondessential.slack.com/archives/C01MAA3NKM1/p1656303472872569:

Pretty simple issue here. We added a translation for the word `Population` during this release, and the `I18n` library is set up to translate all fields of a report that it knows a translation for. 

It does feel a bit awkward to translate the key we're using on the frontend, as typically keys aren't translated in these kinds of scenarios. But given that this part of the UI is rendered from data coming from a report it seems acceptable to me.

Quite a small change here, mainly just whitespace, changes.