### PR TITLE
RN-527: Fix arithmetic questions not including all variables in expression

### DIFF
--- a/packages/central-server/src/apiV2/utilities/translateExpression.js
+++ b/packages/central-server/src/apiV2/utilities/translateExpression.js
@@ -4,6 +4,23 @@
  */
 
 /**
+ * We want to order the codes such that no code is a substring of a later code
+ * This avoids bugs when replacing the values in the regex, as we don't accidentally replace
+ * a substring
+ * @param {string[]} codes
+ */
+const sortByFewestSubstrings = codes => {
+  const codesAndNumSubstrings = codes.map(code => [
+    code,
+    codes.filter(otherCode => otherCode !== code && otherCode.includes(code)).length,
+  ]);
+  const codesOrderedByFewestSubstrings = codesAndNumSubstrings
+    .sort(([, numSubstrings1], [, numSubstrings2]) => numSubstrings1 - numSubstrings2)
+    .map(([code]) => code);
+  return codesOrderedByFewestSubstrings;
+};
+
+/**
  * Replace question code with question UUID in an expression.
  *
  * Important: This function also assumes that all the variables in an expression have prefix '$'
@@ -22,7 +39,8 @@
 export const translateExpression = async (models, rawExpression, codes) => {
   const questionCodeToId = await models.question.findIdByCode(codes);
   let expression = rawExpression;
-  for (const code of codes) {
+  const codesOrderedByFewestSubstrings = sortByFewestSubstrings(codes);
+  for (const code of codesOrderedByFewestSubstrings) {
     const questionId = questionCodeToId[code];
     // Retain the $ prefix, as UUID often starts with a number (breaks evaluation in mathjs)
     // Using the global regular expression ensures we replace all instances

--- a/packages/central-server/src/tests/apiV2/export/exportSurveys/configCellBuilders/configCellBuilders.test.js
+++ b/packages/central-server/src/tests/apiV2/export/exportSurveys/configCellBuilders/configCellBuilders.test.js
@@ -75,7 +75,7 @@ describe('configCellBuilders', () => {
       });
     });
 
-    it('Question code translation with substrings', async () => {
+    it('Question codes are substrings of one another', async () => {
       const config = 'formula: $baba * $ab + $bab + $abab + $abbaba + ($ba * 2) - $abbababa';
       const expectedProcessedFormula =
         '$mnbv * $zx + $kjh + $oiuy + $sdffgh + ($cv * 2) - $dfglkjyt';

--- a/packages/central-server/src/tests/apiV2/export/exportSurveys/configCellBuilders/configCellBuilders.test.js
+++ b/packages/central-server/src/tests/apiV2/export/exportSurveys/configCellBuilders/configCellBuilders.test.js
@@ -74,6 +74,21 @@ describe('configCellBuilders', () => {
         await runArithmeticTestCase(testCase);
       });
     });
+
+    it('Question code translation with substrings', async () => {
+      const config = 'formula: $baba * $ab + $bab + $abab + $abbaba + ($ba * 2) - $abbababa';
+      const expectedProcessedFormula =
+        '$mnbv * $zx + $kjh + $oiuy + $sdffgh + ($cv * 2) - $dfglkjyt';
+
+      const processedConfig = await processArithmeticConfig(modelsStub, convertCellToJson(config));
+      expect(processedConfig.formula).to.equal(expectedProcessedFormula);
+
+      const builtConfig = await arithmeticConfigCellBuilder.build({
+        arithmetic: processedConfig,
+      });
+
+      return expect(builtConfig).to.equal(config);
+    });
   });
   describe('ConditionConfigCellBuilder', () => {
     CONDITION_TEST_CASES.forEach(testCase => {

--- a/packages/central-server/src/tests/apiV2/export/exportSurveys/configCellBuilders/fixtures/common.js
+++ b/packages/central-server/src/tests/apiV2/export/exportSurveys/configCellBuilders/fixtures/common.js
@@ -12,4 +12,32 @@ export const QUESTIONS = [
     code: 'question_2_code',
     id: 'question_2_id',
   },
+  {
+    code: 'ab',
+    id: 'zx',
+  },
+  {
+    code: 'ba',
+    id: 'cv',
+  },
+  {
+    code: 'bab',
+    id: 'kjh',
+  },
+  {
+    code: 'abab',
+    id: 'oiuy',
+  },
+  {
+    code: 'baba',
+    id: 'mnbv',
+  },
+  {
+    code: 'abbaba',
+    id: 'sdffgh',
+  },
+  {
+    code: 'abbababa',
+    id: 'dfglkjyt',
+  },
 ];


### PR DESCRIPTION
### Issue RN-527:

Full explanation of this issue outlined [in the ticket](https://linear.app/bes/issue/RN-527#comment-58c49107). Went with the simple fix here of just ensuring that we don't accidentally replace substrings within the question codes. A more structured re-write of this logic might be possible if we break down the expression tree, but I don't know how it build it up again using mathjs...