### PR TITLE
RN-175: Add order columns transform (p1. switch to managing columns explicitly in report-server)

### DIFF
--- a/packages/admin-panel-server/src/__tests__/viz-builder/dashboardVisualisation/DashboardVisualisationExtractor.test.ts
+++ b/packages/admin-panel-server/src/__tests__/viz-builder/dashboardVisualisation/DashboardVisualisationExtractor.test.ts
@@ -331,6 +331,11 @@ describe('DashboardVisualisationExtractor', () => {
             aggregations: ['SUM_EACH_WEEK'],
           },
           transform: ['keyValueByDataElementName'],
+          output: {
+            type: 'bar',
+            x: 'period',
+            y: 'BCD1',
+          },
         },
         permissionGroup: 'Admin',
       });
@@ -375,6 +380,49 @@ describe('DashboardVisualisationExtractor', () => {
             type: 'bar',
             x: 'period',
             y: 'BCD1',
+          },
+        },
+        permissionGroup: 'Admin',
+      });
+    });
+
+    it('includes rowsAndColumns output if previewMode is data', () => {
+      const extractor = new DashboardVisualisationExtractor(
+        {
+          code: 'viz',
+          name: 'My Viz',
+          data: {
+            fetch: {
+              dataElements: ['BCD1', 'BCD2'],
+            },
+            transform: ['keyValueByDataElementName'],
+          },
+          presentation: {
+            type: 'chart',
+            chartType: 'bar',
+            output: {
+              type: 'bar',
+              x: 'period',
+              y: 'BCD1',
+            },
+          },
+          permissionGroup: 'Admin',
+        },
+        draftDashboardItemValidator,
+        draftReportValidator,
+      );
+
+      const report = extractor.getReport(PreviewMode.DATA);
+
+      expect(report).toEqual({
+        code: 'viz',
+        config: {
+          fetch: {
+            dataElements: ['BCD1', 'BCD2'],
+          },
+          transform: ['keyValueByDataElementName'],
+          output: {
+            type: 'rowsAndColumns',
           },
         },
         permissionGroup: 'Admin',

--- a/packages/admin-panel-server/src/viz-builder/dashboardVisualisation/DashboardVisualisationExtractor.ts
+++ b/packages/admin-panel-server/src/viz-builder/dashboardVisualisation/DashboardVisualisationExtractor.ts
@@ -11,6 +11,7 @@ import type { DashboardVisualisationResource } from './types';
 import type { LegacyReport, Report, ExpandType } from '../types';
 import { PreviewMode } from '../types';
 import { baseVisualisationValidator, baseVisualisationDataValidator } from '../validators';
+import { getVizOutputConfig } from '../utils';
 
 export class DashboardVisualisationExtractor<
   DashboardItemValidator extends yup.AnyObjectSchema,
@@ -72,7 +73,9 @@ export class DashboardVisualisationExtractor<
     return this.dashboardItemValidator.validateSync(this.vizToDashboardItem());
   }
 
-  private vizToReport(previewMode?: PreviewMode): Record<keyof Report, unknown> {
+  private vizToReport(
+    previewMode: PreviewMode = PreviewMode.PRESENTATION,
+  ): Record<keyof Report, unknown> {
     const { code, permissionGroup, data, presentation } = this.visualisation;
     const validatedData = baseVisualisationDataValidator.validateSync(data);
 
@@ -95,11 +98,14 @@ export class DashboardVisualisationExtractor<
       },
       isNil,
     );
+
+    const output = getVizOutputConfig(previewMode, presentation);
+
     const config = omitBy(
       {
         fetch,
         transform,
-        output: previewMode === PreviewMode.PRESENTATION ? presentation?.output : null,
+        output,
       },
       isNil,
     );

--- a/packages/admin-panel-server/src/viz-builder/mapOverlayVisualisation/MapOverlayVisualisationExtractor.ts
+++ b/packages/admin-panel-server/src/viz-builder/mapOverlayVisualisation/MapOverlayVisualisationExtractor.ts
@@ -11,6 +11,7 @@ import type { MapOverlayVisualisationResource } from './types';
 import type { LegacyReport, Report, ExpandType } from '../types';
 import { PreviewMode } from '../types';
 import { baseVisualisationValidator, baseVisualisationDataValidator } from '../validators';
+import { getVizOutputConfig } from '../utils';
 
 export class MapOverlayVisualisationExtractor<
   MapOverlayValidator extends yup.AnyObjectSchema,
@@ -77,7 +78,9 @@ export class MapOverlayVisualisationExtractor<
     return this.mapOverlayValidator.validateSync(this.vizToMapOverlay());
   }
 
-  private vizToReport(previewMode?: PreviewMode): Record<keyof Report, unknown> {
+  private vizToReport(
+    previewMode: PreviewMode = PreviewMode.PRESENTATION,
+  ): Record<keyof Report, unknown> {
     const { code, reportPermissionGroup: permissionGroup, data, presentation } = this.visualisation;
     const validatedData = baseVisualisationDataValidator.validateSync(data);
 
@@ -90,11 +93,14 @@ export class MapOverlayVisualisationExtractor<
       },
       isNil,
     );
+
+    const output = getVizOutputConfig(previewMode, presentation);
+
     const config = omitBy(
       {
         fetch,
         transform,
-        output: previewMode === PreviewMode.PRESENTATION ? presentation?.output : null,
+        output,
       },
       isNil,
     );

--- a/packages/admin-panel-server/src/viz-builder/utils/extractDataFromReport.ts
+++ b/packages/admin-panel-server/src/viz-builder/utils/extractDataFromReport.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
  */
 
-import { Report } from './types';
+import { Report } from '../types';
 
 // Used when combining the report and dashboardItem/mapOverlay
 export const extractDataFromReport = (report: Report) => {

--- a/packages/admin-panel-server/src/viz-builder/utils/getVizOutputConfig.ts
+++ b/packages/admin-panel-server/src/viz-builder/utils/getVizOutputConfig.ts
@@ -1,0 +1,25 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import { PreviewMode } from '../types';
+
+export const getVizOutputConfig = (
+  previewMode: PreviewMode,
+  presentation: Record<string, unknown>,
+) => {
+  switch (previewMode) {
+    case PreviewMode.PRESENTATION: {
+      // Use whatever is configured in the viz's output config in the presentation options
+      return presentation?.output;
+    }
+    case PreviewMode.DATA: {
+      // Use rowsAndColumns output to render the viz-builder data-table with correct columns order
+      return { type: 'rowsAndColumns' };
+    }
+    default: {
+      throw new Error(`Unknown preview mode ${previewMode}`);
+    }
+  }
+};

--- a/packages/admin-panel-server/src/viz-builder/utils/index.ts
+++ b/packages/admin-panel-server/src/viz-builder/utils/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+export { extractDataFromReport } from './extractDataFromReport';
+export { getVizOutputConfig } from './getVizOutputConfig';

--- a/packages/admin-panel/src/VizBuilderApp/api/queries/useReportPreview.js
+++ b/packages/admin-panel/src/VizBuilderApp/api/queries/useReportPreview.js
@@ -14,6 +14,7 @@ export const useReportPreview = ({
   enabled,
   onSettled,
   vizType,
+  previewMode,
 }) =>
   useQuery(
     ['fetchReportPreviewData', visualisation],
@@ -23,6 +24,7 @@ export const useReportPreview = ({
           entityCode: location,
           hierarchy: project,
           vizType,
+          previewMode,
         },
         data: {
           testData,

--- a/packages/data-api/package.json
+++ b/packages/data-api/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@tupaia/database": "1.0.0",
+    "@tupaia/tsutils": "1.0.0",
     "@tupaia/utils": "1.0.0",
     "@types/lodash.groupby": "^4.6.0",
     "db-migrate": "^0.11.5",

--- a/packages/data-api/src/TupaiaDataApi.ts
+++ b/packages/data-api/src/TupaiaDataApi.ts
@@ -8,9 +8,10 @@ import groupBy from 'lodash.groupby';
 import moment from 'moment';
 import { TupaiaDatabase, SqlQuery } from '@tupaia/database';
 import { getSortByKey, DEFAULT_BINARY_OPTIONS, yup } from '@tupaia/utils';
+import { isNotNullish } from '@tupaia/tsutils';
 import { AnalyticsFetchQuery } from './AnalyticsFetchQuery';
 import { EventsFetchQuery, EventAnswer } from './EventsFetchQuery';
-import { sanitizeMetadataValue, sanitizeAnalyticsTableValue, isDefined } from './utils';
+import { sanitizeMetadataValue, sanitizeAnalyticsTableValue } from './utils';
 import { eventOptionsValidator, analyticsOptionsValidator } from './validators';
 import { sanitiseFetchDataOptions } from './sanitiseFetchDataOptions';
 
@@ -175,7 +176,7 @@ export class TupaiaDataApi {
     if (includeOptions) {
       // Get all possible option_set_ids from questions
       const optionSetIds = [
-        ...new Set(dataElementsMetadata.map(d => d.option_set_id).filter(isDefined)),
+        ...new Set(dataElementsMetadata.map(d => d.option_set_id).filter(isNotNullish)),
       ];
       // Get all the options from the option sets and grouped by set ids.
       const optionsGroupedBySetId = await this.getOptionsGroupedBySetId(optionSetIds);

--- a/packages/data-api/src/utils.ts
+++ b/packages/data-api/src/utils.ts
@@ -33,7 +33,3 @@ export const sanitizeAnalyticsTableValue = (value: string, type: string) => {
       return value;
   }
 };
-
-// TODO: Move to ts-utils package
-export const isDefined = <T>(val: T): val is Exclude<T, undefined | null> =>
-  val !== undefined && val !== null;

--- a/packages/report-server/package.json
+++ b/packages/report-server/package.json
@@ -45,6 +45,7 @@
     "lodash.keyby": "^4.6.0",
     "lodash.pick": "^4.4.0",
     "mathjs": "^9.4.0",
+    "moment": "^2.24.0",
     "winston": "^3.2.1"
   },
   "devDependencies": {

--- a/packages/report-server/src/__tests__/reportBuilder/output/default.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/output/default.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import { Aggregator } from '@tupaia/aggregator';
+import { ReportServerAggregator } from '../../../aggregator';
+import { buildOutput } from '../../../reportBuilder/output';
+import { TransformTable } from '../../../reportBuilder/transform';
+import { MULTIPLE_TRANSFORMED_DATA } from './output.fixtures';
+
+describe('default', () => {
+  const dataBroker = { context: {} };
+  const aggregator = new Aggregator(dataBroker);
+
+  it('defaults to rows', async () => {
+    const table = TransformTable.fromRows(MULTIPLE_TRANSFORMED_DATA);
+    const expectedData = table.getRows();
+    const context = {};
+    const reportServerAggregator = new ReportServerAggregator(aggregator);
+    const output = buildOutput(undefined, context, reportServerAggregator);
+
+    const results = await output(table);
+    expect(results).toEqual(expectedData);
+  });
+});

--- a/packages/report-server/src/__tests__/reportBuilder/output/matrix.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/output/matrix.test.ts
@@ -5,6 +5,7 @@
 
 import { ReportServerAggregator } from '../../../aggregator';
 import { buildOutput } from '../../../reportBuilder/output';
+import { TransformTable } from '../../../reportBuilder/transform';
 import {
   MULTIPLE_TRANSFORMED_DATA,
   MULTIPLE_TRANSFORMED_DATA_WITH_CATEGORIES,
@@ -28,7 +29,7 @@ describe('matrix', () => {
       );
 
       const outputFn = async () => {
-        await output([]);
+        await output(new TransformTable());
       };
 
       await expect(outputFn()).rejects.toThrow("columns must be either '*' or an array");
@@ -88,7 +89,9 @@ describe('matrix', () => {
         {},
         reportServerAggregator,
       );
-      const result = await output(MULTIPLE_TRANSFORMED_DATA_WITH_CATEGORIES);
+      const result = await output(
+        TransformTable.fromRows(MULTIPLE_TRANSFORMED_DATA_WITH_CATEGORIES),
+      );
       expect(result).toEqual(expectedData);
     });
 
@@ -147,7 +150,9 @@ describe('matrix', () => {
         {},
         reportServerAggregator,
       );
-      const result = await output(MULTIPLE_TRANSFORMED_DATA_WITH_CATEGORIES);
+      const result = await output(
+        TransformTable.fromRows(MULTIPLE_TRANSFORMED_DATA_WITH_CATEGORIES),
+      );
       expect(result).toEqual(expectedData);
     });
 
@@ -185,7 +190,9 @@ describe('matrix', () => {
         {},
         reportServerAggregator,
       );
-      const result = await output(MULTIPLE_TRANSFORMED_DATA_FOR_SPECIFIED_COLUMNS);
+      const result = await output(
+        TransformTable.fromRows(MULTIPLE_TRANSFORMED_DATA_FOR_SPECIFIED_COLUMNS),
+      );
       expect(result).toEqual(expectedData);
     });
 
@@ -239,7 +246,9 @@ describe('matrix', () => {
         {},
         reportServerAggregator,
       );
-      const result = await output(MULTIPLE_TRANSFORMED_DATA_FOR_SPECIFIED_COLUMNS);
+      const result = await output(
+        TransformTable.fromRows(MULTIPLE_TRANSFORMED_DATA_FOR_SPECIFIED_COLUMNS),
+      );
       expect(result).toEqual(expectedData);
     });
   });
@@ -257,7 +266,7 @@ describe('matrix', () => {
         reportServerAggregator,
       );
       await expect(async () => {
-        await output([]);
+        await output(new TransformTable());
       }).rejects.toThrow(
         'categoryField cannot be one of: [InfrastructureType,Laos,Tonga] they are already specified as columns',
       );
@@ -274,7 +283,7 @@ describe('matrix', () => {
         reportServerAggregator,
       );
       await expect(async () => {
-        await output([]);
+        await output(new TransformTable());
       }).rejects.toThrow(
         'rowField cannot be: FacilityType, it is already specified as categoryField',
       );
@@ -323,7 +332,7 @@ describe('matrix', () => {
         {},
         reportServerAggregator,
       );
-      const result = await output(MULTIPLE_TRANSFORMED_DATA);
+      const result = await output(TransformTable.fromRows(MULTIPLE_TRANSFORMED_DATA));
       expect(result).toEqual(expectedData);
     });
 
@@ -382,7 +391,9 @@ describe('matrix', () => {
         {},
         reportServerAggregator,
       );
-      const result = await output(MULTIPLE_TRANSFORMED_DATA_WITH_CATEGORIES);
+      const result = await output(
+        TransformTable.fromRows(MULTIPLE_TRANSFORMED_DATA_WITH_CATEGORIES),
+      );
       expect(result).toEqual(expectedData);
     });
   });
@@ -400,7 +411,7 @@ describe('matrix', () => {
         reportServerAggregator,
       );
       await expect(async () => {
-        await output([]);
+        await output(new TransformTable());
       }).rejects.toThrow(
         'rowField cannot be one of: [FacilityType,Laos,Tonga] they are already specified as columns',
       );
@@ -417,7 +428,7 @@ describe('matrix', () => {
         reportServerAggregator,
       );
       await expect(async () => {
-        await output([]);
+        await output(new TransformTable());
       }).rejects.toThrow(
         'rowField cannot be: FacilityType, it is already specified as categoryField',
       );
@@ -433,7 +444,7 @@ describe('matrix', () => {
         reportServerAggregator,
       );
       await expect(async () => {
-        await output([]);
+        await output(new TransformTable());
       }).rejects.toThrow('rowField is a required field');
     });
 
@@ -488,7 +499,9 @@ describe('matrix', () => {
         {},
         reportServerAggregator,
       );
-      const result = await output(MULTIPLE_TRANSFORMED_DATA_WITH_CATEGORIES);
+      const result = await output(
+        TransformTable.fromRows(MULTIPLE_TRANSFORMED_DATA_WITH_CATEGORIES),
+      );
       expect(result).toEqual(expectedData);
     });
   });

--- a/packages/report-server/src/__tests__/reportBuilder/output/rawDataExport.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/output/rawDataExport.test.ts
@@ -6,6 +6,7 @@
 import { Aggregator } from '@tupaia/aggregator';
 import { ReportServerAggregator } from '../../../aggregator';
 import { buildOutput } from '../../../reportBuilder/output';
+import { TransformTable } from '../../../reportBuilder/transform';
 import { MULTIPLE_TRANSFORMED_DATA_FOR_RAW_DATA_EXPORT } from './output.fixtures';
 
 describe('rawDataExport', () => {
@@ -80,7 +81,9 @@ describe('rawDataExport', () => {
     const reportServerAggregator = new ReportServerAggregator(aggregator);
     const output = buildOutput(config, context, reportServerAggregator);
 
-    const results = await output(MULTIPLE_TRANSFORMED_DATA_FOR_RAW_DATA_EXPORT);
+    const results = await output(
+      TransformTable.fromRows(MULTIPLE_TRANSFORMED_DATA_FOR_RAW_DATA_EXPORT),
+    );
     expect(results).toEqual(expectedData);
   });
 });

--- a/packages/report-server/src/__tests__/reportBuilder/output/rows.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/output/rows.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import { Aggregator } from '@tupaia/aggregator';
+import { ReportServerAggregator } from '../../../aggregator';
+import { buildOutput } from '../../../reportBuilder/output';
+import { TransformTable } from '../../../reportBuilder/transform';
+import { MULTIPLE_TRANSFORMED_DATA } from './output.fixtures';
+
+describe('rows', () => {
+  const dataBroker = { context: {} };
+  const aggregator = new Aggregator(dataBroker);
+
+  it('returns the rows of the table', async () => {
+    const table = TransformTable.fromRows(MULTIPLE_TRANSFORMED_DATA);
+    const expectedData = table.getRows();
+    const config = {
+      type: 'rows',
+    };
+    const context = {};
+    const reportServerAggregator = new ReportServerAggregator(aggregator);
+    const output = buildOutput(config, context, reportServerAggregator);
+
+    const results = await output(table);
+    expect(results).toEqual(expectedData);
+  });
+});

--- a/packages/report-server/src/__tests__/reportBuilder/output/rowsAndColumns.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/output/rowsAndColumns.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import { Aggregator } from '@tupaia/aggregator';
+import { ReportServerAggregator } from '../../../aggregator';
+import { buildOutput } from '../../../reportBuilder/output';
+import { TransformTable } from '../../../reportBuilder/transform';
+import { MULTIPLE_TRANSFORMED_DATA } from './output.fixtures';
+
+describe('rowsAndColumns', () => {
+  const dataBroker = { context: {} };
+  const aggregator = new Aggregator(dataBroker);
+
+  it('returns the rows and columns of the data', async () => {
+    const table = TransformTable.fromRows(MULTIPLE_TRANSFORMED_DATA);
+    const expectedData = {
+      columns: table.getColumns(),
+      rows: table.getRows(),
+    };
+    const config = {
+      type: 'rowsAndColumns',
+    };
+    const context = {};
+    const reportServerAggregator = new ReportServerAggregator(aggregator);
+    const output = buildOutput(config, context, reportServerAggregator);
+
+    const results = await output(table);
+    expect(results).toEqual(expectedData);
+  });
+});

--- a/packages/report-server/src/__tests__/reportBuilder/testUtils/entityApiMock.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/testUtils/entityApiMock.ts
@@ -3,6 +3,7 @@
  * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
  */
 
+import { isDefined } from '@tupaia/tsutils';
 import pick from 'lodash.pick';
 
 export const entityApiMock = (
@@ -25,7 +26,6 @@ export const entityApiMock = (
         continue;
       }
 
-      const isDefined = <T>(val: T): val is Exclude<T, undefined> => val !== undefined;
       const children = relationsInHierarchy
         .filter(({ parent: parentCode }) => parent.code === parentCode)
         .map(({ child }) => entitiesInHierarchy.find(entity => entity.code === child))

--- a/packages/report-server/src/__tests__/reportBuilder/transform/aliases.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/transform/aliases.test.ts
@@ -17,7 +17,7 @@ import { buildTransform, TransformTable } from '../../../reportBuilder/transform
 describe('aliases', () => {
   it('keyValueByDataElementName', () => {
     const transform = buildTransform(['keyValueByDataElementName']);
-    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toEqual(
+    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toStrictEqual(
       TransformTable.fromRows([
         { period: '20200101', organisationUnit: 'TO', BCD1: 4 },
         { period: '20200102', organisationUnit: 'TO', BCD1: 2 },
@@ -28,7 +28,7 @@ describe('aliases', () => {
 
   it('keyValueByOrgUnit', () => {
     const transform = buildTransform(['keyValueByOrgUnit']);
-    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toEqual(
+    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toStrictEqual(
       TransformTable.fromRows([
         { period: '20200101', dataElement: 'BCD1', TO: 4 },
         { period: '20200102', dataElement: 'BCD1', TO: 2 },
@@ -39,7 +39,7 @@ describe('aliases', () => {
 
   it('keyValueByPeriod', () => {
     const transform = buildTransform(['keyValueByPeriod']);
-    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toEqual(
+    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toStrictEqual(
       TransformTable.fromRows(
         [
           { organisationUnit: 'TO', dataElement: 'BCD1', '20200101': 4 },
@@ -53,7 +53,7 @@ describe('aliases', () => {
 
   it('mostRecentValuePerOrgUnit', () => {
     const transform = buildTransform(['mostRecentValuePerOrgUnit']);
-    expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toEqual(
+    expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toStrictEqual(
       TransformTable.fromRows([
         { period: '20200103', organisationUnit: 'TO', BCD1: 5, BCD2: 0 },
         { period: '20200103', organisationUnit: 'PG', BCD1: 2, BCD2: -1 },
@@ -63,7 +63,7 @@ describe('aliases', () => {
 
   it('firstValuePerPeriodPerOrgUnit', () => {
     const transform = buildTransform(['firstValuePerPeriodPerOrgUnit']);
-    expect(transform(TransformTable.fromRows(MULTIPLE_MERGEABLE_ANALYTICS))).toEqual(
+    expect(transform(TransformTable.fromRows(MULTIPLE_MERGEABLE_ANALYTICS))).toStrictEqual(
       TransformTable.fromRows([
         { period: '20200101', organisationUnit: 'TO', BCD1: 4, BCD2: 11 },
         { period: '20200102', organisationUnit: 'TO', BCD1: 2, BCD2: 1 },
@@ -77,7 +77,7 @@ describe('aliases', () => {
 
   it('lastValuePerPeriodPerOrgUnit', () => {
     const transform = buildTransform(['lastValuePerPeriodPerOrgUnit']);
-    expect(transform(TransformTable.fromRows(MULTIPLE_MERGEABLE_ANALYTICS))).toEqual(
+    expect(transform(TransformTable.fromRows(MULTIPLE_MERGEABLE_ANALYTICS))).toStrictEqual(
       TransformTable.fromRows([
         { period: '20200101', organisationUnit: 'TO', BCD1: 7, BCD2: 4 },
         { period: '20200102', organisationUnit: 'TO', BCD1: 12, BCD2: 18 },
@@ -91,14 +91,14 @@ describe('aliases', () => {
 
   it('convertPeriodToWeek', () => {
     const transform = buildTransform(['convertPeriodToWeek']);
-    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toStrictEqual(
       TransformTable.fromRows([{ ...SINGLE_ANALYTIC[0], period: '2020W01' }]),
     );
   });
 
   it('convertEventDateToWeek', () => {
     const transform = buildTransform(['convertEventDateToWeek']);
-    expect(transform(TransformTable.fromRows(SINGLE_EVENT))).toEqual(
+    expect(transform(TransformTable.fromRows(SINGLE_EVENT))).toStrictEqual(
       TransformTable.fromRows([{ ...SINGLE_EVENT[0], period: '2020W01' }]),
     );
   });
@@ -107,7 +107,7 @@ describe('aliases', () => {
     const transform = buildTransform(['insertNumberOfFacilitiesColumn'], {
       facilityCountByOrgUnit: { TO: 14 },
     });
-    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toStrictEqual(
       TransformTable.fromRows([{ ...SINGLE_ANALYTIC[0], numberOfFacilities: 14 }]),
     );
   });
@@ -116,7 +116,7 @@ describe('aliases', () => {
 describe('insertSummaryRowAndColumn', () => {
   it('inserts a summary row and summary column', () => {
     const transform = buildTransform(['insertSummaryRowAndColumn']);
-    expect(transform(TransformTable.fromRows(TRANSFORMED_SUMMARY_BINARY))).toEqual(
+    expect(transform(TransformTable.fromRows(TRANSFORMED_SUMMARY_BINARY))).toStrictEqual(
       TransformTable.fromRows([
         { dataElement: 'Male condoms', TO: 'N', FJ: 'N', NR: 'Y', KI: 'N', summaryColumn: '75.0%' },
         {
@@ -140,7 +140,7 @@ describe('insertSummaryRowAndColumn', () => {
 
   it('only summarises columns that have only Y | N | undefined values', () => {
     const transform = buildTransform(['insertSummaryRowAndColumn']);
-    expect(transform(TransformTable.fromRows(TRANSFORMED_SUMMARY_VARIOUS))).toEqual(
+    expect(transform(TransformTable.fromRows(TRANSFORMED_SUMMARY_VARIOUS))).toStrictEqual(
       TransformTable.fromRows([
         {
           dataElement: 'Male condoms',

--- a/packages/report-server/src/__tests__/reportBuilder/transform/aliases.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/transform/aliases.test.ts
@@ -4,122 +4,168 @@
  */
 
 import {
-  MULTIPLE_ANALYTICS,
   MERGEABLE_ANALYTICS,
+  MULTIPLE_ANALYTICS,
   MULTIPLE_MERGEABLE_ANALYTICS,
   SINGLE_ANALYTIC,
   SINGLE_EVENT,
   TRANSFORMED_SUMMARY_BINARY,
   TRANSFORMED_SUMMARY_VARIOUS,
 } from './transform.fixtures';
-import { buildTransform } from '../../../reportBuilder/transform';
+import { buildTransform, TransformTable } from '../../../reportBuilder/transform';
 
 describe('aliases', () => {
   it('keyValueByDataElementName', () => {
     const transform = buildTransform(['keyValueByDataElementName']);
-    expect(transform(MULTIPLE_ANALYTICS)).toEqual([
-      { period: '20200101', organisationUnit: 'TO', BCD1: 4 },
-      { period: '20200102', organisationUnit: 'TO', BCD1: 2 },
-      { period: '20200103', organisationUnit: 'TO', BCD1: 5 },
-    ]);
+    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toEqual(
+      TransformTable.fromRows([
+        { period: '20200101', organisationUnit: 'TO', BCD1: 4 },
+        { period: '20200102', organisationUnit: 'TO', BCD1: 2 },
+        { period: '20200103', organisationUnit: 'TO', BCD1: 5 },
+      ]),
+    );
   });
 
   it('keyValueByOrgUnit', () => {
     const transform = buildTransform(['keyValueByOrgUnit']);
-    expect(transform(MULTIPLE_ANALYTICS)).toEqual([
-      { period: '20200101', TO: 4, dataElement: 'BCD1' },
-      { period: '20200102', TO: 2, dataElement: 'BCD1' },
-      { period: '20200103', TO: 5, dataElement: 'BCD1' },
-    ]);
+    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toEqual(
+      TransformTable.fromRows([
+        { period: '20200101', dataElement: 'BCD1', TO: 4 },
+        { period: '20200102', dataElement: 'BCD1', TO: 2 },
+        { period: '20200103', dataElement: 'BCD1', TO: 5 },
+      ]),
+    );
   });
 
   it('keyValueByPeriod', () => {
     const transform = buildTransform(['keyValueByPeriod']);
-    expect(transform(MULTIPLE_ANALYTICS)).toEqual([
-      { '20200101': 4, organisationUnit: 'TO', dataElement: 'BCD1' },
-      { '20200102': 2, organisationUnit: 'TO', dataElement: 'BCD1' },
-      { '20200103': 5, organisationUnit: 'TO', dataElement: 'BCD1' },
-    ]);
+    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toEqual(
+      TransformTable.fromRows(
+        [
+          { organisationUnit: 'TO', dataElement: 'BCD1', '20200101': 4 },
+          { organisationUnit: 'TO', dataElement: 'BCD1', '20200102': 2 },
+          { organisationUnit: 'TO', dataElement: 'BCD1', '20200103': 5 },
+        ],
+        ['organisationUnit', 'dataElement', '20200101', '20200102', '20200103'],
+      ),
+    );
   });
 
   it('mostRecentValuePerOrgUnit', () => {
     const transform = buildTransform(['mostRecentValuePerOrgUnit']);
-    expect(transform(MERGEABLE_ANALYTICS)).toEqual([
-      { period: '20200103', organisationUnit: 'TO', BCD1: 5, BCD2: 0 },
-      { period: '20200103', organisationUnit: 'PG', BCD1: 2, BCD2: -1 },
-    ]);
+    expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toEqual(
+      TransformTable.fromRows([
+        { period: '20200103', organisationUnit: 'TO', BCD1: 5, BCD2: 0 },
+        { period: '20200103', organisationUnit: 'PG', BCD1: 2, BCD2: -1 },
+      ]),
+    );
   });
 
   it('firstValuePerPeriodPerOrgUnit', () => {
     const transform = buildTransform(['firstValuePerPeriodPerOrgUnit']);
-    expect(transform(MULTIPLE_MERGEABLE_ANALYTICS)).toEqual([
-      { period: '20200101', organisationUnit: 'TO', BCD1: 4, BCD2: 11 },
-      { period: '20200102', organisationUnit: 'TO', BCD1: 2, BCD2: 1 },
-      { period: '20200103', organisationUnit: 'TO', BCD1: 5, BCD2: 0 },
-      { period: '20200101', organisationUnit: 'PG', BCD1: 7, BCD2: 13 },
-      { period: '20200102', organisationUnit: 'PG', BCD1: 8, BCD2: 99 },
-      { period: '20200103', organisationUnit: 'PG', BCD1: 2, BCD2: -1 },
-    ]);
+    expect(transform(TransformTable.fromRows(MULTIPLE_MERGEABLE_ANALYTICS))).toEqual(
+      TransformTable.fromRows([
+        { period: '20200101', organisationUnit: 'TO', BCD1: 4, BCD2: 11 },
+        { period: '20200102', organisationUnit: 'TO', BCD1: 2, BCD2: 1 },
+        { period: '20200103', organisationUnit: 'TO', BCD1: 5, BCD2: 0 },
+        { period: '20200101', organisationUnit: 'PG', BCD1: 7, BCD2: 13 },
+        { period: '20200102', organisationUnit: 'PG', BCD1: 8, BCD2: 99 },
+        { period: '20200103', organisationUnit: 'PG', BCD1: 2, BCD2: -1 },
+      ]),
+    );
   });
 
   it('lastValuePerPeriodPerOrgUnit', () => {
     const transform = buildTransform(['lastValuePerPeriodPerOrgUnit']);
-    expect(transform(MULTIPLE_MERGEABLE_ANALYTICS)).toEqual([
-      { period: '20200101', organisationUnit: 'TO', BCD1: 7, BCD2: 4 },
-      { period: '20200102', organisationUnit: 'TO', BCD1: 12, BCD2: 18 },
-      { period: '20200103', organisationUnit: 'TO', BCD1: 23, BCD2: 9 },
-      { period: '20200101', organisationUnit: 'PG', BCD1: 17, BCD2: 23 },
-      { period: '20200102', organisationUnit: 'PG', BCD1: 4, BCD2: -4 },
-      { period: '20200103', organisationUnit: 'PG', BCD1: 1, BCD2: 12 },
-    ]);
+    expect(transform(TransformTable.fromRows(MULTIPLE_MERGEABLE_ANALYTICS))).toEqual(
+      TransformTable.fromRows([
+        { period: '20200101', organisationUnit: 'TO', BCD1: 7, BCD2: 4 },
+        { period: '20200102', organisationUnit: 'TO', BCD1: 12, BCD2: 18 },
+        { period: '20200103', organisationUnit: 'TO', BCD1: 23, BCD2: 9 },
+        { period: '20200101', organisationUnit: 'PG', BCD1: 17, BCD2: 23 },
+        { period: '20200102', organisationUnit: 'PG', BCD1: 4, BCD2: -4 },
+        { period: '20200103', organisationUnit: 'PG', BCD1: 1, BCD2: 12 },
+      ]),
+    );
   });
 
   it('convertPeriodToWeek', () => {
     const transform = buildTransform(['convertPeriodToWeek']);
-    expect(transform(SINGLE_ANALYTIC)).toEqual([{ ...SINGLE_ANALYTIC[0], period: '2020W01' }]);
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+      TransformTable.fromRows([{ ...SINGLE_ANALYTIC[0], period: '2020W01' }]),
+    );
   });
 
   it('convertEventDateToWeek', () => {
     const transform = buildTransform(['convertEventDateToWeek']);
-    expect(transform(SINGLE_EVENT)).toEqual([{ ...SINGLE_EVENT[0], period: '2020W01' }]);
+    expect(transform(TransformTable.fromRows(SINGLE_EVENT))).toEqual(
+      TransformTable.fromRows([{ ...SINGLE_EVENT[0], period: '2020W01' }]),
+    );
   });
 
   it('insertNumberOfFacilitiesColumn', () => {
     const transform = buildTransform(['insertNumberOfFacilitiesColumn'], {
       facilityCountByOrgUnit: { TO: 14 },
     });
-    expect(transform(SINGLE_ANALYTIC)).toEqual([{ ...SINGLE_ANALYTIC[0], numberOfFacilities: 14 }]);
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+      TransformTable.fromRows([{ ...SINGLE_ANALYTIC[0], numberOfFacilities: 14 }]),
+    );
   });
 });
 
 describe('insertSummaryRowAndColumn', () => {
   it('inserts a summary row and summary column', () => {
     const transform = buildTransform(['insertSummaryRowAndColumn']);
-    expect(transform(TRANSFORMED_SUMMARY_BINARY)).toEqual([
-      { summaryColumn: '75.0%', dataElement: 'Male condoms', TO: 'N', FJ: 'N', NR: 'Y', KI: 'N' },
-      { summaryColumn: '25.0%', dataElement: 'Female condoms', TO: 'N', FJ: 'Y', NR: 'Y', KI: 'Y' },
-      {
-        summaryColumn: '0.0%',
-        dataElement: 'Injectable contraceptives',
-        TO: 'Y',
-        FJ: 'Y',
-      },
-      { TO: '66.7%', FJ: '33.3%', NR: '0.0%', KI: '50.0%' },
-    ]);
+    expect(transform(TransformTable.fromRows(TRANSFORMED_SUMMARY_BINARY))).toEqual(
+      TransformTable.fromRows([
+        { dataElement: 'Male condoms', TO: 'N', FJ: 'N', NR: 'Y', KI: 'N', summaryColumn: '75.0%' },
+        {
+          dataElement: 'Female condoms',
+          TO: 'N',
+          FJ: 'Y',
+          NR: 'Y',
+          KI: 'Y',
+          summaryColumn: '25.0%',
+        },
+        {
+          dataElement: 'Injectable contraceptives',
+          TO: 'Y',
+          FJ: 'Y',
+          summaryColumn: '0.0%',
+        },
+        { TO: '66.7%', FJ: '33.3%', NR: '0.0%', KI: '50.0%' },
+      ]),
+    );
   });
 
   it('only summarises columns that have only Y | N | undefined values', () => {
     const transform = buildTransform(['insertSummaryRowAndColumn']);
-    expect(transform(TRANSFORMED_SUMMARY_VARIOUS)).toEqual([
-      { summaryColumn: '66.7%', dataElement: 'Male condoms', TO: 'Yes', FJ: 'N', NR: 'Y', KI: 'N' },
-      { summaryColumn: '0.0%', dataElement: 'Female condoms', TO: 'N', FJ: 'Y', NR: 'Y', KI: 'Y' },
-      {
-        summaryColumn: '0.0%',
-        dataElement: 'Injectable contraceptives',
-        TO: 'Y',
-        FJ: 'Y',
-      },
-      { FJ: '33.3%', NR: '0.0%', KI: '50.0%' },
-    ]);
+    expect(transform(TransformTable.fromRows(TRANSFORMED_SUMMARY_VARIOUS))).toEqual(
+      TransformTable.fromRows([
+        {
+          dataElement: 'Male condoms',
+          TO: 'Yes',
+          FJ: 'N',
+          NR: 'Y',
+          KI: 'N',
+          summaryColumn: '66.7%',
+        },
+        {
+          dataElement: 'Female condoms',
+          TO: 'N',
+          FJ: 'Y',
+          NR: 'Y',
+          KI: 'Y',
+          summaryColumn: '0.0%',
+        },
+        {
+          dataElement: 'Injectable contraceptives',
+          TO: 'Y',
+          FJ: 'Y',
+          summaryColumn: '0.0%',
+        },
+        { FJ: '33.3%', NR: '0.0%', KI: '50.0%' },
+      ]),
+    );
   });
 });

--- a/packages/report-server/src/__tests__/reportBuilder/transform/excludeColumns.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/transform/excludeColumns.test.ts
@@ -14,7 +14,7 @@ describe('excludeColumns', () => {
         columns: '*',
       },
     ]);
-    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toStrictEqual(
       TransformTable.fromRows([{}]),
     );
   });
@@ -26,7 +26,7 @@ describe('excludeColumns', () => {
         columns: ['organisationUnit', 'value'],
       },
     ]);
-    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toEqual(
+    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toStrictEqual(
       TransformTable.fromRows([
         { period: '20200101', dataElement: 'BCD1' },
         { period: '20200102', dataElement: 'BCD1' },

--- a/packages/report-server/src/__tests__/reportBuilder/transform/excludeColumns.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/transform/excludeColumns.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { SINGLE_ANALYTIC, MULTIPLE_ANALYTICS } from './transform.fixtures';
-import { buildTransform } from '../../../reportBuilder/transform';
+import { buildTransform, TransformTable } from '../../../reportBuilder/transform';
 
 describe('excludeColumns', () => {
   it('can exclude all fields', () => {
@@ -14,7 +14,9 @@ describe('excludeColumns', () => {
         columns: '*',
       },
     ]);
-    expect(transform(SINGLE_ANALYTIC)).toEqual([{}]);
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+      TransformTable.fromRows([{}]),
+    );
   });
 
   it('can exclude selected fields', () => {
@@ -24,10 +26,12 @@ describe('excludeColumns', () => {
         columns: ['organisationUnit', 'value'],
       },
     ]);
-    expect(transform(MULTIPLE_ANALYTICS)).toEqual([
-      { period: '20200101', dataElement: 'BCD1' },
-      { period: '20200102', dataElement: 'BCD1' },
-      { period: '20200103', dataElement: 'BCD1' },
-    ]);
+    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toEqual(
+      TransformTable.fromRows([
+        { period: '20200101', dataElement: 'BCD1' },
+        { period: '20200102', dataElement: 'BCD1' },
+        { period: '20200103', dataElement: 'BCD1' },
+      ]),
+    );
   });
 });

--- a/packages/report-server/src/__tests__/reportBuilder/transform/excludeRows.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/transform/excludeRows.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { EXCLUDEABLE_ANALYTICS } from './transform.fixtures';
-import { buildTransform } from '../../../reportBuilder/transform';
+import { buildTransform, TransformTable } from '../../../reportBuilder/transform';
 
 describe('excludeRows', () => {
   it('can exclude by boolean expression on row', () => {
@@ -14,9 +14,11 @@ describe('excludeRows', () => {
         where: '=$BCD1 < 6',
       },
     ]);
-    expect(transform(EXCLUDEABLE_ANALYTICS)).toEqual([
-      { period: '20200101', organisationUnit: 'PG', BCD1: 7 },
-      { period: '20200102', organisationUnit: 'PG', BCD1: 8 },
-    ]);
+    expect(transform(TransformTable.fromRows(EXCLUDEABLE_ANALYTICS))).toEqual(
+      TransformTable.fromRows([
+        { period: '20200101', organisationUnit: 'PG', BCD1: 7 },
+        { period: '20200102', organisationUnit: 'PG', BCD1: 8 },
+      ]),
+    );
   });
 });

--- a/packages/report-server/src/__tests__/reportBuilder/transform/excludeRows.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/transform/excludeRows.test.ts
@@ -14,7 +14,7 @@ describe('excludeRows', () => {
         where: '=$BCD1 < 6',
       },
     ]);
-    expect(transform(TransformTable.fromRows(EXCLUDEABLE_ANALYTICS))).toEqual(
+    expect(transform(TransformTable.fromRows(EXCLUDEABLE_ANALYTICS))).toStrictEqual(
       TransformTable.fromRows([
         { period: '20200101', organisationUnit: 'PG', BCD1: 7 },
         { period: '20200102', organisationUnit: 'PG', BCD1: 8 },

--- a/packages/report-server/src/__tests__/reportBuilder/transform/gatherColumns.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/transform/gatherColumns.test.ts
@@ -13,7 +13,7 @@ describe('gatherColumns', () => {
         transform: 'gatherColumns',
       },
     ]);
-    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toStrictEqual(
       TransformTable.fromRows([
         { value: '20200101', columnName: 'period' },
         { value: 'TO', columnName: 'organisationUnit' },
@@ -30,7 +30,7 @@ describe('gatherColumns', () => {
         keep: 'organisationUnit',
       },
     ]);
-    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toStrictEqual(
       TransformTable.fromRows([
         { organisationUnit: 'TO', value: '20200101', columnName: 'period' },
         { organisationUnit: 'TO', value: 'BCD1', columnName: 'dataElement' },
@@ -46,7 +46,7 @@ describe('gatherColumns', () => {
         keep: ['organisationUnit', 'period'],
       },
     ]);
-    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toStrictEqual(
       TransformTable.fromRows([
         { period: '20200101', organisationUnit: 'TO', value: 'BCD1', columnName: 'dataElement' },
         { period: '20200101', organisationUnit: 'TO', value: 4, columnName: 'value' },
@@ -61,7 +61,7 @@ describe('gatherColumns', () => {
         keep: ['period'],
       },
     ]);
-    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toEqual(
+    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toStrictEqual(
       TransformTable.fromRows([
         { period: '20200101', value: 'TO', columnName: 'organisationUnit' },
         { period: '20200101', value: 'BCD1', columnName: 'dataElement' },

--- a/packages/report-server/src/__tests__/reportBuilder/transform/gatherColumns.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/transform/gatherColumns.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { MULTIPLE_ANALYTICS, SINGLE_ANALYTIC } from './transform.fixtures';
-import { buildTransform } from '../../../reportBuilder/transform';
+import { buildTransform, TransformTable } from '../../../reportBuilder/transform';
 
 describe('gatherColumns', () => {
   it('can gather columns for single analytic', () => {
@@ -13,12 +13,14 @@ describe('gatherColumns', () => {
         transform: 'gatherColumns',
       },
     ]);
-    expect(transform(SINGLE_ANALYTIC)).toEqual([
-      { value: '20200101', columnName: 'period' },
-      { value: 'TO', columnName: 'organisationUnit' },
-      { value: 'BCD1', columnName: 'dataElement' },
-      { value: 4, columnName: 'value' },
-    ]);
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+      TransformTable.fromRows([
+        { value: '20200101', columnName: 'period' },
+        { value: 'TO', columnName: 'organisationUnit' },
+        { value: 'BCD1', columnName: 'dataElement' },
+        { value: 4, columnName: 'value' },
+      ]),
+    );
   });
 
   it('can gather columns with one included field as string', () => {
@@ -28,11 +30,13 @@ describe('gatherColumns', () => {
         keep: 'organisationUnit',
       },
     ]);
-    expect(transform(SINGLE_ANALYTIC)).toEqual([
-      { organisationUnit: 'TO', value: '20200101', columnName: 'period' },
-      { organisationUnit: 'TO', value: 'BCD1', columnName: 'dataElement' },
-      { organisationUnit: 'TO', value: 4, columnName: 'value' },
-    ]);
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+      TransformTable.fromRows([
+        { organisationUnit: 'TO', value: '20200101', columnName: 'period' },
+        { organisationUnit: 'TO', value: 'BCD1', columnName: 'dataElement' },
+        { organisationUnit: 'TO', value: 4, columnName: 'value' },
+      ]),
+    );
   });
 
   it('can gather columns with included fields', () => {
@@ -42,10 +46,12 @@ describe('gatherColumns', () => {
         keep: ['organisationUnit', 'period'],
       },
     ]);
-    expect(transform(SINGLE_ANALYTIC)).toEqual([
-      { organisationUnit: 'TO', period: '20200101', value: 'BCD1', columnName: 'dataElement' },
-      { organisationUnit: 'TO', period: '20200101', value: 4, columnName: 'value' },
-    ]);
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+      TransformTable.fromRows([
+        { period: '20200101', organisationUnit: 'TO', value: 'BCD1', columnName: 'dataElement' },
+        { period: '20200101', organisationUnit: 'TO', value: 4, columnName: 'value' },
+      ]),
+    );
   });
 
   it('can gather columns for multiple analytics', () => {
@@ -55,16 +61,18 @@ describe('gatherColumns', () => {
         keep: ['period'],
       },
     ]);
-    expect(transform(MULTIPLE_ANALYTICS)).toEqual([
-      { period: '20200101', value: 'TO', columnName: 'organisationUnit' },
-      { period: '20200101', value: 'BCD1', columnName: 'dataElement' },
-      { period: '20200101', value: 4, columnName: 'value' },
-      { period: '20200102', value: 'TO', columnName: 'organisationUnit' },
-      { period: '20200102', value: 'BCD1', columnName: 'dataElement' },
-      { period: '20200102', value: 2, columnName: 'value' },
-      { period: '20200103', value: 'TO', columnName: 'organisationUnit' },
-      { period: '20200103', value: 'BCD1', columnName: 'dataElement' },
-      { period: '20200103', value: 5, columnName: 'value' },
-    ]);
+    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toEqual(
+      TransformTable.fromRows([
+        { period: '20200101', value: 'TO', columnName: 'organisationUnit' },
+        { period: '20200101', value: 'BCD1', columnName: 'dataElement' },
+        { period: '20200101', value: 4, columnName: 'value' },
+        { period: '20200102', value: 'TO', columnName: 'organisationUnit' },
+        { period: '20200102', value: 'BCD1', columnName: 'dataElement' },
+        { period: '20200102', value: 2, columnName: 'value' },
+        { period: '20200103', value: 'TO', columnName: 'organisationUnit' },
+        { period: '20200103', value: 'BCD1', columnName: 'dataElement' },
+        { period: '20200103', value: 5, columnName: 'value' },
+      ]),
+    );
   });
 });

--- a/packages/report-server/src/__tests__/reportBuilder/transform/insertColumns.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/transform/insertColumns.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { SINGLE_ANALYTIC, MULTIPLE_ANALYTICS, MERGEABLE_ANALYTICS } from './transform.fixtures';
-import { buildTransform } from '../../../reportBuilder/transform';
+import { buildTransform, TransformTable } from '../../../reportBuilder/transform';
 
 describe('insertColumns', () => {
   it('can insert basic values', () => {
@@ -18,9 +18,9 @@ describe('insertColumns', () => {
         },
       },
     ]);
-    expect(transform(SINGLE_ANALYTIC)).toEqual([
-      { ...SINGLE_ANALYTIC[0], number: 1, string: 'Hi', boolean: false },
-    ]);
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+      TransformTable.fromRows([{ ...SINGLE_ANALYTIC[0], number: 1, string: 'Hi', boolean: false }]),
+    );
   });
 
   it('can insert using a value from the row', () => {
@@ -32,7 +32,9 @@ describe('insertColumns', () => {
         },
       },
     ]);
-    expect(transform(SINGLE_ANALYTIC)).toEqual([{ ...SINGLE_ANALYTIC[0], dataElementValue: 4 }]);
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+      TransformTable.fromRows([{ ...SINGLE_ANALYTIC[0], dataElementValue: 4 }]),
+    );
   });
 
   it('can use a value from the row as a column name', () => {
@@ -44,7 +46,9 @@ describe('insertColumns', () => {
         },
       },
     ]);
-    expect(transform(SINGLE_ANALYTIC)).toEqual([{ ...SINGLE_ANALYTIC[0], BCD1: 4 }]);
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+      TransformTable.fromRows([{ ...SINGLE_ANALYTIC[0], BCD1: 4 }]),
+    );
   });
 
   it('can execute functions', () => {
@@ -56,7 +60,9 @@ describe('insertColumns', () => {
         },
       },
     ]);
-    expect(transform(SINGLE_ANALYTIC)).toEqual([{ ...SINGLE_ANALYTIC[0], period: '1st Jan 2020' }]);
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+      TransformTable.fromRows([{ ...SINGLE_ANALYTIC[0], period: '1st Jan 2020' }]),
+    );
   });
 
   it('can perform the insert on all rows', () => {
@@ -69,11 +75,13 @@ describe('insertColumns', () => {
         },
       },
     ]);
-    expect(transform(MULTIPLE_ANALYTICS)).toEqual([
-      { ...MULTIPLE_ANALYTICS[0], period: '1st Jan 2020', BCD1: 4 },
-      { ...MULTIPLE_ANALYTICS[1], period: '2nd Jan 2020', BCD1: 2 },
-      { ...MULTIPLE_ANALYTICS[2], period: '3rd Jan 2020', BCD1: 5 },
-    ]);
+    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toEqual(
+      TransformTable.fromRows([
+        { ...MULTIPLE_ANALYTICS[0], period: '1st Jan 2020', BCD1: 4 },
+        { ...MULTIPLE_ANALYTICS[1], period: '2nd Jan 2020', BCD1: 2 },
+        { ...MULTIPLE_ANALYTICS[2], period: '3rd Jan 2020', BCD1: 5 },
+      ]),
+    );
   });
 
   it('where is processed before remaining fields', () => {
@@ -86,19 +94,24 @@ describe('insertColumns', () => {
         },
       },
     ]);
-    expect(transform(MERGEABLE_ANALYTICS)).toEqual([
-      { ...MERGEABLE_ANALYTICS[0], newVal: 8 },
-      { ...MERGEABLE_ANALYTICS[1], newVal: 4 },
-      { ...MERGEABLE_ANALYTICS[2], newVal: 10 },
-      { ...MERGEABLE_ANALYTICS[3] },
-      { ...MERGEABLE_ANALYTICS[4] },
-      { ...MERGEABLE_ANALYTICS[5] },
-      { ...MERGEABLE_ANALYTICS[6], newVal: 14 },
-      { ...MERGEABLE_ANALYTICS[7], newVal: 16 },
-      { ...MERGEABLE_ANALYTICS[8], newVal: 4 },
-      { ...MERGEABLE_ANALYTICS[9] },
-      { ...MERGEABLE_ANALYTICS[10] },
-      { ...MERGEABLE_ANALYTICS[11] },
-    ]);
+    expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toEqual(
+      TransformTable.fromRows(
+        [
+          { ...MERGEABLE_ANALYTICS[0], newVal: 8 },
+          { ...MERGEABLE_ANALYTICS[1], newVal: 4 },
+          { ...MERGEABLE_ANALYTICS[2], newVal: 10 },
+          { ...MERGEABLE_ANALYTICS[3] },
+          { ...MERGEABLE_ANALYTICS[4] },
+          { ...MERGEABLE_ANALYTICS[5] },
+          { ...MERGEABLE_ANALYTICS[6], newVal: 14 },
+          { ...MERGEABLE_ANALYTICS[7], newVal: 16 },
+          { ...MERGEABLE_ANALYTICS[8], newVal: 4 },
+          { ...MERGEABLE_ANALYTICS[9] },
+          { ...MERGEABLE_ANALYTICS[10] },
+          { ...MERGEABLE_ANALYTICS[11] },
+        ],
+        ['period', 'organisationUnit', 'BCD1', 'BCD2', 'newVal'],
+      ),
+    );
   });
 });

--- a/packages/report-server/src/__tests__/reportBuilder/transform/insertColumns.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/transform/insertColumns.test.ts
@@ -18,7 +18,7 @@ describe('insertColumns', () => {
         },
       },
     ]);
-    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toStrictEqual(
       TransformTable.fromRows([{ ...SINGLE_ANALYTIC[0], number: 1, string: 'Hi', boolean: false }]),
     );
   });
@@ -32,7 +32,7 @@ describe('insertColumns', () => {
         },
       },
     ]);
-    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toStrictEqual(
       TransformTable.fromRows([{ ...SINGLE_ANALYTIC[0], dataElementValue: 4 }]),
     );
   });
@@ -46,7 +46,7 @@ describe('insertColumns', () => {
         },
       },
     ]);
-    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toStrictEqual(
       TransformTable.fromRows([{ ...SINGLE_ANALYTIC[0], BCD1: 4 }]),
     );
   });
@@ -60,7 +60,7 @@ describe('insertColumns', () => {
         },
       },
     ]);
-    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toStrictEqual(
       TransformTable.fromRows([{ ...SINGLE_ANALYTIC[0], period: '1st Jan 2020' }]),
     );
   });
@@ -75,7 +75,7 @@ describe('insertColumns', () => {
         },
       },
     ]);
-    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toEqual(
+    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toStrictEqual(
       TransformTable.fromRows([
         { ...MULTIPLE_ANALYTICS[0], period: '1st Jan 2020', BCD1: 4 },
         { ...MULTIPLE_ANALYTICS[1], period: '2nd Jan 2020', BCD1: 2 },
@@ -94,7 +94,7 @@ describe('insertColumns', () => {
         },
       },
     ]);
-    expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toEqual(
+    expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toStrictEqual(
       TransformTable.fromRows(
         [
           { ...MERGEABLE_ANALYTICS[0], newVal: 8 },

--- a/packages/report-server/src/__tests__/reportBuilder/transform/insertRows.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/transform/insertRows.test.ts
@@ -19,7 +19,7 @@ describe('insertRows', () => {
         },
       },
     ]);
-    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toStrictEqual(
       TransformTable.fromRows([...SINGLE_ANALYTIC, { number: 1, string: 'Hi', boolean: false }]),
     );
   });
@@ -33,7 +33,7 @@ describe('insertRows', () => {
         },
       },
     ]);
-    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toStrictEqual(
       TransformTable.fromRows([...SINGLE_ANALYTIC, { dataElementValue: 4 }]),
     );
   });
@@ -47,7 +47,7 @@ describe('insertRows', () => {
         },
       },
     ]);
-    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toStrictEqual(
       TransformTable.fromRows([...SINGLE_ANALYTIC, { BCD1: 4 }]),
     );
   });
@@ -61,7 +61,7 @@ describe('insertRows', () => {
         },
       },
     ]);
-    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toStrictEqual(
       TransformTable.fromRows([...SINGLE_ANALYTIC, { period: '1st Jan 2020' }]),
     );
   });
@@ -80,7 +80,7 @@ describe('insertRows', () => {
         },
       },
     ]);
-    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toEqual(
+    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toStrictEqual(
       TransformTable.fromRows(
         [
           { number: 1, string: 'Hi', boolean: false },
@@ -105,7 +105,7 @@ describe('insertRows', () => {
         },
       },
     ]);
-    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toEqual(
+    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toStrictEqual(
       TransformTable.fromRows([
         { period: '20200101', organisationUnit: 'TO', dataElement: 'BCD1', value: 4 },
         { period: '20200102', organisationUnit: 'TO', dataElement: 'BCD1', value: 2 },
@@ -124,7 +124,7 @@ describe('insertRows', () => {
         },
       },
     ]);
-    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toEqual(
+    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toStrictEqual(
       TransformTable.fromRows([
         { period: '20200101', organisationUnit: 'TO', dataElement: 'BCD1', value: 4 },
         { dataElementValue: 4 },
@@ -146,7 +146,7 @@ describe('insertRows', () => {
         position: 'before',
       },
     ]);
-    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toEqual(
+    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toStrictEqual(
       TransformTable.fromRows(
         [
           { dataElementValue: 4 },
@@ -171,7 +171,7 @@ describe('insertRows', () => {
         position: 'start',
       },
     ]);
-    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toEqual(
+    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toStrictEqual(
       TransformTable.fromRows(
         [
           { dataElementValue: 4 },
@@ -197,7 +197,7 @@ describe('insertRows', () => {
         where: "=not(eq($period, '20200101'))",
       },
     ]);
-    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toEqual(
+    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toStrictEqual(
       TransformTable.fromRows([
         { period: '20200101', organisationUnit: 'TO', dataElement: 'BCD1', value: 4 },
         { period: '20200102', organisationUnit: 'TO', dataElement: 'BCD1', value: 2 },
@@ -219,7 +219,7 @@ describe('insertRows', () => {
         },
       },
     ]);
-    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toEqual(
+    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toStrictEqual(
       TransformTable.fromRows([
         { period: '20200101', organisationUnit: 'TO', dataElement: 'BCD1', value: 4 },
         { period: '20200102', organisationUnit: 'TO', dataElement: 'BCD1', value: 2 },
@@ -242,7 +242,7 @@ describe('insertRows', () => {
         },
       },
     ]);
-    expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toEqual(
+    expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toStrictEqual(
       TransformTable.fromRows([
         { period: '20200101', organisationUnit: 'TO', BCD1: 4 },
         { period: '20200102', organisationUnit: 'TO', BCD1: 2 },

--- a/packages/report-server/src/__tests__/reportBuilder/transform/insertRows.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/transform/insertRows.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { SINGLE_ANALYTIC, MULTIPLE_ANALYTICS, MERGEABLE_ANALYTICS } from './transform.fixtures';
-import { buildTransform } from '../../../reportBuilder/transform';
+import { buildTransform, TransformTable } from '../../../reportBuilder/transform';
 
 describe('insertRows', () => {
   // SAME AS INSERT COLUMNS FUNCTIONALITY
@@ -19,10 +19,9 @@ describe('insertRows', () => {
         },
       },
     ]);
-    expect(transform(SINGLE_ANALYTIC)).toEqual([
-      ...SINGLE_ANALYTIC,
-      { number: 1, string: 'Hi', boolean: false },
-    ]);
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+      TransformTable.fromRows([...SINGLE_ANALYTIC, { number: 1, string: 'Hi', boolean: false }]),
+    );
   });
 
   it('can insert row with values from previous row', () => {
@@ -34,7 +33,9 @@ describe('insertRows', () => {
         },
       },
     ]);
-    expect(transform(SINGLE_ANALYTIC)).toEqual([...SINGLE_ANALYTIC, { dataElementValue: 4 }]);
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+      TransformTable.fromRows([...SINGLE_ANALYTIC, { dataElementValue: 4 }]),
+    );
   });
 
   it('can select a value from the row as a field name', () => {
@@ -46,7 +47,9 @@ describe('insertRows', () => {
         },
       },
     ]);
-    expect(transform(SINGLE_ANALYTIC)).toEqual([...SINGLE_ANALYTIC, { BCD1: 4 }]);
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+      TransformTable.fromRows([...SINGLE_ANALYTIC, { BCD1: 4 }]),
+    );
   });
 
   it('can execute functions', () => {
@@ -58,7 +61,9 @@ describe('insertRows', () => {
         },
       },
     ]);
-    expect(transform(SINGLE_ANALYTIC)).toEqual([...SINGLE_ANALYTIC, { period: '1st Jan 2020' }]);
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+      TransformTable.fromRows([...SINGLE_ANALYTIC, { period: '1st Jan 2020' }]),
+    );
   });
 
   // SPECIFIC TO INSERT
@@ -75,12 +80,17 @@ describe('insertRows', () => {
         },
       },
     ]);
-    expect(transform(MULTIPLE_ANALYTICS)).toEqual([
-      { number: 1, string: 'Hi', boolean: false },
-      { period: '20200101', organisationUnit: 'TO', dataElement: 'BCD1', value: 4 },
-      { period: '20200102', organisationUnit: 'TO', dataElement: 'BCD1', value: 2 },
-      { period: '20200103', organisationUnit: 'TO', dataElement: 'BCD1', value: 5 },
-    ]);
+    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toEqual(
+      TransformTable.fromRows(
+        [
+          { number: 1, string: 'Hi', boolean: false },
+          { period: '20200101', organisationUnit: 'TO', dataElement: 'BCD1', value: 4 },
+          { period: '20200102', organisationUnit: 'TO', dataElement: 'BCD1', value: 2 },
+          { period: '20200103', organisationUnit: 'TO', dataElement: 'BCD1', value: 5 },
+        ],
+        ['period', 'organisationUnit', 'dataElement', 'value', 'number', 'string', 'boolean'],
+      ),
+    );
   });
 
   it('can insert a single row at end', () => {
@@ -95,12 +105,14 @@ describe('insertRows', () => {
         },
       },
     ]);
-    expect(transform(MULTIPLE_ANALYTICS)).toEqual([
-      { period: '20200101', organisationUnit: 'TO', dataElement: 'BCD1', value: 4 },
-      { period: '20200102', organisationUnit: 'TO', dataElement: 'BCD1', value: 2 },
-      { period: '20200103', organisationUnit: 'TO', dataElement: 'BCD1', value: 5 },
-      { number: 1, string: 'Hi', boolean: false },
-    ]);
+    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toEqual(
+      TransformTable.fromRows([
+        { period: '20200101', organisationUnit: 'TO', dataElement: 'BCD1', value: 4 },
+        { period: '20200102', organisationUnit: 'TO', dataElement: 'BCD1', value: 2 },
+        { period: '20200103', organisationUnit: 'TO', dataElement: 'BCD1', value: 5 },
+        { number: 1, string: 'Hi', boolean: false },
+      ]),
+    );
   });
 
   it('can insert multiple rows', () => {
@@ -112,14 +124,16 @@ describe('insertRows', () => {
         },
       },
     ]);
-    expect(transform(MULTIPLE_ANALYTICS)).toEqual([
-      { period: '20200101', organisationUnit: 'TO', dataElement: 'BCD1', value: 4 },
-      { dataElementValue: 4 },
-      { period: '20200102', organisationUnit: 'TO', dataElement: 'BCD1', value: 2 },
-      { dataElementValue: 2 },
-      { period: '20200103', organisationUnit: 'TO', dataElement: 'BCD1', value: 5 },
-      { dataElementValue: 5 },
-    ]);
+    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toEqual(
+      TransformTable.fromRows([
+        { period: '20200101', organisationUnit: 'TO', dataElement: 'BCD1', value: 4 },
+        { dataElementValue: 4 },
+        { period: '20200102', organisationUnit: 'TO', dataElement: 'BCD1', value: 2 },
+        { dataElementValue: 2 },
+        { period: '20200103', organisationUnit: 'TO', dataElement: 'BCD1', value: 5 },
+        { dataElementValue: 5 },
+      ]),
+    );
   });
 
   it('can insert new rows before the relative row', () => {
@@ -132,14 +146,19 @@ describe('insertRows', () => {
         position: 'before',
       },
     ]);
-    expect(transform(MULTIPLE_ANALYTICS)).toEqual([
-      { dataElementValue: 4 },
-      { period: '20200101', organisationUnit: 'TO', dataElement: 'BCD1', value: 4 },
-      { dataElementValue: 2 },
-      { period: '20200102', organisationUnit: 'TO', dataElement: 'BCD1', value: 2 },
-      { dataElementValue: 5 },
-      { period: '20200103', organisationUnit: 'TO', dataElement: 'BCD1', value: 5 },
-    ]);
+    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toEqual(
+      TransformTable.fromRows(
+        [
+          { dataElementValue: 4 },
+          { period: '20200101', organisationUnit: 'TO', dataElement: 'BCD1', value: 4 },
+          { dataElementValue: 2 },
+          { period: '20200102', organisationUnit: 'TO', dataElement: 'BCD1', value: 2 },
+          { dataElementValue: 5 },
+          { period: '20200103', organisationUnit: 'TO', dataElement: 'BCD1', value: 5 },
+        ],
+        ['period', 'organisationUnit', 'dataElement', 'value', 'dataElementValue'],
+      ),
+    );
   });
 
   it('can insert new rows at the beginning of the list', () => {
@@ -152,14 +171,19 @@ describe('insertRows', () => {
         position: 'start',
       },
     ]);
-    expect(transform(MULTIPLE_ANALYTICS)).toEqual([
-      { dataElementValue: 4 },
-      { dataElementValue: 2 },
-      { dataElementValue: 5 },
-      { period: '20200101', organisationUnit: 'TO', dataElement: 'BCD1', value: 4 },
-      { period: '20200102', organisationUnit: 'TO', dataElement: 'BCD1', value: 2 },
-      { period: '20200103', organisationUnit: 'TO', dataElement: 'BCD1', value: 5 },
-    ]);
+    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toEqual(
+      TransformTable.fromRows(
+        [
+          { dataElementValue: 4 },
+          { dataElementValue: 2 },
+          { dataElementValue: 5 },
+          { period: '20200101', organisationUnit: 'TO', dataElement: 'BCD1', value: 4 },
+          { period: '20200102', organisationUnit: 'TO', dataElement: 'BCD1', value: 2 },
+          { period: '20200103', organisationUnit: 'TO', dataElement: 'BCD1', value: 5 },
+        ],
+        ['period', 'organisationUnit', 'dataElement', 'value', 'dataElementValue'],
+      ),
+    );
   });
 
   it('can insert specific new rows using a where clause', () => {
@@ -173,13 +197,15 @@ describe('insertRows', () => {
         where: "=not(eq($period, '20200101'))",
       },
     ]);
-    expect(transform(MULTIPLE_ANALYTICS)).toEqual([
-      { period: '20200101', organisationUnit: 'TO', dataElement: 'BCD1', value: 4 },
-      { period: '20200102', organisationUnit: 'TO', dataElement: 'BCD1', value: 2 },
-      { dataElementValue: 2 },
-      { period: '20200103', organisationUnit: 'TO', dataElement: 'BCD1', value: 5 },
-      { dataElementValue: 5 },
-    ]);
+    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toEqual(
+      TransformTable.fromRows([
+        { period: '20200101', organisationUnit: 'TO', dataElement: 'BCD1', value: 4 },
+        { period: '20200102', organisationUnit: 'TO', dataElement: 'BCD1', value: 2 },
+        { dataElementValue: 2 },
+        { period: '20200103', organisationUnit: 'TO', dataElement: 'BCD1', value: 5 },
+        { dataElementValue: 5 },
+      ]),
+    );
   });
 
   // USE CASES
@@ -193,12 +219,14 @@ describe('insertRows', () => {
         },
       },
     ]);
-    expect(transform(MULTIPLE_ANALYTICS)).toEqual([
-      { period: '20200101', organisationUnit: 'TO', dataElement: 'BCD1', value: 4 },
-      { period: '20200102', organisationUnit: 'TO', dataElement: 'BCD1', value: 2 },
-      { period: '20200103', organisationUnit: 'TO', dataElement: 'BCD1', value: 5 },
-      { Total: 11 },
-    ]);
+    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toEqual(
+      TransformTable.fromRows([
+        { period: '20200101', organisationUnit: 'TO', dataElement: 'BCD1', value: 4 },
+        { period: '20200102', organisationUnit: 'TO', dataElement: 'BCD1', value: 2 },
+        { period: '20200103', organisationUnit: 'TO', dataElement: 'BCD1', value: 5 },
+        { Total: 11 },
+      ]),
+    );
   });
 
   it('compare adjacent rows to insert between', () => {
@@ -214,24 +242,26 @@ describe('insertRows', () => {
         },
       },
     ]);
-    expect(transform(MERGEABLE_ANALYTICS)).toEqual([
-      { period: '20200101', organisationUnit: 'TO', BCD1: 4 },
-      { period: '20200102', organisationUnit: 'TO', BCD1: 2 },
-      { period: '20200103', organisationUnit: 'TO', BCD1: 5 },
-      { period: '20200101', organisationUnit: 'TO', BCD2: 11 },
-      { period: '20200102', organisationUnit: 'TO', BCD2: 1 },
-      { period: '20200103', organisationUnit: 'TO', BCD2: 0 },
+    expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toEqual(
+      TransformTable.fromRows([
+        { period: '20200101', organisationUnit: 'TO', BCD1: 4 },
+        { period: '20200102', organisationUnit: 'TO', BCD1: 2 },
+        { period: '20200103', organisationUnit: 'TO', BCD1: 5 },
+        { period: '20200101', organisationUnit: 'TO', BCD2: 11 },
+        { period: '20200102', organisationUnit: 'TO', BCD2: 1 },
+        { period: '20200103', organisationUnit: 'TO', BCD2: 0 },
 
-      { Total_BCD1: 11, Total_BCD2: 12 },
+        { Total_BCD1: 11, Total_BCD2: 12 },
 
-      { period: '20200101', organisationUnit: 'PG', BCD1: 7 },
-      { period: '20200102', organisationUnit: 'PG', BCD1: 8 },
-      { period: '20200103', organisationUnit: 'PG', BCD1: 2 },
-      { period: '20200101', organisationUnit: 'PG', BCD2: 13 },
-      { period: '20200102', organisationUnit: 'PG', BCD2: 99 },
-      { period: '20200103', organisationUnit: 'PG', BCD2: -1 },
+        { period: '20200101', organisationUnit: 'PG', BCD1: 7 },
+        { period: '20200102', organisationUnit: 'PG', BCD1: 8 },
+        { period: '20200103', organisationUnit: 'PG', BCD1: 2 },
+        { period: '20200101', organisationUnit: 'PG', BCD2: 13 },
+        { period: '20200102', organisationUnit: 'PG', BCD2: 99 },
+        { period: '20200103', organisationUnit: 'PG', BCD2: -1 },
 
-      { Total_BCD1: 17, Total_BCD2: 111 },
-    ]);
+        { Total_BCD1: 17, Total_BCD2: 111 },
+      ]),
+    );
   });
 });

--- a/packages/report-server/src/__tests__/reportBuilder/transform/mergeRows.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/transform/mergeRows.test.ts
@@ -30,7 +30,7 @@ describe('mergeRows', () => {
         groupBy: 'period',
       },
     ]);
-    expect(transform(TransformTable.fromRows(SINGLE_MERGEABLE_ANALYTICS))).toEqual(
+    expect(transform(TransformTable.fromRows(SINGLE_MERGEABLE_ANALYTICS))).toStrictEqual(
       TransformTable.fromRows([{ period: '20200101', BCD1: 4, BCD2: 4, BCD3: 4 }]),
     );
   });
@@ -40,15 +40,15 @@ describe('mergeRows', () => {
       {
         transform: 'mergeRows',
         using: {
-          organisationUnit: 'exclude',
-          period: 'exclude',
+          organisationUnit: 'first',
+          period: 'first',
           '*': 'sum',
         },
       },
     ]);
-    expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toEqual(
+    expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toStrictEqual(
       TransformTable.fromRows([
-        { period: undefined, organisationUnit: undefined, BCD1: 28, BCD2: 123 },
+        { period: '20200101', organisationUnit: 'TO', BCD1: 28, BCD2: 123 },
       ]),
     );
   });
@@ -61,7 +61,7 @@ describe('mergeRows', () => {
         using: 'last',
       },
     ]);
-    expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toEqual(
+    expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toStrictEqual(
       TransformTable.fromRows([
         { period: '20200103', organisationUnit: 'TO', BCD1: 5, BCD2: 0 },
         { period: '20200103', organisationUnit: 'PG', BCD1: 2, BCD2: -1 },
@@ -77,7 +77,7 @@ describe('mergeRows', () => {
         using: 'sum',
       },
     ]);
-    expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toEqual(
+    expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toStrictEqual(
       TransformTable.fromRows([
         { period: '20200101', organisationUnit: 'TO', BCD1: 4, BCD2: 11 },
         { period: '20200102', organisationUnit: 'TO', BCD1: 2, BCD2: 1 },
@@ -101,7 +101,7 @@ describe('mergeRows', () => {
         },
       },
     ]);
-    expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toEqual(
+    expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toStrictEqual(
       TransformTable.fromRows([
         { period: '20200103', organisationUnit: 'TO', BCD1: 11, BCD2: 0 },
         { period: '20200103', organisationUnit: 'PG', BCD1: 17, BCD2: -1 },
@@ -116,15 +116,15 @@ describe('mergeRows', () => {
           transform: 'mergeRows',
           groupBy: 'organisationUnit',
           using: {
-            period: 'exclude',
+            period: 'first',
             '*': 'sum',
           },
         },
       ]);
-      expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toEqual(
+      expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toStrictEqual(
         TransformTable.fromRows([
-          { period: undefined, organisationUnit: 'TO', BCD1: 11, BCD2: 12 },
-          { period: undefined, organisationUnit: 'PG', BCD1: 17, BCD2: 111 },
+          { period: '20200101', organisationUnit: 'TO', BCD1: 11, BCD2: 12 },
+          { period: '20200101', organisationUnit: 'PG', BCD1: 17, BCD2: 111 },
         ]),
       );
     });
@@ -135,7 +135,7 @@ describe('mergeRows', () => {
           transform: 'mergeRows',
           groupBy: 'organisationUnit',
           using: {
-            period: 'exclude',
+            period: 'first',
             '*': 'sum',
           },
         },
@@ -147,10 +147,10 @@ describe('mergeRows', () => {
             ...MERGEABLE_ANALYTICS_WITH_NULL_VALUES,
           ]),
         ),
-      ).toEqual(
+      ).toStrictEqual(
         TransformTable.fromRows([
-          { period: undefined, organisationUnit: 'TO', BCD1: 11, BCD2: 12 },
-          { period: undefined, organisationUnit: 'PG', BCD1: 17, BCD2: 111 },
+          { period: '20200101', organisationUnit: 'TO', BCD1: 11, BCD2: 12 },
+          { period: '20200101', organisationUnit: 'PG', BCD1: 17, BCD2: 111 },
         ]),
       );
     });
@@ -161,15 +161,15 @@ describe('mergeRows', () => {
           transform: 'mergeRows',
           groupBy: 'organisationUnit',
           using: {
-            period: 'exclude',
+            period: 'first',
             '*': 'average',
           },
         },
       ]);
-      expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toEqual(
+      expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toStrictEqual(
         TransformTable.fromRows([
-          { period: undefined, organisationUnit: 'TO', BCD1: 3.6666666666666665, BCD2: 4 },
-          { period: undefined, organisationUnit: 'PG', BCD1: 5.666666666666667, BCD2: 37 },
+          { period: '20200101', organisationUnit: 'TO', BCD1: 3.6666666666666665, BCD2: 4 },
+          { period: '20200101', organisationUnit: 'PG', BCD1: 5.666666666666667, BCD2: 37 },
         ]),
       );
     });
@@ -182,7 +182,7 @@ describe('mergeRows', () => {
           using: 'count',
         },
       ]);
-      expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toEqual(
+      expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toStrictEqual(
         TransformTable.fromRows([
           { period: '20200101', organisationUnit: 4, BCD1: 2, BCD2: 2 },
           { period: '20200102', organisationUnit: 4, BCD1: 2, BCD2: 2 },
@@ -199,7 +199,7 @@ describe('mergeRows', () => {
           using: 'max',
         },
       ]);
-      expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toEqual(
+      expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toStrictEqual(
         TransformTable.fromRows([
           { period: '20200103', organisationUnit: 'TO', BCD1: 5, BCD2: 11 },
           { period: '20200103', organisationUnit: 'PG', BCD1: 8, BCD2: 99 },
@@ -215,7 +215,7 @@ describe('mergeRows', () => {
           using: 'min',
         },
       ]);
-      expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toEqual(
+      expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toStrictEqual(
         TransformTable.fromRows([
           { period: '20200101', organisationUnit: 'PG', BCD1: 4, BCD2: 11 },
           { period: '20200102', organisationUnit: 'PG', BCD1: 2, BCD2: 1 },
@@ -239,7 +239,7 @@ describe('mergeRows', () => {
             ...MERGEABLE_ANALYTICS_WITH_NULL_VALUES,
           ]),
         ),
-      ).toEqual(
+      ).toStrictEqual(
         TransformTable.fromRows([
           { period: '20200101', organisationUnit: 'PG', BCD1: null, BCD2: null },
           { period: '20200102', organisationUnit: 'PG', BCD1: 2, BCD2: 1 },
@@ -256,7 +256,7 @@ describe('mergeRows', () => {
           using: 'unique',
         },
       ]);
-      expect(transform(TransformTable.fromRows(UNIQUE_MERGEABLE_ANALYTICS))).toEqual(
+      expect(transform(TransformTable.fromRows(UNIQUE_MERGEABLE_ANALYTICS))).toStrictEqual(
         TransformTable.fromRows([
           {
             period: 'NO_UNIQUE_VALUE',
@@ -282,12 +282,11 @@ describe('mergeRows', () => {
           using: 'exclude',
         },
       ]);
-      expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toEqual(
-        TransformTable.fromRows([
-          { period: '20200101', organisationUnit: undefined, BCD1: undefined, BCD2: undefined },
-          { period: '20200102', organisationUnit: undefined, BCD1: undefined, BCD2: undefined },
-          { period: '20200103', organisationUnit: undefined, BCD1: undefined, BCD2: undefined },
-        ]),
+      expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toStrictEqual(
+        TransformTable.fromRows(
+          [{ period: '20200101' }, { period: '20200102' }, { period: '20200103' }],
+          ['period', 'organisationUnit', 'BCD1', 'BCD2'], // excludes values, but keeps columns
+        ),
       );
     });
 
@@ -299,7 +298,7 @@ describe('mergeRows', () => {
           using: 'first',
         },
       ]);
-      expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toEqual(
+      expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toStrictEqual(
         TransformTable.fromRows([
           { period: '20200101', organisationUnit: 'TO', BCD1: 4, BCD2: 11 },
           { period: '20200101', organisationUnit: 'PG', BCD1: 7, BCD2: 13 },
@@ -315,7 +314,7 @@ describe('mergeRows', () => {
           using: 'last',
         },
       ]);
-      expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toEqual(
+      expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toStrictEqual(
         TransformTable.fromRows([
           { period: '20200101', organisationUnit: 'PG', BCD1: 7, BCD2: 13 },
           { period: '20200102', organisationUnit: 'PG', BCD1: 8, BCD2: 99 },
@@ -344,7 +343,7 @@ describe('mergeRows', () => {
             using: 'single',
           },
         ]);
-        expect(transform(TransformTable.fromRows(SINGLE_MERGEABLE_ANALYTICS))).toEqual(
+        expect(transform(TransformTable.fromRows(SINGLE_MERGEABLE_ANALYTICS))).toStrictEqual(
           TransformTable.fromRows([{ period: '20200101', BCD1: 4, BCD2: 4, BCD3: 4 }]),
         );
       });

--- a/packages/report-server/src/__tests__/reportBuilder/transform/mergeRows.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/transform/mergeRows.test.ts
@@ -9,7 +9,7 @@ import {
   MERGEABLE_ANALYTICS_WITH_NULL_VALUES,
   SINGLE_MERGEABLE_ANALYTICS,
 } from './transform.fixtures';
-import { buildTransform } from '../../../reportBuilder/transform';
+import { buildTransform, TransformTable } from '../../../reportBuilder/transform';
 
 describe('mergeRows', () => {
   it('throws error when mergeUsing contains an invalid merge strategy', () => {
@@ -30,9 +30,9 @@ describe('mergeRows', () => {
         groupBy: 'period',
       },
     ]);
-    expect(transform(SINGLE_MERGEABLE_ANALYTICS)).toEqual([
-      { period: '20200101', BCD1: 4, BCD2: 4, BCD3: 4 },
-    ]);
+    expect(transform(TransformTable.fromRows(SINGLE_MERGEABLE_ANALYTICS))).toEqual(
+      TransformTable.fromRows([{ period: '20200101', BCD1: 4, BCD2: 4, BCD3: 4 }]),
+    );
   });
 
   it('when no groupBy is specified, group to a single row', () => {
@@ -46,7 +46,11 @@ describe('mergeRows', () => {
         },
       },
     ]);
-    expect(transform(MERGEABLE_ANALYTICS)).toEqual([{ BCD1: 28, BCD2: 123 }]);
+    expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toEqual(
+      TransformTable.fromRows([
+        { period: undefined, organisationUnit: undefined, BCD1: 28, BCD2: 123 },
+      ]),
+    );
   });
 
   it('can group by a single field', () => {
@@ -57,10 +61,12 @@ describe('mergeRows', () => {
         using: 'last',
       },
     ]);
-    expect(transform(MERGEABLE_ANALYTICS)).toEqual([
-      { organisationUnit: 'TO', period: '20200103', BCD1: 5, BCD2: 0 },
-      { organisationUnit: 'PG', period: '20200103', BCD1: 2, BCD2: -1 },
-    ]);
+    expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toEqual(
+      TransformTable.fromRows([
+        { period: '20200103', organisationUnit: 'TO', BCD1: 5, BCD2: 0 },
+        { period: '20200103', organisationUnit: 'PG', BCD1: 2, BCD2: -1 },
+      ]),
+    );
   });
 
   it('can group by a multiple fields', () => {
@@ -71,14 +77,16 @@ describe('mergeRows', () => {
         using: 'sum',
       },
     ]);
-    expect(transform(MERGEABLE_ANALYTICS)).toEqual([
-      { organisationUnit: 'TO', period: '20200101', BCD1: 4, BCD2: 11 },
-      { organisationUnit: 'TO', period: '20200102', BCD1: 2, BCD2: 1 },
-      { organisationUnit: 'TO', period: '20200103', BCD1: 5, BCD2: 0 },
-      { organisationUnit: 'PG', period: '20200101', BCD1: 7, BCD2: 13 },
-      { organisationUnit: 'PG', period: '20200102', BCD1: 8, BCD2: 99 },
-      { organisationUnit: 'PG', period: '20200103', BCD1: 2, BCD2: -1 },
-    ]);
+    expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toEqual(
+      TransformTable.fromRows([
+        { period: '20200101', organisationUnit: 'TO', BCD1: 4, BCD2: 11 },
+        { period: '20200102', organisationUnit: 'TO', BCD1: 2, BCD2: 1 },
+        { period: '20200103', organisationUnit: 'TO', BCD1: 5, BCD2: 0 },
+        { period: '20200101', organisationUnit: 'PG', BCD1: 7, BCD2: 13 },
+        { period: '20200102', organisationUnit: 'PG', BCD1: 8, BCD2: 99 },
+        { period: '20200103', organisationUnit: 'PG', BCD1: 2, BCD2: -1 },
+      ]),
+    );
   });
 
   it('can perform different merge strategies on different fields', () => {
@@ -93,10 +101,12 @@ describe('mergeRows', () => {
         },
       },
     ]);
-    expect(transform(MERGEABLE_ANALYTICS)).toEqual([
-      { organisationUnit: 'TO', period: '20200103', BCD1: 11, BCD2: 0 },
-      { organisationUnit: 'PG', period: '20200103', BCD1: 17, BCD2: -1 },
-    ]);
+    expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toEqual(
+      TransformTable.fromRows([
+        { period: '20200103', organisationUnit: 'TO', BCD1: 11, BCD2: 0 },
+        { period: '20200103', organisationUnit: 'PG', BCD1: 17, BCD2: -1 },
+      ]),
+    );
   });
 
   describe('merge strategies', () => {
@@ -111,10 +121,12 @@ describe('mergeRows', () => {
           },
         },
       ]);
-      expect(transform(MERGEABLE_ANALYTICS)).toEqual([
-        { organisationUnit: 'TO', BCD1: 11, BCD2: 12 },
-        { organisationUnit: 'PG', BCD1: 17, BCD2: 111 },
-      ]);
+      expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toEqual(
+        TransformTable.fromRows([
+          { period: undefined, organisationUnit: 'TO', BCD1: 11, BCD2: 12 },
+          { period: undefined, organisationUnit: 'PG', BCD1: 17, BCD2: 111 },
+        ]),
+      );
     });
 
     it('sum -> exclude null values', () => {
@@ -128,10 +140,19 @@ describe('mergeRows', () => {
           },
         },
       ]);
-      expect(transform([...MERGEABLE_ANALYTICS, ...MERGEABLE_ANALYTICS_WITH_NULL_VALUES])).toEqual([
-        { organisationUnit: 'TO', BCD1: 11, BCD2: 12 },
-        { organisationUnit: 'PG', BCD1: 17, BCD2: 111 },
-      ]);
+      expect(
+        transform(
+          TransformTable.fromRows([
+            ...MERGEABLE_ANALYTICS,
+            ...MERGEABLE_ANALYTICS_WITH_NULL_VALUES,
+          ]),
+        ),
+      ).toEqual(
+        TransformTable.fromRows([
+          { period: undefined, organisationUnit: 'TO', BCD1: 11, BCD2: 12 },
+          { period: undefined, organisationUnit: 'PG', BCD1: 17, BCD2: 111 },
+        ]),
+      );
     });
 
     it('average', () => {
@@ -145,10 +166,12 @@ describe('mergeRows', () => {
           },
         },
       ]);
-      expect(transform(MERGEABLE_ANALYTICS)).toEqual([
-        { organisationUnit: 'TO', BCD1: 3.6666666666666665, BCD2: 4 },
-        { organisationUnit: 'PG', BCD1: 5.666666666666667, BCD2: 37 },
-      ]);
+      expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toEqual(
+        TransformTable.fromRows([
+          { period: undefined, organisationUnit: 'TO', BCD1: 3.6666666666666665, BCD2: 4 },
+          { period: undefined, organisationUnit: 'PG', BCD1: 5.666666666666667, BCD2: 37 },
+        ]),
+      );
     });
 
     it('count', () => {
@@ -159,11 +182,13 @@ describe('mergeRows', () => {
           using: 'count',
         },
       ]);
-      expect(transform(MERGEABLE_ANALYTICS)).toEqual([
-        { organisationUnit: 4, period: '20200101', BCD1: 2, BCD2: 2 },
-        { organisationUnit: 4, period: '20200102', BCD1: 2, BCD2: 2 },
-        { organisationUnit: 4, period: '20200103', BCD1: 2, BCD2: 2 },
-      ]);
+      expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toEqual(
+        TransformTable.fromRows([
+          { period: '20200101', organisationUnit: 4, BCD1: 2, BCD2: 2 },
+          { period: '20200102', organisationUnit: 4, BCD1: 2, BCD2: 2 },
+          { period: '20200103', organisationUnit: 4, BCD1: 2, BCD2: 2 },
+        ]),
+      );
     });
 
     it('max', () => {
@@ -174,10 +199,12 @@ describe('mergeRows', () => {
           using: 'max',
         },
       ]);
-      expect(transform(MERGEABLE_ANALYTICS)).toEqual([
-        { organisationUnit: 'TO', period: '20200103', BCD1: 5, BCD2: 11 },
-        { organisationUnit: 'PG', period: '20200103', BCD1: 8, BCD2: 99 },
-      ]);
+      expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toEqual(
+        TransformTable.fromRows([
+          { period: '20200103', organisationUnit: 'TO', BCD1: 5, BCD2: 11 },
+          { period: '20200103', organisationUnit: 'PG', BCD1: 8, BCD2: 99 },
+        ]),
+      );
     });
 
     it('min', () => {
@@ -188,11 +215,13 @@ describe('mergeRows', () => {
           using: 'min',
         },
       ]);
-      expect(transform(MERGEABLE_ANALYTICS)).toEqual([
-        { organisationUnit: 'PG', period: '20200101', BCD1: 4, BCD2: 11 },
-        { organisationUnit: 'PG', period: '20200102', BCD1: 2, BCD2: 1 },
-        { organisationUnit: 'PG', period: '20200103', BCD1: 2, BCD2: -1 },
-      ]);
+      expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toEqual(
+        TransformTable.fromRows([
+          { period: '20200101', organisationUnit: 'PG', BCD1: 4, BCD2: 11 },
+          { period: '20200102', organisationUnit: 'PG', BCD1: 2, BCD2: 1 },
+          { period: '20200103', organisationUnit: 'PG', BCD1: 2, BCD2: -1 },
+        ]),
+      );
     });
 
     it('min -> consider null as minimum', () => {
@@ -203,11 +232,20 @@ describe('mergeRows', () => {
           using: 'min',
         },
       ]);
-      expect(transform([...MERGEABLE_ANALYTICS, ...MERGEABLE_ANALYTICS_WITH_NULL_VALUES])).toEqual([
-        { organisationUnit: 'PG', period: '20200101', BCD1: null, BCD2: null },
-        { organisationUnit: 'PG', period: '20200102', BCD1: 2, BCD2: 1 },
-        { organisationUnit: 'PG', period: '20200103', BCD1: 2, BCD2: -1 },
-      ]);
+      expect(
+        transform(
+          TransformTable.fromRows([
+            ...MERGEABLE_ANALYTICS,
+            ...MERGEABLE_ANALYTICS_WITH_NULL_VALUES,
+          ]),
+        ),
+      ).toEqual(
+        TransformTable.fromRows([
+          { period: '20200101', organisationUnit: 'PG', BCD1: null, BCD2: null },
+          { period: '20200102', organisationUnit: 'PG', BCD1: 2, BCD2: 1 },
+          { period: '20200103', organisationUnit: 'PG', BCD1: 2, BCD2: -1 },
+        ]),
+      );
     });
 
     it('unique', () => {
@@ -218,20 +256,22 @@ describe('mergeRows', () => {
           using: 'unique',
         },
       ]);
-      expect(transform(UNIQUE_MERGEABLE_ANALYTICS)).toEqual([
-        {
-          organisationUnit: 'TO',
-          period: 'NO_UNIQUE_VALUE',
-          BCD1: 4,
-          BCD2: 'NO_UNIQUE_VALUE',
-        },
-        {
-          organisationUnit: 'PG',
-          period: 'NO_UNIQUE_VALUE',
-          BCD1: 'NO_UNIQUE_VALUE',
-          BCD2: 99,
-        },
-      ]);
+      expect(transform(TransformTable.fromRows(UNIQUE_MERGEABLE_ANALYTICS))).toEqual(
+        TransformTable.fromRows([
+          {
+            period: 'NO_UNIQUE_VALUE',
+            organisationUnit: 'TO',
+            BCD1: 4,
+            BCD2: 'NO_UNIQUE_VALUE',
+          },
+          {
+            period: 'NO_UNIQUE_VALUE',
+            organisationUnit: 'PG',
+            BCD1: 'NO_UNIQUE_VALUE',
+            BCD2: 99,
+          },
+        ]),
+      );
     });
 
     it('exclude', () => {
@@ -242,11 +282,13 @@ describe('mergeRows', () => {
           using: 'exclude',
         },
       ]);
-      expect(transform(MERGEABLE_ANALYTICS)).toEqual([
-        { period: '20200101' },
-        { period: '20200102' },
-        { period: '20200103' },
-      ]);
+      expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toEqual(
+        TransformTable.fromRows([
+          { period: '20200101', organisationUnit: undefined, BCD1: undefined, BCD2: undefined },
+          { period: '20200102', organisationUnit: undefined, BCD1: undefined, BCD2: undefined },
+          { period: '20200103', organisationUnit: undefined, BCD1: undefined, BCD2: undefined },
+        ]),
+      );
     });
 
     it('first', () => {
@@ -257,10 +299,12 @@ describe('mergeRows', () => {
           using: 'first',
         },
       ]);
-      expect(transform(MERGEABLE_ANALYTICS)).toEqual([
-        { organisationUnit: 'TO', period: '20200101', BCD1: 4, BCD2: 11 },
-        { organisationUnit: 'PG', period: '20200101', BCD1: 7, BCD2: 13 },
-      ]);
+      expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toEqual(
+        TransformTable.fromRows([
+          { period: '20200101', organisationUnit: 'TO', BCD1: 4, BCD2: 11 },
+          { period: '20200101', organisationUnit: 'PG', BCD1: 7, BCD2: 13 },
+        ]),
+      );
     });
 
     it('last', () => {
@@ -271,11 +315,13 @@ describe('mergeRows', () => {
           using: 'last',
         },
       ]);
-      expect(transform(MERGEABLE_ANALYTICS)).toEqual([
-        { organisationUnit: 'PG', period: '20200101', BCD1: 7, BCD2: 13 },
-        { organisationUnit: 'PG', period: '20200102', BCD1: 8, BCD2: 99 },
-        { organisationUnit: 'PG', period: '20200103', BCD1: 2, BCD2: -1 },
-      ]);
+      expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toEqual(
+        TransformTable.fromRows([
+          { period: '20200101', organisationUnit: 'PG', BCD1: 7, BCD2: 13 },
+          { period: '20200102', organisationUnit: 'PG', BCD1: 8, BCD2: 99 },
+          { period: '20200103', organisationUnit: 'PG', BCD1: 2, BCD2: -1 },
+        ]),
+      );
     });
 
     describe('single', () => {
@@ -287,7 +333,7 @@ describe('mergeRows', () => {
             using: 'single',
           },
         ]);
-        expect(() => transform(MERGEABLE_ANALYTICS)).toThrow();
+        expect(() => transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toThrow();
       });
 
       it('returns the value if a single value exists per group', () => {
@@ -298,9 +344,9 @@ describe('mergeRows', () => {
             using: 'single',
           },
         ]);
-        expect(transform(SINGLE_MERGEABLE_ANALYTICS)).toEqual([
-          { period: '20200101', BCD1: 4, BCD2: 4, BCD3: 4 },
-        ]);
+        expect(transform(TransformTable.fromRows(SINGLE_MERGEABLE_ANALYTICS))).toEqual(
+          TransformTable.fromRows([{ period: '20200101', BCD1: 4, BCD2: 4, BCD3: 4 }]),
+        );
       });
     });
   });

--- a/packages/report-server/src/__tests__/reportBuilder/transform/orderColumns.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/transform/orderColumns.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
+ */
+
+import { SINGLE_ANALYTIC, DATE_COLUMNS, PERIOD_COLUMNS } from './transform.fixtures';
+import { buildTransform, TransformTable } from '../../../reportBuilder/transform';
+
+describe('orderColumns', () => {
+  it('can re-order columns explicitly', () => {
+    const transform = buildTransform([
+      {
+        transform: 'orderColumns',
+        order: ['dataElement', 'value', 'period', 'organisationUnit'],
+      },
+    ]);
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+      TransformTable.fromRows([
+        { dataElement: 'BCD1', value: 4, period: '20200101', organisationUnit: 'TO' },
+      ]),
+    );
+  });
+
+  it('can re-order columns explicitly with a wildCard', () => {
+    const transform = buildTransform([
+      {
+        transform: 'orderColumns',
+        order: ['dataElement', '*', 'organisationUnit'],
+      },
+    ]);
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+      TransformTable.fromRows([
+        { dataElement: 'BCD1', period: '20200101', value: 4, organisationUnit: 'TO' },
+      ]),
+    );
+  });
+
+  it('ignores columns in the explicit order that do not exist in the table', () => {
+    const transform = buildTransform([
+      {
+        transform: 'orderColumns',
+        order: ['dataElement', 'BCD1', 'period', 'value', 'organisationUnit'],
+      },
+    ]);
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+      TransformTable.fromRows([
+        { dataElement: 'BCD1', period: '20200101', value: 4, organisationUnit: 'TO' },
+      ]),
+    );
+  });
+
+  it('defaults to appending columns to the end if they are not listed in the order', () => {
+    const transform = buildTransform([
+      {
+        transform: 'orderColumns',
+        order: ['dataElement', 'organisationUnit'],
+      },
+    ]);
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+      TransformTable.fromRows([
+        { dataElement: 'BCD1', organisationUnit: 'TO', period: '20200101', value: 4 },
+      ]),
+    );
+  });
+
+  describe('sortBy functions', () => {
+    it('throws error for unknown sortBy function', () => {
+      expect(() =>
+        buildTransform([
+          {
+            transform: 'orderColumns',
+            sortBy: 'not_a_real_sort_by_function',
+          },
+        ]),
+      ).toThrow('sortBy must be one of the following values:');
+    });
+
+    describe('alphabetic', () => {
+      it('can sort columns alphabetically', () => {
+        const transform = buildTransform([
+          {
+            transform: 'orderColumns',
+            sortBy: 'alphabetic',
+          },
+        ]);
+        expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+          TransformTable.fromRows([
+            { dataElement: 'BCD1', organisationUnit: 'TO', period: '20200101', value: 4 },
+          ]),
+        );
+      });
+    });
+
+    describe('date', () => {
+      it('can sort columns by date', () => {
+        const transform = buildTransform([
+          {
+            transform: 'orderColumns',
+            sortBy: 'date',
+          },
+        ]);
+        expect(transform(TransformTable.fromRows(DATE_COLUMNS))).toEqual(
+          TransformTable.fromRows([
+            {
+              'Q1 2021': 4,
+              '13th Jan 2022': 2,
+              '2nd Aug 2022': 1,
+              'Sep 2022': 3,
+              organisationUnit: 'Tonga',
+            },
+          ]),
+        );
+      });
+    });
+
+    describe('period', () => {
+      it('can sort columns by period', () => {
+        const transform = buildTransform([
+          {
+            transform: 'orderColumns',
+            sortBy: 'period',
+          },
+        ]);
+        expect(transform(TransformTable.fromRows(PERIOD_COLUMNS))).toEqual(
+          TransformTable.fromRows(
+            [
+              {
+                '2021Q1': 4,
+                '2022W03': 2,
+                '20220802': 1,
+                '202209': 3,
+                organisationUnit: 'Tonga',
+              },
+            ],
+            ['2021Q1', '2022W03', '20220802', '202209', 'organisationUnit'],
+          ),
+        );
+      });
+    });
+  });
+});

--- a/packages/report-server/src/__tests__/reportBuilder/transform/parser/functions.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/transform/parser/functions.test.ts
@@ -138,7 +138,7 @@ describe('functions', () => {
     describe('orgUnitAttribute()', () => {
       const context = {
         orgUnits: [
-          { id: '1234', code: 'FJ', name: 'Fiji', attributes: { x: 1 }},
+          { id: '1234', code: 'FJ', name: 'Fiji', attributes: { x: 1 } },
           { id: '5678', code: 'TO', name: 'Tonga', attributes: { y: 2 } },
         ],
       };

--- a/packages/report-server/src/__tests__/reportBuilder/transform/parser/parser.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/transform/parser/parser.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { PARSABLE_ANALYTICS } from '../transform.fixtures';
-import { buildTransform } from '../../../../reportBuilder/transform';
+import { buildTransform, TransformTable } from '../../../../reportBuilder/transform';
 
 describe('parser', () => {
   it('can do lookups', () => {
@@ -30,78 +30,81 @@ describe('parser', () => {
       ],
       { query: { animal: 'cat' } },
     );
-    expect(transform(PARSABLE_ANALYTICS)).toEqual([
-      {
-        variable: 4,
-        current: 4,
-        index: 1,
-        next: 2,
-        lastAll: 2,
-        sumAllPrevious: 4,
-        sumWhereMatchingOrgUnit: 11,
-        tableLength: 6,
-        requestParam: 'cat',
-      },
-      {
-        variable: 2,
-        current: 2,
-        index: 2,
-        previous: 4,
-        next: 5,
-        lastAll: 2,
-        sumAllPrevious: 6,
-        sumWhereMatchingOrgUnit: 11,
-        tableLength: 6,
-        requestParam: 'cat',
-      },
-      {
-        variable: 5,
-        current: 5,
-        index: 3,
-        previous: 2,
-        next: 7,
-        lastAll: 2,
-        sumAllPrevious: 11,
-        sumWhereMatchingOrgUnit: 11,
-        tableLength: 6,
-        requestParam: 'cat',
-      },
-      {
-        variable: 7,
-        current: 7,
-        index: 4,
-        previous: 5,
-        next: 8,
-        lastAll: 2,
-        sumAllPrevious: 18,
-        sumWhereMatchingOrgUnit: 17,
-        tableLength: 6,
-        requestParam: 'cat',
-      },
-      {
-        variable: 8,
-        current: 8,
-        index: 5,
-        previous: 7,
-        next: 2,
-        lastAll: 2,
-        sumAllPrevious: 26,
-        sumWhereMatchingOrgUnit: 17,
-        tableLength: 6,
-        requestParam: 'cat',
-      },
-      {
-        variable: 2,
-        current: 2,
-        index: 6,
-        previous: 8,
-        lastAll: 2,
-        sumAllPrevious: 28,
-        sumWhereMatchingOrgUnit: 17,
-        tableLength: 6,
-        requestParam: 'cat',
-      },
-    ]);
+    expect(transform(TransformTable.fromRows(PARSABLE_ANALYTICS))).toEqual(
+      TransformTable.fromRows([
+        {
+          variable: 4,
+          current: 4,
+          index: 1,
+          previous: undefined,
+          next: 2,
+          lastAll: 2,
+          sumAllPrevious: 4,
+          sumWhereMatchingOrgUnit: 11,
+          tableLength: 6,
+          requestParam: 'cat',
+        },
+        {
+          variable: 2,
+          current: 2,
+          index: 2,
+          previous: 4,
+          next: 5,
+          lastAll: 2,
+          sumAllPrevious: 6,
+          sumWhereMatchingOrgUnit: 11,
+          tableLength: 6,
+          requestParam: 'cat',
+        },
+        {
+          variable: 5,
+          current: 5,
+          index: 3,
+          previous: 2,
+          next: 7,
+          lastAll: 2,
+          sumAllPrevious: 11,
+          sumWhereMatchingOrgUnit: 11,
+          tableLength: 6,
+          requestParam: 'cat',
+        },
+        {
+          variable: 7,
+          current: 7,
+          index: 4,
+          previous: 5,
+          next: 8,
+          lastAll: 2,
+          sumAllPrevious: 18,
+          sumWhereMatchingOrgUnit: 17,
+          tableLength: 6,
+          requestParam: 'cat',
+        },
+        {
+          variable: 8,
+          current: 8,
+          index: 5,
+          previous: 7,
+          next: 2,
+          lastAll: 2,
+          sumAllPrevious: 26,
+          sumWhereMatchingOrgUnit: 17,
+          tableLength: 6,
+          requestParam: 'cat',
+        },
+        {
+          variable: 2,
+          current: 2,
+          index: 6,
+          previous: 8,
+          lastAll: 2,
+          sumAllPrevious: 28,
+          sumWhereMatchingOrgUnit: 17,
+          tableLength: 6,
+          requestParam: 'cat',
+        },
+      ]),
+    );
   });
 
   describe('in transforms', () => {
@@ -117,12 +120,14 @@ describe('parser', () => {
           where: "=eq($organisationUnit, 'TO')",
         },
       ]);
-      expect(transform(PARSABLE_ANALYTICS)).toEqual([
-        { BCD1: 11 },
-        { period: '20200101', organisationUnit: 'PG', BCD1: 7 },
-        { period: '20200102', organisationUnit: 'PG', BCD1: 8 },
-        { period: '20200103', organisationUnit: 'PG', BCD1: 2 },
-      ]);
+      expect(transform(TransformTable.fromRows(PARSABLE_ANALYTICS))).toEqual(
+        TransformTable.fromRows([
+          { period: undefined, organisationUnit: undefined, BCD1: 11 },
+          { period: '20200101', organisationUnit: 'PG', BCD1: 7 },
+          { period: '20200102', organisationUnit: 'PG', BCD1: 8 },
+          { period: '20200103', organisationUnit: 'PG', BCD1: 2 },
+        ]),
+      );
     });
 
     it('excludeRows supports parser lookups on where', () => {
@@ -133,12 +138,14 @@ describe('parser', () => {
             '=$BCD1 <= mean(where(f(@otherRow) = eq($organisationUnit, @otherRow.organisationUnit)).BCD1)',
         },
       ]);
-      expect(transform(PARSABLE_ANALYTICS)).toEqual([
-        { period: '20200101', organisationUnit: 'TO', BCD1: 4 },
-        { period: '20200103', organisationUnit: 'TO', BCD1: 5 },
-        { period: '20200101', organisationUnit: 'PG', BCD1: 7 },
-        { period: '20200102', organisationUnit: 'PG', BCD1: 8 },
-      ]);
+      expect(transform(TransformTable.fromRows(PARSABLE_ANALYTICS))).toEqual(
+        TransformTable.fromRows([
+          { period: '20200101', organisationUnit: 'TO', BCD1: 4 },
+          { period: '20200103', organisationUnit: 'TO', BCD1: 5 },
+          { period: '20200101', organisationUnit: 'PG', BCD1: 7 },
+          { period: '20200102', organisationUnit: 'PG', BCD1: 8 },
+        ]),
+      );
     });
 
     it('updateColumns supports parser lookups in column name and values', () => {
@@ -151,14 +158,16 @@ describe('parser', () => {
           exclude: ['organisationUnit', 'BCD1'],
         },
       ]);
-      expect(transform(PARSABLE_ANALYTICS)).toEqual([
-        { period: '20200101', TO: 4 },
-        { period: '20200102', TO: 2 },
-        { period: '20200103', TO: 5 },
-        { period: '20200101', PG: 7 },
-        { period: '20200102', PG: 8 },
-        { period: '20200103', PG: 2 },
-      ]);
+      expect(transform(TransformTable.fromRows(PARSABLE_ANALYTICS))).toEqual(
+        TransformTable.fromRows([
+          { period: '20200101', TO: 4 },
+          { period: '20200102', TO: 2 },
+          { period: '20200103', TO: 5 },
+          { period: '20200101', PG: 7 },
+          { period: '20200102', PG: 8 },
+          { period: '20200103', PG: 2 },
+        ]),
+      );
     });
 
     it('sortRows supports row parser lookups', () => {
@@ -168,14 +177,16 @@ describe('parser', () => {
           by: '=$BCD1',
         },
       ]);
-      expect(transform(PARSABLE_ANALYTICS)).toEqual([
-        { period: '20200102', organisationUnit: 'TO', BCD1: 2 },
-        { period: '20200103', organisationUnit: 'PG', BCD1: 2 },
-        { period: '20200101', organisationUnit: 'TO', BCD1: 4 },
-        { period: '20200103', organisationUnit: 'TO', BCD1: 5 },
-        { period: '20200101', organisationUnit: 'PG', BCD1: 7 },
-        { period: '20200102', organisationUnit: 'PG', BCD1: 8 },
-      ]);
+      expect(transform(TransformTable.fromRows(PARSABLE_ANALYTICS))).toEqual(
+        TransformTable.fromRows([
+          { period: '20200102', organisationUnit: 'TO', BCD1: 2 },
+          { period: '20200103', organisationUnit: 'PG', BCD1: 2 },
+          { period: '20200101', organisationUnit: 'TO', BCD1: 4 },
+          { period: '20200103', organisationUnit: 'TO', BCD1: 5 },
+          { period: '20200101', organisationUnit: 'PG', BCD1: 7 },
+          { period: '20200102', organisationUnit: 'PG', BCD1: 8 },
+        ]),
+      );
     });
   });
 });

--- a/packages/report-server/src/__tests__/reportBuilder/transform/parser/parser.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/transform/parser/parser.test.ts
@@ -30,80 +30,93 @@ describe('parser', () => {
       ],
       { query: { animal: 'cat' } },
     );
-    expect(transform(TransformTable.fromRows(PARSABLE_ANALYTICS))).toEqual(
-      TransformTable.fromRows([
-        {
-          variable: 4,
-          current: 4,
-          index: 1,
-          previous: undefined,
-          next: 2,
-          lastAll: 2,
-          sumAllPrevious: 4,
-          sumWhereMatchingOrgUnit: 11,
-          tableLength: 6,
-          requestParam: 'cat',
-        },
-        {
-          variable: 2,
-          current: 2,
-          index: 2,
-          previous: 4,
-          next: 5,
-          lastAll: 2,
-          sumAllPrevious: 6,
-          sumWhereMatchingOrgUnit: 11,
-          tableLength: 6,
-          requestParam: 'cat',
-        },
-        {
-          variable: 5,
-          current: 5,
-          index: 3,
-          previous: 2,
-          next: 7,
-          lastAll: 2,
-          sumAllPrevious: 11,
-          sumWhereMatchingOrgUnit: 11,
-          tableLength: 6,
-          requestParam: 'cat',
-        },
-        {
-          variable: 7,
-          current: 7,
-          index: 4,
-          previous: 5,
-          next: 8,
-          lastAll: 2,
-          sumAllPrevious: 18,
-          sumWhereMatchingOrgUnit: 17,
-          tableLength: 6,
-          requestParam: 'cat',
-        },
-        {
-          variable: 8,
-          current: 8,
-          index: 5,
-          previous: 7,
-          next: 2,
-          lastAll: 2,
-          sumAllPrevious: 26,
-          sumWhereMatchingOrgUnit: 17,
-          tableLength: 6,
-          requestParam: 'cat',
-        },
-        {
-          variable: 2,
-          current: 2,
-          index: 6,
-          previous: 8,
-          lastAll: 2,
-          sumAllPrevious: 28,
-          sumWhereMatchingOrgUnit: 17,
-          tableLength: 6,
-          requestParam: 'cat',
-        },
-      ]),
+    expect(transform(TransformTable.fromRows(PARSABLE_ANALYTICS))).toStrictEqual(
+      TransformTable.fromRows(
+        [
+          {
+            variable: 4,
+            current: 4,
+            index: 1,
+            next: 2,
+            lastAll: 2,
+            sumAllPrevious: 4,
+            sumWhereMatchingOrgUnit: 11,
+            tableLength: 6,
+            requestParam: 'cat',
+          },
+          {
+            variable: 2,
+            current: 2,
+            index: 2,
+            previous: 4,
+            next: 5,
+            lastAll: 2,
+            sumAllPrevious: 6,
+            sumWhereMatchingOrgUnit: 11,
+            tableLength: 6,
+            requestParam: 'cat',
+          },
+          {
+            variable: 5,
+            current: 5,
+            index: 3,
+            previous: 2,
+            next: 7,
+            lastAll: 2,
+            sumAllPrevious: 11,
+            sumWhereMatchingOrgUnit: 11,
+            tableLength: 6,
+            requestParam: 'cat',
+          },
+          {
+            variable: 7,
+            current: 7,
+            index: 4,
+            previous: 5,
+            next: 8,
+            lastAll: 2,
+            sumAllPrevious: 18,
+            sumWhereMatchingOrgUnit: 17,
+            tableLength: 6,
+            requestParam: 'cat',
+          },
+          {
+            variable: 8,
+            current: 8,
+            index: 5,
+            previous: 7,
+            next: 2,
+            lastAll: 2,
+            sumAllPrevious: 26,
+            sumWhereMatchingOrgUnit: 17,
+            tableLength: 6,
+            requestParam: 'cat',
+          },
+          {
+            variable: 2,
+            current: 2,
+            index: 6,
+            previous: 8,
+            lastAll: 2,
+            sumAllPrevious: 28,
+            sumWhereMatchingOrgUnit: 17,
+            tableLength: 6,
+            requestParam: 'cat',
+          },
+        ],
+        [
+          'variable',
+          'current',
+          'index',
+          'previous',
+          'next',
+          'lastAll',
+          'sumAllPrevious',
+          'sumWhereMatchingOrgUnit',
+          'tableLength',
+          'requestParam',
+        ],
+      ),
     );
   });
 
@@ -120,13 +133,16 @@ describe('parser', () => {
           where: "=eq($organisationUnit, 'TO')",
         },
       ]);
-      expect(transform(TransformTable.fromRows(PARSABLE_ANALYTICS))).toEqual(
-        TransformTable.fromRows([
-          { period: undefined, organisationUnit: undefined, BCD1: 11 },
-          { period: '20200101', organisationUnit: 'PG', BCD1: 7 },
-          { period: '20200102', organisationUnit: 'PG', BCD1: 8 },
-          { period: '20200103', organisationUnit: 'PG', BCD1: 2 },
-        ]),
+      expect(transform(TransformTable.fromRows(PARSABLE_ANALYTICS))).toStrictEqual(
+        TransformTable.fromRows(
+          [
+            { BCD1: 11 },
+            { period: '20200101', organisationUnit: 'PG', BCD1: 7 },
+            { period: '20200102', organisationUnit: 'PG', BCD1: 8 },
+            { period: '20200103', organisationUnit: 'PG', BCD1: 2 },
+          ],
+          ['period', 'organisationUnit', 'BCD1'],
+        ),
       );
     });
 
@@ -138,7 +154,7 @@ describe('parser', () => {
             '=$BCD1 <= mean(where(f(@otherRow) = eq($organisationUnit, @otherRow.organisationUnit)).BCD1)',
         },
       ]);
-      expect(transform(TransformTable.fromRows(PARSABLE_ANALYTICS))).toEqual(
+      expect(transform(TransformTable.fromRows(PARSABLE_ANALYTICS))).toStrictEqual(
         TransformTable.fromRows([
           { period: '20200101', organisationUnit: 'TO', BCD1: 4 },
           { period: '20200103', organisationUnit: 'TO', BCD1: 5 },
@@ -158,7 +174,7 @@ describe('parser', () => {
           exclude: ['organisationUnit', 'BCD1'],
         },
       ]);
-      expect(transform(TransformTable.fromRows(PARSABLE_ANALYTICS))).toEqual(
+      expect(transform(TransformTable.fromRows(PARSABLE_ANALYTICS))).toStrictEqual(
         TransformTable.fromRows([
           { period: '20200101', TO: 4 },
           { period: '20200102', TO: 2 },
@@ -177,7 +193,7 @@ describe('parser', () => {
           by: '=$BCD1',
         },
       ]);
-      expect(transform(TransformTable.fromRows(PARSABLE_ANALYTICS))).toEqual(
+      expect(transform(TransformTable.fromRows(PARSABLE_ANALYTICS))).toStrictEqual(
         TransformTable.fromRows([
           { period: '20200102', organisationUnit: 'TO', BCD1: 2 },
           { period: '20200103', organisationUnit: 'PG', BCD1: 2 },

--- a/packages/report-server/src/__tests__/reportBuilder/transform/sortRows.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/transform/sortRows.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { SORTABLE_ANALYTICS } from './transform.fixtures';
-import { buildTransform } from '../../../reportBuilder/transform';
+import { buildTransform, TransformTable } from '../../../reportBuilder/transform';
 
 describe('sortRows', () => {
   it('throws an error if by is not specified', () => {
@@ -25,20 +25,22 @@ describe('sortRows', () => {
         by: 'period',
       },
     ]);
-    expect(transform(SORTABLE_ANALYTICS)).toEqual([
-      { period: '20200101', organisationUnit: 'TO', BCD1: 4 },
-      { period: '20200101', organisationUnit: 'TO', BCD1: 11 },
-      { period: '20200101', organisationUnit: 'PG', BCD1: 7 },
-      { period: '20200101', organisationUnit: 'PG', BCD1: 13 },
-      { period: '20200102', organisationUnit: 'TO', BCD1: 2 },
-      { period: '20200102', organisationUnit: 'TO', BCD1: 1 },
-      { period: '20200102', organisationUnit: 'PG', BCD1: 8 },
-      { period: '20200102', organisationUnit: 'PG', BCD1: 99 },
-      { period: '20200103', organisationUnit: 'TO', BCD1: 5 },
-      { period: '20200103', organisationUnit: 'TO', BCD1: 0 },
-      { period: '20200103', organisationUnit: 'PG', BCD1: 2 },
-      { period: '20200103', organisationUnit: 'PG', BCD1: -1 },
-    ]);
+    expect(transform(TransformTable.fromRows(SORTABLE_ANALYTICS))).toEqual(
+      TransformTable.fromRows([
+        { period: '20200101', organisationUnit: 'TO', BCD1: 4 },
+        { period: '20200101', organisationUnit: 'TO', BCD1: 11 },
+        { period: '20200101', organisationUnit: 'PG', BCD1: 7 },
+        { period: '20200101', organisationUnit: 'PG', BCD1: 13 },
+        { period: '20200102', organisationUnit: 'TO', BCD1: 2 },
+        { period: '20200102', organisationUnit: 'TO', BCD1: 1 },
+        { period: '20200102', organisationUnit: 'PG', BCD1: 8 },
+        { period: '20200102', organisationUnit: 'PG', BCD1: 99 },
+        { period: '20200103', organisationUnit: 'TO', BCD1: 5 },
+        { period: '20200103', organisationUnit: 'TO', BCD1: 0 },
+        { period: '20200103', organisationUnit: 'PG', BCD1: 2 },
+        { period: '20200103', organisationUnit: 'PG', BCD1: -1 },
+      ]),
+    );
   });
 
   it('can reverse sort by a column', () => {
@@ -49,20 +51,22 @@ describe('sortRows', () => {
         direction: 'desc',
       },
     ]);
-    expect(transform(SORTABLE_ANALYTICS)).toEqual([
-      { period: '20200103', organisationUnit: 'TO', BCD1: 5 },
-      { period: '20200103', organisationUnit: 'TO', BCD1: 0 },
-      { period: '20200103', organisationUnit: 'PG', BCD1: 2 },
-      { period: '20200103', organisationUnit: 'PG', BCD1: -1 },
-      { period: '20200102', organisationUnit: 'TO', BCD1: 2 },
-      { period: '20200102', organisationUnit: 'TO', BCD1: 1 },
-      { period: '20200102', organisationUnit: 'PG', BCD1: 8 },
-      { period: '20200102', organisationUnit: 'PG', BCD1: 99 },
-      { period: '20200101', organisationUnit: 'TO', BCD1: 4 },
-      { period: '20200101', organisationUnit: 'TO', BCD1: 11 },
-      { period: '20200101', organisationUnit: 'PG', BCD1: 7 },
-      { period: '20200101', organisationUnit: 'PG', BCD1: 13 },
-    ]);
+    expect(transform(TransformTable.fromRows(SORTABLE_ANALYTICS))).toEqual(
+      TransformTable.fromRows([
+        { period: '20200103', organisationUnit: 'TO', BCD1: 5 },
+        { period: '20200103', organisationUnit: 'TO', BCD1: 0 },
+        { period: '20200103', organisationUnit: 'PG', BCD1: 2 },
+        { period: '20200103', organisationUnit: 'PG', BCD1: -1 },
+        { period: '20200102', organisationUnit: 'TO', BCD1: 2 },
+        { period: '20200102', organisationUnit: 'TO', BCD1: 1 },
+        { period: '20200102', organisationUnit: 'PG', BCD1: 8 },
+        { period: '20200102', organisationUnit: 'PG', BCD1: 99 },
+        { period: '20200101', organisationUnit: 'TO', BCD1: 4 },
+        { period: '20200101', organisationUnit: 'TO', BCD1: 11 },
+        { period: '20200101', organisationUnit: 'PG', BCD1: 7 },
+        { period: '20200101', organisationUnit: 'PG', BCD1: 13 },
+      ]),
+    );
   });
 
   it('can sort by multiple columns', () => {
@@ -72,20 +76,22 @@ describe('sortRows', () => {
         by: ['period', 'organisationUnit'],
       },
     ]);
-    expect(transform(SORTABLE_ANALYTICS)).toEqual([
-      { period: '20200101', organisationUnit: 'PG', BCD1: 7 },
-      { period: '20200101', organisationUnit: 'PG', BCD1: 13 },
-      { period: '20200101', organisationUnit: 'TO', BCD1: 4 },
-      { period: '20200101', organisationUnit: 'TO', BCD1: 11 },
-      { period: '20200102', organisationUnit: 'PG', BCD1: 8 },
-      { period: '20200102', organisationUnit: 'PG', BCD1: 99 },
-      { period: '20200102', organisationUnit: 'TO', BCD1: 2 },
-      { period: '20200102', organisationUnit: 'TO', BCD1: 1 },
-      { period: '20200103', organisationUnit: 'PG', BCD1: 2 },
-      { period: '20200103', organisationUnit: 'PG', BCD1: -1 },
-      { period: '20200103', organisationUnit: 'TO', BCD1: 5 },
-      { period: '20200103', organisationUnit: 'TO', BCD1: 0 },
-    ]);
+    expect(transform(TransformTable.fromRows(SORTABLE_ANALYTICS))).toEqual(
+      TransformTable.fromRows([
+        { period: '20200101', organisationUnit: 'PG', BCD1: 7 },
+        { period: '20200101', organisationUnit: 'PG', BCD1: 13 },
+        { period: '20200101', organisationUnit: 'TO', BCD1: 4 },
+        { period: '20200101', organisationUnit: 'TO', BCD1: 11 },
+        { period: '20200102', organisationUnit: 'PG', BCD1: 8 },
+        { period: '20200102', organisationUnit: 'PG', BCD1: 99 },
+        { period: '20200102', organisationUnit: 'TO', BCD1: 2 },
+        { period: '20200102', organisationUnit: 'TO', BCD1: 1 },
+        { period: '20200103', organisationUnit: 'PG', BCD1: 2 },
+        { period: '20200103', organisationUnit: 'PG', BCD1: -1 },
+        { period: '20200103', organisationUnit: 'TO', BCD1: 5 },
+        { period: '20200103', organisationUnit: 'TO', BCD1: 0 },
+      ]),
+    );
   });
 
   it('can sort by different directions per column', () => {
@@ -96,20 +102,22 @@ describe('sortRows', () => {
         direction: ['asc', 'desc'],
       },
     ]);
-    expect(transform(SORTABLE_ANALYTICS)).toEqual([
-      { period: '20200101', organisationUnit: 'PG', BCD1: 13 },
-      { period: '20200101', organisationUnit: 'TO', BCD1: 11 },
-      { period: '20200101', organisationUnit: 'PG', BCD1: 7 },
-      { period: '20200101', organisationUnit: 'TO', BCD1: 4 },
-      { period: '20200102', organisationUnit: 'PG', BCD1: 99 },
-      { period: '20200102', organisationUnit: 'PG', BCD1: 8 },
-      { period: '20200102', organisationUnit: 'TO', BCD1: 2 },
-      { period: '20200102', organisationUnit: 'TO', BCD1: 1 },
-      { period: '20200103', organisationUnit: 'TO', BCD1: 5 },
-      { period: '20200103', organisationUnit: 'PG', BCD1: 2 },
-      { period: '20200103', organisationUnit: 'TO', BCD1: 0 },
-      { period: '20200103', organisationUnit: 'PG', BCD1: -1 },
-    ]);
+    expect(transform(TransformTable.fromRows(SORTABLE_ANALYTICS))).toEqual(
+      TransformTable.fromRows([
+        { period: '20200101', organisationUnit: 'PG', BCD1: 13 },
+        { period: '20200101', organisationUnit: 'TO', BCD1: 11 },
+        { period: '20200101', organisationUnit: 'PG', BCD1: 7 },
+        { period: '20200101', organisationUnit: 'TO', BCD1: 4 },
+        { period: '20200102', organisationUnit: 'PG', BCD1: 99 },
+        { period: '20200102', organisationUnit: 'PG', BCD1: 8 },
+        { period: '20200102', organisationUnit: 'TO', BCD1: 2 },
+        { period: '20200102', organisationUnit: 'TO', BCD1: 1 },
+        { period: '20200103', organisationUnit: 'TO', BCD1: 5 },
+        { period: '20200103', organisationUnit: 'PG', BCD1: 2 },
+        { period: '20200103', organisationUnit: 'TO', BCD1: 0 },
+        { period: '20200103', organisationUnit: 'PG', BCD1: -1 },
+      ]),
+    );
   });
 
   it('can sort by expressions', () => {
@@ -119,19 +127,21 @@ describe('sortRows', () => {
         by: '=$BCD1 * $BCD1',
       },
     ]);
-    expect(transform(SORTABLE_ANALYTICS)).toEqual([
-      { period: '20200103', organisationUnit: 'TO', BCD1: 0 },
-      { period: '20200102', organisationUnit: 'TO', BCD1: 1 },
-      { period: '20200103', organisationUnit: 'PG', BCD1: -1 },
-      { period: '20200102', organisationUnit: 'TO', BCD1: 2 },
-      { period: '20200103', organisationUnit: 'PG', BCD1: 2 },
-      { period: '20200101', organisationUnit: 'TO', BCD1: 4 },
-      { period: '20200103', organisationUnit: 'TO', BCD1: 5 },
-      { period: '20200101', organisationUnit: 'PG', BCD1: 7 },
-      { period: '20200102', organisationUnit: 'PG', BCD1: 8 },
-      { period: '20200101', organisationUnit: 'TO', BCD1: 11 },
-      { period: '20200101', organisationUnit: 'PG', BCD1: 13 },
-      { period: '20200102', organisationUnit: 'PG', BCD1: 99 },
-    ]);
+    expect(transform(TransformTable.fromRows(SORTABLE_ANALYTICS))).toEqual(
+      TransformTable.fromRows([
+        { period: '20200103', organisationUnit: 'TO', BCD1: 0 },
+        { period: '20200102', organisationUnit: 'TO', BCD1: 1 },
+        { period: '20200103', organisationUnit: 'PG', BCD1: -1 },
+        { period: '20200102', organisationUnit: 'TO', BCD1: 2 },
+        { period: '20200103', organisationUnit: 'PG', BCD1: 2 },
+        { period: '20200101', organisationUnit: 'TO', BCD1: 4 },
+        { period: '20200103', organisationUnit: 'TO', BCD1: 5 },
+        { period: '20200101', organisationUnit: 'PG', BCD1: 7 },
+        { period: '20200102', organisationUnit: 'PG', BCD1: 8 },
+        { period: '20200101', organisationUnit: 'TO', BCD1: 11 },
+        { period: '20200101', organisationUnit: 'PG', BCD1: 13 },
+        { period: '20200102', organisationUnit: 'PG', BCD1: 99 },
+      ]),
+    );
   });
 });

--- a/packages/report-server/src/__tests__/reportBuilder/transform/sortRows.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/transform/sortRows.test.ts
@@ -25,7 +25,7 @@ describe('sortRows', () => {
         by: 'period',
       },
     ]);
-    expect(transform(TransformTable.fromRows(SORTABLE_ANALYTICS))).toEqual(
+    expect(transform(TransformTable.fromRows(SORTABLE_ANALYTICS))).toStrictEqual(
       TransformTable.fromRows([
         { period: '20200101', organisationUnit: 'TO', BCD1: 4 },
         { period: '20200101', organisationUnit: 'TO', BCD1: 11 },
@@ -51,7 +51,7 @@ describe('sortRows', () => {
         direction: 'desc',
       },
     ]);
-    expect(transform(TransformTable.fromRows(SORTABLE_ANALYTICS))).toEqual(
+    expect(transform(TransformTable.fromRows(SORTABLE_ANALYTICS))).toStrictEqual(
       TransformTable.fromRows([
         { period: '20200103', organisationUnit: 'TO', BCD1: 5 },
         { period: '20200103', organisationUnit: 'TO', BCD1: 0 },
@@ -76,7 +76,7 @@ describe('sortRows', () => {
         by: ['period', 'organisationUnit'],
       },
     ]);
-    expect(transform(TransformTable.fromRows(SORTABLE_ANALYTICS))).toEqual(
+    expect(transform(TransformTable.fromRows(SORTABLE_ANALYTICS))).toStrictEqual(
       TransformTable.fromRows([
         { period: '20200101', organisationUnit: 'PG', BCD1: 7 },
         { period: '20200101', organisationUnit: 'PG', BCD1: 13 },
@@ -102,7 +102,7 @@ describe('sortRows', () => {
         direction: ['asc', 'desc'],
       },
     ]);
-    expect(transform(TransformTable.fromRows(SORTABLE_ANALYTICS))).toEqual(
+    expect(transform(TransformTable.fromRows(SORTABLE_ANALYTICS))).toStrictEqual(
       TransformTable.fromRows([
         { period: '20200101', organisationUnit: 'PG', BCD1: 13 },
         { period: '20200101', organisationUnit: 'TO', BCD1: 11 },
@@ -127,7 +127,7 @@ describe('sortRows', () => {
         by: '=$BCD1 * $BCD1',
       },
     ]);
-    expect(transform(TransformTable.fromRows(SORTABLE_ANALYTICS))).toEqual(
+    expect(transform(TransformTable.fromRows(SORTABLE_ANALYTICS))).toStrictEqual(
       TransformTable.fromRows([
         { period: '20200103', organisationUnit: 'TO', BCD1: 0 },
         { period: '20200102', organisationUnit: 'TO', BCD1: 1 },

--- a/packages/report-server/src/__tests__/reportBuilder/transform/table/TransformTable.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/transform/table/TransformTable.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import { TransformTable } from '../../../../reportBuilder/transform';
+
+const TEST_TABLE = new TransformTable(
+  ['animal', 'name', 'age'],
+  [
+    { animal: 'cat', name: 'Mr. Meow', age: 7 },
+    { animal: 'dog', name: 'Wooferton Barkly', age: 5 },
+    { animal: 'fish', name: 'Bubbles', age: 50000 },
+  ],
+);
+
+describe('TransformTable', () => {
+  describe('insertRows', () => {
+    it('throws an error if index is out of bounds', () => {
+      const row = { animal: 'wolf', name: 'Howl', age: 9 };
+      const insertRowOutOfRange = () =>
+        TEST_TABLE.insertRows([
+          {
+            row,
+            index: TEST_TABLE.length() + 1,
+          },
+        ]);
+
+      const insertRowAtNegativeIndex = () => TEST_TABLE.insertRows([{ row, index: -1 }]);
+
+      expect(insertRowOutOfRange).toThrow(`Error inserting row`);
+      expect(insertRowAtNegativeIndex).toThrow('Error inserting row');
+    });
+
+    it('returns a table with the new row inserted', () => {
+      const row = { animal: 'wolf', name: 'Howl', age: 9 };
+      const index = 0;
+      const newTable = TEST_TABLE.insertRows([{ row, index }]);
+
+      expect(newTable).toEqual(
+        new TransformTable(TEST_TABLE.getColumns(), [row, ...TEST_TABLE.getRows()]),
+      );
+    });
+
+    it('inserts at the end of the table by default', () => {
+      const row = { animal: 'wolf', name: 'Howl', age: 9 };
+      const newTable = TEST_TABLE.insertRows([{ row }]);
+
+      expect(newTable).toEqual(
+        new TransformTable(TEST_TABLE.getColumns(), [...TEST_TABLE.getRows(), row]),
+      );
+    });
+
+    it('can insert at any index in the table', () => {
+      const columnNames = TEST_TABLE.getColumns();
+      const row = { animal: 'wolf', name: 'Howl', age: 9 };
+      const indexToInsertAt = 2;
+      const newTable = TEST_TABLE.insertRows([{ row, index: indexToInsertAt }]);
+
+      expect(newTable).toEqual(
+        new TransformTable(columnNames, [
+          ...TEST_TABLE.getRows().filter((_, index) => index < indexToInsertAt),
+          row,
+          ...TEST_TABLE.getRows().filter((_, index) => index >= indexToInsertAt),
+        ]),
+      );
+    });
+
+    it('can insert with a different column order, and preserve the original column order', () => {
+      const columnNames = TEST_TABLE.getColumns();
+      const row = { age: 9, name: 'Howl', animal: 'wolf' };
+      const newTable = TEST_TABLE.insertRows([
+        {
+          row,
+        },
+      ]);
+
+      expect(newTable).toEqual(
+        new TransformTable(columnNames, [
+          ...TEST_TABLE.getRows(),
+          {
+            animal: row.animal,
+            name: row.name,
+            age: row.age,
+          },
+        ]),
+      );
+    });
+
+    it('can insert a row with only partial columns', () => {
+      const columnNames = TEST_TABLE.getColumns();
+      const row = { animal: 'wolf', age: 9 };
+      const newTable = TEST_TABLE.insertRows([
+        {
+          row,
+        },
+      ]);
+
+      expect(newTable).toEqual(
+        new TransformTable(columnNames, [
+          ...TEST_TABLE.getRows(),
+          { animal: row.animal, name: undefined, age: row.age },
+        ]),
+      );
+    });
+
+    it('can insert a row with new columns in it, and those columns will be added to the table', () => {
+      const row = { animal: 'wolf', favourite_food: 'banana', favourite_place: 'cave' };
+      const newTable = TEST_TABLE.insertRows([{ row }]);
+
+      expect(newTable).toEqual(
+        new TransformTable(
+          [...TEST_TABLE.getColumns(), 'favourite_food', 'favourite_place'],
+          [...TEST_TABLE.getRows(), row],
+        ),
+      );
+    });
+  });
+
+  describe('upsertColumn', () => {
+    it('throws an error if incorrect column length is given', () => {
+      const upsertColumnTooShort = () =>
+        TEST_TABLE.upsertColumns([
+          { columnName: 'too_short', values: new Array(TEST_TABLE.length() - 1).fill(undefined) },
+        ]);
+
+      const upsertColumnTooLong = () =>
+        TEST_TABLE.upsertColumns([
+          { columnName: 'too_long', values: new Array(TEST_TABLE.length() + 1).fill(undefined) },
+        ]);
+
+      expect(upsertColumnTooShort).toThrow(`Error upserting column`);
+      expect(upsertColumnTooLong).toThrow('Error upserting column');
+    });
+
+    it('can insert a new column', () => {
+      const columnName = 'favourite_food';
+      const values = ['butter', 'bones', 'bitcoin'];
+      const newTable = TEST_TABLE.upsertColumns([{ columnName, values }]);
+
+      expect(newTable).toEqual(
+        new TransformTable(
+          [...TEST_TABLE.getColumns(), columnName],
+          TEST_TABLE.getRows().map((row, index) => ({ ...row, favourite_food: values[index] })),
+        ),
+      );
+    });
+
+    it('can overwrite an existing column', () => {
+      const columnName = 'age';
+      const values = ['butter', 'bones', 'bitcoin'];
+      const newTable = TEST_TABLE.upsertColumns([
+        {
+          columnName,
+          values,
+        },
+      ]);
+
+      expect(newTable).toEqual(
+        new TransformTable(
+          TEST_TABLE.getColumns(),
+          TEST_TABLE.getRows().map((row, index) => ({ ...row, [columnName]: values[index] })),
+        ),
+      );
+    });
+  });
+
+  describe('dropRows', () => {
+    it('can drop multiple rows', () => {
+      const rowsToDrop = [1, 3];
+      const newTable = TEST_TABLE.dropRows(rowsToDrop);
+
+      expect(newTable).toEqual(
+        new TransformTable(
+          TEST_TABLE.getColumns(),
+          TEST_TABLE.getRows().filter((_, index) => !rowsToDrop.includes(index)),
+        ),
+      );
+    });
+
+    it('can handle index out of range gracefully', () => {
+      const rowsToDrop = [-1, 1, 5];
+      const newTable = TEST_TABLE.dropRows(rowsToDrop);
+
+      expect(newTable).toEqual(
+        new TransformTable(
+          TEST_TABLE.getColumns(),
+          TEST_TABLE.getRows().filter((_, index) => !rowsToDrop.includes(index)),
+        ),
+      );
+    });
+
+    it('can drop in any order', () => {
+      const rowsToDrop = [2, 1];
+      const newTable = TEST_TABLE.dropRows(rowsToDrop);
+
+      expect(newTable).toEqual(
+        new TransformTable(
+          TEST_TABLE.getColumns(),
+          TEST_TABLE.getRows().filter((_, index) => !rowsToDrop.includes(index)),
+        ),
+      );
+    });
+  });
+
+  describe('dropColumns', () => {
+    it('can drop columns', () => {
+      const columnsToDrop = ['name', 'age'];
+      const newTable = TEST_TABLE.dropColumns(columnsToDrop);
+
+      expect(newTable).toEqual(
+        new TransformTable(
+          TEST_TABLE.getColumns().filter(columnName => !columnsToDrop.includes(columnName)),
+          TEST_TABLE.getRows().map(row =>
+            Object.fromEntries(
+              Object.entries(row).filter(([columnName]) => !columnsToDrop.includes(columnName)),
+            ),
+          ),
+        ),
+      );
+    });
+
+    it('can handle unknown columns gracefully', () => {
+      const newTable = TEST_TABLE.dropColumns(['not a real column']);
+
+      expect(newTable).toEqual(TEST_TABLE);
+    });
+  });
+});

--- a/packages/report-server/src/__tests__/reportBuilder/transform/transform.fixtures.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/transform/transform.fixtures.ts
@@ -129,3 +129,23 @@ export const PARSABLE_ANALYTICS = [
   { period: '20200102', organisationUnit: 'PG', BCD1: 8 },
   { period: '20200103', organisationUnit: 'PG', BCD1: 2 },
 ];
+
+export const DATE_COLUMNS = [
+  {
+    organisationUnit: 'Tonga',
+    '2nd Aug 2022': 1,
+    '13th Jan 2022': 2,
+    'Sep 2022': 3,
+    'Q1 2021': 4,
+  },
+];
+
+export const PERIOD_COLUMNS = [
+  {
+    organisationUnit: 'Tonga',
+    '20220802': 1,
+    '2022W03': 2,
+    '202209': 3,
+    '2021Q1': 4,
+  },
+];

--- a/packages/report-server/src/__tests__/reportBuilder/transform/transform.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/transform/transform.test.ts
@@ -42,7 +42,7 @@ describe('transform', () => {
         exclude: '*',
       },
     ]);
-    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toEqual(
+    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toStrictEqual(
       TransformTable.fromRows([{ Total: 11 }]),
     );
   });
@@ -74,7 +74,7 @@ describe('transform', () => {
         exclude: '*',
       },
     ]);
-    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toEqual(
+    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toStrictEqual(
       TransformTable.fromRows([{ Total: 11 }]),
     );
   });

--- a/packages/report-server/src/__tests__/reportBuilder/transform/transform.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/transform/transform.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { MULTIPLE_ANALYTICS } from './transform.fixtures';
-import { buildTransform } from '../../../reportBuilder/transform';
+import { buildTransform, TransformTable } from '../../../reportBuilder/transform';
 
 describe('transform', () => {
   it('throws an error for an unknown transform', () => {
@@ -42,7 +42,9 @@ describe('transform', () => {
         exclude: '*',
       },
     ]);
-    expect(transform(MULTIPLE_ANALYTICS)).toEqual([{ Total: 11 }]);
+    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toEqual(
+      TransformTable.fromRows([{ Total: 11 }]),
+    );
   });
 
   it('supports title and description in transforms', () => {
@@ -72,6 +74,8 @@ describe('transform', () => {
         exclude: '*',
       },
     ]);
-    expect(transform(MULTIPLE_ANALYTICS)).toEqual([{ Total: 11 }]);
+    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toEqual(
+      TransformTable.fromRows([{ Total: 11 }]),
+    );
   });
 });

--- a/packages/report-server/src/__tests__/reportBuilder/transform/updateColumns.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/transform/updateColumns.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { SINGLE_ANALYTIC, MULTIPLE_ANALYTICS, MERGEABLE_ANALYTICS } from './transform.fixtures';
-import { buildTransform } from '../../../reportBuilder/transform';
+import { buildTransform, TransformTable } from '../../../reportBuilder/transform';
 
 describe('updateColumns', () => {
   it('can do nothing', () => {
@@ -13,7 +13,9 @@ describe('updateColumns', () => {
         transform: 'updateColumns',
       },
     ]);
-    expect(transform(SINGLE_ANALYTIC)).toEqual([{ ...SINGLE_ANALYTIC[0] }]);
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+      TransformTable.fromRows([{ ...SINGLE_ANALYTIC[0] }]),
+    );
   });
 
   it('can insert basic values', () => {
@@ -27,9 +29,9 @@ describe('updateColumns', () => {
         },
       },
     ]);
-    expect(transform(SINGLE_ANALYTIC)).toEqual([
-      { ...SINGLE_ANALYTIC[0], number: 1, string: 'Hi', boolean: false },
-    ]);
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+      TransformTable.fromRows([{ ...SINGLE_ANALYTIC[0], number: 1, string: 'Hi', boolean: false }]),
+    );
   });
 
   it('can update a value from the row', () => {
@@ -41,7 +43,9 @@ describe('updateColumns', () => {
         },
       },
     ]);
-    expect(transform(SINGLE_ANALYTIC)).toEqual([{ ...SINGLE_ANALYTIC[0], dataElementValue: 4 }]);
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+      TransformTable.fromRows([{ ...SINGLE_ANALYTIC[0], dataElementValue: 4 }]),
+    );
   });
 
   it('can use a value from the row as a column name', () => {
@@ -53,7 +57,9 @@ describe('updateColumns', () => {
         },
       },
     ]);
-    expect(transform(SINGLE_ANALYTIC)).toEqual([{ ...SINGLE_ANALYTIC[0], BCD1: 4 }]);
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+      TransformTable.fromRows([{ ...SINGLE_ANALYTIC[0], BCD1: 4 }]),
+    );
   });
 
   it('can execute functions', () => {
@@ -65,7 +71,9 @@ describe('updateColumns', () => {
         },
       },
     ]);
-    expect(transform(SINGLE_ANALYTIC)).toEqual([{ ...SINGLE_ANALYTIC[0], period: '1st Jan 2020' }]);
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+      TransformTable.fromRows([{ ...SINGLE_ANALYTIC[0], period: '1st Jan 2020' }]),
+    );
   });
 
   it('can include all remaining fields', () => {
@@ -78,9 +86,11 @@ describe('updateColumns', () => {
         include: '*',
       },
     ]);
-    expect(transform(SINGLE_ANALYTIC)).toEqual([
-      { period: '1st Jan 2020', organisationUnit: 'TO', dataElement: 'BCD1', value: 4 },
-    ]);
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+      TransformTable.fromRows([
+        { period: '1st Jan 2020', organisationUnit: 'TO', dataElement: 'BCD1', value: 4 },
+      ]),
+    );
   });
 
   it('can include selected remaining fields', () => {
@@ -93,9 +103,9 @@ describe('updateColumns', () => {
         include: ['organisationUnit', 'value'],
       },
     ]);
-    expect(transform(SINGLE_ANALYTIC)).toEqual([
-      { period: '1st Jan 2020', organisationUnit: 'TO', value: 4 },
-    ]);
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+      TransformTable.fromRows([{ organisationUnit: 'TO', value: 4, period: '1st Jan 2020' }]),
+    );
   });
 
   it('can exclude all remaining fields', () => {
@@ -108,7 +118,9 @@ describe('updateColumns', () => {
         exclude: '*',
       },
     ]);
-    expect(transform(SINGLE_ANALYTIC)).toEqual([{ period: '1st Jan 2020' }]);
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+      TransformTable.fromRows([{ period: '1st Jan 2020' }]),
+    );
   });
 
   it('can exclude selected remaining fields', () => {
@@ -121,7 +133,9 @@ describe('updateColumns', () => {
         exclude: ['organisationUnit', 'value'],
       },
     ]);
-    expect(transform(SINGLE_ANALYTIC)).toEqual([{ period: '1st Jan 2020', dataElement: 'BCD1' }]);
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+      TransformTable.fromRows([{ period: '1st Jan 2020', dataElement: 'BCD1' }]),
+    );
   });
 
   it('can perform the update on all rows', () => {
@@ -135,11 +149,13 @@ describe('updateColumns', () => {
         include: ['organisationUnit'],
       },
     ]);
-    expect(transform(MULTIPLE_ANALYTICS)).toEqual([
-      { period: '1st Jan 2020', organisationUnit: 'TO', BCD1: 4 },
-      { period: '2nd Jan 2020', organisationUnit: 'TO', BCD1: 2 },
-      { period: '3rd Jan 2020', organisationUnit: 'TO', BCD1: 5 },
-    ]);
+    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toEqual(
+      TransformTable.fromRows([
+        { organisationUnit: 'TO', period: '1st Jan 2020', BCD1: 4 },
+        { organisationUnit: 'TO', period: '2nd Jan 2020', BCD1: 2 },
+        { organisationUnit: 'TO', period: '3rd Jan 2020', BCD1: 5 },
+      ]),
+    );
   });
 
   it('where is processed before remaining fields', () => {
@@ -153,19 +169,21 @@ describe('updateColumns', () => {
         include: ['period', 'organisationUnit'],
       },
     ]);
-    expect(transform(MERGEABLE_ANALYTICS)).toEqual([
-      { period: '20200101', organisationUnit: 'TO', newVal: 8 },
-      { period: '20200102', organisationUnit: 'TO', newVal: 4 },
-      { period: '20200103', organisationUnit: 'TO', newVal: 10 },
-      { period: '20200101', organisationUnit: 'TO', BCD2: 11 },
-      { period: '20200102', organisationUnit: 'TO', BCD2: 1 },
-      { period: '20200103', organisationUnit: 'TO', BCD2: 0 },
-      { period: '20200101', organisationUnit: 'PG', newVal: 14 },
-      { period: '20200102', organisationUnit: 'PG', newVal: 16 },
-      { period: '20200103', organisationUnit: 'PG', newVal: 4 },
-      { period: '20200101', organisationUnit: 'PG', BCD2: 13 },
-      { period: '20200102', organisationUnit: 'PG', BCD2: 99 },
-      { period: '20200103', organisationUnit: 'PG', BCD2: -1 },
-    ]);
+    expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toEqual(
+      TransformTable.fromRows([
+        { period: '20200101', organisationUnit: 'TO', newVal: 8 },
+        { period: '20200102', organisationUnit: 'TO', newVal: 4 },
+        { period: '20200103', organisationUnit: 'TO', newVal: 10 },
+        { period: '20200101', organisationUnit: 'TO', BCD2: 11 },
+        { period: '20200102', organisationUnit: 'TO', BCD2: 1 },
+        { period: '20200103', organisationUnit: 'TO', BCD2: 0 },
+        { period: '20200101', organisationUnit: 'PG', newVal: 14 },
+        { period: '20200102', organisationUnit: 'PG', newVal: 16 },
+        { period: '20200103', organisationUnit: 'PG', newVal: 4 },
+        { period: '20200101', organisationUnit: 'PG', BCD2: 13 },
+        { period: '20200102', organisationUnit: 'PG', BCD2: 99 },
+        { period: '20200103', organisationUnit: 'PG', BCD2: -1 },
+      ]),
+    );
   });
 });

--- a/packages/report-server/src/__tests__/reportBuilder/transform/updateColumns.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/transform/updateColumns.test.ts
@@ -13,7 +13,7 @@ describe('updateColumns', () => {
         transform: 'updateColumns',
       },
     ]);
-    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toStrictEqual(
       TransformTable.fromRows([{ ...SINGLE_ANALYTIC[0] }]),
     );
   });
@@ -29,7 +29,7 @@ describe('updateColumns', () => {
         },
       },
     ]);
-    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toStrictEqual(
       TransformTable.fromRows([{ ...SINGLE_ANALYTIC[0], number: 1, string: 'Hi', boolean: false }]),
     );
   });
@@ -43,7 +43,7 @@ describe('updateColumns', () => {
         },
       },
     ]);
-    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toStrictEqual(
       TransformTable.fromRows([{ ...SINGLE_ANALYTIC[0], dataElementValue: 4 }]),
     );
   });
@@ -57,7 +57,7 @@ describe('updateColumns', () => {
         },
       },
     ]);
-    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toStrictEqual(
       TransformTable.fromRows([{ ...SINGLE_ANALYTIC[0], BCD1: 4 }]),
     );
   });
@@ -71,7 +71,7 @@ describe('updateColumns', () => {
         },
       },
     ]);
-    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toStrictEqual(
       TransformTable.fromRows([{ ...SINGLE_ANALYTIC[0], period: '1st Jan 2020' }]),
     );
   });
@@ -86,7 +86,7 @@ describe('updateColumns', () => {
         include: '*',
       },
     ]);
-    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toStrictEqual(
       TransformTable.fromRows([
         { period: '1st Jan 2020', organisationUnit: 'TO', dataElement: 'BCD1', value: 4 },
       ]),
@@ -103,7 +103,7 @@ describe('updateColumns', () => {
         include: ['organisationUnit', 'value'],
       },
     ]);
-    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toStrictEqual(
       TransformTable.fromRows([{ organisationUnit: 'TO', value: 4, period: '1st Jan 2020' }]),
     );
   });
@@ -118,7 +118,7 @@ describe('updateColumns', () => {
         exclude: '*',
       },
     ]);
-    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toStrictEqual(
       TransformTable.fromRows([{ period: '1st Jan 2020' }]),
     );
   });
@@ -133,7 +133,7 @@ describe('updateColumns', () => {
         exclude: ['organisationUnit', 'value'],
       },
     ]);
-    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toStrictEqual(
       TransformTable.fromRows([{ period: '1st Jan 2020', dataElement: 'BCD1' }]),
     );
   });
@@ -149,7 +149,7 @@ describe('updateColumns', () => {
         include: ['organisationUnit'],
       },
     ]);
-    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toEqual(
+    expect(transform(TransformTable.fromRows(MULTIPLE_ANALYTICS))).toStrictEqual(
       TransformTable.fromRows([
         { organisationUnit: 'TO', period: '1st Jan 2020', BCD1: 4 },
         { organisationUnit: 'TO', period: '2nd Jan 2020', BCD1: 2 },
@@ -169,7 +169,7 @@ describe('updateColumns', () => {
         include: ['period', 'organisationUnit'],
       },
     ]);
-    expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toEqual(
+    expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toStrictEqual(
       TransformTable.fromRows([
         { period: '20200101', organisationUnit: 'TO', newVal: 8 },
         { period: '20200102', organisationUnit: 'TO', newVal: 4 },

--- a/packages/report-server/src/reportBuilder/output/functions/default.ts
+++ b/packages/report-server/src/reportBuilder/output/functions/default.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
  */
 
-import { Row } from '../../types';
+import { TransformTable } from '../../transform';
 
 export const buildDefault = () => {
-  return (rows: Row[]) => rows;
+  return (table: TransformTable) => table.getRows();
 };

--- a/packages/report-server/src/reportBuilder/output/functions/matrix/matrix.ts
+++ b/packages/report-server/src/reportBuilder/output/functions/matrix/matrix.ts
@@ -4,8 +4,8 @@
  */
 
 import { yup } from '@tupaia/utils';
+import { TransformTable } from '../../../transform';
 
-import { Row } from '../../../types';
 import { MatrixBuilder } from './matrixBuilder';
 import { Matrix, MatrixParams } from './types';
 
@@ -56,8 +56,8 @@ const paramsValidator = yup.object().shape(
   [['rowField', 'categoryField']],
 );
 
-const matrix = (rows: Row[], params: MatrixParams): Matrix => {
-  return new MatrixBuilder(rows, params).build();
+const matrix = (table: TransformTable, params: MatrixParams): Matrix => {
+  return new MatrixBuilder(table, params).build();
 };
 
 const buildParams = (params: unknown): MatrixParams => {
@@ -76,5 +76,5 @@ const buildParams = (params: unknown): MatrixParams => {
 
 export const buildMatrix = (params: unknown) => {
   const builtParams = buildParams(params);
-  return (rows: Row[]) => matrix(rows, builtParams);
+  return (table: TransformTable) => matrix(table, builtParams);
 };

--- a/packages/report-server/src/reportBuilder/output/functions/matrix/matrixBuilder.ts
+++ b/packages/report-server/src/reportBuilder/output/functions/matrix/matrixBuilder.ts
@@ -1,4 +1,5 @@
 import pick from 'lodash.pick';
+import { TransformTable } from '../../../transform';
 
 import { Row } from '../../../types';
 import { MatrixParams, Matrix } from './types';
@@ -11,12 +12,12 @@ const CATEGORY_FIELD_KEY = 'categoryId';
 const NON_COLUMNS_KEYS = [CATEGORY_FIELD_KEY, ROW_FIELD_KEY];
 
 export class MatrixBuilder {
-  private rows: Row[];
+  private table: TransformTable;
   private matrixData: Matrix;
   private params: MatrixParams;
 
-  public constructor(rows: Row[], params: MatrixParams) {
-    this.rows = rows;
+  public constructor(table: TransformTable, params: MatrixParams) {
+    this.table = table;
     this.params = params;
     this.matrixData = { columns: [], rows: [] };
   }
@@ -40,15 +41,11 @@ export class MatrixBuilder {
     };
 
     const getRemainingFieldsFromRows = (includeFields: string[], excludeFields: string[]) => {
-      const columns = new Set<string>();
-      this.rows.forEach(row => {
-        Object.keys(row).forEach(key => {
-          if (!excludeFields.includes(key) && !includeFields.includes(key)) {
-            columns.add(key);
-          }
-        });
-      });
-      return Array.from(columns);
+      return this.table
+        .getColumns()
+        .filter(
+          columnName => !excludeFields.includes(columnName) && !includeFields.includes(columnName),
+        );
     };
 
     const { includeFields, excludeFields } = this.params.columns;
@@ -66,7 +63,7 @@ export class MatrixBuilder {
     const rows: Row[] = [];
     const { rowField, categoryField } = this.params.rows;
 
-    this.rows.forEach(row => {
+    this.table.getRows().forEach(row => {
       let newRows: Row;
       if (categoryField) {
         const { [rowField]: rowFieldData, [categoryField]: categoryId, ...restOfRow } = row;

--- a/packages/report-server/src/reportBuilder/output/functions/outputBuilders.ts
+++ b/packages/report-server/src/reportBuilder/output/functions/outputBuilders.ts
@@ -4,7 +4,8 @@
  */
 
 import { Resolved } from '@tupaia/tsutils';
-import { buildDefault } from './default';
+import { buildRows } from './rows';
+import { buildRowsAndColumns } from './rowsAndColumns';
 import { buildMatrix } from './matrix';
 import { buildRawDataExport } from './rawDataExport';
 
@@ -15,5 +16,7 @@ export type OutputType = Resolved<
 export const outputBuilders = {
   matrix: buildMatrix,
   rawDataExport: buildRawDataExport,
-  default: buildDefault,
+  rowsAndColumns: buildRowsAndColumns,
+  rows: buildRows,
+  default: buildRows,
 };

--- a/packages/report-server/src/reportBuilder/output/functions/rawDataExport/rawDataExport.ts
+++ b/packages/report-server/src/reportBuilder/output/functions/rawDataExport/rawDataExport.ts
@@ -6,7 +6,7 @@
 import { yup } from '@tupaia/utils';
 
 import { ReportServerAggregator } from '../../../../aggregator';
-import { Row } from '../../../types';
+import { TransformTable } from '../../../transform';
 import { OutputContext } from '../../types';
 import { RawDataExportBuilder } from './rawDataExportBuilder';
 import { RawDataExport, RawDataExportContext } from './types';
@@ -16,12 +16,12 @@ const contextValidator = yup.object().shape({
 });
 
 const rawDataExport = async (
-  rows: Row[],
+  table: TransformTable,
   params: unknown,
   outputContext: RawDataExportContext,
   aggregator: ReportServerAggregator,
 ): Promise<RawDataExport> => {
-  return new RawDataExportBuilder(rows, params, outputContext, aggregator).build();
+  return new RawDataExportBuilder(table, params, outputContext, aggregator).build();
 };
 
 const buildParams = (params: unknown): unknown => {
@@ -37,6 +37,6 @@ export const buildRawDataExport = (params: unknown, outputContext: OutputContext
   const builtParams = buildParams(params);
   const builtOutputContext = buildContext(outputContext);
 
-  return (rows: Row[], aggregator: ReportServerAggregator) =>
-    rawDataExport(rows, builtParams, builtOutputContext, aggregator);
+  return (table: TransformTable, aggregator: ReportServerAggregator) =>
+    rawDataExport(table, builtParams, builtOutputContext, aggregator);
 };

--- a/packages/report-server/src/reportBuilder/output/functions/rawDataExport/rawDataExportBuilder.ts
+++ b/packages/report-server/src/reportBuilder/output/functions/rawDataExport/rawDataExportBuilder.ts
@@ -4,23 +4,23 @@
  */
 
 import { ReportServerAggregator } from '../../../../aggregator';
-import { Row } from '../../../types';
+import { TransformTable } from '../../../transform';
 import { RawDataExportContext, RawDataExport } from './types';
 
 export class RawDataExportBuilder {
-  private rows: Row[];
+  private table: TransformTable;
   private matrixData: RawDataExport;
   private params: unknown;
   private outputContext: RawDataExportContext;
   private aggregator: ReportServerAggregator;
 
   public constructor(
-    rows: Row[],
+    table: TransformTable,
     params: unknown,
     outputContext: RawDataExportContext,
     aggregator: ReportServerAggregator,
   ) {
-    this.rows = rows;
+    this.table = table;
     this.params = params;
     this.outputContext = outputContext;
     this.aggregator = aggregator;
@@ -29,21 +29,13 @@ export class RawDataExportBuilder {
 
   public async build() {
     this.matrixData.columns = this.buildColumns();
-    this.matrixData.rows = this.rows;
+    this.matrixData.rows = this.table.getRows();
     await this.attachAllDataElementsToColumns();
     return this.matrixData;
   }
 
   private buildColumns() {
-    const columns = new Set<string>();
-    this.rows.forEach(row => {
-      Object.keys(row).forEach(key => {
-        columns.add(key);
-      });
-    });
-    const allFields = Array.from(columns);
-
-    return allFields.map(c => ({ key: c, title: c }));
+    return this.table.getColumns().map(columnName => ({ key: columnName, title: columnName }));
   }
 
   private async attachAllDataElementsToColumns() {

--- a/packages/report-server/src/reportBuilder/output/functions/rows.ts
+++ b/packages/report-server/src/reportBuilder/output/functions/rows.ts
@@ -5,6 +5,6 @@
 
 import { TransformTable } from '../../transform';
 
-export const buildDefault = () => {
+export const buildRows = () => {
   return (table: TransformTable) => table.getRows();
 };

--- a/packages/report-server/src/reportBuilder/output/functions/rowsAndColumns.ts
+++ b/packages/report-server/src/reportBuilder/output/functions/rowsAndColumns.ts
@@ -1,0 +1,13 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+
+import { TransformTable } from '../../transform';
+
+export const buildRowsAndColumns = () => {
+  return (table: TransformTable) => ({
+    columns: table.getColumns(),
+    rows: table.getRows(),
+  });
+};

--- a/packages/report-server/src/reportBuilder/output/output.ts
+++ b/packages/report-server/src/reportBuilder/output/output.ts
@@ -6,7 +6,7 @@
 import { yup } from '@tupaia/utils';
 
 import { ReportServerAggregator } from '../../aggregator';
-import { Row } from '../types';
+import { TransformTable } from '../transform';
 import { outputBuilders } from './functions/outputBuilders';
 import { OutputContext } from './types';
 
@@ -22,7 +22,7 @@ const paramsValidator = yup.object().shape({
 });
 
 const output = (
-  rows: Row[],
+  table: TransformTable,
   params: OutputParams,
   outputContext: OutputContext,
   aggregator: ReportServerAggregator,
@@ -30,7 +30,7 @@ const output = (
   const { type, config } = params;
 
   const outputBuilder = outputBuilders[type](config, outputContext);
-  return outputBuilder(rows, aggregator);
+  return outputBuilder(table, aggregator);
 };
 
 const buildParams = (params: unknown): OutputParams => {
@@ -45,5 +45,5 @@ export const buildOutput = (
   aggregator: ReportServerAggregator,
 ) => {
   const builtParams = buildParams(params);
-  return (rows: Row[]) => output(rows, builtParams, outputContext, aggregator);
+  return (table: TransformTable) => output(table, builtParams, outputContext, aggregator);
 };

--- a/packages/report-server/src/reportBuilder/reportBuilder.ts
+++ b/packages/report-server/src/reportBuilder/reportBuilder.ts
@@ -8,7 +8,7 @@ import { FetchReportQuery, StandardOrCustomReportConfig } from '../types';
 import { configValidator } from './configValidator';
 import { buildContext, ReqContext } from './context';
 import { buildFetch, FetchResponse } from './fetch';
-import { buildTransform } from './transform';
+import { buildTransform, TransformTable } from './transform';
 import { buildOutput } from './output';
 import { Row } from './types';
 import { OutputType } from './output/functions/outputBuilders';
@@ -64,7 +64,7 @@ export class ReportBuilder {
 
     const context = await buildContext(this.config.transform, this.reqContext, data, query);
     const transform = buildTransform(this.config.transform, context);
-    const transformedData = transform(data.results);
+    const transformedData = transform(TransformTable.fromRows(data.results));
 
     const outputContext = { ...this.config.fetch };
     const output = buildOutput(this.config.output, outputContext, aggregator);

--- a/packages/report-server/src/reportBuilder/transform/aliases/entityMetadataAliases.ts
+++ b/packages/report-server/src/reportBuilder/transform/aliases/entityMetadataAliases.ts
@@ -4,7 +4,7 @@
  */
 
 import { Context } from '../../context';
-import { Row } from '../../types';
+import { TransformTable } from '../table';
 
 /**
  * [
@@ -18,7 +18,7 @@ import { Row } from '../../types';
  * ]
  */
 export const insertNumberOfFacilitiesColumn = {
-  transform: (context: Context) => (rows: Row[]) => {
+  transform: (context: Context) => (table: TransformTable) => {
     const { facilityCountByOrgUnit } = context;
 
     if (facilityCountByOrgUnit === undefined) {
@@ -27,21 +27,23 @@ export const insertNumberOfFacilitiesColumn = {
       );
     }
 
-    return rows.map(row => {
-      const { organisationUnit, ...restOfRow } = row;
-
+    const organisationUnitValues = table.getColumnValues('organisationUnit');
+    const numberOfFacilitiesColumnValues = organisationUnitValues.map(organisationUnit => {
       if (typeof organisationUnit !== 'string') {
         throw new Error(
           `'organisationUnit' type must be string, but got: ${typeof organisationUnit}`,
         );
       }
 
-      return {
-        numberOfFacilities: facilityCountByOrgUnit[organisationUnit],
-        organisationUnit,
-        ...restOfRow,
-      };
+      return facilityCountByOrgUnit[organisationUnit];
     });
+
+    return table.upsertColumns([
+      {
+        columnName: 'numberOfFacilities',
+        values: numberOfFacilitiesColumnValues,
+      },
+    ]);
   },
   dependencies: ['facilityCountByOrgUnit'],
 };

--- a/packages/report-server/src/reportBuilder/transform/aliases/keyValueByFieldAliases.ts
+++ b/packages/report-server/src/reportBuilder/transform/aliases/keyValueByFieldAliases.ts
@@ -3,37 +3,56 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
-import { Row } from '../../types';
+import { TransformTable } from '../table';
+import { FieldValue } from '../../types';
+
+const keyValueByField = (table: TransformTable, field: string) => {
+  const fieldValues = table.getColumnValues(field) as string[];
+  const valueValues = table.getColumnValues('value');
+  const newColumnNames = Array.from(new Set(fieldValues));
+  const newColumns: Record<string, FieldValue[]> = Object.fromEntries(
+    newColumnNames.map(columnName => [
+      columnName,
+      // Flag all values as skip char to avoid overwriting data
+      table.hasColumn(columnName)
+        ? table.getColumnValues(columnName)
+        : new Array(valueValues.length).fill(undefined),
+    ]),
+  );
+  valueValues.forEach((value, index) => {
+    const dataElement = fieldValues[index];
+    const column = newColumns[dataElement];
+    column.splice(index, 1, value);
+  });
+
+  const columnUpserts = Object.entries(newColumns).map(([columnName, values]) => ({
+    columnName,
+    values,
+  }));
+
+  return table.dropColumns([field, 'value']).upsertColumns(columnUpserts);
+};
 
 /**
  * { period: '20200101', organisationUnit: 'TO', dataElement: 'CH01', value: 7 }
  *  => { period: '20200101', organisationUnit: 'TO', CH01: 7 }
  */
-export const keyValueByDataElementName = () => (rows: Row[]) => {
-  return rows.map(row => {
-    const { dataElement, value, ...restOfRow } = row;
-    return { [dataElement as string]: value, ...restOfRow };
-  });
+export const keyValueByDataElementName = () => (table: TransformTable) => {
+  return keyValueByField(table, 'dataElement');
 };
 
 /**
  * { period: '20200101', organisationUnit: 'TO', dataElement: 'CH01', value: 7 }
  *  => { period: '20200101', TO: 7, dataElement: 'CH01' }
  */
-export const keyValueByOrgUnit = () => (rows: Row[]) => {
-  return rows.map(row => {
-    const { organisationUnit, value, ...restOfRow } = row;
-    return { [organisationUnit as string]: value, ...restOfRow };
-  });
+export const keyValueByOrgUnit = () => (table: TransformTable) => {
+  return keyValueByField(table, 'organisationUnit');
 };
 
 /**
  * { period: '20200101', organisationUnit: 'TO', dataElement: 'CH01', value: 7 }
  *  => { 20200101: 7, organisationUnit: 'TO', dataElement: 'CH01' }
  */
-export const keyValueByPeriod = () => (rows: Row[]) => {
-  return rows.map(row => {
-    const { period, value, ...restOfRow } = row;
-    return { [period as string]: value, ...restOfRow };
-  });
+export const keyValueByPeriod = () => (table: TransformTable) => {
+  return keyValueByField(table, 'period');
 };

--- a/packages/report-server/src/reportBuilder/transform/functions/excludeColumns.ts
+++ b/packages/report-server/src/reportBuilder/transform/functions/excludeColumns.ts
@@ -4,41 +4,24 @@
  */
 
 import { yup } from '@tupaia/utils';
-import { Context } from '../../context';
-import { TransformParser } from '../parser';
-import { buildWhere } from './where';
-import { Row } from '../../types';
 import { starSingleOrMultipleColumnsValidator } from './transformValidators';
 import { getColumnMatcher } from './helpers';
+import { TransformTable } from '../table';
 
 type ExcludeColumnsParams = {
   shouldIncludeColumn: (field: string) => boolean;
-  where: (parser: TransformParser) => boolean;
 };
 
 export const paramsValidator = yup.object().shape({
   columns: starSingleOrMultipleColumnsValidator,
-  where: yup.string(),
 });
 
-const excludeColumns = (rows: Row[], params: ExcludeColumnsParams, context: Context): Row[] => {
-  const parser = new TransformParser(rows, context);
-  return rows.map(row => {
-    const matchesWhere = params.where(parser);
-    if (!matchesWhere) {
-      parser.next();
-      return row;
-    }
-    const newRow: Row = {};
-    Object.entries(row).forEach(([field, value]) => {
-      if (params.shouldIncludeColumn(field)) {
-        newRow[field] = value;
-      }
-    });
+const excludeColumns = (table: TransformTable, params: ExcludeColumnsParams) => {
+  const columnsToDelete = table
+    .getColumns()
+    .filter(columnName => !params.shouldIncludeColumn(columnName));
 
-    parser.next();
-    return newRow;
-  });
+  return table.dropColumns(columnsToDelete);
 };
 
 const buildParams = (params: unknown): ExcludeColumnsParams => {
@@ -50,10 +33,10 @@ const buildParams = (params: unknown): ExcludeColumnsParams => {
   const columnMatcher = getColumnMatcher(columns);
   const shouldIncludeColumn = (column: string) => !columnMatcher(column);
 
-  return { shouldIncludeColumn, where: buildWhere(params) };
+  return { shouldIncludeColumn };
 };
 
-export const buildExcludeColumns = (params: unknown, context: Context) => {
+export const buildExcludeColumns = (params: unknown) => {
   const builtParams = buildParams(params);
-  return (rows: Row[]) => excludeColumns(rows, builtParams, context);
+  return (table: TransformTable) => excludeColumns(table, builtParams);
 };

--- a/packages/report-server/src/reportBuilder/transform/functions/index.ts
+++ b/packages/report-server/src/reportBuilder/transform/functions/index.ts
@@ -25,6 +25,7 @@ import {
   buildGatherColumns,
   paramsValidator as gatherColumnsParamsValidator,
 } from './gatherColumns';
+import { buildOrderColumns, orderColumnsSchema } from './orderColumns';
 import { TransformTable } from '../table';
 
 type TransformBuilder = (
@@ -41,6 +42,7 @@ export const transformBuilders: Record<string, TransformBuilder> = {
   excludeRows: buildExcludeRows,
   insertRows: buildInsertRows,
   gatherColumns: buildGatherColumns,
+  orderColumns: buildOrderColumns,
 };
 
 export const transformSchemas: Record<
@@ -58,4 +60,5 @@ export const transformSchemas: Record<
   excludeRows: excludeRowsParamsValidator.describe(),
   insertRows: insertRowsParamsValidator.describe(),
   gatherColumns: gatherColumnsParamsValidator.describe(),
+  orderColumns: orderColumnsSchema,
 };

--- a/packages/report-server/src/reportBuilder/transform/functions/index.ts
+++ b/packages/report-server/src/reportBuilder/transform/functions/index.ts
@@ -4,7 +4,6 @@
  */
 
 import { Context } from '../../context';
-import { Row } from '../../types';
 
 import {
   buildInsertColumns,
@@ -26,8 +25,12 @@ import {
   buildGatherColumns,
   paramsValidator as gatherColumnsParamsValidator,
 } from './gatherColumns';
+import { TransformTable } from '../table';
 
-type TransformBuilder = (params: unknown, context: Context) => (rows: Row[]) => Row[];
+type TransformBuilder = (
+  params: unknown,
+  context: Context,
+) => (table: TransformTable) => TransformTable;
 
 export const transformBuilders: Record<string, TransformBuilder> = {
   insertColumns: buildInsertColumns,

--- a/packages/report-server/src/reportBuilder/transform/functions/mergeRows/createGroupKey.ts
+++ b/packages/report-server/src/reportBuilder/transform/functions/mergeRows/createGroupKey.ts
@@ -15,6 +15,6 @@ export const buildCreateGroupKey = (groupBy: undefined | string | string[]) => {
       return `${row[groupBy]}`;
     }
 
-    return groupBy.map(field => row[field]).join('___');
+    return groupBy.map(columnName => row[columnName]).join('___');
   };
 };

--- a/packages/report-server/src/reportBuilder/transform/functions/mergeRows/mergeRows.ts
+++ b/packages/report-server/src/reportBuilder/transform/functions/mergeRows/mergeRows.ts
@@ -10,10 +10,11 @@ import { Context } from '../../../context';
 import { TransformParser } from '../../parser';
 import { mergeStrategies } from './mergeStrategies';
 import { buildWhere } from '../where';
-import { Row, FieldValue } from '../../../types';
+import { FieldValue, Row } from '../../../types';
 import { buildCreateGroupKey } from './createGroupKey';
 import { buildGetMergeStrategy } from './getMergeStrategy';
 import { starSingleOrMultipleColumnsValidator } from '../transformValidators';
+import { TransformTable } from '../../table';
 
 type MergeRowsParams = {
   createGroupKey: (row: Row) => string;
@@ -61,15 +62,15 @@ export const paramsValidator = yup.object().shape({
  * [{orgUnit: TO, BCD1: 4 }, {orgUnit: TO, BCD1: 7 }], groupBy orgUnit => group: { BCD1: [4, 7] }
  */
 type Group = {
-  [fieldKey: string]: FieldValue[];
+  [columnName: string]: FieldValue[];
 };
 
-const groupRows = (rows: Row[], params: MergeRowsParams, context: Context) => {
+const groupRows = (table: TransformTable, params: MergeRowsParams, context: Context) => {
   const groupsByKey: Record<string, Group> = {};
-  const parser = new TransformParser(rows, context);
+  const parser = new TransformParser(table, context);
   const ungroupedRows: Row[] = []; // Rows that don't match the 'where' clause are left ungrouped
 
-  rows.forEach((row: Row) => {
+  table.getRows().forEach((row: Row) => {
     if (!params.where(parser)) {
       ungroupedRows.push(row);
       parser.next();
@@ -91,33 +92,32 @@ const addRowToGroup = (groupsByKey: Record<string, Group>, groupKey: string, row
 
   const group = groupsByKey[groupKey];
 
-  Object.keys(row).forEach((field: string) => {
-    if (!group[field]) {
+  Object.entries(row).forEach(([columnName, value]) => {
+    if (!group[columnName]) {
       // eslint-disable-next-line no-param-reassign
-      group[field] = [];
+      group[columnName] = [];
     }
-    group[field].push(row[field]);
+    group[columnName].push(value);
   });
 };
 
-const mergeGroups = (groups: Group[], params: MergeRowsParams): Row[] => {
+const mergeGroups = (groups: Group[], params: MergeRowsParams) => {
   return groups.map(group => {
     const mergedRow: Row = {};
-    Object.entries(group).forEach(([fieldKey, fieldValue]) => {
-      const mergeStrategy = params.getMergeStrategy(fieldKey);
-      const mergedValue = mergeStrategies[mergeStrategy](fieldValue);
-      if (mergedValue !== undefined) {
-        mergedRow[fieldKey] = mergedValue;
-      }
+    Object.entries(group).forEach(([columnName, groupValues]) => {
+      const mergeStrategy = params.getMergeStrategy(columnName);
+      const mergedValue = mergeStrategies[mergeStrategy](groupValues);
+      mergedRow[columnName] = mergedValue;
     });
     return mergedRow;
   });
 };
 
-const mergeRows = (rows: Row[], params: MergeRowsParams, context: Context): Row[] => {
-  const { groups, ungroupedRows } = groupRows(rows, params, context);
+const mergeRows = (table: TransformTable, params: MergeRowsParams, context: Context) => {
+  const { groups, ungroupedRows } = groupRows(table, params, context);
   const mergedRows = mergeGroups(groups, params);
-  return mergedRows.concat(ungroupedRows);
+  const newRowData = mergedRows.concat(ungroupedRows);
+  return new TransformTable(table.getColumns(), newRowData);
 };
 
 const buildParams = (params: unknown): MergeRowsParams => {
@@ -134,5 +134,5 @@ const buildParams = (params: unknown): MergeRowsParams => {
 
 export const buildMergeRows = (params: unknown, context: Context) => {
   const builtParams = buildParams(params);
-  return (rows: Row[]) => mergeRows(rows, builtParams, context);
+  return (table: TransformTable) => mergeRows(table, builtParams, context);
 };

--- a/packages/report-server/src/reportBuilder/transform/functions/mergeRows/mergeRows.ts
+++ b/packages/report-server/src/reportBuilder/transform/functions/mergeRows/mergeRows.ts
@@ -107,7 +107,9 @@ const mergeGroups = (groups: Group[], params: MergeRowsParams) => {
     Object.entries(group).forEach(([columnName, groupValues]) => {
       const mergeStrategy = params.getMergeStrategy(columnName);
       const mergedValue = mergeStrategies[mergeStrategy](groupValues);
-      mergedRow[columnName] = mergedValue;
+      if (mergedValue !== undefined) {
+        mergedRow[columnName] = mergedValue;
+      }
     });
     return mergedRow;
   });

--- a/packages/report-server/src/reportBuilder/transform/functions/mergeRows/mergeStrategies.ts
+++ b/packages/report-server/src/reportBuilder/transform/functions/mergeRows/mergeStrategies.ts
@@ -3,15 +3,8 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
+import { isDefined, isNotNullish } from '@tupaia/tsutils';
 import { FieldValue } from '../../../types';
-
-const isNotUndefined = <T>(value: T): value is Exclude<T, undefined> => {
-  return value !== undefined;
-};
-
-const isNotNullOrUndefined = <T>(value: T): value is NonNullable<T> => {
-  return value !== undefined && value !== null;
-};
 
 // checkIsNum([1, 2, 3, null, undefined]) = 1, 2, 3]
 const checkIsNum = (values: FieldValue[]): number[] => {
@@ -21,7 +14,7 @@ const checkIsNum = (values: FieldValue[]): number[] => {
     }
     return true;
   };
-  const filteredUndefinedAndNullValues = values.filter(isNotNullOrUndefined);
+  const filteredUndefinedAndNullValues = values.filter(isNotNullish);
   return filteredUndefinedAndNullValues.filter(assertIsNumber);
 };
 
@@ -42,19 +35,19 @@ const average = (values: FieldValue[]): number | undefined => {
   const checkedValues = checkIsNum(values);
   const numerator = sum(checkedValues);
   const denominator = count(checkedValues);
-  if (isNotUndefined(numerator) && denominator !== 0) {
+  if (isDefined(numerator) && denominator !== 0) {
     return numerator / denominator;
   }
   return undefined;
 };
 
 const count = (values: FieldValue[]): number => {
-  return values.length;
+  return values.filter(isDefined).length;
 };
 
 // helper of max() and min(), e.g.: customSort([1, 2, 3, null]) = [null, 1, 2, 3]
 const customSort = (values: FieldValue[]): FieldValue[] => {
-  const filteredUndefinedValues = values.filter(isNotUndefined);
+  const filteredUndefinedValues = values.filter(isDefined);
   return filteredUndefinedValues.sort((a, b) => {
     if (a === null) {
       return -1;
@@ -79,7 +72,7 @@ const min = (values: FieldValue[]): FieldValue => {
 };
 
 const unique = (values: FieldValue[]): FieldValue => {
-  const distinctValues = [...new Set(values.filter(isNotUndefined))];
+  const distinctValues = [...new Set(values.filter(isDefined))];
   return distinctValues.length === 1 ? distinctValues[0] : 'NO_UNIQUE_VALUE';
 };
 
@@ -90,15 +83,15 @@ const exclude = (values: FieldValue[]): FieldValue => {
 };
 
 const first = (values: FieldValue[]): FieldValue => {
-  return values.find(isNotUndefined);
+  return values.find(isDefined);
 };
 
 const last = (values: FieldValue[]): FieldValue => {
-  return values.slice().reverse().find(isNotUndefined);
+  return values.slice().reverse().find(isDefined);
 };
 
 const single = (values: FieldValue[]): FieldValue => {
-  const definedValues = values.filter(isNotUndefined);
+  const definedValues = values.filter(isDefined);
   if (definedValues.length === 0) {
     return undefined;
   }

--- a/packages/report-server/src/reportBuilder/transform/functions/orderColumns/index.ts
+++ b/packages/report-server/src/reportBuilder/transform/functions/orderColumns/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+export { buildOrderColumns, orderColumnsSchema } from './orderColumns';

--- a/packages/report-server/src/reportBuilder/transform/functions/orderColumns/orderColumns.ts
+++ b/packages/report-server/src/reportBuilder/transform/functions/orderColumns/orderColumns.ts
@@ -1,0 +1,105 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import { isDefined } from '@tupaia/tsutils';
+import { yup } from '@tupaia/utils';
+import { TransformTable } from '../../table';
+import { sortByFunctions } from './sortByFunctions';
+
+type OrderColumnsParams = {
+  columnOrder?: string[];
+  sorter?: (column1: string, column2: string) => number;
+};
+
+export const paramsValidator = yup.object().shape({
+  order: yup.array().of(yup.string().required()),
+  sortBy: yup
+    .mixed<keyof typeof sortByFunctions>()
+    .oneOf(Object.keys(sortByFunctions) as (keyof typeof sortByFunctions)[]),
+});
+
+const orderColumns = (table: TransformTable, params: OrderColumnsParams) => {
+  const { columnOrder = ['*'], sorter } = params;
+
+  if (sorter) {
+    return new TransformTable(table.getColumns().sort(sorter), table.getRows());
+  }
+
+  if (!columnOrder.includes('*')) {
+    columnOrder.push('*'); // Add wildcard to the end if it's not specified
+  }
+
+  const existingColumns = table.getColumns();
+  const newColumns = new Array<string | undefined>(existingColumns.length).fill(undefined);
+  const orderedColumns = existingColumns.filter(column => columnOrder.includes(column));
+  const wildcardColumns = existingColumns.filter(column => !columnOrder.includes(column));
+
+  // Filter out columns that are not in the table
+  const order = columnOrder.filter(column => existingColumns.includes(column) || column === '*');
+  const indexOfWildcard = order.indexOf('*');
+
+  wildcardColumns.forEach((column, index) => {
+    newColumns[indexOfWildcard + index] = column;
+  });
+
+  orderedColumns.forEach(column => {
+    const indexInOrder = order.indexOf(column);
+    const indexInNewColumns =
+      indexInOrder < indexOfWildcard
+        ? indexInOrder // It's before the wildcard, just use the index
+        : indexInOrder + orderedColumns.length - 1; // It's after the wildcard, so account for all wildcard columns (minus wildcard itself)
+    newColumns[indexInNewColumns] = column;
+  });
+
+  const validatedColumns = newColumns.map(column => {
+    if (!isDefined(column)) {
+      throw new Error('Missing columns when determining new column order');
+    }
+
+    return column;
+  });
+
+  return new TransformTable(validatedColumns, table.getRows());
+};
+
+const buildParams = (params: unknown): OrderColumnsParams => {
+  const validatedParams = paramsValidator.validateSync(params);
+
+  const { order, sortBy } = validatedParams;
+
+  if (order && sortBy) {
+    throw new Error('Cannot provide explicit column order and a sort by function');
+  }
+
+  if (order) {
+    return {
+      columnOrder: Array.from(new Set(order)),
+    };
+  }
+
+  if (sortBy) {
+    return {
+      sorter: sortByFunctions[sortBy],
+    };
+  }
+
+  throw new Error('Must provide either explicit column order or a sort by function');
+};
+
+export const buildOrderColumns = (params: unknown) => {
+  const builtParams = buildParams(params);
+  return (table: TransformTable) => orderColumns(table, builtParams);
+};
+
+export const orderColumnsSchema = {
+  ...paramsValidator.describe(),
+  fields: {
+    ...paramsValidator.describe().fields,
+    // Override sortBy describe, as viz-builder doesn't support mixed schemas
+    sortBy: {
+      enum: Object.keys(sortByFunctions),
+    },
+  },
+};

--- a/packages/report-server/src/reportBuilder/transform/functions/orderColumns/sortByFunctions.ts
+++ b/packages/report-server/src/reportBuilder/transform/functions/orderColumns/sortByFunctions.ts
@@ -1,0 +1,36 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import { Moment } from 'moment';
+import { displayStringToMoment, periodToMoment, isInvalidMoment } from '@tupaia/utils';
+
+const alphabetic = (column1: string, column2: string) => column1.localeCompare(column2);
+
+const sortMoment = (moment1: Moment, moment2: Moment) => {
+  if (isInvalidMoment(moment1) && isInvalidMoment(moment2)) return 0;
+  if (isInvalidMoment(moment1)) return 1;
+  if (isInvalidMoment(moment2)) return -1;
+  if (moment1.isSame(moment2)) return 0;
+  if (moment1.isBefore(moment2)) return -1;
+  return 1;
+};
+
+const date = (column1: string, column2: string) => {
+  const col1Moment = displayStringToMoment(column1);
+  const col2Moment = displayStringToMoment(column2);
+  return sortMoment(col1Moment, col2Moment);
+};
+
+const period = (column1: string, column2: string) => {
+  const col1Moment = periodToMoment(column1);
+  const col2Moment = periodToMoment(column2);
+  return sortMoment(col1Moment, col2Moment);
+};
+
+export const sortByFunctions = {
+  alphabetic,
+  date,
+  period,
+};

--- a/packages/report-server/src/reportBuilder/transform/index.ts
+++ b/packages/report-server/src/reportBuilder/transform/index.ts
@@ -5,4 +5,5 @@
 
 export { buildTransform } from './transform';
 export { contextFunctionDependencies, TransformParser } from './parser';
+export { TransformTable } from './table';
 export { contextAliasDependencies } from './aliases';

--- a/packages/report-server/src/reportBuilder/transform/parser/TransformParser.ts
+++ b/packages/report-server/src/reportBuilder/transform/parser/TransformParser.ts
@@ -6,6 +6,7 @@
 import { ExpressionParser } from '@tupaia/expression-parser';
 
 import { Context } from '../../context';
+import { TransformTable } from '../table';
 import { Row, FieldValue } from '../../types';
 import {
   customFunctions,
@@ -49,10 +50,10 @@ export class TransformParser extends ExpressionParser {
   // eslint-disable-next-line react/static-property-placement
   private context?: Context;
 
-  public constructor(rows: Row[] = [], context?: Context) {
+  public constructor(table: TransformTable = new TransformTable(), context?: Context) {
     super(new TransformScope());
 
-    this.rows = rows;
+    this.rows = table.getRows();
     this.lookups = {
       params: context?.query || {},
       current: {},
@@ -64,7 +65,7 @@ export class TransformParser extends ExpressionParser {
       table: this.rows,
     };
 
-    if (rows.length > 0) {
+    if (this.rows.length > 0) {
       this.lookups.current = this.rows[this.currentRow];
       this.lookups.next = this.rows[this.currentRow + 1] || {};
       this.rows.forEach(row => addRowToLookup(row, this.lookups.all));

--- a/packages/report-server/src/reportBuilder/transform/parser/functions/utils.ts
+++ b/packages/report-server/src/reportBuilder/transform/parser/functions/utils.ts
@@ -15,7 +15,7 @@ export const convertToPeriod = (period: string, targetType: string): string => {
   return baseConvertToPeriod(period, targetType);
 };
 
-export const periodToTimestamp = (period: string): string => {
+export const periodToTimestamp = (period: string): number => {
   return basePeriodToTimestamp(period);
 };
 

--- a/packages/report-server/src/reportBuilder/transform/table/TransformTable.ts
+++ b/packages/report-server/src/reportBuilder/transform/table/TransformTable.ts
@@ -1,0 +1,208 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+
+import { FieldValue, Row } from '../../types';
+
+/**
+ * Data structure for managing tabular data during report building process.
+ *
+ * Designed to be immutable, so that operations on the table return a new copy of the table
+ * with the operations applied (rather than mutating the original table)
+ *
+ * Operations on table are all bulk operations for efficiency reasons
+ */
+export class TransformTable {
+  private readonly columns: string[];
+  private readonly rows: Row[];
+
+  public constructor(columns: string[] = [], rows: Row[] = []) {
+    this.columns = columns;
+    this.rows = rows;
+  }
+
+  /**
+   * Convenience constructor. Often we find ourselves wanting to convert an array of objects
+   * into a TransformTable
+   */
+  public static fromRows(rowObjects: Row[], columnOrder?: string[]) {
+    const columnsInRows = columnOrder || Array.from(new Set(rowObjects.map(Object.keys).flat()));
+    return new TransformTable(columnsInRows, rowObjects);
+  }
+
+  public getColumns() {
+    return [...this.columns]; // Spread to protect a caller mutating the original array
+  }
+
+  public getRows() {
+    return this.rows.map(row => ({ ...row })); // Spread to protect a caller mutating the original array
+  }
+
+  public length() {
+    return this.rows.length;
+  }
+
+  public width() {
+    return this.columns.length;
+  }
+
+  public indexOfColumn(columnName: string) {
+    return this.columns.indexOf(columnName);
+  }
+
+  public hasColumn(columnName: string) {
+    return this.indexOfColumn(columnName) > -1;
+  }
+
+  public hasIndex(index: number) {
+    return index > -1 && index < this.length();
+  }
+
+  public getColumnValues(columnName: string) {
+    if (!this.hasColumn(columnName)) {
+      throw new Error(
+        `Cannot get values for column name: ${columnName}, it does not exist in the table`,
+      );
+    }
+
+    return this.rows.map(row => row[columnName]);
+  }
+
+  /**
+   *
+   * @returns A new TransformTable with the rows inserted
+   */
+  public insertRows(inserts: { row: Row; index?: number }[]) {
+    if (inserts.length === 0) {
+      return this;
+    }
+
+    const newTable = this.clone();
+    inserts.forEach(({ row, index = newTable.length() }) => {
+      if (index !== newTable.length() && !newTable.hasIndex(index)) {
+        throw new Error(
+          `Error inserting row, index must be within 0:${newTable.length()}, but was ${index}`,
+        );
+      }
+
+      const newRowWithExistingColumns: Row = {};
+      const newRowWithNewColumns: Row = {};
+      Object.entries(row).forEach(([columnName, value]) => {
+        if (newTable.hasColumn(columnName)) {
+          newRowWithExistingColumns[columnName] = value;
+        } else {
+          newRowWithNewColumns[columnName] = value;
+        }
+      });
+
+      // STEP 1: Insert a row with values for all existing columns
+      newTable.rows.splice(index, 0, newRowWithExistingColumns);
+
+      // STEP 2: Insert a column for each new column being created in this row
+      Object.entries(newRowWithNewColumns).forEach(([columnName, value]) => {
+        // Create a new column with all values being undefined except the new row value
+        const newColumnWithExistingRows = new Array(newTable.length())
+          .fill(0)
+          .map((_, rowIndex) => (rowIndex === index ? value : undefined));
+        newTable.writeColumnToTable(columnName, newColumnWithExistingRows);
+      });
+    });
+
+    return newTable;
+  }
+
+  /**
+   *
+   * @returns A new TransformTable with the columns upserted
+   */
+  public upsertColumns(upserts: { columnName: string; values: FieldValue[] }[]) {
+    if (upserts.length === 0) {
+      return this;
+    }
+
+    const newTable = this.clone();
+    upserts.forEach(({ columnName, values }) => newTable.writeColumnToTable(columnName, values));
+
+    return newTable;
+  }
+
+  /**
+   * Upserts the column to the table. Mutates the existing table. For internal use only
+   * @param columnName to edit/create
+   * @param values column values
+   */
+  private writeColumnToTable(columnName: string, values: FieldValue[]) {
+    if (values.length !== this.length()) {
+      throw new Error(
+        `Error upserting column, incorrect column length (required: ${this.length()}, but got: ${
+          values.length
+        }`,
+      );
+    }
+
+    const isExistingColumn = this.hasColumn(columnName);
+    if (!isExistingColumn) {
+      this.columns.push(columnName);
+    }
+
+    values.forEach((value, index) => {
+      this.rows[index][columnName] = value;
+    });
+  }
+
+  /**
+   * @returns A new TransformTable with the columns dropped
+   */
+  public dropColumns(columnNames: string[]) {
+    if (columnNames.length === 0) {
+      return this;
+    }
+
+    const newTable = this.clone();
+    columnNames.forEach(columnName => {
+      if (!newTable.hasColumn(columnName)) {
+        // Column does not exist, so do nothing
+        return;
+      }
+
+      const indexOfColumn = newTable.indexOfColumn(columnName);
+      newTable.columns.splice(indexOfColumn, 1);
+      newTable.rows.forEach(row => {
+        // eslint-disable-next-line no-param-reassign
+        delete row[columnName];
+      });
+    });
+
+    return newTable;
+  }
+
+  /**
+   * @param indexes indexes to drop
+   * @returns A new TransformTable with the rows dropped
+   */
+  public dropRows(indexes: number[]) {
+    if (indexes.length === 0) {
+      return this;
+    }
+
+    const newTable = this.clone();
+    const sortDescending = (num1: number, num2: number) => num2 - num1;
+    [...indexes].sort(sortDescending).forEach(index => {
+      if (!newTable.hasIndex(index)) {
+        // Row does not exist, so do nothing
+        return;
+      }
+
+      newTable.rows.splice(index, 1);
+    });
+    return newTable;
+  }
+
+  private clone() {
+    return new TransformTable(
+      [...this.columns],
+      this.rows.map(row => ({ ...row })),
+    );
+  }
+}

--- a/packages/report-server/src/reportBuilder/transform/table/TransformTable.ts
+++ b/packages/report-server/src/reportBuilder/transform/table/TransformTable.ts
@@ -147,7 +147,12 @@ export class TransformTable {
     }
 
     values.forEach((value, index) => {
-      this.rows[index][columnName] = value;
+      if (isExistingColumn) {
+        delete this.rows[index][columnName];
+      }
+      if (value !== undefined) {
+        this.rows[index][columnName] = value;
+      }
     });
   }
 

--- a/packages/report-server/src/reportBuilder/transform/table/index.ts
+++ b/packages/report-server/src/reportBuilder/transform/table/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+export { TransformTable } from './TransformTable';

--- a/packages/tsutils/src/index.ts
+++ b/packages/tsutils/src/index.ts
@@ -1,4 +1,5 @@
-export * from './validation';
-export * from './types';
 export * from './downloadPageAsPDF';
 export * from './hashStringToInt';
+export * from './typeGuards';
+export * from './types';
+export * from './validation';

--- a/packages/tsutils/src/typeGuards.ts
+++ b/packages/tsutils/src/typeGuards.ts
@@ -1,0 +1,9 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+export const isDefined = <T>(value: T): value is Exclude<T, undefined> => value !== undefined;
+
+export const isNotNullish = <T>(val: T): val is Exclude<T, undefined | null> =>
+  val !== undefined && val !== null;

--- a/packages/utils/src/period/period.js
+++ b/packages/utils/src/period/period.js
@@ -4,6 +4,8 @@
  */
 
 import get from 'lodash.get';
+// eslint-disable-next-line no-unused-vars
+import { Moment } from 'moment'; // Used in jsdoc
 
 import { utcMoment } from '../datetime';
 import { reduceToDictionary } from '../object';
@@ -154,10 +156,22 @@ export const parsePeriodType = periodTypeString => {
   return periodType;
 };
 
+/**
+ * Parse period into a moment object
+ * @param {string} period
+ * @returns {Moment} moment object
+ */
 export const periodToMoment = period => {
   const periodType = periodToType(period);
   return utcMoment(period, periodTypeToFormat(periodType));
 };
+
+/**
+ * Checks if moment is invalid
+ * @param {Moment} moment
+ * @returns
+ */
+export const isInvalidMoment = moment => moment.format().toUpperCase() === 'INVALID DATE';
 
 export const periodToDateString = (period, isEndPeriod) => {
   const mutatingMoment = periodToMoment(period);
@@ -191,6 +205,32 @@ export const getCurrentPeriod = periodType => utcMoment().format(periodTypeToFor
 export const periodToDisplayString = (period, targetType) => {
   const formattedPeriodType = targetType || periodToType(period);
   return periodToMoment(period).format(periodTypeToDisplayFormat(formattedPeriodType));
+};
+
+/**
+ * Parse display string into a moment object
+ * @param {string} displayString
+ * @param {string} [targetType]
+ * @returns {Moment} moment object
+ */
+export const displayStringToMoment = (displayString, targetType) => {
+  const validatedTargetType = targetType ? parsePeriodType(targetType) : null;
+  if (validatedTargetType) {
+    return utcMoment(displayString, PERIOD_TYPES[validatedTargetType].displayFormat, true);
+  }
+
+  const allDisplayFormats = Object.values(PERIOD_TYPE_CONFIG).map(
+    ({ displayFormat }) => displayFormat,
+  );
+
+  for (let i = 0; i < allDisplayFormats.length; i++) {
+    const moment = utcMoment(displayString, allDisplayFormats[i], true);
+    if (!isInvalidMoment(moment)) {
+      return moment;
+    }
+  }
+
+  return utcMoment(displayString);
 };
 
 /**

--- a/tupaia-packages.code-workspace
+++ b/tupaia-packages.code-workspace
@@ -197,6 +197,7 @@
       "Tupaia",
       "updaters",
       "upsert",
+      "Upserts",
       "vars"
     ],
     "eslint.validate": ["typescript", "typescriptreact"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -5162,6 +5162,7 @@ __metadata:
   resolution: "@tupaia/data-api@workspace:packages/data-api"
   dependencies:
     "@tupaia/database": 1.0.0
+    "@tupaia/tsutils": 1.0.0
     "@tupaia/utils": 1.0.0
     "@types/lodash.groupby": ^4.6.0
     db-migrate: ^0.11.5

--- a/yarn.lock
+++ b/yarn.lock
@@ -5587,6 +5587,7 @@ __metadata:
     lodash.keyby: ^4.6.0
     lodash.pick: ^4.4.0
     mathjs: ^9.4.0
+    moment: ^2.24.0
     winston: ^3.2.1
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
### Issue RN-175:

Part 1 of 3.

We want to introduce an ability to order the columns of the data in the viz-builder. However, before we do this, we need to actually have an explicit order to the columns in the report-server in the first place.

There are other reasons it is advantageous to switch to tracking an explicit column order as well:
- It opens opportunities for controlling how vizes are presented more easily
- It allows us to introduce excel style columns range lookups (eg. `sum(col1:col5)`)
- It makes behaviour of transforms a bit more consistent

Here we are introducing a simple data-structure called a `TransformTable`. It manages the rows of the table as before, but also separately tracks an array of columns. It has a number of utility methods for manipulating the rows/columns atomically, so that the caller doesn't need to ensure they're kept in sync manually.

Tried to make this review as digestable as possible for the reviewer by breaking up changes to each transform step into its own commit, so going commit-by-commit might be the easiest approach.