### PR TITLE
RN-597: Explicitly install ndk 21.0.6113669 in appcenter-pre-build.sh

### DIFF
--- a/packages/meditrak-app/appcenter-pre-build.sh
+++ b/packages/meditrak-app/appcenter-pre-build.sh
@@ -11,4 +11,8 @@ if [[ ! -z "$APPCENTER_XCODE_PROJECT" ]]; then
 else
   # on android, set up gradle.properties
   mv android/appcenter-gradle.properties android/gradle.properties
+
+  # install ndk 21.0.6113669 as it's required by realm (https://github.com/realm/realm-js/issues/4740)
+  SDKMANAGER=$ANDROID_HOME/tools/bin/sdkmanager
+  echo y | $SDKMANAGER "ndk;21.0.6113669"
 fi


### PR DESCRIPTION
### Issue RN-597:

Followed the advice in [this issue](https://github.com/realm/realm-js/issues/4740) in the Realm project. It's a bit of a simplistic solution, the issue's only a day old, so maybe we can keep and eye on it and see if it gets fixed by the Realm team more effectively?