### PR TITLE
hotfix: Add .cdn to host domain

### DIFF
--- a/packages/lesmis-server/src/routes/PDFExportRoute.ts
+++ b/packages/lesmis-server/src/routes/PDFExportRoute.ts
@@ -6,6 +6,7 @@
 import { Request, Response, NextFunction } from 'express';
 import { Route } from '@tupaia/server-boilerplate';
 import { downloadPageAsPdf } from '@tupaia/tsutils';
+import { convertToCDNHost } from '@tupaia/utils';
 
 type Body = {
   pdfPageUrl: string;
@@ -26,8 +27,8 @@ export class PDFExportRoute extends Route<PDFExportRequest> {
 
   public async buildResponse() {
     const { pdfPageUrl } = this.req.body;
-    const { cookie } = this.req.headers;
-    const { host: cookieDomain } = this.req.headers;
+    const { cookie, host, via } = this.req.headers;
+    const cookieDomain = via && via.includes('cloudfront.net') ? convertToCDNHost(host) : host;
 
     const buffer = await downloadPageAsPdf(pdfPageUrl, cookie, cookieDomain);
     this.res.set({

--- a/packages/utils/src/convertToCDNHost.js
+++ b/packages/utils/src/convertToCDNHost.js
@@ -1,0 +1,10 @@
+/**
+ * dev.tupaia.org -> dev.cdn.tupaia.org
+ * @param {string} host
+ * @returns
+ */
+
+export const convertToCDNHost = host => {
+  const domainIndex = host.indexOf('.tupaia.org');
+  return `${host.slice(0, domainIndex)}.cdn${host.slice(domainIndex)}`;
+};

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -41,3 +41,4 @@ export { VALUE_TYPES, formatDataValueByType } from './formatDataValueByType';
 export { createClassExtendingProxy } from './proxy';
 export { fetchPatiently } from './fetchPatiently';
 export { oneSecondSleep, sleep } from './sleep';
+export { convertToCDNHost } from './convertToCDNHost';

--- a/packages/web-config-server/src/export/PDFExportHandler.js
+++ b/packages/web-config-server/src/export/PDFExportHandler.js
@@ -1,9 +1,10 @@
 import { downloadPageAsPdf } from '@tupaia/tsutils';
+import { convertToCDNHost } from '@tupaia/utils';
 
 export const PDFExportHandler = async (req, res) => {
   const { pdfPageUrl } = req.body;
-  const { cookie } = req.headers;
-  const { host: cookieDomain } = req.headers;
+  const { cookie, host, via } = req.headers;
+  const cookieDomain = via && via.includes('cloudfront.net') ? convertToCDNHost(host) : host;
 
   const buffer = await downloadPageAsPdf(pdfPageUrl, cookie, cookieDomain);
   res.set({


### PR DESCRIPTION
### Issue #:
CDN does not forward CDN host to origin, which causes PDF export failed.

### Change #:
Add `.cdn` to host. 