### PR TITLE
RN-484: Add ability for defining 'custom reports' in the report-server 

### DIFF
--- a/packages/admin-panel-server/src/__tests__/viz-builder/dashboardVisualisation/DashboardVisualisationExtractor.test.ts
+++ b/packages/admin-panel-server/src/__tests__/viz-builder/dashboardVisualisation/DashboardVisualisationExtractor.test.ts
@@ -107,6 +107,27 @@ describe('DashboardVisualisationExtractor', () => {
           },
         });
       });
+
+      it('can get a draft report which uses a custom report', () => {
+        const extractor = new DashboardVisualisationExtractor(
+          {
+            code: 'viz',
+            data: { customReport: 'custom' },
+            presentation: {},
+          },
+          yup.object(),
+          draftReportValidator,
+        );
+
+        const report = extractor.getReport();
+
+        expect(report).toEqual({
+          code: 'viz',
+          config: {
+            customReport: 'custom',
+          },
+        });
+      });
     });
 
     describe('getReport() - legacyReport', () => {

--- a/packages/admin-panel-server/src/viz-builder/dashboardVisualisation/DashboardVisualisationExtractor.ts
+++ b/packages/admin-panel-server/src/viz-builder/dashboardVisualisation/DashboardVisualisationExtractor.ts
@@ -76,6 +76,16 @@ export class DashboardVisualisationExtractor<
     const { code, permissionGroup, data, presentation } = this.visualisation;
     const validatedData = baseVisualisationDataValidator.validateSync(data);
 
+    if (validatedData.customReport) {
+      return {
+        config: {
+          customReport: validatedData.customReport,
+        },
+        code,
+        permissionGroup,
+      };
+    }
+
     const { fetch: vizFetch, aggregate, transform } = validatedData;
 
     const fetch = omitBy(

--- a/packages/admin-panel-server/src/viz-builder/dashboardVisualisation/combineDashboardVisualisation.ts
+++ b/packages/admin-panel-server/src/viz-builder/dashboardVisualisation/combineDashboardVisualisation.ts
@@ -3,11 +3,15 @@
  * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
  */
 
-import { LegacyReport, Report} from '../types';
+import { LegacyReport, Report } from '../types';
 import { DashboardItem, DashboardViz, DashboardVizResource } from './types';
 
 const getData = (report: Report) => {
   const { config } = report;
+  if ('customReport' in config) {
+    return { customReport: config.customReport };
+  }
+
   const { fetch, transform } = config;
   const { aggregations, ...restOfFetch } = fetch;
   return { fetch: restOfFetch, aggregate: aggregations, transform };
@@ -24,14 +28,16 @@ const getPresentation = (dashboardItem: DashboardItem, report: Report | LegacyRe
   const { type, name, ...config } = dashboardItemConfig;
 
   const presentation: Record<string, unknown> = { type, ...config };
-  if (!dashboardItem.legacy) {
+  if (!dashboardItem.legacy && 'output' in reportConfig) {
     presentation.output = reportConfig.output;
   }
 
   return presentation;
 };
 
-export function combineDashboardVisualisation(visualisationResource: DashboardVizResource): DashboardViz {
+export function combineDashboardVisualisation(
+  visualisationResource: DashboardVizResource,
+): DashboardViz {
   const { dashboardItem, report } = visualisationResource;
   const { id, code, config, legacy } = dashboardItem;
   const { name } = config;

--- a/packages/admin-panel-server/src/viz-builder/dashboardVisualisation/combineDashboardVisualisation.ts
+++ b/packages/admin-panel-server/src/viz-builder/dashboardVisualisation/combineDashboardVisualisation.ts
@@ -4,18 +4,8 @@
  */
 
 import { LegacyReport, Report } from '../types';
+import { extractDataFromReport } from '../utils';
 import { DashboardItem, DashboardViz, DashboardVizResource } from './types';
-
-const getData = (report: Report) => {
-  const { config } = report;
-  if ('customReport' in config) {
-    return { customReport: config.customReport };
-  }
-
-  const { fetch, transform } = config;
-  const { aggregations, ...restOfFetch } = fetch;
-  return { fetch: restOfFetch, aggregate: aggregations, transform };
-};
 
 const getLegacyData = (report: LegacyReport) => {
   const { dataBuilder, config, dataServices } = report;
@@ -43,7 +33,7 @@ export function combineDashboardVisualisation(
   const { name } = config;
   const data = dashboardItem.legacy
     ? getLegacyData(report as LegacyReport)
-    : getData(report as Report);
+    : extractDataFromReport(report as Report);
   const presentation = getPresentation(dashboardItem, report);
 
   const visualisation: Record<string, unknown> = {

--- a/packages/admin-panel-server/src/viz-builder/mapOverlayVisualisation/combineMapOverlayVisualisation.ts
+++ b/packages/admin-panel-server/src/viz-builder/mapOverlayVisualisation/combineMapOverlayVisualisation.ts
@@ -4,12 +4,16 @@
  */
 
 import { ValidationError } from '@tupaia/utils';
-import { LegacyReport, Report} from '../types';
+import { LegacyReport, Report } from '../types';
 import { MapOverlay, MapOverlayViz, MapOverlayVizResource } from './types';
 
 // TODO: DRY
 const getData = (report: Report) => {
   const { config } = report;
+  if ('customReport' in config) {
+    return { customReport: config.customReport };
+  }
+
   const { fetch, transform } = config;
   const { aggregations, ...restOfFetch } = fetch;
   return { fetch: restOfFetch, aggregate: aggregations, transform };
@@ -20,14 +24,16 @@ const getPresentation = (mapOverlay: MapOverlay, report: Report | LegacyReport) 
   const { config } = mapOverlay;
 
   const presentation = config;
-  if (!mapOverlay.legacy) {
+  if (!mapOverlay.legacy && 'output' in reportConfig) {
     presentation.output = reportConfig.output;
   }
 
   return presentation;
 };
 
-export function combineMapOverlayVisualisation(visualisationResource: MapOverlayVizResource): MapOverlayViz {
+export function combineMapOverlayVisualisation(
+  visualisationResource: MapOverlayVizResource,
+): MapOverlayViz {
   const { mapOverlay, report } = visualisationResource;
 
   if (mapOverlay.legacy) {

--- a/packages/admin-panel-server/src/viz-builder/mapOverlayVisualisation/combineMapOverlayVisualisation.ts
+++ b/packages/admin-panel-server/src/viz-builder/mapOverlayVisualisation/combineMapOverlayVisualisation.ts
@@ -5,19 +5,8 @@
 
 import { ValidationError } from '@tupaia/utils';
 import { LegacyReport, Report } from '../types';
+import { extractDataFromReport } from '../utils';
 import { MapOverlay, MapOverlayViz, MapOverlayVizResource } from './types';
-
-// TODO: DRY
-const getData = (report: Report) => {
-  const { config } = report;
-  if ('customReport' in config) {
-    return { customReport: config.customReport };
-  }
-
-  const { fetch, transform } = config;
-  const { aggregations, ...restOfFetch } = fetch;
-  return { fetch: restOfFetch, aggregate: aggregations, transform };
-};
 
 const getPresentation = (mapOverlay: MapOverlay, report: Report | LegacyReport) => {
   const { config: reportConfig } = report;
@@ -41,7 +30,7 @@ export function combineMapOverlayVisualisation(
   }
 
   const { config, permissionGroup: mapOverlayPermissionGroup, ...rest } = mapOverlay;
-  const data = getData(report);
+  const data = extractDataFromReport(report);
   const presentation = getPresentation(mapOverlay, report);
 
   const visualisation: Record<string, unknown> = {

--- a/packages/admin-panel-server/src/viz-builder/reportConfigValidator.ts
+++ b/packages/admin-panel-server/src/viz-builder/reportConfigValidator.ts
@@ -53,7 +53,11 @@ const dateSpecsValidator = polymorphic({
   string: yup.string().min(4),
 });
 
-export const configValidator = yup.object().shape({
+const customReportConfigValidator = yup.object().shape({
+  customReport: yup.string().required(),
+});
+
+const standardConfigValidator = yup.object().shape({
   fetch: yup
     .object()
     .shape(
@@ -69,4 +73,15 @@ export const configValidator = yup.object().shape({
     .required(),
   transform: yup.array().required(),
   output: yup.object(),
+});
+
+// TODO: Consolidate this and the validator in @tupaia/report-server in a common @tupaia/types package
+export const configValidator = yup.lazy<
+  typeof standardConfigValidator | typeof customReportConfigValidator
+>((config: unknown) => {
+  if (typeof config === 'object' && config && 'customReport' in config) {
+    return customReportConfigValidator;
+  }
+
+  return standardConfigValidator;
 });

--- a/packages/admin-panel-server/src/viz-builder/types.ts
+++ b/packages/admin-panel-server/src/viz-builder/types.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
  */
 
-import { ReportConfig } from '@tupaia/report-server';
+import { ReportConfig, StandardOrCustomReportConfig } from '@tupaia/report-server';
 
 export type VizData = {
   dataElements: ReportConfig['fetch']['dataElements'];
@@ -22,7 +22,7 @@ export enum PreviewMode {
 export type Report = {
   code: string;
   permissionGroup: string;
-  config: ReportConfig;
+  config: StandardOrCustomReportConfig;
 };
 
 export type LegacyReport = {
@@ -47,7 +47,7 @@ export type CamelKeysToSnake<T extends Record<string, unknown>> = {
 export type ExpandType<T> = T extends Record<string, unknown>
   ? T extends infer O
     ? {
-      [K in keyof O]: ExpandType<O[K]>;
-    }
+        [K in keyof O]: ExpandType<O[K]>;
+      }
     : never
   : T;

--- a/packages/admin-panel-server/src/viz-builder/utils.ts
+++ b/packages/admin-panel-server/src/viz-builder/utils.ts
@@ -1,0 +1,18 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import { Report } from './types';
+
+// Used when combining the report and dashboardItem/mapOverlay
+export const extractDataFromReport = (report: Report) => {
+  const { config } = report;
+  if ('customReport' in config) {
+    return { customReport: config.customReport };
+  }
+
+  const { fetch, transform } = config;
+  const { aggregations, ...restOfFetch } = fetch;
+  return { fetch: restOfFetch, aggregate: aggregations, transform };
+};

--- a/packages/admin-panel-server/src/viz-builder/validators.ts
+++ b/packages/admin-panel-server/src/viz-builder/validators.ts
@@ -10,8 +10,22 @@ export const baseVisualisationValidator = yup.object().shape({
   data: yup.object().required(),
 });
 
-export const baseVisualisationDataValidator = yup.object().shape({
+const baseCustomReportDataValidator = yup.object().shape({
+  customReport: yup.string().required(),
+});
+
+const baseStandardReportDataValidator = yup.object().shape({
   fetch: yup.object().required(),
+});
+
+export const baseVisualisationDataValidator = yup.lazy<
+  typeof baseStandardReportDataValidator | typeof baseCustomReportDataValidator
+>((dataConfig: unknown) => {
+  if (typeof dataConfig === 'object' && dataConfig && 'customReport' in dataConfig) {
+    return baseCustomReportDataValidator;
+  }
+
+  return baseStandardReportDataValidator;
 });
 
 export const draftReportValidator = yup.object().shape({

--- a/packages/admin-panel/src/VizBuilderApp/components/Panel.js
+++ b/packages/admin-panel/src/VizBuilderApp/components/Panel.js
@@ -76,17 +76,6 @@ const PanelTabPanel = styled.div`
   }
 `;
 
-const CustomReportName = styled.span`
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-
-  > div {
-    width: 100%;
-    height: 100%;
-  }
-`;
-
 export const Panel = () => {
   const { hasDataError, setDataError } = useVizConfigError();
   const { jsonToggleEnabled } = useTabPanel();
@@ -125,7 +114,7 @@ export const Panel = () => {
     return (
       <Container>
         <PanelNav>
-          <CustomReportName>Custom Report: {vizData.customReport}</CustomReportName>
+          <>Custom Report: {vizData.customReport}</>
           <PlayButton />
         </PanelNav>
       </Container>

--- a/packages/admin-panel/src/VizBuilderApp/components/Panel.js
+++ b/packages/admin-panel/src/VizBuilderApp/components/Panel.js
@@ -76,6 +76,17 @@ const PanelTabPanel = styled.div`
   }
 `;
 
+const CustomReportName = styled.span`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+
+  > div {
+    width: 100%;
+    height: 100%;
+  }
+`;
+
 export const Panel = () => {
   const { hasDataError, setDataError } = useVizConfigError();
   const { jsonToggleEnabled } = useTabPanel();
@@ -88,7 +99,7 @@ export const Panel = () => {
   ] = useVizConfig();
 
   const {
-    visualisation: { data: finalData },
+    visualisation: { data: vizData },
   } = useVisualisation();
 
   const handleChange = (event, newValue) => {
@@ -107,6 +118,19 @@ export const Panel = () => {
   const isTabDisabled = tabId => {
     return tab !== tabId && hasDataError;
   };
+
+  const isCustomReport = 'customReport' in vizData;
+  // Custom report vizes don't support any configuration so just show the name
+  if (isCustomReport) {
+    return (
+      <Container>
+        <PanelNav>
+          <CustomReportName>Custom Report: {vizData.customReport}</CustomReportName>
+          <PlayButton />
+        </PanelNav>
+      </Container>
+    );
+  }
 
   return (
     <Container>
@@ -128,7 +152,7 @@ export const Panel = () => {
       <TabPanel isSelected={tab === 0} Panel={PanelTabPanel}>
         {jsonToggleEnabled ? (
           <JsonEditor
-            value={finalData.fetch}
+            value={vizData.fetch}
             onChange={value => setTabValue('fetch', value)}
             onInvalidChange={handleInvalidChange}
           />
@@ -144,7 +168,7 @@ export const Panel = () => {
       <TabPanel isSelected={tab === 1} Panel={PanelTabPanel}>
         {jsonToggleEnabled ? (
           <JsonEditor
-            value={finalData.aggregate}
+            value={vizData.aggregate}
             onChange={value => setTabValue('aggregate', value)}
             onInvalidChange={handleInvalidChange}
           />
@@ -161,7 +185,7 @@ export const Panel = () => {
       <TabPanel isSelected={tab === 2} Panel={PanelTabPanel}>
         {jsonToggleEnabled ? (
           <JsonEditor
-            value={finalData.transform}
+            value={vizData.transform}
             onChange={value => setTabValue('transform', value)}
             onInvalidChange={handleInvalidChange}
           />

--- a/packages/admin-panel/src/VizBuilderApp/context/VizConfig.js
+++ b/packages/admin-panel/src/VizBuilderApp/context/VizConfig.js
@@ -97,6 +97,10 @@ const useConfigStore = () => {
   const setProject = value => dispatch({ type: SET_PROJECT, value });
   const setTestData = value => dispatch({ type: SET_TEST_DATA, value });
   const setVisualisation = value => {
+    if (!value.data.transform) {
+      return dispatch({ type: SET_VISUALISATION, value });
+    }
+
     const { transform } = value.data;
     const sanitisedTransform = transform.map(conf =>
       typeof conf === 'string' ? { transform: conf, alias: true } : conf,

--- a/packages/report-server/examples.http
+++ b/packages/report-server/examples.http
@@ -75,3 +75,14 @@ Authorization: {{authorization}}
     ]
   }
 }
+
+### Fetch Report With Test Config for custom report
+POST {{baseUrl}}/testReport?organisationUnitCodes=VU&hierarchy=explore HTTP/1.1
+content-type: {{contentType}}
+Authorization: {{authorization}}
+
+{
+  "testConfig": {
+    "customReport": "testCustomReport"
+  }
+}

--- a/packages/report-server/src/__tests__/reportBuilder/customReport/testCustomReport.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/customReport/testCustomReport.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import { AccessPolicy } from '@tupaia/access-policy';
+import { ReqContext } from '../../../reportBuilder/context';
+
+import { testCustomReport } from '../../../reportBuilder/customReports/testCustomReport';
+
+import { entityApiMock } from '../testUtils';
+
+describe('buildContext', () => {
+  const HIERARCHY = 'test_hierarchy';
+  const ENTITIES = {
+    test_hierarchy: [
+      { code: 'FJ', name: 'Fiji', type: 'country' },
+      { code: 'FJ_Facility', name: 'Fiji Facility', type: 'facility' },
+      { code: 'TO', name: 'Tonga', type: 'country' },
+      {
+        code: 'TO_District',
+        name: 'Tonga District',
+        type: 'district',
+      },
+      {
+        code: 'TO_Facility1',
+        name: 'Tonga Facility 1',
+        type: 'facility',
+      },
+      {
+        code: 'TO_Facility2',
+        name: 'Tonga Facility 2',
+        type: 'facility',
+      },
+    ],
+  };
+
+  const RELATIONS = {
+    test_hierarchy: [
+      { parent: 'TO', child: 'TO_District' },
+      { parent: 'TO_District', child: 'TO_Facility1' },
+      { parent: 'TO_District', child: 'TO_Facility2' },
+      { parent: 'FJ', child: 'FJ_Facility' },
+    ],
+  };
+
+  const apiMock = entityApiMock(ENTITIES, RELATIONS);
+
+  const reqContext: ReqContext = {
+    hierarchy: HIERARCHY,
+    permissionGroup: 'Public',
+    services: {
+      entity: apiMock,
+    } as ReqContext['services'],
+    accessPolicy: new AccessPolicy({ AU: ['Public'] }),
+  };
+
+  it('calculates number of facilities in requested entity', async () => {
+    const numberOfFacilitiesInTonga = await testCustomReport(reqContext, {
+      organisationUnitCodes: ['TO'],
+      hierarchy: 'test_hierarchy',
+    });
+
+    expect(numberOfFacilitiesInTonga).toEqual([{ value: 2 }]);
+  });
+
+  it('calculates number of facilities in requested entities', async () => {
+    const numberOfFacilitiesInFijiAndTonga = await testCustomReport(reqContext, {
+      organisationUnitCodes: ['TO', 'FJ'],
+      hierarchy: 'test_hierarchy',
+    });
+
+    expect(numberOfFacilitiesInFijiAndTonga).toEqual([{ value: 3 }]);
+  });
+});

--- a/packages/report-server/src/reportBuilder/configValidator.ts
+++ b/packages/report-server/src/reportBuilder/configValidator.ts
@@ -50,18 +50,35 @@ const dateSpecsValidator = polymorphic({
   string: yup.string().min(4),
 });
 
-export const configValidator = yup.object().shape({
-  fetch: yup.object().shape(
-    {
-      dataElements: dataElementValidator,
-      dataGroups: dataGroupValidator,
-      aggregations: yup.array().of(aggregationValidator as any), // https://github.com/jquense/yup/issues/1283#issuecomment-786559444
-      organisationUnits: yup.array().of(yup.string().required()),
-      startDate: dateSpecsValidator,
-      endDate: dateSpecsValidator,
-    },
-    [['dataElements', 'dataGroups']],
-  ),
+const customReportConfigValidator = yup.object().shape({
+  customReport: yup.string().required(),
+});
+
+const standardConfigValidator = yup.object().shape({
+  fetch: yup
+    .object()
+    .shape(
+      {
+        dataElements: dataElementValidator,
+        dataGroups: dataGroupValidator,
+        aggregations: yup.array().of(aggregationValidator as any), // https://github.com/jquense/yup/issues/1283#issuecomment-786559444
+        organisationUnits: yup.array().of(yup.string().required()),
+        startDate: dateSpecsValidator,
+        endDate: dateSpecsValidator,
+      },
+      [['dataElements', 'dataGroups']],
+    )
+    .required(),
   transform: yup.array().required(),
   output: yup.object(),
+});
+
+export const configValidator = yup.lazy<
+  typeof standardConfigValidator | typeof customReportConfigValidator
+>((config: unknown) => {
+  if (typeof config === 'object' && config && 'customReport' in config) {
+    return customReportConfigValidator;
+  }
+
+  return standardConfigValidator;
 });

--- a/packages/report-server/src/reportBuilder/customReports/index.ts
+++ b/packages/report-server/src/reportBuilder/customReports/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import { Resolved } from '@tupaia/tsutils';
+import { FetchReportQuery } from '../../types';
+import { ReqContext } from '../context';
+import { testCustomReport } from './testCustomReport';
+
+type CustomReportBuilder = (reqContext: ReqContext, query: FetchReportQuery) => Promise<unknown>;
+
+export const customReports: Record<string, CustomReportBuilder> = { testCustomReport };
+
+export type CustomReportOutputType = Resolved<
+  ReturnType<typeof customReports[keyof typeof customReports]>
+>;

--- a/packages/report-server/src/reportBuilder/customReports/testCustomReport.ts
+++ b/packages/report-server/src/reportBuilder/customReports/testCustomReport.ts
@@ -1,0 +1,17 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import { FetchReportQuery } from '../../types';
+import { ReqContext } from '../context';
+
+export const testCustomReport = async (reqContext: ReqContext, query: FetchReportQuery) => {
+  const { organisationUnitCodes: entityCodes, hierarchy } = query;
+  const facilities = await reqContext.services.entity.getDescendantsOfEntities(
+    hierarchy,
+    entityCodes,
+    { filter: { type: 'facility' } },
+  );
+  return [{ value: facilities.length }];
+};

--- a/packages/report-server/src/reportBuilder/output/functions/outputBuilders.ts
+++ b/packages/report-server/src/reportBuilder/output/functions/outputBuilders.ts
@@ -3,13 +3,12 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
+import { Resolved } from '@tupaia/tsutils';
 import { buildDefault } from './default';
 import { buildMatrix } from './matrix';
 import { buildRawDataExport } from './rawDataExport';
 
-type Await<T> = T extends PromiseLike<infer U> ? U : T;
-
-export type OutputType = Await<
+export type OutputType = Resolved<
   ReturnType<ReturnType<typeof outputBuilders[keyof typeof outputBuilders]>>
 >;
 

--- a/packages/report-server/src/reportBuilder/reportBuilder.ts
+++ b/packages/report-server/src/reportBuilder/reportBuilder.ts
@@ -4,7 +4,7 @@
  */
 
 import { ReportServerAggregator } from '../aggregator';
-import { FetchReportQuery, ReportConfig } from '../types';
+import { FetchReportQuery, StandardOrCustomReportConfig } from '../types';
 import { configValidator } from './configValidator';
 import { buildContext, ReqContext } from './context';
 import { buildFetch, FetchResponse } from './fetch';
@@ -13,14 +13,15 @@ import { buildOutput } from './output';
 import { Row } from './types';
 import { OutputType } from './output/functions/outputBuilders';
 import { QueryBuilder } from './query';
+import { CustomReportOutputType, customReports } from './customReports';
 
 export interface BuiltReport {
-  results: OutputType;
+  results: OutputType | CustomReportOutputType;
 }
 
 export class ReportBuilder {
   private readonly reqContext: ReqContext;
-  private config?: ReportConfig;
+  private config?: StandardOrCustomReportConfig;
   private testData?: Row[];
 
   public constructor(reqContext: ReqContext) {
@@ -43,6 +44,16 @@ export class ReportBuilder {
   ): Promise<BuiltReport> => {
     if (!this.config) {
       throw new Error('Report requires a config be set');
+    }
+
+    if ('customReport' in this.config) {
+      const customReportBuilder = customReports[this.config.customReport];
+      if (!customReportBuilder) {
+        throw new Error(`Custom report ${this.config.customReport} does not exist`);
+      }
+
+      const customReportData = await customReportBuilder(this.reqContext, query);
+      return { results: customReportData };
     }
 
     const fetch = this.testData

--- a/packages/report-server/src/types.ts
+++ b/packages/report-server/src/types.ts
@@ -4,14 +4,13 @@
  */
 
 import { ModelRegistry } from '@tupaia/database';
-import { ReportModel } from './models';
-
-import type { DateSpecs } from './reportBuilder';
 import { TupaiaApiClient } from '@tupaia/api-client';
+import { ReportModel } from './models';
+import type { DateSpecs } from './reportBuilder';
 
 export type RequestContext = {
   services: TupaiaApiClient;
-}
+};
 
 export interface ReportServerModelRegistry extends ModelRegistry {
   readonly report: ReportModel;
@@ -37,7 +36,11 @@ export type Aggregation = string | AggregationObject;
 
 type Transform = string | Record<string, unknown>;
 
-export interface ReportConfig {
+type CustomReportConfig = {
+  customReport: string;
+};
+
+export type ReportConfig = {
   fetch: {
     dataElements?: string[];
     dataGroups?: string[];
@@ -48,7 +51,9 @@ export interface ReportConfig {
   };
   transform: Transform[];
   output?: Record<string, unknown>;
-}
+};
+
+export type StandardOrCustomReportConfig = ReportConfig | CustomReportConfig;
 
 export interface Event {
   event: string;

--- a/packages/tsutils/src/types.ts
+++ b/packages/tsutils/src/types.ts
@@ -4,7 +4,7 @@
  */
 
 // TODO: Switch to 'Awaited' when upgrading to typescript 4.5+
-export type Resolved<T> = T extends Promise<infer R> ? R : T;
+export type Resolved<T> = T extends PromiseLike<infer R> ? R : T;
 
 /**
  * Returns keys of type that cannot be null, eg.


### PR DESCRIPTION
### Issue RN-484:

There often come times where we need to rush out a viz, and the demands to get it to work are too tricky for the viz builder at the moment.

The 'Custom Report' is an option to just handcraft a single JS function that pulls and transforms all the data we need. I prefer this option over using the legacy databuilders for a few reason:
1. We will probably always need some capacity for this, so it's worthwhile to manage it in a non-legacy way
2. The legacy pattern really blurs the line between what should be config, and what should be code. This however is very clear. Either use the viz-builder transform configs, or just code. I think that makes it simpler to understand and reverse engineer these custom reports when we need to
3. They're in typescript which makes them a lot easier to work with, and the have access to the `@tupaia/api-client`

But happy to hear push back from the reviewer if they feel this really muddies the report-server code?

Thoughts on the name 'Custom Reports' btw? It feel a bit weak and non-descriptive to me... HardCodedReport? idk...