### PR TITLE
hotfix: typescript validation error

### DIFF
--- a/packages/lesmis-server/src/routes/PDFExportRoute.ts
+++ b/packages/lesmis-server/src/routes/PDFExportRoute.ts
@@ -28,6 +28,9 @@ export class PDFExportRoute extends Route<PDFExportRequest> {
   public async buildResponse() {
     const { pdfPageUrl } = this.req.body;
     const { cookie, host, via } = this.req.headers;
+    if (!host) {
+      throw new Error('host must be provided');
+    }
     const cookieDomain = via && via.includes('cloudfront.net') ? convertToCDNHost(host) : host;
 
     const buffer = await downloadPageAsPdf(pdfPageUrl, cookie, cookieDomain);

--- a/packages/lesmis-server/src/routes/PDFExportRoute.ts
+++ b/packages/lesmis-server/src/routes/PDFExportRoute.ts
@@ -6,7 +6,6 @@
 import { Request, Response, NextFunction } from 'express';
 import { Route } from '@tupaia/server-boilerplate';
 import { downloadPageAsPdf } from '@tupaia/tsutils';
-import { convertToCDNHost } from '@tupaia/utils';
 
 type Body = {
   pdfPageUrl: string;
@@ -27,11 +26,7 @@ export class PDFExportRoute extends Route<PDFExportRequest> {
 
   public async buildResponse() {
     const { pdfPageUrl } = this.req.body;
-    const { cookie, host, via } = this.req.headers;
-    if (!host) {
-      throw new Error('host must be provided');
-    }
-    const cookieDomain = via && via.includes('cloudfront.net') ? convertToCDNHost(host) : host;
+    const { cookie, host: cookieDomain } = this.req.headers;
 
     const buffer = await downloadPageAsPdf(pdfPageUrl, cookie, cookieDomain);
     this.res.set({


### PR DESCRIPTION
No CDN for lesmis-server, we don't need to add `.cdn` to the host. This PR will simply revert previous changes.