### PR TITLE
Hotfix: Fix broken PSSS Countries tab

### DIFF
--- a/packages/ui-components/src/components/Table/Table.js
+++ b/packages/ui-components/src/components/Table/Table.js
@@ -7,7 +7,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import MuiTable from '@material-ui/core/Table';
-import { TablePaginator } from './TablePaginator';
+import { TablePaginator, DEFAULT_ROWS_PER_PAGE_OPTIONS } from './TablePaginator';
 import { TableHeader } from './TableHeader';
 import { TableBody } from './TableBody';
 import { TableMessageProvider } from './TableMessageProvider';
@@ -128,7 +128,7 @@ Table.defaultProps = {
   order: 'asc',
   page: null,
   rowsPerPage: 10,
-  rowsPerPageOptions: null,
+  rowsPerPageOptions: DEFAULT_ROWS_PER_PAGE_OPTIONS,
   rowIdKey: 'id',
   className: null,
 };

--- a/packages/ui-components/src/components/Table/TablePaginator.js
+++ b/packages/ui-components/src/components/Table/TablePaginator.js
@@ -10,7 +10,7 @@ import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { tableColumnShape } from './tableColumnShape';
 
-const ROWS_PER_PAGE_OPTIONS = [10, 25, 50];
+export const DEFAULT_ROWS_PER_PAGE_OPTIONS = [10, 25, 50];
 
 const TableFooter = styled(MuiTableFooter)`
   .MuiTableCell-footer.MuiTablePagination-root {
@@ -125,6 +125,6 @@ TablePaginator.defaultProps = {
   onChangeRowsPerPage: null,
   page: null,
   rowsPerPage: 10,
-  rowsPerPageOptions: ROWS_PER_PAGE_OPTIONS,
+  rowsPerPageOptions: DEFAULT_ROWS_PER_PAGE_OPTIONS,
   isFetching: false,
 };


### PR DESCRIPTION
### Issue https://beyondessential.slack.com/archives/C01MAA3NKM1/p1662345309705509:

I mistakenly assumed that `null` props would be overridden by child default props  🤦 
Fix is to ensure valid value for `rowsPerPageOptions` is passed to TablePaginator
