### PR TITLE
Hotfix: force install internal deps

### DIFF
--- a/packages/devops/scripts/deployment/buildDeployablePackages.sh
+++ b/packages/devops/scripts/deployment/buildDeployablePackages.sh
@@ -14,6 +14,11 @@ PACKAGES=$(${TUPAIA_DIR}/scripts/bash/getDeployablePackages.sh)
 cd ${TUPAIA_DIR}
 yarn install --frozen-lockfile
 
+# "postinstall" hook may only fire if the dependency tree changes. This may not happen on feature branches based off dev,
+# because our AMI performs a yarn install already. In this case we can end up in a situation where "internal-depenednecies"
+# packages' dists are not rebuilt. This will be fixed by changing to a single yarn:build command in a future PR.
+yarn build:internal-dependencies
+
 # Inject environment variables from LastPass
 LASTPASS_EMAIL=$($DIR/fetchParameterStoreValue.sh LASTPASS_EMAIL)
 LASTPASS_PASSWORD=$($DIR/fetchParameterStoreValue.sh LASTPASS_PASSWORD)


### PR DESCRIPTION
Found while testing rn-403-clean-up-data-services. If it fixes that feature branch deployment, we can consider it ready for release to master.