### PR TITLE
Silence noisy warning when building @tupaia/ui-components

### DIFF
--- a/packages/ui-components/.babelrc.js
+++ b/packages/ui-components/.babelrc.js
@@ -30,7 +30,13 @@ module.exports = {
       '@babel/plugin-proposal-private-property-in-object',
       {
         loose: true,
-      }
-    ]
-  ]
+      },
+    ],
+    [
+      '@babel/plugin-proposal-private-methods',
+      {
+        loose: true,
+      },
+    ],
+  ],
 };


### PR DESCRIPTION
We currently see a lot of this warning when building ui-components:
```
[ui-components] Though the "loose" option was set to "false" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-private-methods since the "loose" mode option was set to "true" for @babel/plugin-proposal-private-property-in-object.
[ui-components] The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding
[ui-components]         ["@babel/plugin-proposal-private-methods", { "loose": true }]
[ui-components] to the "plugins" section of your Babel config.
```

So I followed the recommendation to silence the warning