### PR TITLE
Log pm2 dump file on deployment

### DIFF
--- a/packages/devops/scripts/deployment/startBackEnds.sh
+++ b/packages/devops/scripts/deployment/startBackEnds.sh
@@ -41,4 +41,7 @@ setup_startup_command=$(pm2 startup ubuntu -u ubuntu --hp /home/ubuntu | tail -1
 eval "$setup_startup_command"
 pm2 save
 
+# Log dump file
+grep status /home/ubuntu/.pm2/dump.pm2
+
 echo "Finished deploying latest"


### PR DESCRIPTION
Replaces #4124 for branch name

--

PR to add logging to initial dump file. Adds some logs so we can tell next time if the issue was caused at deployment time or after

https://beyondessential.slack.com/archives/CT0KTFSHZ/p1661729468357769

Tested by deploying this feature branch:
<img width="862" alt="Screen Shot 2022-08-29 at 11 46 28 am" src="https://user-images.githubusercontent.com/667652/187106847-b8a32a8e-e9c5-4504-b3cd-94ee9e9ac78b.png">

