### PR TITLE
Fixup for flaky meditrak-app-server tests

### DIFF
--- a/packages/meditrak-app-server/src/__tests__/__integration__/sync/PullChangesRoute.test.ts
+++ b/packages/meditrak-app-server/src/__tests__/__integration__/sync/PullChangesRoute.test.ts
@@ -140,8 +140,9 @@ describe('changes (GET)', () => {
     await oneSecondSleep();
     for (let i = 0; i < numberOfQuestionsToAdd; i++) {
       newQuestions.push(await upsertDummyQuestion(models));
-      await models.database.waitForAllChangeHandlers();
     }
+
+    await models.database.waitForAllChangeHandlers();
 
     const response = await app.get('changes', {
       headers: {
@@ -172,7 +173,6 @@ describe('changes (GET)', () => {
     const questionsInFirstUpdate = [];
     for (let i = 0; i < numberOfQuestionsToAddInFirstUpdate; i++) {
       questionsInFirstUpdate.push(await upsertDummyQuestion(models));
-      await models.database.waitForAllChangeHandlers();
     }
 
     // Add some more questions
@@ -187,7 +187,6 @@ describe('changes (GET)', () => {
     const questionsInSecondUpdate = [];
     for (let i = 0; i < numberOfQuestionsToAddInSecondUpdate; i++) {
       questionsInSecondUpdate.push(await upsertDummyQuestion(models));
-      await models.database.waitForAllChangeHandlers();
     }
 
     // Delete some of the questions added in the first update
@@ -211,7 +210,6 @@ describe('changes (GET)', () => {
     );
     for (let i = 0; i < numberOfQuestionsToDeleteFromFirstUpdate; i++) {
       await models.question.deleteById(questionsInFirstUpdate[i].id);
-      await models.database.waitForAllChangeHandlers();
     }
 
     // Delete some of the questions added in the second update
@@ -235,8 +233,9 @@ describe('changes (GET)', () => {
     );
     for (let i = 0; i < numberOfQuestionsToDeleteFromSecondUpdate; i++) {
       await models.question.deleteById(questionsInSecondUpdate[i].id);
-      await models.database.waitForAllChangeHandlers();
     }
+
+    await models.database.waitForAllChangeHandlers();
 
     // If syncing from before the first update, should only need to sync the number of records that
     // actually need to be added. No need to know about deletes of records we never integrated
@@ -326,8 +325,9 @@ describe('changes (GET)', () => {
     const newEntities = [];
     for (let i = 0; i < numberOfEntitiesToAdd; i++) {
       newEntities.push(await upsertDummyRecord(models.entity, {}));
-      await models.database.waitForAllChangeHandlers();
     }
+
+    await models.database.waitForAllChangeHandlers();
 
     const entitySupportedResponse = await app.get('changes', {
       headers: {
@@ -364,14 +364,14 @@ describe('changes (GET)', () => {
     const newEntities = [];
     for (let i = 0; i < numberOfEntitiesToAdd; i++) {
       newEntities.push(await upsertDummyRecord(models.entity, {}));
-      await models.database.waitForAllChangeHandlers();
     }
 
     const newQuestions = [];
     for (let i = 0; i < numberOfQuestionsToAdd; i++) {
       newQuestions.push(await upsertDummyQuestion(models));
-      await models.database.waitForAllChangeHandlers();
     }
+
+    await models.database.waitForAllChangeHandlers();
 
     const entityChangesResponse = await app.get('changes', {
       headers: {
@@ -426,8 +426,9 @@ describe('changes (GET)', () => {
     await oneSecondSleep();
     for (let i = 0; i < numberOfQuestionsToAdd; i++) {
       newQuestions.push(await upsertDummyQuestion(models));
-      await models.database.waitForAllChangeHandlers();
     }
+
+    await models.database.waitForAllChangeHandlers();
 
     const expectedResults = await Promise.all(
       newQuestions.map(questionCreated => recordToChange('question', questionCreated, 'update')),


### PR DESCRIPTION
I've seen the tests fail when one of them times out, so this should reduce the likelihood of timeouts