### PR TITLE
(Hotfix) RN-617: Fix broken Entity Searchbar

### DIFF
--- a/packages/web-frontend/src/sagas/index.js
+++ b/packages/web-frontend/src/sagas/index.js
@@ -3,6 +3,7 @@ import * as watchMapOverlay from './watchMapOverlay';
 import * as watchOrgUnit from './watchOrgUnit';
 import * as watchProject from './watchProject';
 import * as watchUser from './watchUser';
+import * as watchSearchbar from './watchSearchbar';
 
 export default [
   ...Object.values(watchDashboard),
@@ -10,4 +11,5 @@ export default [
   ...Object.values(watchOrgUnit),
   ...Object.values(watchProject),
   ...Object.values(watchUser),
+  ...Object.values(watchSearchbar),
 ];


### PR DESCRIPTION
### Issue RN-617:

The issue was that editing the search bar never triggered a search request. Fixed missing export of `watchSearchBar` sagas, now they trigger a request properly again.
