### PR TITLE
RN-641: Support importing project entities without a country

### DIFF
--- a/packages/central-server/src/apiV2/import/importEntities/importEntities.js
+++ b/packages/central-server/src/apiV2/import/importEntities/importEntities.js
@@ -5,8 +5,8 @@
 
 import { respond, DatabaseError, UploadError } from '@tupaia/utils';
 import { populateCoordinatesForCountry } from './populateCoordinatesForCountry';
-import { updateCountryEntities } from './updateCountryEntities';
-import { extractEntitiesByCountryName } from './extractEntitiesByCountryName';
+import { updateCountry, updateEntities } from './updateEntities';
+import { extractEntitiesByCountry } from './extractEntitiesByCountryName';
 import { assertAnyPermissions, assertBESAdminAccess } from '../../../permissions';
 import { assertCanImportEntities } from './assertCanImportEntities';
 
@@ -17,36 +17,37 @@ export async function importEntities(req, res) {
   try {
     const { models, query } = req;
 
-    let entitiesByCountryName;
+    let entitiesByCountry;
+    let entitiesWithoutCountry;
     const pushToDhis = query?.pushToDhis ? query?.pushToDhis === 'true' : true;
     const automaticallyFetchGeojson = query?.automaticallyFetchGeojson
       ? query?.automaticallyFetchGeojson === 'true'
       : true;
 
     try {
-      entitiesByCountryName = extractEntitiesByCountryName(req.file.path);
+      ({ entitiesByCountry, entitiesWithoutCountry } = extractEntitiesByCountry(req.file.path));
     } catch (error) {
       throw new UploadError(error);
     }
 
     const importEntitiesPermissionsChecker = async accessPolicy =>
-      assertCanImportEntities(accessPolicy, Object.keys(entitiesByCountryName));
+      assertCanImportEntities(accessPolicy, Object.keys(entitiesByCountry));
 
     await req.assertPermissions(
       assertAnyPermissions([assertBESAdminAccess, importEntitiesPermissionsChecker]),
     );
 
     await models.wrapInTransaction(async transactingModels => {
-      for (const countryEntries of Object.entries(entitiesByCountryName)) {
+      // First import all entities without countries (ie. project entities)
+      await updateEntities(transactingModels, entitiesWithoutCountry, null, pushToDhis);
+
+      for (const countryEntries of Object.entries(entitiesByCountry)) {
         const [countryName, entities] = countryEntries;
 
-        // Create the entities, along with matching country, geographical_area, and clinic records
-        const country = await updateCountryEntities(
-          transactingModels,
-          countryName,
-          entities,
-          pushToDhis,
-        );
+        // Create the matching country, geographical_area, and clinic records
+        const country = await updateCountry(transactingModels, countryName, pushToDhis);
+        // Create entities in the country
+        await updateEntities(transactingModels, entities, pushToDhis, country);
 
         if (automaticallyFetchGeojson) {
           // Go through country and all district/subdistricts, and if any are missing coordinates,

--- a/packages/central-server/src/tests/apiV2/import/importEntities/importEntities.test.js
+++ b/packages/central-server/src/tests/apiV2/import/importEntities/importEntities.test.js
@@ -11,7 +11,7 @@ import {
   BES_ADMIN_PERMISSION_GROUP,
 } from '../../../../permissions';
 import * as PopulateCoordinatesForCountry from '../../../../apiV2/import/importEntities/populateCoordinatesForCountry';
-import * as UpdateCountryEntities from '../../../../apiV2/import/importEntities/updateCountryEntities';
+import * as UpdateEntities from '../../../../apiV2/import/importEntities/updateEntities';
 import { expectPermissionError, TestableApp } from '../../../testUtilities';
 
 const DEFAULT_POLICY = {
@@ -48,12 +48,14 @@ describe('importEntities(): POST import/entities', () => {
 
     before(() => {
       // Only test permissions part so stub these methods to avoid them being called
-      sinon.stub(UpdateCountryEntities, 'updateCountryEntities').resolves({ code: 'DL' });
+      sinon.stub(UpdateEntities, 'updateCountry').resolves({ code: 'DL' });
+      sinon.stub(UpdateEntities, 'updateEntities').resolves(undefined);
       sinon.stub(PopulateCoordinatesForCountry, 'populateCoordinatesForCountry');
     });
 
     after(() => {
-      UpdateCountryEntities.updateCountryEntities.restore();
+      UpdateEntities.updateCountry.restore();
+      UpdateEntities.updateEntities.restore();
       PopulateCoordinatesForCountry.populateCoordinatesForCountry.restore();
     });
 


### PR DESCRIPTION
### Issue RN-641:

Support being able to import project entities without a country associated with them. Project entities shouldn't have an associated country, and setting one may cause issues. 

Specify new value 'No Country' in the sheet name, or the geojson property, and the entities will be imported without a country (only works for projects).