### PR TITLE
RN-662: Support searching with underscore in the Admin Panel

### DIFF
--- a/packages/admin-panel/src/VizBuilderApp/api/queries/useSearchDataSources.js
+++ b/packages/admin-panel/src/VizBuilderApp/api/queries/useSearchDataSources.js
@@ -14,7 +14,7 @@ export const useSearchDataSources = ({ search, type = 'dataElement', maxResults 
       const endpoint = stringifyQuery(undefined, `${type}s`, {
         columns: JSON.stringify(['code']),
         filter: JSON.stringify({
-          code: { comparator: 'ilike', comparisonValue: `${search}%`, castAs: 'text' },
+          code: { comparator: 'ilike', comparisonValue: `%${search}%`, castAs: 'text' },
         }),
         pageSize: maxResults,
       });

--- a/packages/admin-panel/src/utilities/convertSearchTermToFilter.js
+++ b/packages/admin-panel/src/utilities/convertSearchTermToFilter.js
@@ -13,7 +13,7 @@ export const convertSearchTermToFilter = (unprocessedFilterObject = {}) => {
 
     filterObject[key] = {
       comparator: `ilike`,
-      comparisonValue: `${value}%`,
+      comparisonValue: `%${value}%`,
       castAs: 'text',
     };
   });


### PR DESCRIPTION
### Issue RN-662:

Actually felt it might be best to make this a global change in our database layer. 

In postgres, `_` is treated as a wildcard character when doing text like comparison. I don't think we make use of the feature at all, and instead it's just confusing when we actually want to search for a text string with an underscore. There is a workaround that the user can escape the underscore using `\_` but it's not very user friendly....

Happy to hear pushback from the reviewer if they feel we're obfuscating native postgres functionality?