### PR TITLE
RN-661: Prevent dead records appearing in the Meditrak Sync Queue

### DIFF
--- a/packages/central-server/src/database/meditrakSyncQueue/MeditrakSyncRecordUpdater.js
+++ b/packages/central-server/src/database/meditrakSyncQueue/MeditrakSyncRecordUpdater.js
@@ -15,7 +15,10 @@ export class MeditrakSyncRecordUpdater {
    * @public
    */
   async updateSyncRecords(changes) {
-    return Promise.all(changes.map(change => this.processChange(change)));
+    for (let i = 0; i < changes.length; i++) {
+      const change = changes[i];
+      await this.processChange(change);
+    }
   }
 
   /**

--- a/packages/meditrak-app-server/src/sync/SyncableChangeEnqueuer.ts
+++ b/packages/meditrak-app-server/src/sync/SyncableChangeEnqueuer.ts
@@ -48,6 +48,9 @@ export class SyncableChangeEnqueuer extends ChangeHandler {
     transactingModels: MeditrakAppServerModelRegistry,
     changes: Change[],
   ) {
-    await Promise.all(changes.map(change => this.addToSyncQueue(transactingModels, change)));
+    for (let i = 0; i < changes.length; i++) {
+      const change = changes[i];
+      await this.addToSyncQueue(transactingModels, change);
+    }
   }
 }


### PR DESCRIPTION
### Issue RN-661:

Add changes to the meditrak sync queue one by one to avoid updates being processed after deletes. 