### PR TITLE
RN-175: Add order columns transform (p2. respect the column order in the viz-builder)

### DIFF
--- a/packages/admin-panel-server/src/__tests__/viz-builder/dashboardVisualisation/DashboardVisualisationExtractor.test.ts
+++ b/packages/admin-panel-server/src/__tests__/viz-builder/dashboardVisualisation/DashboardVisualisationExtractor.test.ts
@@ -331,6 +331,11 @@ describe('DashboardVisualisationExtractor', () => {
             aggregations: ['SUM_EACH_WEEK'],
           },
           transform: ['keyValueByDataElementName'],
+          output: {
+            type: 'bar',
+            x: 'period',
+            y: 'BCD1',
+          },
         },
         permissionGroup: 'Admin',
       });
@@ -375,6 +380,49 @@ describe('DashboardVisualisationExtractor', () => {
             type: 'bar',
             x: 'period',
             y: 'BCD1',
+          },
+        },
+        permissionGroup: 'Admin',
+      });
+    });
+
+    it('includes rowsAndColumns output if previewMode is data', () => {
+      const extractor = new DashboardVisualisationExtractor(
+        {
+          code: 'viz',
+          name: 'My Viz',
+          data: {
+            fetch: {
+              dataElements: ['BCD1', 'BCD2'],
+            },
+            transform: ['keyValueByDataElementName'],
+          },
+          presentation: {
+            type: 'chart',
+            chartType: 'bar',
+            output: {
+              type: 'bar',
+              x: 'period',
+              y: 'BCD1',
+            },
+          },
+          permissionGroup: 'Admin',
+        },
+        draftDashboardItemValidator,
+        draftReportValidator,
+      );
+
+      const report = extractor.getReport(PreviewMode.DATA);
+
+      expect(report).toEqual({
+        code: 'viz',
+        config: {
+          fetch: {
+            dataElements: ['BCD1', 'BCD2'],
+          },
+          transform: ['keyValueByDataElementName'],
+          output: {
+            type: 'rowsAndColumns',
           },
         },
         permissionGroup: 'Admin',

--- a/packages/admin-panel-server/src/viz-builder/dashboardVisualisation/DashboardVisualisationExtractor.ts
+++ b/packages/admin-panel-server/src/viz-builder/dashboardVisualisation/DashboardVisualisationExtractor.ts
@@ -11,6 +11,7 @@ import type { DashboardVisualisationResource } from './types';
 import type { LegacyReport, Report, ExpandType } from '../types';
 import { PreviewMode } from '../types';
 import { baseVisualisationValidator, baseVisualisationDataValidator } from '../validators';
+import { getVizOutputConfig } from '../utils';
 
 export class DashboardVisualisationExtractor<
   DashboardItemValidator extends yup.AnyObjectSchema,
@@ -72,7 +73,7 @@ export class DashboardVisualisationExtractor<
     return this.dashboardItemValidator.validateSync(this.vizToDashboardItem());
   }
 
-  private vizToReport(previewMode?: PreviewMode): Record<keyof Report, unknown> {
+  private vizToReport(previewMode: PreviewMode = PreviewMode.DATA): Record<keyof Report, unknown> {
     const { code, permissionGroup, data, presentation } = this.visualisation;
     const validatedData = baseVisualisationDataValidator.validateSync(data);
 
@@ -95,11 +96,14 @@ export class DashboardVisualisationExtractor<
       },
       isNil,
     );
+
+    const output = getVizOutputConfig(previewMode, presentation);
+
     const config = omitBy(
       {
         fetch,
         transform,
-        output: previewMode === PreviewMode.PRESENTATION ? presentation?.output : null,
+        output,
       },
       isNil,
     );

--- a/packages/admin-panel-server/src/viz-builder/dashboardVisualisation/DashboardVisualisationExtractor.ts
+++ b/packages/admin-panel-server/src/viz-builder/dashboardVisualisation/DashboardVisualisationExtractor.ts
@@ -73,7 +73,9 @@ export class DashboardVisualisationExtractor<
     return this.dashboardItemValidator.validateSync(this.vizToDashboardItem());
   }
 
-  private vizToReport(previewMode: PreviewMode = PreviewMode.DATA): Record<keyof Report, unknown> {
+  private vizToReport(
+    previewMode: PreviewMode = PreviewMode.PRESENTATION,
+  ): Record<keyof Report, unknown> {
     const { code, permissionGroup, data, presentation } = this.visualisation;
     const validatedData = baseVisualisationDataValidator.validateSync(data);
 

--- a/packages/admin-panel-server/src/viz-builder/mapOverlayVisualisation/MapOverlayVisualisationExtractor.ts
+++ b/packages/admin-panel-server/src/viz-builder/mapOverlayVisualisation/MapOverlayVisualisationExtractor.ts
@@ -11,6 +11,7 @@ import type { MapOverlayVisualisationResource } from './types';
 import type { LegacyReport, Report, ExpandType } from '../types';
 import { PreviewMode } from '../types';
 import { baseVisualisationValidator, baseVisualisationDataValidator } from '../validators';
+import { getVizOutputConfig } from '../utils';
 
 export class MapOverlayVisualisationExtractor<
   MapOverlayValidator extends yup.AnyObjectSchema,
@@ -77,7 +78,7 @@ export class MapOverlayVisualisationExtractor<
     return this.mapOverlayValidator.validateSync(this.vizToMapOverlay());
   }
 
-  private vizToReport(previewMode?: PreviewMode): Record<keyof Report, unknown> {
+  private vizToReport(previewMode: PreviewMode = PreviewMode.DATA): Record<keyof Report, unknown> {
     const { code, reportPermissionGroup: permissionGroup, data, presentation } = this.visualisation;
     const validatedData = baseVisualisationDataValidator.validateSync(data);
 
@@ -90,11 +91,14 @@ export class MapOverlayVisualisationExtractor<
       },
       isNil,
     );
+
+    const output = getVizOutputConfig(previewMode, presentation);
+
     const config = omitBy(
       {
         fetch,
         transform,
-        output: previewMode === PreviewMode.PRESENTATION ? presentation?.output : null,
+        output,
       },
       isNil,
     );

--- a/packages/admin-panel-server/src/viz-builder/mapOverlayVisualisation/MapOverlayVisualisationExtractor.ts
+++ b/packages/admin-panel-server/src/viz-builder/mapOverlayVisualisation/MapOverlayVisualisationExtractor.ts
@@ -78,7 +78,9 @@ export class MapOverlayVisualisationExtractor<
     return this.mapOverlayValidator.validateSync(this.vizToMapOverlay());
   }
 
-  private vizToReport(previewMode: PreviewMode = PreviewMode.DATA): Record<keyof Report, unknown> {
+  private vizToReport(
+    previewMode: PreviewMode = PreviewMode.PRESENTATION,
+  ): Record<keyof Report, unknown> {
     const { code, reportPermissionGroup: permissionGroup, data, presentation } = this.visualisation;
     const validatedData = baseVisualisationDataValidator.validateSync(data);
 

--- a/packages/admin-panel-server/src/viz-builder/utils/extractDataFromReport.ts
+++ b/packages/admin-panel-server/src/viz-builder/utils/extractDataFromReport.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
  */
 
-import { Report } from './types';
+import { Report } from '../types';
 
 // Used when combining the report and dashboardItem/mapOverlay
 export const extractDataFromReport = (report: Report) => {

--- a/packages/admin-panel-server/src/viz-builder/utils/getVizOutputConfig.ts
+++ b/packages/admin-panel-server/src/viz-builder/utils/getVizOutputConfig.ts
@@ -1,0 +1,25 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import { PreviewMode } from '../types';
+
+export const getVizOutputConfig = (
+  previewMode: PreviewMode,
+  presentation: Record<string, unknown>,
+) => {
+  switch (previewMode) {
+    case PreviewMode.PRESENTATION: {
+      // Use whatever is configured in the viz's output config in the presentation options
+      return presentation?.output;
+    }
+    case PreviewMode.DATA: {
+      // Use rowsAndColumns output to render the viz-builder data-table with correct columns order
+      return { type: 'rowsAndColumns' };
+    }
+    default: {
+      throw new Error(`Unknown preview mode ${previewMode}`);
+    }
+  }
+};

--- a/packages/admin-panel-server/src/viz-builder/utils/index.ts
+++ b/packages/admin-panel-server/src/viz-builder/utils/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+export { extractDataFromReport } from './extractDataFromReport';
+export { getVizOutputConfig } from './getVizOutputConfig';

--- a/packages/admin-panel/src/VizBuilderApp/api/queries/useReportPreview.js
+++ b/packages/admin-panel/src/VizBuilderApp/api/queries/useReportPreview.js
@@ -14,6 +14,7 @@ export const useReportPreview = ({
   enabled,
   onSettled,
   vizType,
+  previewMode,
 }) =>
   useQuery(
     ['fetchReportPreviewData', visualisation],
@@ -23,6 +24,7 @@ export const useReportPreview = ({
           entityCode: location,
           hierarchy: project,
           vizType,
+          previewMode,
         },
         data: {
           testData,

--- a/packages/report-server/package.json
+++ b/packages/report-server/package.json
@@ -45,6 +45,7 @@
     "lodash.keyby": "^4.6.0",
     "lodash.pick": "^4.4.0",
     "mathjs": "^9.4.0",
+    "moment": "^2.24.0",
     "winston": "^3.2.1"
   },
   "devDependencies": {

--- a/packages/report-server/src/__tests__/reportBuilder/output/default.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/output/default.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import { Aggregator } from '@tupaia/aggregator';
+import { ReportServerAggregator } from '../../../aggregator';
+import { buildOutput } from '../../../reportBuilder/output';
+import { TransformTable } from '../../../reportBuilder/transform';
+import { MULTIPLE_TRANSFORMED_DATA } from './output.fixtures';
+
+describe('default', () => {
+  const dataBroker = { context: {} };
+  const aggregator = new Aggregator(dataBroker);
+
+  it('defaults to rows', async () => {
+    const table = TransformTable.fromRows(MULTIPLE_TRANSFORMED_DATA);
+    const expectedData = table.getRows();
+    const context = {};
+    const reportServerAggregator = new ReportServerAggregator(aggregator);
+    const output = buildOutput(undefined, context, reportServerAggregator);
+
+    const results = await output(table);
+    expect(results).toEqual(expectedData);
+  });
+});

--- a/packages/report-server/src/__tests__/reportBuilder/output/rows.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/output/rows.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import { Aggregator } from '@tupaia/aggregator';
+import { ReportServerAggregator } from '../../../aggregator';
+import { buildOutput } from '../../../reportBuilder/output';
+import { TransformTable } from '../../../reportBuilder/transform';
+import { MULTIPLE_TRANSFORMED_DATA } from './output.fixtures';
+
+describe('rows', () => {
+  const dataBroker = { context: {} };
+  const aggregator = new Aggregator(dataBroker);
+
+  it('returns the rows of the table', async () => {
+    const table = TransformTable.fromRows(MULTIPLE_TRANSFORMED_DATA);
+    const expectedData = table.getRows();
+    const config = {
+      type: 'rows',
+    };
+    const context = {};
+    const reportServerAggregator = new ReportServerAggregator(aggregator);
+    const output = buildOutput(config, context, reportServerAggregator);
+
+    const results = await output(table);
+    expect(results).toEqual(expectedData);
+  });
+});

--- a/packages/report-server/src/__tests__/reportBuilder/output/rowsAndColumns.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/output/rowsAndColumns.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import { Aggregator } from '@tupaia/aggregator';
+import { ReportServerAggregator } from '../../../aggregator';
+import { buildOutput } from '../../../reportBuilder/output';
+import { TransformTable } from '../../../reportBuilder/transform';
+import { MULTIPLE_TRANSFORMED_DATA } from './output.fixtures';
+
+describe('rowsAndColumns', () => {
+  const dataBroker = { context: {} };
+  const aggregator = new Aggregator(dataBroker);
+
+  it('returns the rows and columns of the data', async () => {
+    const table = TransformTable.fromRows(MULTIPLE_TRANSFORMED_DATA);
+    const expectedData = {
+      columns: table.getColumns(),
+      rows: table.getRows(),
+    };
+    const config = {
+      type: 'rowsAndColumns',
+    };
+    const context = {};
+    const reportServerAggregator = new ReportServerAggregator(aggregator);
+    const output = buildOutput(config, context, reportServerAggregator);
+
+    const results = await output(table);
+    expect(results).toEqual(expectedData);
+  });
+});

--- a/packages/report-server/src/__tests__/reportBuilder/transform/orderColumns.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/transform/orderColumns.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
+ */
+
+import { SINGLE_ANALYTIC, DATE_COLUMNS, PERIOD_COLUMNS } from './transform.fixtures';
+import { buildTransform, TransformTable } from '../../../reportBuilder/transform';
+
+describe('orderColumns', () => {
+  it('can re-order columns explicitly', () => {
+    const transform = buildTransform([
+      {
+        transform: 'orderColumns',
+        order: ['dataElement', 'value', 'period', 'organisationUnit'],
+      },
+    ]);
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+      TransformTable.fromRows([
+        { dataElement: 'BCD1', value: 4, period: '20200101', organisationUnit: 'TO' },
+      ]),
+    );
+  });
+
+  it('can re-order columns explicitly with a wildCard', () => {
+    const transform = buildTransform([
+      {
+        transform: 'orderColumns',
+        order: ['dataElement', '*', 'organisationUnit'],
+      },
+    ]);
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+      TransformTable.fromRows([
+        { dataElement: 'BCD1', period: '20200101', value: 4, organisationUnit: 'TO' },
+      ]),
+    );
+  });
+
+  it('ignores columns in the explicit order that do not exist in the table', () => {
+    const transform = buildTransform([
+      {
+        transform: 'orderColumns',
+        order: ['dataElement', 'BCD1', 'period', 'value', 'organisationUnit'],
+      },
+    ]);
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+      TransformTable.fromRows([
+        { dataElement: 'BCD1', period: '20200101', value: 4, organisationUnit: 'TO' },
+      ]),
+    );
+  });
+
+  it('defaults to appending columns to the end if they are not listed in the order', () => {
+    const transform = buildTransform([
+      {
+        transform: 'orderColumns',
+        order: ['dataElement', 'organisationUnit'],
+      },
+    ]);
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+      TransformTable.fromRows([
+        { dataElement: 'BCD1', organisationUnit: 'TO', period: '20200101', value: 4 },
+      ]),
+    );
+  });
+
+  describe('sortBy functions', () => {
+    it('throws error for unknown sortBy function', () => {
+      expect(() =>
+        buildTransform([
+          {
+            transform: 'orderColumns',
+            sortBy: 'not_a_real_sort_by_function',
+          },
+        ]),
+      ).toThrow('sortBy must be one of the following values:');
+    });
+
+    describe('alphabetic', () => {
+      it('can sort columns alphabetically', () => {
+        const transform = buildTransform([
+          {
+            transform: 'orderColumns',
+            sortBy: 'alphabetic',
+          },
+        ]);
+        expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+          TransformTable.fromRows([
+            { dataElement: 'BCD1', organisationUnit: 'TO', period: '20200101', value: 4 },
+          ]),
+        );
+      });
+    });
+
+    describe('date', () => {
+      it('can sort columns by date', () => {
+        const transform = buildTransform([
+          {
+            transform: 'orderColumns',
+            sortBy: 'date',
+          },
+        ]);
+        expect(transform(TransformTable.fromRows(DATE_COLUMNS))).toEqual(
+          TransformTable.fromRows([
+            {
+              'Q1 2021': 4,
+              '13th Jan 2022': 2,
+              '2nd Aug 2022': 1,
+              'Sep 2022': 3,
+              organisationUnit: 'Tonga',
+            },
+          ]),
+        );
+      });
+    });
+
+    describe('period', () => {
+      it('can sort columns by period', () => {
+        const transform = buildTransform([
+          {
+            transform: 'orderColumns',
+            sortBy: 'period',
+          },
+        ]);
+        expect(transform(TransformTable.fromRows(PERIOD_COLUMNS))).toEqual(
+          TransformTable.fromRows(
+            [
+              {
+                '2021Q1': 4,
+                '2022W03': 2,
+                '20220802': 1,
+                '202209': 3,
+                organisationUnit: 'Tonga',
+              },
+            ],
+            ['2021Q1', '2022W03', '20220802', '202209', 'organisationUnit'],
+          ),
+        );
+      });
+    });
+  });
+});

--- a/packages/report-server/src/__tests__/reportBuilder/transform/transform.fixtures.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/transform/transform.fixtures.ts
@@ -129,3 +129,23 @@ export const PARSABLE_ANALYTICS = [
   { period: '20200102', organisationUnit: 'PG', BCD1: 8 },
   { period: '20200103', organisationUnit: 'PG', BCD1: 2 },
 ];
+
+export const DATE_COLUMNS = [
+  {
+    organisationUnit: 'Tonga',
+    '2nd Aug 2022': 1,
+    '13th Jan 2022': 2,
+    'Sep 2022': 3,
+    'Q1 2021': 4,
+  },
+];
+
+export const PERIOD_COLUMNS = [
+  {
+    organisationUnit: 'Tonga',
+    '20220802': 1,
+    '2022W03': 2,
+    '202209': 3,
+    '2021Q1': 4,
+  },
+];

--- a/packages/report-server/src/reportBuilder/output/functions/outputBuilders.ts
+++ b/packages/report-server/src/reportBuilder/output/functions/outputBuilders.ts
@@ -4,7 +4,8 @@
  */
 
 import { Resolved } from '@tupaia/tsutils';
-import { buildDefault } from './default';
+import { buildRows } from './rows';
+import { buildRowsAndColumns } from './rowsAndColumns';
 import { buildMatrix } from './matrix';
 import { buildRawDataExport } from './rawDataExport';
 
@@ -15,5 +16,7 @@ export type OutputType = Resolved<
 export const outputBuilders = {
   matrix: buildMatrix,
   rawDataExport: buildRawDataExport,
-  default: buildDefault,
+  rowsAndColumns: buildRowsAndColumns,
+  rows: buildRows,
+  default: buildRows,
 };

--- a/packages/report-server/src/reportBuilder/output/functions/rows.ts
+++ b/packages/report-server/src/reportBuilder/output/functions/rows.ts
@@ -5,6 +5,6 @@
 
 import { TransformTable } from '../../transform';
 
-export const buildDefault = () => {
+export const buildRows = () => {
   return (table: TransformTable) => table.getRows();
 };

--- a/packages/report-server/src/reportBuilder/output/functions/rowsAndColumns.ts
+++ b/packages/report-server/src/reportBuilder/output/functions/rowsAndColumns.ts
@@ -1,0 +1,13 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+
+import { TransformTable } from '../../transform';
+
+export const buildRowsAndColumns = () => {
+  return (table: TransformTable) => ({
+    columns: table.getColumns(),
+    rows: table.getRows(),
+  });
+};

--- a/packages/report-server/src/reportBuilder/transform/functions/index.ts
+++ b/packages/report-server/src/reportBuilder/transform/functions/index.ts
@@ -25,6 +25,7 @@ import {
   buildGatherColumns,
   paramsValidator as gatherColumnsParamsValidator,
 } from './gatherColumns';
+import { buildOrderColumns, orderColumnsSchema } from './orderColumns';
 import { TransformTable } from '../table';
 
 type TransformBuilder = (
@@ -41,6 +42,7 @@ export const transformBuilders: Record<string, TransformBuilder> = {
   excludeRows: buildExcludeRows,
   insertRows: buildInsertRows,
   gatherColumns: buildGatherColumns,
+  orderColumns: buildOrderColumns,
 };
 
 export const transformSchemas: Record<
@@ -58,4 +60,5 @@ export const transformSchemas: Record<
   excludeRows: excludeRowsParamsValidator.describe(),
   insertRows: insertRowsParamsValidator.describe(),
   gatherColumns: gatherColumnsParamsValidator.describe(),
+  orderColumns: orderColumnsSchema,
 };

--- a/packages/report-server/src/reportBuilder/transform/functions/orderColumns/index.ts
+++ b/packages/report-server/src/reportBuilder/transform/functions/orderColumns/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+export { buildOrderColumns, orderColumnsSchema } from './orderColumns';

--- a/packages/report-server/src/reportBuilder/transform/functions/orderColumns/orderColumns.ts
+++ b/packages/report-server/src/reportBuilder/transform/functions/orderColumns/orderColumns.ts
@@ -1,0 +1,105 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import { isDefined } from '@tupaia/tsutils';
+import { yup } from '@tupaia/utils';
+import { TransformTable } from '../../table';
+import { sortByFunctions } from './sortByFunctions';
+
+type OrderColumnsParams = {
+  columnOrder?: string[];
+  sorter?: (column1: string, column2: string) => number;
+};
+
+export const paramsValidator = yup.object().shape({
+  order: yup.array().of(yup.string().required()),
+  sortBy: yup
+    .mixed<keyof typeof sortByFunctions>()
+    .oneOf(Object.keys(sortByFunctions) as (keyof typeof sortByFunctions)[]),
+});
+
+const orderColumns = (table: TransformTable, params: OrderColumnsParams) => {
+  const { columnOrder = ['*'], sorter } = params;
+
+  if (sorter) {
+    return new TransformTable(table.getColumns().sort(sorter), table.getRows());
+  }
+
+  if (!columnOrder.includes('*')) {
+    columnOrder.push('*'); // Add wildcard to the end if it's not specified
+  }
+
+  const existingColumns = table.getColumns();
+  const newColumns = new Array<string | undefined>(existingColumns.length).fill(undefined);
+  const orderedColumns = existingColumns.filter(column => columnOrder.includes(column));
+  const wildcardColumns = existingColumns.filter(column => !columnOrder.includes(column));
+
+  // Filter out columns that are not in the table
+  const order = columnOrder.filter(column => existingColumns.includes(column) || column === '*');
+  const indexOfWildcard = order.indexOf('*');
+
+  wildcardColumns.forEach((column, index) => {
+    newColumns[indexOfWildcard + index] = column;
+  });
+
+  orderedColumns.forEach(column => {
+    const indexInOrder = order.indexOf(column);
+    const indexInNewColumns =
+      indexInOrder < indexOfWildcard
+        ? indexInOrder // It's before the wildcard, just use the index
+        : indexInOrder + orderedColumns.length - 1; // It's after the wildcard, so account for all wildcard columns (minus wildcard itself)
+    newColumns[indexInNewColumns] = column;
+  });
+
+  const validatedColumns = newColumns.map(column => {
+    if (!isDefined(column)) {
+      throw new Error('Missing columns when determining new column order');
+    }
+
+    return column;
+  });
+
+  return new TransformTable(validatedColumns, table.getRows());
+};
+
+const buildParams = (params: unknown): OrderColumnsParams => {
+  const validatedParams = paramsValidator.validateSync(params);
+
+  const { order, sortBy } = validatedParams;
+
+  if (order && sortBy) {
+    throw new Error('Cannot provide explicit column order and a sort by function');
+  }
+
+  if (order) {
+    return {
+      columnOrder: Array.from(new Set(order)),
+    };
+  }
+
+  if (sortBy) {
+    return {
+      sorter: sortByFunctions[sortBy],
+    };
+  }
+
+  throw new Error('Must provide either explicit column order or a sort by function');
+};
+
+export const buildOrderColumns = (params: unknown) => {
+  const builtParams = buildParams(params);
+  return (table: TransformTable) => orderColumns(table, builtParams);
+};
+
+export const orderColumnsSchema = {
+  ...paramsValidator.describe(),
+  fields: {
+    ...paramsValidator.describe().fields,
+    // Override sortBy describe, as viz-builder doesn't support mixed schemas
+    sortBy: {
+      enum: Object.keys(sortByFunctions),
+    },
+  },
+};

--- a/packages/report-server/src/reportBuilder/transform/functions/orderColumns/sortByFunctions.ts
+++ b/packages/report-server/src/reportBuilder/transform/functions/orderColumns/sortByFunctions.ts
@@ -1,0 +1,36 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import { Moment } from 'moment';
+import { displayStringToMoment, periodToMoment, isInvalidMoment } from '@tupaia/utils';
+
+const alphabetic = (column1: string, column2: string) => column1.localeCompare(column2);
+
+const sortMoment = (moment1: Moment, moment2: Moment) => {
+  if (isInvalidMoment(moment1) && isInvalidMoment(moment2)) return 0;
+  if (isInvalidMoment(moment1)) return 1;
+  if (isInvalidMoment(moment2)) return -1;
+  if (moment1.isSame(moment2)) return 0;
+  if (moment1.isBefore(moment2)) return -1;
+  return 1;
+};
+
+const date = (column1: string, column2: string) => {
+  const col1Moment = displayStringToMoment(column1);
+  const col2Moment = displayStringToMoment(column2);
+  return sortMoment(col1Moment, col2Moment);
+};
+
+const period = (column1: string, column2: string) => {
+  const col1Moment = periodToMoment(column1);
+  const col2Moment = periodToMoment(column2);
+  return sortMoment(col1Moment, col2Moment);
+};
+
+export const sortByFunctions = {
+  alphabetic,
+  date,
+  period,
+};

--- a/packages/report-server/src/reportBuilder/transform/parser/functions/utils.ts
+++ b/packages/report-server/src/reportBuilder/transform/parser/functions/utils.ts
@@ -15,7 +15,7 @@ export const convertToPeriod = (period: string, targetType: string): string => {
   return baseConvertToPeriod(period, targetType);
 };
 
-export const periodToTimestamp = (period: string): string => {
+export const periodToTimestamp = (period: string): number => {
   return basePeriodToTimestamp(period);
 };
 

--- a/packages/utils/src/period/period.js
+++ b/packages/utils/src/period/period.js
@@ -4,6 +4,8 @@
  */
 
 import get from 'lodash.get';
+// eslint-disable-next-line no-unused-vars
+import { Moment } from 'moment'; // Used in jsdoc
 
 import { utcMoment } from '../datetime';
 import { reduceToDictionary } from '../object';
@@ -154,10 +156,22 @@ export const parsePeriodType = periodTypeString => {
   return periodType;
 };
 
+/**
+ * Parse period into a moment object
+ * @param {string} period
+ * @returns {Moment} moment object
+ */
 export const periodToMoment = period => {
   const periodType = periodToType(period);
   return utcMoment(period, periodTypeToFormat(periodType));
 };
+
+/**
+ * Checks if moment is invalid
+ * @param {Moment} moment
+ * @returns
+ */
+export const isInvalidMoment = moment => moment.format().toUpperCase() === 'INVALID DATE';
 
 export const periodToDateString = (period, isEndPeriod) => {
   const mutatingMoment = periodToMoment(period);
@@ -191,6 +205,32 @@ export const getCurrentPeriod = periodType => utcMoment().format(periodTypeToFor
 export const periodToDisplayString = (period, targetType) => {
   const formattedPeriodType = targetType || periodToType(period);
   return periodToMoment(period).format(periodTypeToDisplayFormat(formattedPeriodType));
+};
+
+/**
+ * Parse display string into a moment object
+ * @param {string} displayString
+ * @param {string} [targetType]
+ * @returns {Moment} moment object
+ */
+export const displayStringToMoment = (displayString, targetType) => {
+  const validatedTargetType = targetType ? parsePeriodType(targetType) : null;
+  if (validatedTargetType) {
+    return utcMoment(displayString, PERIOD_TYPES[validatedTargetType].displayFormat, true);
+  }
+
+  const allDisplayFormats = Object.values(PERIOD_TYPE_CONFIG).map(
+    ({ displayFormat }) => displayFormat,
+  );
+
+  for (let i = 0; i < allDisplayFormats.length; i++) {
+    const moment = utcMoment(displayString, allDisplayFormats[i], true);
+    if (!isInvalidMoment(moment)) {
+      return moment;
+    }
+  }
+
+  return utcMoment(displayString);
 };
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -5587,6 +5587,7 @@ __metadata:
     lodash.keyby: ^4.6.0
     lodash.pick: ^4.4.0
     mathjs: ^9.4.0
+    moment: ^2.24.0
     winston: ^3.2.1
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
### Issue RN-175:

Part 2 of 3.

This is a fairly simple PR to switch the viz-builder to respect the column order defined during the data transformation in the report-server.

In order to be backwards compatible, we need to return data as just a simple array of objects from the report-server by default. However, we'd like the viz-builder to know the column order for this array of objects. So I added a new `output` type (`rowsAndColumns`) which returns the rows (array of objects) and the ordered list of column names. Then just a few changes in the admin-panel-server to use this new output type when previewing the data-table.