### PR TITLE
RN-265 Always use dhis instance code on data element / group

### DIFF
--- a/packages/data-broker/src/__tests__/services/dhis/DhisService.stubs.js
+++ b/packages/data-broker/src/__tests__/services/dhis/DhisService.stubs.js
@@ -54,7 +54,6 @@ export const stubGetDhisApi = mockDhisApi => {
   // Mock return value of all getDhisApi functions to return this mock api
   jest.spyOn(GetDhisApi, 'getApiForDataSource').mockReturnValue(mockDhisApi);
   jest.spyOn(GetDhisApi, 'getApisForDataSources').mockReturnValue([mockDhisApi]);
-  jest.spyOn(GetDhisApi, 'getApisForLegacyDataSourceConfig').mockReturnValue([mockDhisApi]);
   jest.spyOn(GetDhisApi, 'getApiFromServerName').mockReturnValue(mockDhisApi);
 };
 

--- a/packages/data-broker/src/__tests__/services/dhis/DhisService.test.js
+++ b/packages/data-broker/src/__tests__/services/dhis/DhisService.test.js
@@ -264,86 +264,24 @@ describe('DhisService', () => {
 
     describe('pull api resolution', () => {
       let getApisForDataSourcesSpy;
-      let getApisForLegacyDataSourceConfigSpy;
 
       beforeEach(() => {
         getApisForDataSourcesSpy = jest.spyOn(GetDhisApi, 'getApisForDataSources');
-        getApisForLegacyDataSourceConfigSpy = jest.spyOn(
-          GetDhisApi,
-          'getApisForLegacyDataSourceConfig',
-        );
       });
 
-      it('has a default data service', async () => {
-        const dataSources = [DATA_SOURCES.POP01, DATA_SOURCES.POP02];
-        const options = {
-          organisationUnitCodes: ['TO'],
-        };
-
-        const mockedDhisApi = createMockDhisApi({ serverName: 'myDhisApi1' });
-        getApisForLegacyDataSourceConfigSpy.mockReturnValue(mockedDhisApi);
-
-        await dhisService.pull(dataSources, 'dataElement', options);
-
-        expect(getApisForLegacyDataSourceConfigSpy).toHaveBeenCalledOnceWith(
-          expect.anything(),
-          [{ isDataRegional: true }], // default data service legacy config
-        );
-
-        // expect those apis to be passed to pull
-        expect(dhisService.analyticsPuller.pull).toHaveBeenCalledOnceWith(
-          mockedDhisApi,
-          expect.anything(),
-          expect.anything(),
-        );
-      });
-
-      it('allows data services to be explicitly specified', async () => {
-        const dataSources = [DATA_SOURCES.POP01, DATA_SOURCES.POP02];
-        const options = {
-          organisationUnitCodes: ['TO'],
-          dataServices: [{ isDataRegional: true }, { isDataRegional: false }],
-        };
-
-        const mockedDhisApi1 = createMockDhisApi({ serverName: 'myDhisApi1' });
-        const mockedDhisApi2 = createMockDhisApi({ serverName: 'myDhisApi2' });
-        getApisForLegacyDataSourceConfigSpy.mockReturnValue([mockedDhisApi1, mockedDhisApi2]);
-
-        await dhisService.pull(dataSources, 'dataElement', options);
-
-        // expect DhisService to ask for the apis for the given data services
-        expect(getApisForLegacyDataSourceConfigSpy).toHaveBeenCalledOnceWith(expect.anything(), [
-          { isDataRegional: true },
-          { isDataRegional: false },
-        ]);
-
-        // expect those apis to be passed to pull
-        expect(dhisService.analyticsPuller.pull).toHaveBeenCalledOnceWith(
-          [mockedDhisApi1, mockedDhisApi2],
-          expect.anything(),
-          expect.anything(),
-        );
-      });
-
-      it('allows flag detectDataServices', async () => {
+      it('looks up the api from the given data source', async () => {
         const dataSources = [
           {
             ...DATA_SOURCES.POP01,
             config: { dhisInstanceCode: 'test_dhis_instance_1' },
           },
-          {
-            ...DATA_SOURCES.POP02,
-            config: {}, // no dhisInstanceCode, means we need to resolve dhis instance by entity
-          },
         ];
         const options = {
           organisationUnitCodes: ['TO'],
-          detectDataServices: true,
         };
 
         const mockedDhisApi1 = createMockDhisApi({ serverName: 'myDhisApi1' });
-        const mockedDhisApi2 = createMockDhisApi({ serverName: 'myDhisApi2' });
-        getApisForDataSourcesSpy.mockReturnValue([mockedDhisApi1, mockedDhisApi2]);
+        getApisForDataSourcesSpy.mockReturnValue([mockedDhisApi1]);
 
         await dhisService.pull(dataSources, 'dataElement', options);
 
@@ -352,7 +290,7 @@ describe('DhisService', () => {
 
         // expect those apis to be passed to pull
         expect(dhisService.analyticsPuller.pull).toHaveBeenCalledOnceWith(
-          [mockedDhisApi1, mockedDhisApi2],
+          [mockedDhisApi1],
           expect.anything(),
           expect.anything(),
         );

--- a/packages/data-broker/src/__tests__/services/dhis/getDhisApi.test.js
+++ b/packages/data-broker/src/__tests__/services/dhis/getDhisApi.test.js
@@ -3,18 +3,11 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
-import { legacy_configToDhisInstanceCode } from '@tupaia/utils';
 import {
   getApiForDataSource,
   getApiFromServerName,
   getApisForDataSources,
-  getApisForLegacyDataSourceConfig,
 } from '../../../services/dhis/getDhisApi';
-
-jest.mock('@tupaia/utils', () => ({
-  ...jest.requireActual('@tupaia/utils'),
-  legacy_configToDhisInstanceCode: jest.fn(),
-}));
 
 const TEST_DHIS_INSTANCE = {
   code: 'test_dhis_instance',
@@ -39,14 +32,6 @@ const TEST_DATA_SOURCE_2 = {
   config: {
     dhisInstanceCode: 'test_dhis_instance',
   },
-};
-
-const TEST_DATA_SERVICE_1 = {
-  isDataRegional: true,
-};
-
-const TEST_DATA_SERVICE_2 = {
-  isDataRegional: false,
 };
 
 const mockModels = {
@@ -78,29 +63,6 @@ describe('getDhisApi', () => {
       const apis = await getApisForDataSources(mockModels, [
         TEST_DATA_SOURCE_1,
         TEST_DATA_SOURCE_2,
-      ]);
-      expect(apis.length).toBe(1);
-    });
-  });
-
-  describe('getApisForLegacyDataSourceConfig()', () => {
-    beforeAll(() => {
-      legacy_configToDhisInstanceCode.mockReturnValue('test_dhis_instance');
-    });
-
-    it('resolves', async () => {
-      const apis = await getApisForLegacyDataSourceConfig(mockModels, [TEST_DATA_SERVICE_1]);
-      expect(apis.length).toBe(1);
-      expect(apis[0].getServerName()).toBe('test_dhis_instance');
-    });
-
-    it('only returns unique apis', async () => {
-      // (See RN-104)
-      // This should not be possible due to unique constraint on code (serverName)
-      // but we test for it regardless to be safe.
-      const apis = await getApisForLegacyDataSourceConfig(mockModels, [
-        TEST_DATA_SERVICE_1,
-        TEST_DATA_SERVICE_2,
       ]);
       expect(apis.length).toBe(1);
     });

--- a/packages/data-broker/src/services/dhis/getDhisApi.js
+++ b/packages/data-broker/src/services/dhis/getDhisApi.js
@@ -4,7 +4,7 @@
  */
 
 import { DhisApi } from '@tupaia/dhis-api';
-import { createClassExtendingProxy, legacy_configToDhisInstanceCode } from '@tupaia/utils';
+import { createClassExtendingProxy } from '@tupaia/utils';
 import { DhisCodeToIdTranslator } from './translators';
 
 const instances = {};
@@ -29,21 +29,6 @@ export const getApisForDataSources = async (models, dataSources) => {
   const apis = new Set();
   for (const dataSource of dataSources) {
     const { dhisInstanceCode } = dataSource.config;
-    const dhisInstance = await getDhisInstanceByCode(models, dhisInstanceCode);
-    apis.add(await getDhisApiInstance(models, dhisInstance));
-  }
-  return Array.from(apis);
-};
-
-/**
- * @param {{}} models
- * @param {{ isDataRegional: boolean }[]} dataServices
- * @return {Promise<DhisApi[]>}
- */
-export const getApisForLegacyDataSourceConfig = async (models, dataServices) => {
-  const apis = new Set();
-  for (const dataService of dataServices) {
-    const dhisInstanceCode = legacy_configToDhisInstanceCode(dataService);
     const dhisInstance = await getDhisInstanceByCode(models, dhisInstanceCode);
     apis.add(await getDhisApiInstance(models, dhisInstance));
   }

--- a/packages/report-server/src/aggregator/ReportServerAggregator.ts
+++ b/packages/report-server/src/aggregator/ReportServerAggregator.ts
@@ -42,16 +42,16 @@ export class ReportServerAggregator {
         period,
         startDate,
         endDate,
-        detectDataServices: true,
       },
       { aggregations },
     );
   }
 
   private async getDateElementCodes(programCode: string) {
-    const { dataElements } = (await this.aggregator.fetchDataGroup(programCode, {
-      detectDataServices: true,
-    })) as EventMetaData;
+    const { dataElements } = (await this.aggregator.fetchDataGroup(
+      programCode,
+      {},
+    )) as EventMetaData;
     return dataElements.map(({ code }) => code);
   }
 
@@ -83,7 +83,6 @@ export class ReportServerAggregator {
         period,
         startDate,
         endDate,
-        detectDataServices: true,
       },
       { aggregations },
     );

--- a/packages/utils/src/legacyDhis.js
+++ b/packages/utils/src/legacyDhis.js
@@ -104,20 +104,3 @@ export const legacy_getDhisServerName = ({
   const serverName = serverNameInput || getServerName(entityCode, isDataRegional);
   return serverName;
 };
-
-/**
- * @deprecated Use data-broker instead
- *
- * Legacy to modern config mapping function. Clean up after legacy reports are all migrated.
- *
- * Note: some parts of Tupaia will not function correctly in deployments where a DHIS Instance
- * with code 'regional' does not exist
- *
- * @param {{ isDataRegional: boolean}} legacyConfig
- * @return {string|undefined} DhisInstance code
- */
-export const legacy_configToDhisInstanceCode = legacyConfig => {
-  const { isDataRegional = true } = legacyConfig;
-  if (isDataRegional) return 'regional';
-  return undefined;
-};


### PR DESCRIPTION
### Issue RN-265

### Changes:

- Always use the dhisInstanceCode marked against the DE/DG when pulling via data-broker

Note: this PR is based on rn-625-disable-1-many-mapping, therefore once both are in, there will be no cases* where we use entity based resolution to figure out which DHIS instance to pull from. To do 625 cleanly, we also need to do this.

* in data-broker... After these changes, there will still be parts of the codebase which rely on entity config for this, e.g. the dhis sync logic, which will be migrated over in a future PR.