### PR TITLE
[no-issue]: Fixed intermittent failure in dateRangePicker.test.js

### DIFF
--- a/packages/web-frontend/package.json
+++ b/packages/web-frontend/package.json
@@ -84,6 +84,7 @@
     "fs-extra": "3.0.1",
     "jest": "^27.0.6",
     "js-beautify": "^1.13.0",
+    "mockdate": "^3.0.5",
     "npm-run-all": "^4.1.5",
     "object-assign": "4.1.1",
     "promise": "7.1.1",

--- a/packages/web-frontend/src/tests/components/dateRangePicker.test.js
+++ b/packages/web-frontend/src/tests/components/dateRangePicker.test.js
@@ -7,6 +7,7 @@ import React from 'react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import moment from 'moment';
+import MockDate from 'mockdate';
 import { render } from '../testableRender';
 import { DateRangePicker } from '../../components/DateRangePicker';
 import {
@@ -17,7 +18,7 @@ import {
   GRANULARITIES,
 } from '../../utils/periodGranularities';
 
-const MAX_MOMENT_DATE = moment();
+const CURRENT_DATE_STUB = '2020-01-31T00:00:00Z';
 
 const START_DATE = '2016-09-23';
 const END_DATE = '2018-03-20';
@@ -62,6 +63,14 @@ const TEST_END_DATE_STRINGS = {
 };
 
 describe('dateRangePicker', () => {
+  beforeAll(() => {
+    MockDate.set(CURRENT_DATE_STUB);
+  });
+
+  afterAll(() => {
+    MockDate.reset();
+  });
+
   it('Has a DEFAULT_MIN_DATE consistent with tests', () => {
     expect(DEFAULT_MIN_DATE).toBe('20150101');
   });
@@ -72,7 +81,7 @@ describe('dateRangePicker', () => {
 
       const labelText = screen.getByLabelText('active-date');
       const startDate = MIN_MOMENT_STRINGS[key];
-      const endDate = momentToDateString(MAX_MOMENT_DATE, key, value.rangeFormat);
+      const endDate = momentToDateString(moment(), key, value.rangeFormat);
 
       if (GRANULARITIES_WITH_ONE_DATE.includes(key)) {
         expect(labelText).toHaveTextContent(endDate);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5778,6 +5778,7 @@ __metadata:
     markdown-to-jsx: ^6.4.1
     material-ui: ^0.18.3
     material-ui-datetimepicker: ^1.0.7
+    mockdate: ^3.0.5
     moment: ^2.21.0
     moment-timezone: ^0.5.14
     npm-run-all: ^4.1.5


### PR DESCRIPTION
I experienced the rarest intermittent [test failure](https://app.codeship.com/projects/70159bc0-0dac-0138-fdcb-260b82737f4e/builds/021f612f-6e14-40c7-9d9f-8beace5d0120?component=step_Validate_and_test_Test_Test_batch_2_Test_internal-dependencies) (date rolled over in the very short time between this test starting and asserting)

I swear to never again have this test fail due to date not being mocked!