### PR TITLE
Set default dashboard to the first from list

### DIFF
--- a/packages/web-frontend/src/sagas/watchOrgUnit/watchOrgUnitChangeAndFetchDashboard.js
+++ b/packages/web-frontend/src/sagas/watchOrgUnit/watchOrgUnitChangeAndFetchDashboard.js
@@ -39,10 +39,11 @@ function* fetchDashboards(action) {
     // If there is no dashboard code defined, assign the default if it is valid for the user
     if (!currentDashboardName) {
       const projectDefaultDashboardName = project.dashboardGroupName;
-      const dashboard = dashboards.find(d => d.dashboardName === projectDefaultDashboardName);
-      if (dashboard) {
-        yield put(setDashboardGroup(project.dashboardGroupName));
-      }
+      const presetDefaultDashboard = dashboards.find(
+        d => d.dashboardName === projectDefaultDashboardName,
+      );
+      const defaultDashboard = presetDefaultDashboard || dashboards[0];
+      yield put(setDashboardGroup(defaultDashboard.dashboardName));
     } else {
       const dashboard = dashboards.find(d => d.dashboardName === currentDashboardName);
       // Check if the user has permission to view the dashboard


### PR DESCRIPTION
### Issue #:
We preset the default dashboard for every project in `project` table. Tupaia frontend will use it as the default dashboard when clicking into a project. 

The issue is when default dashboard is renamed in `dashboard_group` table, and we didn't update it in `project` table, frontend will not set `dashboard` code in URL, because it is 'not found'. Example: Project `Strive PNG`.

Everything works fine, the only effect is the 'incomplete' URL will cause issue for dashboard PDF export. 

I feel it would be better to change the default dashboard to a dashboard id as a foreign key in `project` table.