### PR TITLE
Removed 'pre' scripts from package.json as yarn3 doesn't support them

### DIFF
--- a/packages/admin-panel-server/package.json
+++ b/packages/admin-panel-server/package.json
@@ -19,7 +19,6 @@
     "build-dev": "npm run build",
     "lint": "yarn package:lint:ts",
     "lint:fix": "yarn lint --fix",
-    "prestart": "npm run build",
     "start": "node dist",
     "start-dev": "yarn package:start:backend-start-dev 9994 -ts",
     "test": "yarn package:test",

--- a/packages/central-server/package.json
+++ b/packages/central-server/package.json
@@ -18,7 +18,6 @@
     "build-dev": "npm run build",
     "lint": "yarn package:lint:js",
     "lint:fix": "yarn lint --fix",
-    "prestart": "npm run build",
     "start": "node dist",
     "start-dev": "yarn package:start:backend-start-dev 9999",
     "start-verbose": "LOG_LEVEL=debug yarn start-dev",

--- a/packages/entity-server/package.json
+++ b/packages/entity-server/package.json
@@ -19,7 +19,6 @@
     "build-dev": "npm run build",
     "lint": "yarn package:lint:ts",
     "lint:fix": "yarn lint --fix",
-    "prestart": "npm run build",
     "start": "node dist",
     "start-dev": "yarn package:start:backend-start-dev 9996 -ts",
     "start-verbose": "LOG_LEVEL=debug yarn start-dev",

--- a/packages/lesmis-server/package.json
+++ b/packages/lesmis-server/package.json
@@ -19,7 +19,6 @@
     "build-dev": "npm run build",
     "lint": "yarn package:lint:ts",
     "lint:fix": "yarn lint --fix",
-    "prestart": "npm run build",
     "start": "node dist",
     "start-dev": "LOG_LEVEL=debug yarn package:start:backend-start-dev 9998 -ts",
     "start-verbose": "LOG_LEVEL=debug yarn start-dev",

--- a/packages/meditrak-app-server/package.json
+++ b/packages/meditrak-app-server/package.json
@@ -19,7 +19,6 @@
     "build-dev": "npm run build",
     "lint": "yarn package:lint:ts",
     "lint:fix": "yarn lint --fix",
-    "prestart": "npm run build",
     "start": "node dist",
     "start-dev": "LOG_LEVEL=debug yarn package:start:backend-start-dev 9998 -ts",
     "start-verbose": "LOG_LEVEL=debug yarn start-dev",

--- a/packages/pdf-export-server/package.json
+++ b/packages/pdf-export-server/package.json
@@ -19,7 +19,6 @@
     "build-dev": "npm run build",
     "lint": "yarn package:lint:ts",
     "lint:fix": "yarn lint --fix",
-    "prestart": "npm run build",
     "start": "node dist",
     "start-dev": "yarn package:start:backend-start-dev 9993 -ts",
     "start-verbose": "LOG_LEVEL=debug yarn start-dev",

--- a/packages/psss-server/package.json
+++ b/packages/psss-server/package.json
@@ -19,7 +19,6 @@
     "build-dev": "npm run build",
     "lint": "yarn package:lint:ts",
     "lint:fix": "yarn lint --fix",
-    "prestart": "npm run build",
     "start": "node dist",
     "start-dev": "LOG_LEVEL=debug yarn package:start:backend-start-dev 9998 -ts",
     "start-verbose": "LOG_LEVEL=debug yarn start-dev",

--- a/packages/psss/package.json
+++ b/packages/psss/package.json
@@ -18,7 +18,6 @@
     "eject": "yarn package:eject",
     "lint": "yarn package:lint:js",
     "lint:fix": "yarn lint --fix",
-    "pretest:test:cypress:run": "yarn build",
     "start-dev": "yarn package:start:react-scripts",
     "start-fullstack": "npm-run-all -c -l -p start-psss-server start-entity-server start-central-server start-report-server  start-dev",
     "start-psss-server": "yarn workspace @tupaia/psss-server start-dev -s",

--- a/packages/report-server/package.json
+++ b/packages/report-server/package.json
@@ -19,7 +19,6 @@
     "build-dev": "npm run build",
     "lint": "yarn package:lint:ts",
     "lint:fix": "yarn lint --fix",
-    "prestart": "npm run build",
     "start": "node dist",
     "start-dev": "yarn package:start:backend-start-dev 9995 -ts",
     "start-verbose": "LOG_LEVEL=debug yarn start-dev",

--- a/packages/web-config-server/package.json
+++ b/packages/web-config-server/package.json
@@ -14,7 +14,6 @@
     "build": "rm -rf dist && npm run --prefix ../../ package:build:js",
     "lint": "yarn package:lint:js",
     "lint:fix": "yarn lint --fix",
-    "prestart": "npm run build",
     "start": "node dist",
     "start-dev": "yarn package:start:backend-start-dev 9997",
     "start-verbose": "LOG_LEVEL=debug yarn start-dev",


### PR DESCRIPTION
According to [yarn 3 docs](https://yarnpkg.com/advanced/lifecycle-scripts) 
>In particular, we intentionally don't support arbitrary pre and post hooks for user-defined scripts (such as prestart). This behavior, inherited from npm, caused scripts to be implicit rather than explicit, obfuscating the execution flow. It also led to surprising executions with yarn serve also running yarn preserve.