### PR TITLE
Hotfix: Not all surveys showing up in meditrak-app

### DIFF
--- a/packages/central-server/src/database/createPermissionsBasedMeditrakSyncQueue.js
+++ b/packages/central-server/src/database/createPermissionsBasedMeditrakSyncQueue.js
@@ -24,8 +24,9 @@ SELECT msq.*,
 	max(e."type") AS entity_type,
 	
 	COALESCE(
+		${groupToArrayOrNull('co.id')}, 
 		${groupToArrayOrNull('e_co.id')}, 
-		${groupToArrayOrNull('c.id')}, 
+		${groupToArrayOrNull('c.country_id')}, 
 		${groupToArrayOrNull('ga.country_id')}, 
 		${groupToFlatArrayOrNull('s.country_ids')},
 		${groupToFlatArrayOrNull('sg_s.country_ids')},
@@ -47,6 +48,7 @@ SELECT msq.*,
 		${groupToArrayOrNull('o_os_q_ssc_ss_s_pg."name"')}
 	) as permission_groups
 FROM meditrak_sync_queue msq 
+LEFT JOIN country co ON msq.record_id = co.id
 LEFT JOIN entity e ON msq.record_id = e.id
 LEFT JOIN country e_co ON e_co.code = e.country_code 
 LEFT JOIN clinic c ON msq.record_id = c.id

--- a/packages/central-server/src/tests/apiV2/changes/getChangesMetadata.test.js
+++ b/packages/central-server/src/tests/apiV2/changes/getChangesMetadata.test.js
@@ -98,7 +98,7 @@ describe('GET /changes/metadata', async () => {
         });
 
         const { changeCount, countries, permissionGroups } = response.body;
-        expect(changeCount).to.equal(18);
+        expect(changeCount).to.equal(20);
         expect(countries.sort()).to.eql([PERM_SYNC_COUNTRY_1.code]);
         expect(permissionGroups.sort()).to.eql([PERM_SYNC_PG_PUBLIC.name]);
       });
@@ -117,7 +117,7 @@ describe('GET /changes/metadata', async () => {
         });
 
         const { changeCount, countries, permissionGroups } = response.body;
-        expect(changeCount).to.equal(27);
+        expect(changeCount).to.equal(29);
         expect(countries.sort()).to.eql([PERM_SYNC_COUNTRY_1.code, PERM_SYNC_COUNTRY_2.code]);
         expect(permissionGroups.sort()).to.eql([PERM_SYNC_PG_ADMIN.name, PERM_SYNC_PG_PUBLIC.name]);
       });
@@ -140,7 +140,7 @@ describe('GET /changes/metadata', async () => {
         });
 
         const { changeCount, countries } = response.body;
-        expect(changeCount).to.equal(8);
+        expect(changeCount).to.equal(10);
         expect(countries.sort()).to.eql([PERM_SYNC_COUNTRY_1.code, PERM_SYNC_COUNTRY_2.code]);
       });
 

--- a/packages/central-server/src/tests/apiV2/changes/permissionsBasedSync.fixtures.js
+++ b/packages/central-server/src/tests/apiV2/changes/permissionsBasedSync.fixtures.js
@@ -74,6 +74,12 @@ const SURVEYS = [
     permissionGroup: PERM_SYNC_PG_ADMIN.name,
     countries: [PERM_SYNC_COUNTRY_1.code, PERM_SYNC_COUNTRY_2.code],
   },
+  {
+    code: 'PERM_SYNC_SURVEY_5',
+    name: 'Permission based sync survey 5',
+    permissionGroup: PERM_SYNC_PG_PUBLIC.name,
+    countries: [], // No countries means available to all countries
+  },
 ];
 
 const QUESTIONS = [


### PR DESCRIPTION
### Issue https://beyondessential.slack.com/archives/C01MAA3NKM1/p1661205934386229:

Meditrak treats a survey with no countryIds as being available in all countries. Previously we were not syncing those surveys, so they did not show up in the app.

Personally I find the convention of no countryIds representing all countryIds a bit confusing... I won't change it as part of this PR but I'd prefer if we switched to a wild-card of sorts