### PR TITLE
RN-601: Added ability to reference query parameters in viz-builder expressions

### DIFF
--- a/packages/report-server/src/__tests__/reportBuilder/context/buildContext.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/context/buildContext.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { AccessPolicy } from '@tupaia/access-policy';
+import { Row } from '../../../reportBuilder';
 
 import { buildContext, ReqContext } from '../../../reportBuilder/context/buildContext';
 
@@ -17,8 +18,20 @@ describe('buildContext', () => {
       { id: 'ouId2', code: 'FJ', name: 'Fiji', type: 'country', attributes: {} },
       { id: 'ouId3', code: 'KI', name: 'Kiribati', type: 'country', attributes: {} },
       { id: 'ouId4', code: 'TO', name: 'Tonga', type: 'country', attributes: {} },
-      { id: 'ouId5', code: 'TO_Facility1', name: 'Tonga Facility 1', type: 'facility', attributes: { x: 1 } },
-      { id: 'ouId6', code: 'TO_Facility2', name: 'Tonga Facility 2', type: 'facility', attributes: {} },
+      {
+        id: 'ouId5',
+        code: 'TO_Facility1',
+        name: 'Tonga Facility 1',
+        type: 'facility',
+        attributes: { x: 1 },
+      },
+      {
+        id: 'ouId6',
+        code: 'TO_Facility2',
+        name: 'Tonga Facility 2',
+        type: 'facility',
+        attributes: {},
+      },
       { id: 'ouId7', code: 'FJ_Facility', name: 'Fiji Facility', type: 'facility', attributes: {} },
     ],
   };
@@ -43,6 +56,20 @@ describe('buildContext', () => {
   };
 
   describe('orgUnits', () => {
+    it('adds query to the context', async () => {
+      const transform: unknown = [];
+      const analytics: Row[] = [];
+      const data = { results: analytics };
+      const query = { test: 'yes' };
+
+      const context = await buildContext(transform, reqContext, data, query);
+
+      const expectedContext = {
+        query,
+      };
+      expect(context).toStrictEqual(expectedContext);
+    });
+
     it('builds orgUnits using fetched analytics', async () => {
       const transform = [
         {

--- a/packages/report-server/src/__tests__/reportBuilder/transform/parser/parser.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/transform/parser/parser.test.ts
@@ -8,24 +8,28 @@ import { buildTransform } from '../../../../reportBuilder/transform';
 
 describe('parser', () => {
   it('can do lookups', () => {
-    const transform = buildTransform([
-      {
-        transform: 'updateColumns',
-        insert: {
-          variable: '=$BCD1',
-          current: '=@current.BCD1',
-          index: '=@index',
-          previous: '=@previous.BCD1',
-          next: '=@next.BCD1',
-          lastAll: '=last(@all.BCD1)',
-          sumAllPrevious: '=sum(@allPrevious.BCD1)',
-          sumWhereMatchingOrgUnit:
-            '=sum(where(f(@otherRow) = eq($organisationUnit, @otherRow.organisationUnit)).BCD1)',
-          tableLength: '=length(@table)',
+    const transform = buildTransform(
+      [
+        {
+          transform: 'updateColumns',
+          insert: {
+            variable: '=$BCD1',
+            current: '=@current.BCD1',
+            index: '=@index',
+            previous: '=@previous.BCD1',
+            next: '=@next.BCD1',
+            lastAll: '=last(@all.BCD1)',
+            sumAllPrevious: '=sum(@allPrevious.BCD1)',
+            sumWhereMatchingOrgUnit:
+              '=sum(where(f(@otherRow) = eq($organisationUnit, @otherRow.organisationUnit)).BCD1)',
+            tableLength: '=length(@table)',
+            requestParam: '= @params.animal',
+          },
+          exclude: '*',
         },
-        exclude: '*',
-      },
-    ]);
+      ],
+      { query: { animal: 'cat' } },
+    );
     expect(transform(PARSABLE_ANALYTICS)).toEqual([
       {
         variable: 4,
@@ -36,6 +40,7 @@ describe('parser', () => {
         sumAllPrevious: 4,
         sumWhereMatchingOrgUnit: 11,
         tableLength: 6,
+        requestParam: 'cat',
       },
       {
         variable: 2,
@@ -47,6 +52,7 @@ describe('parser', () => {
         sumAllPrevious: 6,
         sumWhereMatchingOrgUnit: 11,
         tableLength: 6,
+        requestParam: 'cat',
       },
       {
         variable: 5,
@@ -58,6 +64,7 @@ describe('parser', () => {
         sumAllPrevious: 11,
         sumWhereMatchingOrgUnit: 11,
         tableLength: 6,
+        requestParam: 'cat',
       },
       {
         variable: 7,
@@ -69,6 +76,7 @@ describe('parser', () => {
         sumAllPrevious: 18,
         sumWhereMatchingOrgUnit: 17,
         tableLength: 6,
+        requestParam: 'cat',
       },
       {
         variable: 8,
@@ -80,6 +88,7 @@ describe('parser', () => {
         sumAllPrevious: 26,
         sumWhereMatchingOrgUnit: 17,
         tableLength: 6,
+        requestParam: 'cat',
       },
       {
         variable: 2,
@@ -90,6 +99,7 @@ describe('parser', () => {
         sumAllPrevious: 28,
         sumWhereMatchingOrgUnit: 17,
         tableLength: 6,
+        requestParam: 'cat',
       },
     ]);
   });

--- a/packages/report-server/src/reportBuilder/context/buildContext.ts
+++ b/packages/report-server/src/reportBuilder/context/buildContext.ts
@@ -93,10 +93,11 @@ export const buildContext = async (
   transform: unknown,
   reqContext: ReqContext,
   data: FetchResponse,
+  query?: Record<string, unknown>,
 ): Promise<Context> => {
   const dependencies = detectDependencies(transform);
 
-  const context: Context = {};
+  const context: Context = query ? { query } : {};
 
   for (const key of dependencies) {
     validateDependency(key);

--- a/packages/report-server/src/reportBuilder/context/types.ts
+++ b/packages/report-server/src/reportBuilder/context/types.ts
@@ -4,9 +4,10 @@
  */
 
 export interface Context {
-  orgUnits?: { code: string; name: string; id: string, attributes: Record<string, any> }[];
+  query?: Record<string, unknown>;
+  orgUnits?: { code: string; name: string; id: string; attributes: Record<string, any> }[];
   facilityCountByOrgUnit?: Record<string, number>; // { TO: 14, PG: 9 }
   dataElementCodeToName?: Record<string, string>;
 }
 
-export type ContextDependency = keyof Context;
+export type ContextDependency = Exclude<keyof Context, 'query'>;

--- a/packages/report-server/src/reportBuilder/query/buildOrganisationUnitParams.ts
+++ b/packages/report-server/src/reportBuilder/query/buildOrganisationUnitParams.ts
@@ -79,7 +79,7 @@ export const buildOrganisationUnitParams = async (
     .filter(({ country_code }) =>
       accessPolicy.allows(country_code as Exclude<typeof country_code, null>, permissionGroup),
     )
-    .map(({ code }) => code);
+    .map(({ code }: { code: string }) => code);
 
   if (codesWithAccess.length === 0) {
     throw new Error(`No '${permissionGroup}' access to any one of entities: ${codesToFetch}`);

--- a/packages/report-server/src/reportBuilder/reportBuilder.ts
+++ b/packages/report-server/src/reportBuilder/reportBuilder.ts
@@ -51,7 +51,7 @@ export class ReportBuilder {
     const builtQuery = await new QueryBuilder(this.reqContext, this.config, query).build();
     const data = await fetch(aggregator, builtQuery);
 
-    const context = await buildContext(this.config.transform, this.reqContext, data);
+    const context = await buildContext(this.config.transform, this.reqContext, data, query);
     const transform = buildTransform(this.config.transform, context);
     const transformedData = transform(data.results);
 

--- a/packages/report-server/src/reportBuilder/transform/parser/TransformParser.ts
+++ b/packages/report-server/src/reportBuilder/transform/parser/TransformParser.ts
@@ -30,6 +30,7 @@ type RowLookup = {
  * '@current.BCD1 + sum(@allPrevious.BCD1)' => 21
  */
 type Lookups = {
+  params: Record<string, unknown>;
   current: Row;
   previous: Row;
   next: Row;
@@ -53,6 +54,7 @@ export class TransformParser extends ExpressionParser {
 
     this.rows = rows;
     this.lookups = {
+      params: context?.query || {},
       current: {},
       previous: {},
       next: {},


### PR DESCRIPTION
### Issue RN-601:

I've wanted this feature for a while, as there are occasional cases where it'd be really handy to reference the original request parameters of the viz.

I see this as also paving the way for being able to have vizes take additional parameters (eg. A control to filter by Drug Type) which would be really cool.

It's also a pre-requisite for moving 'fetch' into the transform steps, which we want to have in place prior to moving on with the Data Tables epic