### PR TITLE
Fix pdf-export-server deployment error

### DIFF
--- a/packages/devops/configs/servers.conf
+++ b/packages/devops/configs/servers.conf
@@ -346,6 +346,46 @@ server {
   }
 
 }
+
+server {
+
+  listen       80;
+  listen       [::]:80;
+  server_name  ~^.*pdf-export-api\.tupaia\.org$;
+  root         /usr/share/nginx/html;
+
+  # Redirect to HTTPs when behind a proxy
+  if ($http_x_forwarded_proto = "http") {
+    return 301 https://$host$request_uri;
+  }
+
+  # Load configuration files for the default server block.
+  include /etc/nginx/default.d/*.conf;
+  include /etc/nginx/h5bp/basic.conf;
+
+  location / {
+              proxy_pass http://localhost:8010;
+              proxy_set_header Host $host;
+              proxy_set_header X-Real-IP $remote_addr;
+              proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+              proxy_connect_timeout 150;
+              proxy_send_timeout 100;
+              proxy_read_timeout 100;
+              proxy_buffers 4 32k;
+              client_max_body_size 50m;
+              client_body_buffer_size 128k;
+      }
+
+  # Redirect error pages
+  #
+  error_page 404 500 502 503 504 /error_page.html;
+      location = /error_page.html {
+        root /home/ubuntu/tupaia;
+        internal;
+  }
+
+}
+
 server {
 
   listen       80;


### PR DESCRIPTION
### Issue #:
`pdf-export-server` did not get routed in route 53.