### PR TITLE
RN-506 add year label and fix issues

### DIFF
--- a/packages/lesmis/src/components/DashboardExportModal/pages/DashboardReportPage.js
+++ b/packages/lesmis/src/components/DashboardExportModal/pages/DashboardReportPage.js
@@ -4,8 +4,7 @@ import { Divider, Typography } from '@material-ui/core';
 
 import { EntityDetails, DashboardTitleContainer } from '../components';
 import { DashboardReport } from '../../DashboardReport';
-import { yearToApiDates } from '../../../api/queries/utils';
-import { useUrlSearchParam } from '../../../utils';
+import { useIsFavouriteDashboardSelected, useUrlSearchParam } from '../../../utils';
 import { DEFAULT_DATA_YEAR } from '../../../constants';
 import Header from '../components/Header';
 
@@ -20,8 +19,12 @@ export const DashboardReportPage = ({
   PageContent,
   ...configs
 }) => {
-  const [selectedYear] = useUrlSearchParam('year', DEFAULT_DATA_YEAR);
-  const { startDate, endDate } = useYearSelector ? yearToApiDates(selectedYear) : yearToApiDates();
+  // TODO: will be removed when implementing year selector for favourite dashboard, currently use default year.
+  const isFavouriteDashboardSelected = useIsFavouriteDashboardSelected();
+  const [selectedYear] = isFavouriteDashboardSelected
+    ? [DEFAULT_DATA_YEAR]
+    : useUrlSearchParam('year', DEFAULT_DATA_YEAR);
+
   return (
     <PageContainer {...configs}>
       <Header
@@ -39,8 +42,6 @@ export const DashboardReportPage = ({
         <DashboardReport
           reportCode={item.reportCode}
           name={item.name}
-          startDate={startDate}
-          endDate={endDate}
           exportOptions={exportOptions}
           isExporting // render exporting format
           isEnlarged // render exporting format

--- a/packages/lesmis/src/components/DashboardExportModal/pages/DashboardReportPage.js
+++ b/packages/lesmis/src/components/DashboardExportModal/pages/DashboardReportPage.js
@@ -44,6 +44,7 @@ export const DashboardReportPage = ({
           exportOptions={exportOptions}
           isExporting // render exporting format
           isEnlarged // render exporting format
+          useYearSelector={useYearSelector}
         />
       </PageContent>
     </PageContainer>

--- a/packages/lesmis/src/components/DashboardReport.js
+++ b/packages/lesmis/src/components/DashboardReport.js
@@ -14,8 +14,10 @@ import { Chart, ListVisual } from './Visuals';
 import * as COLORS from '../constants';
 import { useDashboardReportDataWithConfig } from '../api/queries';
 import { FlexEnd } from './Layout';
-import { I18n, useUrlParams } from '../utils';
+import { I18n, useIsFavouriteDashboardSelected, useUrlParams, useUrlSearchParam } from '../utils';
 import { useUpdateFavouriteDashboardItem } from '../api';
+import { DEFAULT_DATA_YEAR } from '../constants';
+import { yearToApiDates } from '../api/queries/utils';
 
 const Container = styled.div`
   width: 55rem;
@@ -36,18 +38,17 @@ const Footer = styled(FlexEnd)`
 `;
 
 export const DashboardReport = React.memo(
-  ({
-    name,
-    exportOptions,
-    reportCode,
-    startDate,
-    endDate,
-    isEnlarged,
-    isExporting,
-    useYearSelector,
-  }) => {
+  ({ name, exportOptions, reportCode, isEnlarged, isExporting, useYearSelector }) => {
     const { search } = useLocation();
     const { locale, entityCode } = useUrlParams();
+    // TODO: will be removed when implementing year selector for favourite dashboard, currently use default year.
+    const isFavouriteDashboardSelected = useIsFavouriteDashboardSelected();
+    const [selectedYear] = isFavouriteDashboardSelected
+      ? [DEFAULT_DATA_YEAR]
+      : useUrlSearchParam('year', DEFAULT_DATA_YEAR);
+    const { startDate, endDate } = useYearSelector
+      ? yearToApiDates(selectedYear)
+      : yearToApiDates();
 
     const { data, isLoading, isFetching, isError, error } = useDashboardReportDataWithConfig({
       entityCode,
@@ -127,8 +128,6 @@ export const DashboardReport = React.memo(
 
 DashboardReport.propTypes = {
   exportOptions: PropTypes.object,
-  startDate: PropTypes.string,
-  endDate: PropTypes.string,
   name: PropTypes.string,
   reportCode: PropTypes.string,
   isEnlarged: PropTypes.bool,
@@ -138,8 +137,6 @@ DashboardReport.propTypes = {
 
 DashboardReport.defaultProps = {
   exportOptions: null,
-  startDate: null,
-  endDate: null,
   reportCode: null,
   name: null,
   isEnlarged: false,

--- a/packages/lesmis/src/components/DashboardReport.js
+++ b/packages/lesmis/src/components/DashboardReport.js
@@ -36,7 +36,16 @@ const Footer = styled(FlexEnd)`
 `;
 
 export const DashboardReport = React.memo(
-  ({ name, exportOptions, reportCode, startDate, endDate, isEnlarged, isExporting }) => {
+  ({
+    name,
+    exportOptions,
+    reportCode,
+    startDate,
+    endDate,
+    isEnlarged,
+    isExporting,
+    useYearSelector,
+  }) => {
     const { search } = useLocation();
     const { locale, entityCode } = useUrlParams();
 
@@ -94,6 +103,7 @@ export const DashboardReport = React.memo(
           isEnlarged={isEnlarged}
           isFavourite={isFavourite}
           handleFavouriteStatusChange={handleFavouriteStatusChange}
+          useYearSelector={useYearSelector}
         />
         {!isEnlarged && (
           <Footer>
@@ -123,6 +133,7 @@ DashboardReport.propTypes = {
   reportCode: PropTypes.string,
   isEnlarged: PropTypes.bool,
   isExporting: PropTypes.bool,
+  useYearSelector: PropTypes.bool,
 };
 
 DashboardReport.defaultProps = {
@@ -133,4 +144,5 @@ DashboardReport.defaultProps = {
   name: null,
   isEnlarged: false,
   isExporting: false,
+  useYearSelector: false,
 };

--- a/packages/lesmis/src/components/FavouriteButton.js
+++ b/packages/lesmis/src/components/FavouriteButton.js
@@ -9,7 +9,7 @@ export const FavouriteButton = ({ isFavourite, handleFavouriteStatusChange }) =>
     return (
       <Tooltip title="Log in/sign up to save favourites">
         <span>
-          <FavouriteButtonComponent isDisabled />
+          <FavouriteButtonComponent onChange={() => {}} isDisabled />
         </span>
       </Tooltip>
     );

--- a/packages/lesmis/src/components/Visuals/Chart.js
+++ b/packages/lesmis/src/components/Visuals/Chart.js
@@ -19,6 +19,7 @@ import { ToggleButton } from '../ToggleButton';
 import { VisualHeader } from './VisualHeader';
 import * as COLORS from '../../constants';
 import { FavouriteButton } from '../FavouriteButton';
+import { YearLabel } from '../YearLabel';
 
 const Wrapper = styled.div`
   flex: 1;
@@ -28,7 +29,7 @@ const Wrapper = styled.div`
 
 const GridContainer = styled.div`
   display: grid;
-  grid-template-columns: auto auto;
+  grid-template-columns: auto auto auto;
   gap: 17px;
 `;
 
@@ -148,6 +149,7 @@ export const Chart = ({
   isExporting,
   isFavourite,
   handleFavouriteStatusChange,
+  useYearSelector,
 }) => {
   const [selectedTab, setSelectedTab] = useState(TABS.CHART);
 
@@ -183,6 +185,7 @@ export const Chart = ({
     <>
       <VisualHeader name={name} isLoading={isFetchingInBackground}>
         <GridContainer>
+          <YearLabel useYearSelector={useYearSelector} />
           <Toggle onChange={handleTabChange} value={selectedTab} exclusive />
           <FavouriteButton
             isFavourite={isFavourite}
@@ -212,6 +215,7 @@ Chart.propTypes = {
   isEnlarged: PropTypes.bool,
   isExporting: PropTypes.bool,
   isError: PropTypes.bool,
+  useYearSelector: PropTypes.bool,
   error: PropTypes.string,
   name: PropTypes.string,
 };
@@ -224,6 +228,7 @@ Chart.defaultProps = {
   isEnlarged: false,
   isExporting: false,
   isError: false,
+  useYearSelector: false,
   error: null,
   name: null,
 };

--- a/packages/lesmis/src/components/Visuals/ListVisual.js
+++ b/packages/lesmis/src/components/Visuals/ListVisual.js
@@ -7,14 +7,16 @@ import { ListVisual as ListVisualComponent } from '@tupaia/ui-components';
 import PropTypes from 'prop-types';
 import { VisualHeader } from './VisualHeader';
 import { FavouriteButton } from '../FavouriteButton';
+import { YearLabel } from '../YearLabel';
 
 export const ListVisual = props => {
-  const { name, isEnlarged, isFavourite, handleFavouriteStatusChange } = props;
+  const { name, isEnlarged, isFavourite, handleFavouriteStatusChange, useYearSelector } = props;
 
   return (
     <>
       {!isEnlarged && (
         <VisualHeader name={name}>
+          <YearLabel useYearSelector={useYearSelector} />
           <FavouriteButton
             isFavourite={isFavourite}
             handleFavouriteStatusChange={handleFavouriteStatusChange}
@@ -28,6 +30,7 @@ export const ListVisual = props => {
 
 ListVisual.propTypes = {
   isEnlarged: PropTypes.bool,
+  useYearSelector: PropTypes.bool,
   name: PropTypes.string,
   isFavourite: PropTypes.bool.isRequired,
   handleFavouriteStatusChange: PropTypes.func,
@@ -35,6 +38,7 @@ ListVisual.propTypes = {
 
 ListVisual.defaultProps = {
   isEnlarged: false,
+  useYearSelector: false,
   name: null,
   handleFavouriteStatusChange: () => {},
 };

--- a/packages/lesmis/src/components/Visuals/VisualHeader.js
+++ b/packages/lesmis/src/components/Visuals/VisualHeader.js
@@ -13,6 +13,7 @@ import { FlexSpaceBetween, FlexStart } from '../Layout';
 const Header = styled(FlexSpaceBetween)`
   padding: 1.25rem 1.875rem;
   border-bottom: 1px solid ${props => props.theme.palette.grey['400']};
+  text-align: center;
 `;
 
 const Title = styled(Typography)`

--- a/packages/lesmis/src/components/YearLabel.js
+++ b/packages/lesmis/src/components/YearLabel.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { DEFAULT_DATA_YEAR } from '../constants';
+import { useIsFavouriteDashboardSelected } from '../utils';
+
+// TODO: will be removed when implementing year selector for favourite dashboard
+export const YearLabel = ({ useYearSelector }) => {
+  const isFavouriteDashboardSelected = useIsFavouriteDashboardSelected();
+
+  if (!isFavouriteDashboardSelected || !useYearSelector) {
+    return null;
+  }
+
+  return <span style={{ margin: 'auto', fontWeight: 500 }}>{DEFAULT_DATA_YEAR}</span>;
+};
+
+YearLabel.propTypes = {
+  useYearSelector: PropTypes.bool,
+};
+
+YearLabel.defaultProps = {
+  useYearSelector: false,
+};

--- a/packages/lesmis/src/utils/getExportableSubDashboards.js
+++ b/packages/lesmis/src/utils/getExportableSubDashboards.js
@@ -43,7 +43,7 @@ export const getExportableSubDashboards = dropdownOption => {
             ...configs,
             dashboardLabel: otherDropdownOptions[index].label,
             sortOrder: index,
-            useYearSelector,
+            useYearSelector: otherDropdownOptions[index].useYearSelector,
           };
         })
         .sort((a, b) => a.sortOrder - b.sortOrder);

--- a/packages/lesmis/src/utils/index.js
+++ b/packages/lesmis/src/utils/index.js
@@ -10,6 +10,7 @@ export * from './useAutocomplete';
 export * from './useDashboardDropdownOptions';
 export * from './useDefaultDashboardTab';
 export * from './useHomeUrl';
+export * from './useIsFavouriteDashboardSelected';
 export * from './usePortal';
 export * from './useStickyBar';
 export * from './useUrlParams';

--- a/packages/lesmis/src/utils/useIsFavouriteDashboardSelected.js
+++ b/packages/lesmis/src/utils/useIsFavouriteDashboardSelected.js
@@ -1,0 +1,7 @@
+import { FAVOURITES_DASHBOARD_CODE } from '../constants';
+import { useUrlSearchParams } from './useUrlSearchParams';
+
+export const useIsFavouriteDashboardSelected = () => {
+  const [{ dashboard: selectedDashboard }] = useUrlSearchParams();
+  return selectedDashboard === FAVOURITES_DASHBOARD_CODE;
+};

--- a/packages/lesmis/src/views/DashboardItemsView.js
+++ b/packages/lesmis/src/views/DashboardItemsView.js
@@ -15,6 +15,7 @@ const DashboardItemsView = ({
   searchIsActive,
   activeSubDashboard,
   year,
+  useYearSelector,
   isFavouriteDashboardItemsOnly,
 }) => {
   const { startDate, endDate } = yearToApiDates(year);
@@ -42,6 +43,7 @@ const DashboardItemsView = ({
                   name={item.name}
                   startDate={startDate}
                   endDate={endDate}
+                  useYearSelector={useYearSelector}
                 />
               ))
           ) : (
@@ -63,10 +65,12 @@ DashboardItemsView.propTypes = {
   year: PropTypes.string,
   activeSubDashboard: PropTypes.string,
   isFavouriteDashboardItemsOnly: PropTypes.bool,
+  useYearSelector: PropTypes.bool,
 };
 
 DashboardItemsView.defaultProps = {
   year: null,
   activeSubDashboard: null,
   isFavouriteDashboardItemsOnly: false,
+  useYearSelector: false,
 };

--- a/packages/lesmis/src/views/DashboardItemsView.js
+++ b/packages/lesmis/src/views/DashboardItemsView.js
@@ -3,7 +3,6 @@ import React from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 
-import { yearToApiDates } from '../api/queries/utils';
 import { DashboardReport, PanelComponent, TabPanel } from '../components';
 
 const InfoAlert = styled(SmallAlert)`
@@ -14,12 +13,9 @@ const DashboardItemsView = ({
   subDashboards,
   searchIsActive,
   activeSubDashboard,
-  year,
   useYearSelector,
   isFavouriteDashboardItemsOnly,
 }) => {
-  const { startDate, endDate } = yearToApiDates(year);
-
   return (
     <>
       {subDashboards?.map(subDashboard => (
@@ -41,8 +37,6 @@ const DashboardItemsView = ({
                   key={item.code}
                   reportCode={item.reportCode}
                   name={item.name}
-                  startDate={startDate}
-                  endDate={endDate}
                   useYearSelector={useYearSelector}
                 />
               ))
@@ -62,14 +56,12 @@ export default DashboardItemsView;
 DashboardItemsView.propTypes = {
   subDashboards: PropTypes.array.isRequired,
   searchIsActive: PropTypes.bool.isRequired,
-  year: PropTypes.string,
   activeSubDashboard: PropTypes.string,
   isFavouriteDashboardItemsOnly: PropTypes.bool,
   useYearSelector: PropTypes.bool,
 };
 
 DashboardItemsView.defaultProps = {
-  year: null,
   activeSubDashboard: null,
   isFavouriteDashboardItemsOnly: false,
   useYearSelector: false,

--- a/packages/lesmis/src/views/DashboardReportTabView.js
+++ b/packages/lesmis/src/views/DashboardReportTabView.js
@@ -38,8 +38,8 @@ const DashboardSection = styled(FlexColumn)`
 export const DashboardReportTabView = ({
   entityCode,
   TabBarLeftSection,
-  year,
   filterSubDashboards,
+  useYearSelector,
 }) => {
   const dashboardsRef = useRef(null);
   const [searchIsActive, setSearchIsActive] = useState(false);
@@ -109,7 +109,7 @@ export const DashboardReportTabView = ({
                 subDashboards={subDashboards}
                 searchIsActive={searchIsActive}
                 activeSubDashboard={activeSubDashboard}
-                year={year}
+                useYearSelector={useYearSelector}
               />
             </TabPanel>
           ))}
@@ -123,10 +123,10 @@ export const DashboardReportTabView = ({
 DashboardReportTabView.propTypes = {
   entityCode: PropTypes.string.isRequired,
   TabBarLeftSection: PropTypes.func.isRequired,
-  year: PropTypes.string,
   filterSubDashboards: PropTypes.func.isRequired,
+  useYearSelector: PropTypes.bool,
 };
 
 DashboardReportTabView.defaultProps = {
-  year: null,
+  useYearSelector: false,
 };

--- a/packages/lesmis/src/views/DashboardView.js
+++ b/packages/lesmis/src/views/DashboardView.js
@@ -93,7 +93,7 @@ export const DashboardView = React.memo(({ isOpen, setIsOpen }) => {
             <TabComponent
               {...componentProps}
               entityCode={entityCode}
-              year={useYearSelector && selectedYear}
+              useYearSelector={useYearSelector}
               TabBarLeftSection={() => (
                 <TabBarSection>
                   <StyledSelect

--- a/packages/lesmis/src/views/ExportView.js
+++ b/packages/lesmis/src/views/ExportView.js
@@ -75,7 +75,7 @@ const getChildren = ({
   };
 
   return items.length > 0 ? (
-    subDashboard.items.map((item, index) => {
+    items.map((item, index) => {
       return (
         <DashboardReportPage
           key={item.code}

--- a/packages/lesmis/src/views/FavouriteDashboardTabView.js
+++ b/packages/lesmis/src/views/FavouriteDashboardTabView.js
@@ -54,7 +54,7 @@ export const FavouriteDashboardTabView = ({ TabBarLeftSection, year }) => {
       <DashboardSection ref={dashboardsRef}>
         {!searchIsActive && dropdownOptions.length === 0 && <NoFavouritesView />}
         {!searchIsActive &&
-          dropdownOptions?.map(({ value, subDashboards, label }) => (
+          dropdownOptions?.map(({ value, subDashboards, label, useYearSelector }) => (
             <FavouriteDashboardView
               key={value}
               subDashboards={subDashboards}
@@ -63,6 +63,7 @@ export const FavouriteDashboardTabView = ({ TabBarLeftSection, year }) => {
               isError={isError}
               error={error}
               year={year}
+              useYearSelector={useYearSelector}
             />
           ))}
       </DashboardSection>

--- a/packages/lesmis/src/views/FavouriteDashboardTabView.js
+++ b/packages/lesmis/src/views/FavouriteDashboardTabView.js
@@ -22,7 +22,7 @@ const DashboardSection = styled(FlexColumn)`
   min-height: 40rem;
 `;
 
-export const FavouriteDashboardTabView = ({ TabBarLeftSection, year }) => {
+export const FavouriteDashboardTabView = ({ TabBarLeftSection }) => {
   const dashboardsRef = useRef(null);
   const [searchIsActive, setSearchIsActive] = useState(false);
   const { isScrolledPastTop, scrollToTop, onLoadTabBar } = useStickyBar(dashboardsRef);
@@ -62,7 +62,6 @@ export const FavouriteDashboardTabView = ({ TabBarLeftSection, year }) => {
               isLoading={isLoading}
               isError={isError}
               error={error}
-              year={year}
               useYearSelector={useYearSelector}
             />
           ))}
@@ -75,9 +74,4 @@ export const FavouriteDashboardTabView = ({ TabBarLeftSection, year }) => {
 
 FavouriteDashboardTabView.propTypes = {
   TabBarLeftSection: PropTypes.func.isRequired,
-  year: PropTypes.string,
-};
-
-FavouriteDashboardTabView.defaultProps = {
-  year: null,
 };

--- a/packages/lesmis/src/views/FavouriteDashboardView.js
+++ b/packages/lesmis/src/views/FavouriteDashboardView.js
@@ -45,7 +45,15 @@ const DashboardSection = styled(FlexColumn)`
   min-height: 40rem;
 `;
 
-const FavouriteDashboardView = ({ subDashboards, label, isLoading, year, isError, error }) => {
+const FavouriteDashboardView = ({
+  subDashboards,
+  label,
+  isLoading,
+  year,
+  isError,
+  error,
+  useYearSelector,
+}) => {
   const [selectedSubDashboard, setSelectedSubDashboard] = useState(
     useDefaultDashboardTab(null, subDashboards),
   );
@@ -85,6 +93,7 @@ const FavouriteDashboardView = ({ subDashboards, label, isLoading, year, isError
             subDashboards={subDashboards}
             activeSubDashboard={activeSubDashboard}
             year={year}
+            useYearSelector={useYearSelector}
             isFavouriteDashboardItemsOnly
           />
         </FetchLoader>
@@ -100,6 +109,7 @@ FavouriteDashboardView.propTypes = {
   label: PropTypes.string,
   isLoading: PropTypes.bool,
   isError: PropTypes.bool,
+  useYearSelector: PropTypes.bool,
   error: PropTypes.string,
   year: PropTypes.string,
 };
@@ -109,6 +119,7 @@ FavouriteDashboardView.defaultProps = {
   label: '',
   isLoading: true,
   isError: true,
+  useYearSelector: false,
   error: '',
   year: null,
 };

--- a/packages/lesmis/src/views/FavouriteDashboardView.js
+++ b/packages/lesmis/src/views/FavouriteDashboardView.js
@@ -49,7 +49,6 @@ const FavouriteDashboardView = ({
   subDashboards,
   label,
   isLoading,
-  year,
   isError,
   error,
   useYearSelector,
@@ -92,7 +91,6 @@ const FavouriteDashboardView = ({
           <DashboardItemsView
             subDashboards={subDashboards}
             activeSubDashboard={activeSubDashboard}
-            year={year}
             useYearSelector={useYearSelector}
             isFavouriteDashboardItemsOnly
           />
@@ -111,7 +109,6 @@ FavouriteDashboardView.propTypes = {
   isError: PropTypes.bool,
   useYearSelector: PropTypes.bool,
   error: PropTypes.string,
-  year: PropTypes.string,
 };
 
 FavouriteDashboardView.defaultProps = {
@@ -121,5 +118,4 @@ FavouriteDashboardView.defaultProps = {
   isError: true,
   useYearSelector: false,
   error: '',
-  year: null,
 };


### PR DESCRIPTION
### Issue #:
RN-506

### Changes:
- Add year label ([UX design](https://linear.app/bes/issue/RN-506#comment-a7304173))
- In favourite dashboard, we want dashboard item to fetch data by default year only (no year selector). They either fetch data by year or fetch all data. To be able to do so we pass down `useYearSelector` instead of a fixed `year` from the top for generating `startDate` and `endDate`.     
- Fix [issue 4](https://linear.app/bes/issue/RN-506#comment-42fce320)

### Screenshots:
