### PR TITLE
hot-fix: Change dashboard list item id to code

### DIFF
--- a/packages/web-frontend/src/containers/mobile/Dashboard.js
+++ b/packages/web-frontend/src/containers/mobile/Dashboard.js
@@ -74,13 +74,13 @@ export const DashboardComponent = ({
 
   const filterItems = dashboards.map(({ dashboardName }) => ({
     label: dashboardName,
-    id: dashboardName,
+    code: dashboardName,
     value: dashboardName,
   }));
 
-  const currentFilter = filterItems.find(item => item.id === currentDashboardName) || {
+  const currentFilter = filterItems.find(item => item.code === currentDashboardName) || {
     label: 'General',
-    id: 'General',
+    code: 'General',
   };
 
   return (


### PR DESCRIPTION
#### RN-516

- As in `FilterSelect` we assign `item.code` to `ListItem` key instead of using `item.id` 