### PR TITLE
Fix migrate create

### DIFF
--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -20,7 +20,7 @@
     "lint": "yarn package:lint:js",
     "lint:fix": "yarn lint --fix",
     "migrate": "babel-node ./src/migrate.js up --migrations-dir ./src/migrations -v --config-file \"../../babel.config.json\"",
-    "migrate-create": "read -p \"Enter migration name: \" MIGRATION_NAME && read -p \"Enter the scope of this migration ('schema' or 'data'): \" MIGRATION_SCOPE && babel-node ./src/migrate.js create ${MIGRATION_NAME}-modifies-${MIGRATION_SCOPE} --migrations-dir ./src/migrations -v --config-file \"../../babel.config.json\"",
+    "migrate-create": "scripts/migrateCreate.sh",
     "migrate-down": "babel-node ./src/migrate.js  down --migrations-dir ./src/migrations -v --config-file \"../../babel.config.json\"",
     "refresh-database": "node ./scripts/refreshDatabase.js",
     "test": "yarn workspace @tupaia/database check-test-database-exists && DB_NAME=tupaia_test mocha",

--- a/packages/database/scripts/migrateCreate.sh
+++ b/packages/database/scripts/migrateCreate.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+read -p "Enter migration name: " MIGRATION_NAME
+read -p "Enter the scope of this migration ('schema' or 'data'): " MIGRATION_SCOPE
+
+babel-node ./src/migrate.js create ${MIGRATION_NAME}-modifies-${MIGRATION_SCOPE} --migrations-dir ./src/migrations -v --config-file "../../babel.config.json"


### PR DESCRIPTION
Fixes error `Unbound variable "MIGRATION_NAME"` when running `yarn migrate-create`

Move commands into a bash script.
Not sure why this fixes it, some difference between yarn v1 and v3.