### PR TITLE
MAUI-1269: Improve performance of Survey Response page in Admin Panel

### DIFF
--- a/packages/central-server/src/apiV2/surveyResponses/GETSurveyResponses.js
+++ b/packages/central-server/src/apiV2/surveyResponses/GETSurveyResponses.js
@@ -10,6 +10,7 @@ import {
 } from './assertSurveyResponsePermissions';
 import { assertAnyPermissions, assertBESAdminAccess } from '../../permissions';
 import { assertEntityPermissions } from '../GETEntities';
+import { getQueryOptionsForColumns } from '../GETHandler/helpers';
 
 /**
  * Handles endpoints:
@@ -47,5 +48,17 @@ export class GETSurveyResponses extends GETHandler {
 
     // Apply regular permissions
     return this.getPermissionsFilter(dbConditions, options);
+  }
+
+  async countRecords(criteria) {
+    // Only join tables that we are filtering on
+    const { multiJoin } = getQueryOptionsForColumns(
+      Object.keys(criteria),
+      this.recordType,
+      this.customJoinConditions,
+      this.defaultJoinType,
+    );
+
+    return this.database.count(this.recordType, criteria, { multiJoin });
   }
 }

--- a/packages/database/src/migrations/20220920062403-AddEntityIdIndexOnSurveyResponseTable-modifies-schema.js
+++ b/packages/database/src/migrations/20220920062403-AddEntityIdIndexOnSurveyResponseTable-modifies-schema.js
@@ -1,0 +1,33 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = async function (db) {
+  await db.runSql(`CREATE INDEX survey_response_entity_id_idx ON survey_response (entity_id);`);
+  await db.runSql(`CREATE INDEX survey_response_outdated_id_idx ON survey_response (outdated);`);
+  await db.runSql(
+    `CREATE INDEX survey_response_data_time_idx ON survey_response (data_time DESC);`,
+  );
+};
+
+exports.down = async function (db) {
+  await db.runSql(`DROP INDEX IF EXISTS survey_response_entity_id_idx;`);
+  await db.runSql(`DROP INDEX IF EXISTS survey_response_outdated_id_idx;`);
+  await db.runSql(`DROP INDEX IF EXISTS survey_response_data_time_idx);`);
+};
+
+exports._meta = {
+  version: 1,
+};


### PR DESCRIPTION
### Issue MAUI-1269:

This page runs really slowly, and when a user navigates to it it hangs the UI for 10+ seconds.

Some basic improvements can get it loading fairly smoothly.
1. Add a debounce to the `DataFetchTable` so that it waits between inputs, currently we send an api request for every keystroke
2. Add a few indexes on the `survey_response_table`
3. Re-work how the `count()` works in the route so that it only joins the reference tables if needed