### PR TITLE
[no-issue]: Reduce flakiness in sync queue related tests

### DIFF
--- a/packages/central-server/src/tests/apiV2/changes/getChanges.test.js
+++ b/packages/central-server/src/tests/apiV2/changes/getChanges.test.js
@@ -19,7 +19,7 @@ describe('GET /changes/count', async () => {
 
     // Set up real sync queue for testing the /changes endpoint
     await createPermissionsBasedMeditrakSyncQueue(models.database);
-    meditrakSyncQueue.setDebounceTime(100); // Faster debounce time for tests
+    meditrakSyncQueue.setDebounceTime(50); // Faster debounce time for tests
     meditrakSyncQueue.listenForChanges();
   });
 
@@ -50,7 +50,8 @@ describe('GET /changes/count', async () => {
     }
     // Wait one second for the triggers to have properly added the changes to the queue
     await oneSecondSleep();
-    await meditrakSyncQueue.scheduleChangeQueueHandler();
+    // Wait for the triggers to have properly added the changes to the queue
+    await models.database.waitForAllChangeHandlers();
     const response = await app.get(`changes/count?since=${since}`);
     expect(response.body.changeCount).to.equal(numberOfQuestionsToAdd);
   });
@@ -74,6 +75,10 @@ describe('GET /changes/count', async () => {
 
     // Add some more questions
     await oneSecondSleep();
+
+    // Wait for the triggers to have properly added the changes to the queue
+    await models.database.waitForAllChangeHandlers();
+
     const timestampBeforeSecondUpdate = Date.now();
     await oneSecondSleep();
     const numberOfQuestionsToAddInSecondUpdate = randomIntBetween(1, 20);
@@ -84,6 +89,10 @@ describe('GET /changes/count', async () => {
 
     // Delete some of the questions added in the first update
     await oneSecondSleep();
+
+    // Wait for the triggers to have properly added the changes to the queue
+    await models.database.waitForAllChangeHandlers();
+
     const timestampBeforeFirstDelete = Date.now();
     await oneSecondSleep();
     const numberOfQuestionsToDeleteFromFirstUpdate = randomIntBetween(
@@ -96,6 +105,10 @@ describe('GET /changes/count', async () => {
 
     // Delete some of the questions added in the second update
     await oneSecondSleep();
+
+    // Wait for the triggers to have properly added the changes to the queue
+    await models.database.waitForAllChangeHandlers();
+
     const timestampBeforeSecondDelete = Date.now();
     await oneSecondSleep();
     const numberOfQuestionsToDeleteFromSecondUpdate = randomIntBetween(
@@ -106,8 +119,9 @@ describe('GET /changes/count', async () => {
       await models.question.deleteById(newQuestionsInSecondUpdate[i].id);
     }
 
-    // Wait one second for the triggers to have properly added the changes to the queue
+    // Wait for the triggers to have properly added the changes to the queue
     await oneSecondSleep();
+    await models.database.waitForAllChangeHandlers();
 
     // If syncing from before the first update, should only need to sync the number of records that
     // actually need to be added. No need to know about deletes of records we never integrated
@@ -116,7 +130,6 @@ describe('GET /changes/count', async () => {
     const totalDeletes =
       numberOfQuestionsToDeleteFromFirstUpdate + numberOfQuestionsToDeleteFromSecondUpdate;
     const netNewRecords = grossNewRecords - totalDeletes;
-    await meditrakSyncQueue.scheduleChangeQueueHandler();
     let response = await app.get(`changes/count?since=${timestampBeforeFirstUpdate}`);
     expect(response.body.changeCount).to.equal(netNewRecords);
 
@@ -151,7 +164,8 @@ describe('GET /changes/count', async () => {
     await upsertEntity(); // version 1.7.102
 
     await oneSecondSleep();
-    await meditrakSyncQueue.scheduleChangeQueueHandler();
+    // Wait for the triggers to have properly added the changes to the queue
+    await models.database.waitForAllChangeHandlers();
     let response = await app.get(`changes/count?since=${since}&appVersion=0.0.1`);
     expect(response.body.changeCount).to.equal(1);
 

--- a/packages/meditrak-app-server/src/__tests__/__integration__/sync/CountChangesRoute.test.ts
+++ b/packages/meditrak-app-server/src/__tests__/__integration__/sync/CountChangesRoute.test.ts
@@ -21,7 +21,7 @@ describe('changes/count', () => {
   const syncableChangeEnqueuer = new SyncableChangeEnqueuer(
     getTestModels() as MeditrakAppServerModelRegistry,
   );
-  syncableChangeEnqueuer.setDebounceTime(100);
+  syncableChangeEnqueuer.setDebounceTime(50);
 
   beforeAll(async () => {
     syncableChangeEnqueuer.listenForChanges();
@@ -112,6 +112,10 @@ describe('changes/count', () => {
 
     // Add some more questions
     await oneSecondSleep();
+
+    // Wait for the triggers to have properly added the changes to the queue
+    await models.database.waitForAllChangeHandlers();
+
     const timestampBeforeSecondUpdate = Date.now();
     await oneSecondSleep();
     const numberOfQuestionsToAddInSecondUpdate = randomIntBetween(1, 20);
@@ -122,6 +126,10 @@ describe('changes/count', () => {
 
     // Delete some of the questions added in the first update
     await oneSecondSleep();
+
+    // Wait for the triggers to have properly added the changes to the queue
+    await models.database.waitForAllChangeHandlers();
+
     const timestampBeforeFirstDelete = Date.now();
     await oneSecondSleep();
     const numberOfQuestionsToDeleteFromFirstUpdate = randomIntBetween(
@@ -134,6 +142,10 @@ describe('changes/count', () => {
 
     // Delete some of the questions added in the second update
     await oneSecondSleep();
+
+    // Wait for the triggers to have properly added the changes to the queue
+    await models.database.waitForAllChangeHandlers();
+
     const timestampBeforeSecondDelete = Date.now();
     await oneSecondSleep();
     const numberOfQuestionsToDeleteFromSecondUpdate = randomIntBetween(

--- a/packages/meditrak-app-server/src/__tests__/__integration__/sync/PullChangesRoute.test.ts
+++ b/packages/meditrak-app-server/src/__tests__/__integration__/sync/PullChangesRoute.test.ts
@@ -177,6 +177,10 @@ describe('changes (GET)', () => {
 
     // Add some more questions
     await oneSecondSleep();
+
+    // Wait for the triggers to have properly added the changes to the queue
+    await models.database.waitForAllChangeHandlers();
+
     const timestampBeforeSecondUpdate = Date.now();
     await oneSecondSleep();
     const numberOfQuestionsToAddInSecondUpdate = 4;
@@ -188,6 +192,10 @@ describe('changes (GET)', () => {
 
     // Delete some of the questions added in the first update
     await oneSecondSleep();
+
+    // Wait for the triggers to have properly added the changes to the queue
+    await models.database.waitForAllChangeHandlers();
+
     const timestampBeforeFirstDelete = Date.now();
     await oneSecondSleep();
     const numberOfQuestionsToDeleteFromFirstUpdate = randomIntBetween(
@@ -208,6 +216,10 @@ describe('changes (GET)', () => {
 
     // Delete some of the questions added in the second update
     await oneSecondSleep();
+
+    // Wait for the triggers to have properly added the changes to the queue
+    await models.database.waitForAllChangeHandlers();
+
     const timestampBeforeSecondDelete = Date.now();
     await oneSecondSleep();
     const numberOfQuestionsToDeleteFromSecondUpdate = randomIntBetween(


### PR DESCRIPTION
Since the change to making the ChangeHandlers run in a transaction, these sync queue related tests have all become a bit more flaky (eg. [here](https://app.codeship.com/projects/70159bc0-0dac-0138-fdcb-260b82737f4e/builds/70d3bcf9-099a-4fcf-8b4c-2837bda2b179?component=step_Validate_and_test_Test_Test_batch_1_Test_meditrak-app-server), and [here](https://app.codeship.com/projects/70159bc0-0dac-0138-fdcb-260b82737f4e/builds/be447781-7152-4af8-b3c7-5083f9f1d3b9?component=step_Validate_and_test_Test_Test_batch_1_Test_central-server)). They have previously been relying purely on timing at points, which isn't really all that safe. I've added a bunch of `await database.waitForAllChangeHandlers();` calls in places where they seemed necessary, which should halt the test execution until the change transaction is complete.