### PR TITLE
Hotfix: Reference port safely when starting web-config-server

### DIFF
--- a/packages/web-config-server/src/index.js
+++ b/packages/web-config-server/src/index.js
@@ -9,9 +9,10 @@ async function start() {
     const app = await createApp();
 
     // process.env.PORT as per run command PORT=XXXX npm run dev
-    app.server.listen(process.env.PORT || 8080);
+    const port = process.env.PORT || 8080;
+    app.server.listen(port);
     winston.debug('Logging at debug level');
-    winston.info('Server started', { port: app.server.address().port });
+    winston.info(`Running on port ${port}`);
     const aggregationDescription = process.env.AGGREGATION_URL_PREFIX || 'production';
     winston.info(`Connected to ${aggregationDescription} aggregation`);
 


### PR DESCRIPTION
### Issue https://beyondessential.slack.com/archives/C032DCHKTGR/p1660001151672799:

Not too sure why this suddenly became an issue. But this error has cropped up a few times in the past, and it seems the way we're referencing the port here isn't particularly safe.

Switched to using the standard way we do it on other servers.