### PR TITLE
RN-175: Add order columns transform (p3. order columns transform step)

### DIFF
--- a/packages/report-server/package.json
+++ b/packages/report-server/package.json
@@ -45,6 +45,7 @@
     "lodash.keyby": "^4.6.0",
     "lodash.pick": "^4.4.0",
     "mathjs": "^9.4.0",
+    "moment": "^2.24.0",
     "winston": "^3.2.1"
   },
   "devDependencies": {

--- a/packages/report-server/src/__tests__/reportBuilder/transform/orderColumns.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/transform/orderColumns.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
+ */
+
+import { SINGLE_ANALYTIC, DATE_COLUMNS, PERIOD_COLUMNS } from './transform.fixtures';
+import { buildTransform, TransformTable } from '../../../reportBuilder/transform';
+
+describe('orderColumns', () => {
+  it('can re-order columns explicitly', () => {
+    const transform = buildTransform([
+      {
+        transform: 'orderColumns',
+        order: ['dataElement', 'value', 'period', 'organisationUnit'],
+      },
+    ]);
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+      TransformTable.fromRows([
+        { dataElement: 'BCD1', value: 4, period: '20200101', organisationUnit: 'TO' },
+      ]),
+    );
+  });
+
+  it('can re-order columns explicitly with a wildCard', () => {
+    const transform = buildTransform([
+      {
+        transform: 'orderColumns',
+        order: ['dataElement', '*', 'organisationUnit'],
+      },
+    ]);
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+      TransformTable.fromRows([
+        { dataElement: 'BCD1', period: '20200101', value: 4, organisationUnit: 'TO' },
+      ]),
+    );
+  });
+
+  it('ignores columns in the explicit order that do not exist in the table', () => {
+    const transform = buildTransform([
+      {
+        transform: 'orderColumns',
+        order: ['dataElement', 'BCD1', 'period', 'value', 'organisationUnit'],
+      },
+    ]);
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+      TransformTable.fromRows([
+        { dataElement: 'BCD1', period: '20200101', value: 4, organisationUnit: 'TO' },
+      ]),
+    );
+  });
+
+  it('defaults to appending columns to the end if they are not listed in the order', () => {
+    const transform = buildTransform([
+      {
+        transform: 'orderColumns',
+        order: ['dataElement', 'organisationUnit'],
+      },
+    ]);
+    expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+      TransformTable.fromRows([
+        { dataElement: 'BCD1', organisationUnit: 'TO', period: '20200101', value: 4 },
+      ]),
+    );
+  });
+
+  describe('sortBy functions', () => {
+    it('throws error for unknown sortBy function', () => {
+      expect(() =>
+        buildTransform([
+          {
+            transform: 'orderColumns',
+            sortBy: 'not_a_real_sort_by_function',
+          },
+        ]),
+      ).toThrow('sortBy must be one of the following values:');
+    });
+
+    describe('alphabetic', () => {
+      it('can sort columns alphabetically', () => {
+        const transform = buildTransform([
+          {
+            transform: 'orderColumns',
+            sortBy: 'alphabetic',
+          },
+        ]);
+        expect(transform(TransformTable.fromRows(SINGLE_ANALYTIC))).toEqual(
+          TransformTable.fromRows([
+            { dataElement: 'BCD1', organisationUnit: 'TO', period: '20200101', value: 4 },
+          ]),
+        );
+      });
+    });
+
+    describe('date', () => {
+      it('can sort columns by date', () => {
+        const transform = buildTransform([
+          {
+            transform: 'orderColumns',
+            sortBy: 'date',
+          },
+        ]);
+        expect(transform(TransformTable.fromRows(DATE_COLUMNS))).toEqual(
+          TransformTable.fromRows([
+            {
+              'Q1 2021': 4,
+              '13th Jan 2022': 2,
+              '2nd Aug 2022': 1,
+              'Sep 2022': 3,
+              organisationUnit: 'Tonga',
+            },
+          ]),
+        );
+      });
+    });
+
+    describe('period', () => {
+      it('can sort columns by period', () => {
+        const transform = buildTransform([
+          {
+            transform: 'orderColumns',
+            sortBy: 'period',
+          },
+        ]);
+        expect(transform(TransformTable.fromRows(PERIOD_COLUMNS))).toEqual(
+          TransformTable.fromRows(
+            [
+              {
+                '2021Q1': 4,
+                '2022W03': 2,
+                '20220802': 1,
+                '202209': 3,
+                organisationUnit: 'Tonga',
+              },
+            ],
+            ['2021Q1', '2022W03', '20220802', '202209', 'organisationUnit'],
+          ),
+        );
+      });
+    });
+  });
+});

--- a/packages/report-server/src/__tests__/reportBuilder/transform/transform.fixtures.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/transform/transform.fixtures.ts
@@ -129,3 +129,23 @@ export const PARSABLE_ANALYTICS = [
   { period: '20200102', organisationUnit: 'PG', BCD1: 8 },
   { period: '20200103', organisationUnit: 'PG', BCD1: 2 },
 ];
+
+export const DATE_COLUMNS = [
+  {
+    organisationUnit: 'Tonga',
+    '2nd Aug 2022': 1,
+    '13th Jan 2022': 2,
+    'Sep 2022': 3,
+    'Q1 2021': 4,
+  },
+];
+
+export const PERIOD_COLUMNS = [
+  {
+    organisationUnit: 'Tonga',
+    '20220802': 1,
+    '2022W03': 2,
+    '202209': 3,
+    '2021Q1': 4,
+  },
+];

--- a/packages/report-server/src/reportBuilder/transform/functions/index.ts
+++ b/packages/report-server/src/reportBuilder/transform/functions/index.ts
@@ -25,6 +25,7 @@ import {
   buildGatherColumns,
   paramsValidator as gatherColumnsParamsValidator,
 } from './gatherColumns';
+import { buildOrderColumns, orderColumnsSchema } from './orderColumns';
 import { TransformTable } from '../table';
 
 type TransformBuilder = (
@@ -41,6 +42,7 @@ export const transformBuilders: Record<string, TransformBuilder> = {
   excludeRows: buildExcludeRows,
   insertRows: buildInsertRows,
   gatherColumns: buildGatherColumns,
+  orderColumns: buildOrderColumns,
 };
 
 export const transformSchemas: Record<
@@ -58,4 +60,5 @@ export const transformSchemas: Record<
   excludeRows: excludeRowsParamsValidator.describe(),
   insertRows: insertRowsParamsValidator.describe(),
   gatherColumns: gatherColumnsParamsValidator.describe(),
+  orderColumns: orderColumnsSchema,
 };

--- a/packages/report-server/src/reportBuilder/transform/functions/orderColumns/index.ts
+++ b/packages/report-server/src/reportBuilder/transform/functions/orderColumns/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+export { buildOrderColumns, orderColumnsSchema } from './orderColumns';

--- a/packages/report-server/src/reportBuilder/transform/functions/orderColumns/orderColumns.ts
+++ b/packages/report-server/src/reportBuilder/transform/functions/orderColumns/orderColumns.ts
@@ -1,0 +1,105 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import { isDefined } from '@tupaia/tsutils';
+import { yup } from '@tupaia/utils';
+import { TransformTable } from '../../table';
+import { sortByFunctions } from './sortByFunctions';
+
+type OrderColumnsParams = {
+  columnOrder?: string[];
+  sorter?: (column1: string, column2: string) => number;
+};
+
+export const paramsValidator = yup.object().shape({
+  order: yup.array().of(yup.string().required()),
+  sortBy: yup
+    .mixed<keyof typeof sortByFunctions>()
+    .oneOf(Object.keys(sortByFunctions) as (keyof typeof sortByFunctions)[]),
+});
+
+const orderColumns = (table: TransformTable, params: OrderColumnsParams) => {
+  const { columnOrder = ['*'], sorter } = params;
+
+  if (sorter) {
+    return new TransformTable(table.getColumns().sort(sorter), table.getRows());
+  }
+
+  if (!columnOrder.includes('*')) {
+    columnOrder.push('*'); // Add wildcard to the end if it's not specified
+  }
+
+  const existingColumns = table.getColumns();
+  const newColumns = new Array<string | undefined>(existingColumns.length).fill(undefined);
+  const orderedColumns = existingColumns.filter(column => columnOrder.includes(column));
+  const wildcardColumns = existingColumns.filter(column => !columnOrder.includes(column));
+
+  // Filter out columns that are not in the table
+  const order = columnOrder.filter(column => existingColumns.includes(column) || column === '*');
+  const indexOfWildcard = order.indexOf('*');
+
+  wildcardColumns.forEach((column, index) => {
+    newColumns[indexOfWildcard + index] = column;
+  });
+
+  orderedColumns.forEach(column => {
+    const indexInOrder = order.indexOf(column);
+    const indexInNewColumns =
+      indexInOrder < indexOfWildcard
+        ? indexInOrder // It's before the wildcard, just use the index
+        : indexInOrder + orderedColumns.length - 1; // It's after the wildcard, so account for all wildcard columns (minus wildcard itself)
+    newColumns[indexInNewColumns] = column;
+  });
+
+  const validatedColumns = newColumns.map(column => {
+    if (!isDefined(column)) {
+      throw new Error('Missing columns when determining new column order');
+    }
+
+    return column;
+  });
+
+  return new TransformTable(validatedColumns, table.getRows());
+};
+
+const buildParams = (params: unknown): OrderColumnsParams => {
+  const validatedParams = paramsValidator.validateSync(params);
+
+  const { order, sortBy } = validatedParams;
+
+  if (order && sortBy) {
+    throw new Error('Cannot provide explicit column order and a sort by function');
+  }
+
+  if (order) {
+    return {
+      columnOrder: Array.from(new Set(order)),
+    };
+  }
+
+  if (sortBy) {
+    return {
+      sorter: sortByFunctions[sortBy],
+    };
+  }
+
+  throw new Error('Must provide either explicit column order or a sort by function');
+};
+
+export const buildOrderColumns = (params: unknown) => {
+  const builtParams = buildParams(params);
+  return (table: TransformTable) => orderColumns(table, builtParams);
+};
+
+export const orderColumnsSchema = {
+  ...paramsValidator.describe(),
+  fields: {
+    ...paramsValidator.describe().fields,
+    // Override sortBy describe, as viz-builder doesn't support mixed schemas
+    sortBy: {
+      enum: Object.keys(sortByFunctions),
+    },
+  },
+};

--- a/packages/report-server/src/reportBuilder/transform/functions/orderColumns/sortByFunctions.ts
+++ b/packages/report-server/src/reportBuilder/transform/functions/orderColumns/sortByFunctions.ts
@@ -1,0 +1,36 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import { Moment } from 'moment';
+import { displayStringToMoment, periodToMoment, isInvalidMoment } from '@tupaia/utils';
+
+const alphabetic = (column1: string, column2: string) => column1.localeCompare(column2);
+
+const sortMoment = (moment1: Moment, moment2: Moment) => {
+  if (isInvalidMoment(moment1) && isInvalidMoment(moment2)) return 0;
+  if (isInvalidMoment(moment1)) return 1;
+  if (isInvalidMoment(moment2)) return -1;
+  if (moment1.isSame(moment2)) return 0;
+  if (moment1.isBefore(moment2)) return -1;
+  return 1;
+};
+
+const date = (column1: string, column2: string) => {
+  const col1Moment = displayStringToMoment(column1);
+  const col2Moment = displayStringToMoment(column2);
+  return sortMoment(col1Moment, col2Moment);
+};
+
+const period = (column1: string, column2: string) => {
+  const col1Moment = periodToMoment(column1);
+  const col2Moment = periodToMoment(column2);
+  return sortMoment(col1Moment, col2Moment);
+};
+
+export const sortByFunctions = {
+  alphabetic,
+  date,
+  period,
+};

--- a/packages/report-server/src/reportBuilder/transform/parser/functions/utils.ts
+++ b/packages/report-server/src/reportBuilder/transform/parser/functions/utils.ts
@@ -15,7 +15,7 @@ export const convertToPeriod = (period: string, targetType: string): string => {
   return baseConvertToPeriod(period, targetType);
 };
 
-export const periodToTimestamp = (period: string): string => {
+export const periodToTimestamp = (period: string): number => {
   return basePeriodToTimestamp(period);
 };
 

--- a/packages/utils/src/period/period.js
+++ b/packages/utils/src/period/period.js
@@ -4,6 +4,8 @@
  */
 
 import get from 'lodash.get';
+// eslint-disable-next-line no-unused-vars
+import { Moment } from 'moment'; // Used in jsdoc
 
 import { utcMoment } from '../datetime';
 import { reduceToDictionary } from '../object';
@@ -154,10 +156,22 @@ export const parsePeriodType = periodTypeString => {
   return periodType;
 };
 
+/**
+ * Parse period into a moment object
+ * @param {string} period
+ * @returns {Moment} moment object
+ */
 export const periodToMoment = period => {
   const periodType = periodToType(period);
   return utcMoment(period, periodTypeToFormat(periodType));
 };
+
+/**
+ * Checks if moment is invalid
+ * @param {Moment} moment
+ * @returns
+ */
+export const isInvalidMoment = moment => moment.format().toUpperCase() === 'INVALID DATE';
 
 export const periodToDateString = (period, isEndPeriod) => {
   const mutatingMoment = periodToMoment(period);
@@ -191,6 +205,32 @@ export const getCurrentPeriod = periodType => utcMoment().format(periodTypeToFor
 export const periodToDisplayString = (period, targetType) => {
   const formattedPeriodType = targetType || periodToType(period);
   return periodToMoment(period).format(periodTypeToDisplayFormat(formattedPeriodType));
+};
+
+/**
+ * Parse display string into a moment object
+ * @param {string} displayString
+ * @param {string} [targetType]
+ * @returns {Moment} moment object
+ */
+export const displayStringToMoment = (displayString, targetType) => {
+  const validatedTargetType = targetType ? parsePeriodType(targetType) : null;
+  if (validatedTargetType) {
+    return utcMoment(displayString, PERIOD_TYPES[validatedTargetType].displayFormat, true);
+  }
+
+  const allDisplayFormats = Object.values(PERIOD_TYPE_CONFIG).map(
+    ({ displayFormat }) => displayFormat,
+  );
+
+  for (let i = 0; i < allDisplayFormats.length; i++) {
+    const moment = utcMoment(displayString, allDisplayFormats[i], true);
+    if (!isInvalidMoment(moment)) {
+      return moment;
+    }
+  }
+
+  return utcMoment(displayString);
 };
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -5587,6 +5587,7 @@ __metadata:
     lodash.keyby: ^4.6.0
     lodash.pick: ^4.4.0
     mathjs: ^9.4.0
+    moment: ^2.24.0
     winston: ^3.2.1
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
### Issue RN-175:

Part 3 of 3.

The final and core PR for this feature. The actual transform.

So the idea with this transform is to allow us to re-order the columns of the table. You can either do this explicitly by specifying the column names, or by using a pre-defined sort function.

eg.
Basic explicit re-order
```
[ 
 { name: 'Bo', age: 7, car: 'Subaru' },
 { name: 'Jo', age: 12, car: 'Ferrari' }
]

transform: orderColumns
order: ['car', 'name', 'age']

=>

[ 
 { car: 'Subaru', name: 'Bo', age: 7 },
 { car: 'Ferrari', name: 'Jo', age: 12 }
]
```
Explicit re-order with wildCard
```
[ 
 { name: 'Bo', age: 7, car: 'Subaru' },
 { name: 'Jo', age: 12, car: 'Ferrari' }
]

transform: orderColumns
order: ['*', 'age']

=>

[ 
 { name: 'Bo', car: 'Subaru', age: 7 },
 { name: 'Jo', car: 'Ferrari', age: 12 }
]
```
Re-order with sortBy
```
[ 
 { name: 'Bo', age: 7, car: 'Subaru' },
 { name: 'Jo', age: 12, car: 'Ferrari' }
]

transform: orderColumns
sortBy: 'alphabetic'

=>

[ 
 { age: 7 , car: 'Subaru', name: 'Bo' },
 { age: 12 , car: 'Ferrari', name: 'Jo' }
]
```

Might also want to add a sort direction option (asc/desc)...
Also will add some unit tests