### PR TITLE
RN-675: Added 'External Database Connections' to Tupaia

### DIFF
--- a/packages/admin-panel/src/pages/resources/ExternalDatabaseConnectionsPage.js
+++ b/packages/admin-panel/src/pages/resources/ExternalDatabaseConnectionsPage.js
@@ -1,0 +1,86 @@
+/*
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { ResourcePage } from './ResourcePage';
+import { ArrayFilter } from '../../table/columnTypes/columnFilters';
+import { prettyArray } from '../../utilities';
+import { TestDatabaseConnectionCell } from '../../table/customCells';
+
+const EXTERNAL_DATABASE_CONNECTIONS_ENDPOINT = 'externalDatabaseConnections';
+
+const FIELDS = [
+  {
+    Header: 'Code',
+    source: 'code',
+    type: 'tooltip',
+  },
+  {
+    Header: 'Name',
+    source: 'name',
+  },
+  {
+    Header: 'Description',
+    source: 'description',
+  },
+  {
+    Header: 'Permission groups',
+    source: 'permission_groups',
+    Filter: ArrayFilter,
+    Cell: ({ value }) => prettyArray(value),
+    editConfig: {
+      optionsEndpoint: 'permissionGroups',
+      optionLabelKey: 'name',
+      optionValueKey: 'name',
+      sourceKey: 'permission_groups',
+      allowMultipleValues: true,
+    },
+  },
+];
+
+const COLUMNS = [
+  ...FIELDS,
+  {
+    Header: 'Edit',
+    source: 'id',
+    type: 'edit',
+    actionConfig: {
+      editEndpoint: EXTERNAL_DATABASE_CONNECTIONS_ENDPOINT,
+      title: 'Edit External Database Connection',
+      fields: [...FIELDS],
+    },
+  },
+  {
+    Header: 'Test',
+    source: 'id',
+    filterable: false,
+    sortable: false,
+    Cell: TestDatabaseConnectionCell,
+    width: 70,
+  },
+];
+
+const CREATE_CONFIG = {
+  title: 'Create a new External Database Connection',
+  actionConfig: {
+    editEndpoint: EXTERNAL_DATABASE_CONNECTIONS_ENDPOINT,
+    fields: [...FIELDS],
+  },
+};
+
+export const ExternalDatabaseConnectionsPage = ({ getHeaderEl }) => (
+  <ResourcePage
+    title="External Database Connections"
+    endpoint={EXTERNAL_DATABASE_CONNECTIONS_ENDPOINT}
+    columns={COLUMNS}
+    createConfig={CREATE_CONFIG}
+    getHeaderEl={getHeaderEl}
+  />
+);
+
+ExternalDatabaseConnectionsPage.propTypes = {
+  getHeaderEl: PropTypes.func.isRequired,
+};

--- a/packages/admin-panel/src/pages/resources/UsersPage.js
+++ b/packages/admin-panel/src/pages/resources/UsersPage.js
@@ -77,6 +77,9 @@ const EDIT_FIELDS = [
     Header: 'Password',
     source: 'password',
     hideValue: true,
+    editConfig: {
+      type: 'password',
+    },
   },
 ];
 

--- a/packages/admin-panel/src/pages/resources/index.js
+++ b/packages/admin-panel/src/pages/resources/index.js
@@ -32,3 +32,4 @@ export { DashboardRelationsPage } from './DashboardRelationsPage';
 export { LegacyReportsPage } from './LegacyReportsPage';
 export { ProjectsPage } from './ProjectsPage';
 export { SyncGroupsPage } from './SyncGroupsPage';
+export { ExternalDatabaseConnectionsPage } from './ExternalDatabaseConnectionsPage';

--- a/packages/admin-panel/src/routes.js
+++ b/packages/admin-panel/src/routes.js
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { Assignment, InsertChart, PeopleAlt, Flag, Storage } from '@material-ui/icons';
+import { Assignment, InsertChart, PeopleAlt, Flag, Storage, Language } from '@material-ui/icons';
 import { StrivePage } from './pages/StrivePage';
 import {
   CountriesPage,
@@ -32,6 +32,7 @@ import {
   ProjectsPage,
   SyncGroupsPage,
   DataTablesPage,
+  ExternalDatabaseConnectionsPage,
 } from './pages/resources';
 import { DataElementDataServicesPage } from './pages/resources/DataElementDataServicesPage';
 
@@ -203,6 +204,18 @@ export const ROUTES = [
         label: 'Disaster',
         to: '/disaster',
         component: DisasterResponsePage,
+      },
+    ],
+  },
+  {
+    label: 'External Data',
+    to: '/externalDatabaseConnections',
+    icon: <Language />,
+    tabs: [
+      {
+        label: 'External Database Connections',
+        to: '',
+        component: ExternalDatabaseConnectionsPage,
       },
     ],
   },

--- a/packages/admin-panel/src/routes.js
+++ b/packages/admin-panel/src/routes.js
@@ -209,7 +209,7 @@ export const ROUTES = [
   },
   {
     label: 'External Data',
-    to: '/externalDatabaseConnections',
+    to: '/external-database-connections',
     icon: <Language />,
     tabs: [
       {

--- a/packages/admin-panel/src/table/customCells/TestDatabaseConnectionCell.js
+++ b/packages/admin-panel/src/table/customCells/TestDatabaseConnectionCell.js
@@ -1,0 +1,114 @@
+/**
+ * Tupaia MediTrak
+ * Copyright (c) 2018 Beyond Essential Systems Pty Ltd
+ */
+
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import NetworkCheck from '@material-ui/icons/NetworkCheck';
+import ErrorIcon from '@material-ui/icons/Error';
+import CheckCircleIcon from '@material-ui/icons/CheckCircle';
+import { Tooltip } from '@material-ui/core';
+import styled from 'styled-components';
+import { useApi } from '../../utilities/ApiProvider';
+import { IconButton } from '../../widgets';
+import { makeSubstitutionsInString } from '../../utilities';
+
+const BUTTON_STATES = {
+  IDLE: 'idle',
+  TESTING: 'testing',
+  SUCCESS: 'success',
+  FAILED: 'failed',
+};
+
+const testDatabaseConnectionEndpointTemplate = 'externalDatabaseConnections/{id}/test';
+
+const ButtonContainer = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const SuccessIcon = styled(CheckCircleIcon)`
+  padding-left: 5px;
+  color: ${props => props.theme.palette.success.main};
+`;
+
+const FailedIcon = styled(ErrorIcon)`
+  padding-left: 5px;
+  color: ${props => props.theme.palette.error.main};
+`;
+
+const TestConnectionIconButton = styled(IconButton)`
+  display: flex;
+`;
+
+export const TestDatabaseConnectionCell = ({ row }) => {
+  const api = useApi();
+  const [buttonState, setButtonState] = useState(BUTTON_STATES.IDLE);
+  const [toolTip, setTooltip] = useState(null);
+
+  const testConnectionEndpoint = makeSubstitutionsInString(
+    testDatabaseConnectionEndpointTemplate,
+    row,
+  );
+
+  const testConnection = async () => {
+    try {
+      setButtonState(BUTTON_STATES.TESTING);
+      await api.get(testConnectionEndpoint);
+      setButtonState(BUTTON_STATES.SUCCESS);
+      setTooltip('Connection successful');
+    } catch (error) {
+      setTooltip(error.message);
+      setButtonState(BUTTON_STATES.FAILED);
+    }
+  };
+
+  const TestConnectionButton = ({ disabled = false }) => (
+    <Tooltip title="Click to test database connection">
+      <TestConnectionIconButton disabled={disabled} onClick={testConnection}>
+        <NetworkCheck />
+      </TestConnectionIconButton>
+    </Tooltip>
+  );
+
+  if (buttonState === BUTTON_STATES.SUCCESS) {
+    return (
+      <ButtonContainer>
+        <TestConnectionButton />
+        <Tooltip title={toolTip}>
+          <SuccessIcon />
+        </Tooltip>
+      </ButtonContainer>
+    );
+  }
+
+  if (buttonState === BUTTON_STATES.FAILED) {
+    return (
+      <ButtonContainer>
+        <TestConnectionButton />
+        <Tooltip title={toolTip}>
+          <FailedIcon />
+        </Tooltip>
+      </ButtonContainer>
+    );
+  }
+
+  if (buttonState === BUTTON_STATES.TESTING) {
+    return (
+      <ButtonContainer>
+        <TestConnectionButton disabled />
+      </ButtonContainer>
+    );
+  }
+
+  return (
+    <ButtonContainer>
+      <TestConnectionButton />
+    </ButtonContainer>
+  );
+};
+
+TestDatabaseConnectionCell.propTypes = {
+  row: PropTypes.object.isRequired,
+};

--- a/packages/admin-panel/src/table/customCells/index.js
+++ b/packages/admin-panel/src/table/customCells/index.js
@@ -1,0 +1,6 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+export { TestDatabaseConnectionCell } from './TestDatabaseConnectionCell';

--- a/packages/admin-panel/src/widgets/InputField/registerInputFields.js
+++ b/packages/admin-panel/src/widgets/InputField/registerInputFields.js
@@ -198,4 +198,14 @@ export const registerInputFields = () => {
       type={props.type}
     />
   ));
+  registerInputField('password', props => (
+    <TextField
+      label={props.label}
+      value={props.value === undefined || props.value === null ? '' : props.value} // we still want to show 0 value
+      onChange={event => props.onChange(props.inputKey, event.target.value)}
+      disabled={props.disabled}
+      helperText={props.secondaryLabel}
+      type="password"
+    />
+  ));
 };

--- a/packages/central-server/src/apiV2/externalDatabaseConnections/TestExternalDatabaseConnection.js
+++ b/packages/central-server/src/apiV2/externalDatabaseConnections/TestExternalDatabaseConnection.js
@@ -1,0 +1,34 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
+ */
+
+import { respond, ObjectValidator, constructRecordExistsWithId } from '@tupaia/utils';
+import { CRUDHandler } from '../CRUDHandler';
+import { assertBESAdminAccess } from '../../permissions';
+
+export class TestExternalDatabaseConnection extends CRUDHandler {
+  async validateRecordExists() {
+    const validationCriteria = {
+      id: [constructRecordExistsWithId(this.database, this.recordType)],
+    };
+
+    const validator = new ObjectValidator(validationCriteria);
+    return validator.validate({ id: this.recordId }); // Will throw an error if not valid
+  }
+
+  async assertUserHasAccess() {
+    await this.assertPermissions(assertBESAdminAccess);
+  }
+
+  async handleRequest() {
+    await this.validateRecordExists();
+    await this.assertUserHasAccess();
+
+    const externalDatabaseConnection = await this.resourceModel.findById(this.recordId);
+
+    const testResult = await externalDatabaseConnection.testConnection();
+
+    respond(this.res, { success: testResult });
+  }
+}

--- a/packages/central-server/src/apiV2/externalDatabaseConnections/index.js
+++ b/packages/central-server/src/apiV2/externalDatabaseConnections/index.js
@@ -1,0 +1,6 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+export { TestExternalDatabaseConnection } from './TestExternalDatabaseConnection';

--- a/packages/central-server/src/apiV2/index.js
+++ b/packages/central-server/src/apiV2/index.js
@@ -119,6 +119,7 @@ import {
   ManuallySyncSyncGroup,
 } from './syncGroups';
 import { POSTUpdateUserFavouriteDashboardItem } from './userFavouriteDashboardItem';
+import { TestExternalDatabaseConnection } from './externalDatabaseConnections';
 // quick and dirty permission wrapper for open endpoints
 const allowAnyone = routeHandler => (req, res, next) => {
   req.assertPermissions(allowNoPermissions);
@@ -229,6 +230,11 @@ apiV2.get('/dataServiceSyncGroups/:recordId?', useRouteHandler(GETSyncGroups));
 apiV2.get('/dataServiceSyncGroups/:recordId/logs', useRouteHandler(GETSyncGroupLogs));
 apiV2.get('/dataServiceSyncGroups/:recordId/logs/count', useRouteHandler(GETSyncGroupLogsCount));
 apiV2.get('/dataElementDataServices/:recordId?', useRouteHandler(BESAdminGETHandler));
+apiV2.get('/externalDatabaseConnections/:recordId?', useRouteHandler(BESAdminGETHandler));
+apiV2.get(
+  '/externalDatabaseConnections/:recordId/test',
+  useRouteHandler(TestExternalDatabaseConnection),
+);
 
 /**
  * POST routes
@@ -264,6 +270,7 @@ apiV2.post('/projects', useRouteHandler(CreateProject));
 apiV2.post('/dataServiceSyncGroups', useRouteHandler(CreateSyncGroups));
 apiV2.post('/dataServiceSyncGroups/:recordId/sync', useRouteHandler(ManuallySyncSyncGroup));
 apiV2.post('/dataElementDataServices', useRouteHandler(BESAdminCreateHandler));
+apiV2.post('/externalDatabaseConnections', useRouteHandler(BESAdminCreateHandler));
 
 /**
  * PUT routes
@@ -298,6 +305,7 @@ apiV2.put('/entities/:recordId', useRouteHandler(EditEntity));
 apiV2.put('/me', catchAsyncErrors(editUser));
 apiV2.put('/dataServiceSyncGroups/:recordId', useRouteHandler(EditSyncGroups));
 apiV2.put('/dataElementDataServices/:recordId', useRouteHandler(BESAdminEditHandler));
+apiV2.put('/externalDatabaseConnections/:recordId', useRouteHandler(BESAdminEditHandler));
 
 /**
  * DELETE routes
@@ -329,6 +337,7 @@ apiV2.delete(
 apiV2.delete('/indicators/:recordId', useRouteHandler(BESAdminDeleteHandler));
 apiV2.delete('/dataServiceSyncGroups/:recordId', useRouteHandler(DeleteSyncGroups));
 apiV2.delete('/dataElementDataServices/:recordId', useRouteHandler(BESAdminDeleteHandler));
+apiV2.delete('/externalDatabaseConnections/:recordId', useRouteHandler(BESAdminDeleteHandler));
 
 apiV2.use(handleError); // error handler must come last
 

--- a/packages/central-server/src/apiV2/utilities/constructNewRecordValidationRules.js
+++ b/packages/central-server/src/apiV2/utilities/constructNewRecordValidationRules.js
@@ -95,6 +95,11 @@ export const constructForSingle = (models, recordType) => {
         service_type: [constructIsOneOf(DATA_SOURCE_SERVICE_TYPES)],
         config: [hasContent],
       };
+    case TYPES.EXTERNAL_DATABASE_CONNECTION:
+      return {
+        code: [hasContent],
+        name: [hasContent],
+      };
     case TYPES.INDICATOR:
       return {
         code: [hasContent],

--- a/packages/database/src/migrations/20221001204123-AddExternalDatabaseConnectionTable-modifies-schema.js
+++ b/packages/database/src/migrations/20221001204123-AddExternalDatabaseConnectionTable-modifies-schema.js
@@ -1,0 +1,35 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = async function (db) {
+  await db.runSql(`
+    CREATE TABLE external_database_connection (
+      id TEXT PRIMARY KEY,
+      code TEXT NOT NULL UNIQUE,
+      name TEXT NOT NULL,
+      description TEXT,
+      permission_groups TEXT[] NOT NULL DEFAULT '{}'
+    )
+  `);
+};
+
+exports.down = async function (db) {
+  await db.runSql(`DROP TABLE external_database_connection`);
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/packages/database/src/modelClasses/ExternalDatabaseConnection.js
+++ b/packages/database/src/modelClasses/ExternalDatabaseConnection.js
@@ -1,0 +1,91 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import { getEnvVarOrDefault, requireEnv } from '@tupaia/utils';
+import knex from 'knex';
+
+import { DatabaseModel } from '../DatabaseModel';
+import { DatabaseType } from '../DatabaseType';
+import { TYPES } from '../types';
+
+const EXT_DB_CONNECTION_ENV_VAR_PREFIX = 'EXT_DB';
+
+export class ExternalDatabaseConnectionType extends DatabaseType {
+  static databaseType = TYPES.EXTERNAL_DATABASE_CONNECTION;
+
+  async executeSql(sql, parameters) {
+    const connection = this.model.acquireConnection(this);
+    const result = await connection.raw(sql, parameters);
+    return result.rows;
+  }
+
+  async testConnection() {
+    const [{ is_connected: isConnected }] = await this.executeSql('select TRUE as is_connected');
+    return isConnected;
+  }
+}
+
+export class ExternalDatabaseConnectionModel extends DatabaseModel {
+  // Map of active external connections that have been established
+  // Using singleton pattern to avoid individual instances overwhelming the external
+  // databases with requests
+  activeConnections = {};
+
+  get DatabaseTypeClass() {
+    return ExternalDatabaseConnectionType;
+  }
+
+  async update(whereCondition, fieldsToUpdate) {
+    // Clear connections before updating the records
+    const connectionsToUpdate = await this.find(whereCondition);
+    await Promise.all(connectionsToUpdate.map(connection => this.closeConnection(connection)));
+
+    await super.update(whereCondition, fieldsToUpdate);
+  }
+
+  async delete(whereConditions) {
+    // Clear connections before deleting the records
+    const connectionsToDelete = await this.find(whereConditions);
+    await Promise.all(connectionsToDelete.map(connection => this.closeConnection(connection)));
+
+    await super.delete(whereConditions);
+  }
+
+  acquireConnection(externalDatabaseConnectionType) {
+    const { id: connectionId, code } = externalDatabaseConnectionType;
+    const establishedConnection = this.activeConnections[connectionId];
+    if (establishedConnection) {
+      return establishedConnection;
+    }
+
+    const host = requireEnv(`${EXT_DB_CONNECTION_ENV_VAR_PREFIX}_${code}_HOST`);
+    const port = getEnvVarOrDefault(`${EXT_DB_CONNECTION_ENV_VAR_PREFIX}_${code}_PORT`, 5432);
+    const database = requireEnv(`${EXT_DB_CONNECTION_ENV_VAR_PREFIX}_${code}_DATABASE`);
+    const user = requireEnv(`${EXT_DB_CONNECTION_ENV_VAR_PREFIX}_${code}_USER`);
+    const password = requireEnv(`${EXT_DB_CONNECTION_ENV_VAR_PREFIX}_${code}_PASSWORD`);
+
+    const connection = knex({
+      client: 'pg',
+      connection: {
+        host,
+        port,
+        database,
+        user,
+        password,
+      },
+    });
+    this.activeConnections[connectionId] = connection;
+    return connection;
+  }
+
+  async closeConnection(externalDatabaseConnectionType) {
+    const { id: connectionId } = externalDatabaseConnectionType;
+    const existingConnection = this.activeConnections[connectionId];
+    if (existingConnection) {
+      await existingConnection.destroy();
+      delete this.activeConnections[connectionId];
+    }
+  }
+}

--- a/packages/database/src/modelClasses/index.js
+++ b/packages/database/src/modelClasses/index.js
@@ -24,6 +24,7 @@ import { DisasterEventModel } from './DisasterEvent';
 import { EntityModel } from './Entity';
 import { EntityHierarchyModel } from './EntityHierarchy';
 import { EntityRelationModel } from './EntityRelation';
+import { ExternalDatabaseConnectionModel } from './ExternalDatabaseConnection';
 import { FacilityModel } from './Facility';
 import { FeedItemModel } from './FeedItem';
 import { GeographicalAreaModel } from './GeographicalArea';
@@ -84,6 +85,7 @@ export const modelClasses = {
   Entity: EntityModel,
   EntityHierarchy: EntityHierarchyModel,
   EntityRelation: EntityRelationModel,
+  ExternalDatabaseConnection: ExternalDatabaseConnectionModel,
   Facility: FacilityModel,
   FeedItem: FeedItemModel,
   GeographicalArea: GeographicalAreaModel,

--- a/packages/database/src/types.js
+++ b/packages/database/src/types.js
@@ -31,6 +31,7 @@ export const TYPES = {
   ENTITY_RELATION: 'entity_relation',
   ENTITY: 'entity',
   ERROR_LOG: 'error_log',
+  EXTERNAL_DATABASE_CONNECTION: 'external_database_connection',
   FACILITY: 'clinic',
   FEED_ITEM: 'feed_item',
   GEOGRAPHICAL_AREA: 'geographical_area',


### PR DESCRIPTION
### Issue RN-675:

Added a new concept, the 'External Database Connection' to Tupaia. These are required by SQL data tables, to control what database to pull from.

Fields:
- code: unique identifier code
- name: display name
- description: more detailed explanation of the connection
- permission_groups: which users can use this connection when creating SQL data tables