### PR TITLE
RN-645: Add internal data tables for fetching entities and entity relations

### DIFF
--- a/packages/data-table-server/examples.http
+++ b/packages/data-table-server/examples.http
@@ -42,3 +42,8 @@ Authorization: {{authorization}}
     "startDate": "2020-01-01",
     "endDate" : "2020-12-31"
 }
+
+### Get parameters for analytics data-table
+GET http://{{host}}/{{version}}/dataTable/analytics/parameters HTTP/1.1
+content-type: {{contentType}}
+Authorization: {{authorization}}

--- a/packages/data-table-server/package.json
+++ b/packages/data-table-server/package.json
@@ -35,5 +35,8 @@
     "dotenv": "^8.2.0",
     "express": "^4.16.2",
     "winston": "^3.2.1"
+  },
+  "devDependencies": {
+    "mockdate": "^3.0.5"
   }
 }

--- a/packages/data-table-server/src/@types/express/index.d.ts
+++ b/packages/data-table-server/src/@types/express/index.d.ts
@@ -5,6 +5,8 @@
 
 import { AccessPolicy } from '@tupaia/access-policy';
 import { TupaiaApiClient } from '@tupaia/api-client';
+import { DataTableService } from '../../dataTableService';
+import { DataTableType } from '../../models';
 import { DataTableServerModelRegistry } from '../../types';
 
 declare global {
@@ -12,7 +14,11 @@ declare global {
     export interface Request {
       accessPolicy: AccessPolicy;
       models: DataTableServerModelRegistry;
-      ctx: { services: TupaiaApiClient };
+      ctx: {
+        services: TupaiaApiClient;
+        dataTable: DataTableType;
+        dataTableService: DataTableService;
+      };
     }
   }
 }

--- a/packages/data-table-server/src/__tests__/dataTableService/internal/EntitiesDataTableService.test.ts
+++ b/packages/data-table-server/src/__tests__/dataTableService/internal/EntitiesDataTableService.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import { TupaiaApiClient } from '@tupaia/api-client';
+import { DataTableServiceBuilder } from '../../../dataTableService';
+
+const entitiesDataTableService = new DataTableServiceBuilder()
+  .setServiceType('entities')
+  .setContext({ apiClient: {} as TupaiaApiClient })
+  .build();
+
+describe('EntitiesDataTableService', () => {
+  describe('parameter validation', () => {
+    const testData: [string, unknown, string][] = [
+      ['missing entityCodes', {}, 'entityCodes is a required field'],
+    ];
+
+    it.each(testData)('%s', (_, parameters: unknown, expectedError: string) => {
+      expect(() => entitiesDataTableService.fetchData(parameters)).toThrow(expectedError);
+    });
+  });
+
+  it('getParameters', () => {
+    const parameters = entitiesDataTableService.getParameters();
+    expect(parameters).toEqual([
+      { config: { defaultValue: 'explore', type: 'string' }, name: 'hierarchy' },
+      {
+        config: { innerType: { required: true, type: 'string' }, required: true, type: 'array' },
+        name: 'entityCodes',
+      },
+      {
+        config: { type: 'object' },
+        name: 'filter',
+      },
+      {
+        config: {
+          defaultValue: ['code'],
+          type: 'array',
+          innerType: { type: 'string', required: true },
+        },
+        name: 'fields',
+      },
+      { config: { defaultValue: false, type: 'boolean' }, name: 'includeDescendants' },
+    ]);
+  });
+
+  describe('fetchData', () => {
+    // TODO: Implement these tests when RN-685 is done
+    // it('can fetch entities', async () => {});
+    // it('can fetch entities and descendants', async () => {});
+  });
+});

--- a/packages/data-table-server/src/__tests__/dataTableService/internal/EntityRelationsDataTableService.test.ts
+++ b/packages/data-table-server/src/__tests__/dataTableService/internal/EntityRelationsDataTableService.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import { TupaiaApiClient } from '@tupaia/api-client';
+import { DataTableServiceBuilder } from '../../../dataTableService';
+
+const entityRelationsDataTableService = new DataTableServiceBuilder()
+  .setServiceType('entity_relations')
+  .setContext({ apiClient: {} as TupaiaApiClient })
+  .build();
+
+describe('EntityRelationsDataTableService', () => {
+  describe('parameter validation', () => {
+    const testData: [string, unknown, string][] = [
+      [
+        'missing entityCodes',
+        { ancestorType: 'district', descendantType: 'sub_district' },
+        'entityCodes is a required field',
+      ],
+      [
+        'missing ancestorType',
+        { entityCodes: ['TO'], descendantType: 'sub_district' },
+        'ancestorType is a required field',
+      ],
+      [
+        'missing descendantType',
+        { entityCodes: ['TO'], ancestorType: 'district' },
+        'descendantType is a required field',
+      ],
+    ];
+
+    it.each(testData)('%s', (_, parameters: unknown, expectedError: string) => {
+      expect(() => entityRelationsDataTableService.fetchData(parameters)).toThrow(expectedError);
+    });
+  });
+
+  it('getParameters', () => {
+    const parameters = entityRelationsDataTableService.getParameters();
+    expect(parameters).toEqual([
+      { config: { defaultValue: 'explore', type: 'string' }, name: 'hierarchy' },
+      {
+        config: { innerType: { required: true, type: 'string' }, required: true, type: 'array' },
+        name: 'entityCodes',
+      },
+      { config: { type: 'string', required: true }, name: 'ancestorType' },
+      { config: { type: 'string', required: true }, name: 'descendantType' },
+    ]);
+  });
+
+  describe('fetchData', () => {
+    // TODO: Implement these tests when RN-685 is done
+    // it('can fetch entities', async () => {});
+    // it('can fetch entities and descendants', async () => {});
+  });
+});

--- a/packages/data-table-server/src/__tests__/dataTableService/internal/EventsDataTableService.test.ts
+++ b/packages/data-table-server/src/__tests__/dataTableService/internal/EventsDataTableService.test.ts
@@ -3,9 +3,12 @@
  * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
  */
 
+import MockDate from 'mockdate';
 import { AccessPolicy } from '@tupaia/access-policy';
 import { TupaiaApiClient } from '@tupaia/api-client';
 import { DataTableServiceBuilder } from '../../../dataTableService';
+
+const CURRENT_DATE_STUB = '2020-12-31';
 
 type Event = { eventDate: string; orgUnit: string; dataValues: Record<string, unknown> };
 
@@ -52,7 +55,7 @@ const fetchFakeEvents = (
     dataElementCodes,
     organisationUnitCodes,
     startDate = '2020-01-01',
-    endDate = '2020-12-31',
+    endDate = CURRENT_DATE_STUB,
   }: {
     dataElementCodes: string[];
     organisationUnitCodes: string[];
@@ -94,8 +97,20 @@ jest.mock('@tupaia/data-broker', () => ({
 
 const accessPolicy = new AccessPolicy({ DL: ['Public'] });
 const apiClient = {} as TupaiaApiClient;
+const eventsDataTableService = new DataTableServiceBuilder()
+  .setServiceType('events')
+  .setContext({ apiClient, accessPolicy })
+  .build();
 
 describe('EventsDataTableService', () => {
+  beforeEach(() => {
+    MockDate.set(CURRENT_DATE_STUB);
+  });
+
+  afterEach(() => {
+    MockDate.reset();
+  });
+
   describe('parameter validation', () => {
     const testData: [string, unknown, string][] = [
       [
@@ -115,14 +130,6 @@ describe('EventsDataTableService', () => {
         'organisationUnitCodes is a required field',
       ],
       [
-        'missing hierarchy',
-        {
-          organisationUnitCodes: ['TO'],
-          dataGroupCode: 'PSSS_WNR',
-        },
-        'hierarchy is a required field',
-      ],
-      [
         'startDate wrong format',
         {
           organisationUnitCodes: ['TO'],
@@ -130,7 +137,7 @@ describe('EventsDataTableService', () => {
           dataGroupCode: 'PSSS_WNR',
           startDate: 'cat',
         },
-        'startDate should be in ISO 8601 format',
+        'startDate must be a `date` type',
       ],
       [
         'endDate wrong format',
@@ -140,7 +147,7 @@ describe('EventsDataTableService', () => {
           dataGroupCode: 'PSSS_WNR',
           endDate: 'dog',
         },
-        'endDate should be in ISO 8601 format',
+        'endDate must be a `date` type',
       ],
       [
         'aggregations wrong format',
@@ -155,68 +162,76 @@ describe('EventsDataTableService', () => {
     ];
 
     it.each(testData)('%s', (_, parameters: unknown, expectedError: string) => {
-      const eventsDataTableService = new DataTableServiceBuilder()
-        .setServiceType('events')
-        .setContext({ apiClient, accessPolicy })
-        .build();
-
       expect(() => eventsDataTableService.fetchData(parameters)).toThrow(expectedError);
     });
   });
 
-  it('can fetch data from Aggregator.fetchEvents()', async () => {
-    const eventsDataTableService = new DataTableServiceBuilder()
-      .setServiceType('events')
-      .setContext({ apiClient, accessPolicy })
-      .build();
-
-    const dataGroupCode = 'PSSS_WNR';
-    const dataElementCodes = ['PSSS_AFR_Cases'];
-    const organisationUnitCodes = ['TO'];
-
-    const events = await eventsDataTableService.fetchData({
-      hierarchy: 'psss',
-      dataGroupCode,
-      organisationUnitCodes,
-      dataElementCodes,
-    });
-
-    const expectedEvents = fetchFakeEvents(dataGroupCode, {
-      dataElementCodes,
-      organisationUnitCodes,
-    }).map(flattenEvent);
-
-    expect(events).toEqual(expectedEvents);
+  it('getParameters', () => {
+    const parameters = eventsDataTableService.getParameters();
+    expect(parameters).toEqual([
+      { config: { defaultValue: 'explore', type: 'string' }, name: 'hierarchy' },
+      {
+        config: { innerType: { required: true, type: 'string' }, required: true, type: 'array' },
+        name: 'organisationUnitCodes',
+      },
+      {
+        config: { required: true, type: 'string' },
+        name: 'dataGroupCode',
+      },
+      {
+        config: { innerType: { required: true, type: 'string' }, type: 'array' },
+        name: 'dataElementCodes',
+      },
+      { config: { defaultValue: new Date('2017-01-01'), type: 'date' }, name: 'startDate' },
+      { config: { defaultValue: new Date(), type: 'date' }, name: 'endDate' },
+    ]);
   });
 
-  it('passes all parameters to Aggregator.fetchEvents()', async () => {
-    const eventsDataTableService = new DataTableServiceBuilder()
-      .setServiceType('events')
-      .setContext({ apiClient, accessPolicy })
-      .build();
+  describe('fetchData', () => {
+    it('can fetch data from Aggregator.fetchEvents()', async () => {
+      const dataGroupCode = 'PSSS_WNR';
+      const dataElementCodes = ['PSSS_AFR_Cases'];
+      const organisationUnitCodes = ['TO'];
 
-    const dataGroupCode = 'PSSS_Confirmed_WNR';
-    const dataElementCodes = ['PSSS_AFR_Cases', 'PSSS_ILI_Cases'];
-    const organisationUnitCodes = ['PG'];
-    const startDate = '2020-01-05';
-    const endDate = '2020-01-10';
+      const events = await eventsDataTableService.fetchData({
+        hierarchy: 'psss',
+        dataGroupCode,
+        organisationUnitCodes,
+        dataElementCodes,
+      });
 
-    const events = await eventsDataTableService.fetchData({
-      hierarchy: 'psss',
-      organisationUnitCodes,
-      dataGroupCode,
-      dataElementCodes,
-      startDate,
-      endDate,
+      const expectedEvents = fetchFakeEvents(dataGroupCode, {
+        dataElementCodes,
+        organisationUnitCodes,
+      }).map(flattenEvent);
+
+      expect(events).toEqual(expectedEvents);
     });
 
-    const expectedEvents = fetchFakeEvents(dataGroupCode, {
-      dataElementCodes,
-      organisationUnitCodes,
-      startDate,
-      endDate,
-    }).map(flattenEvent);
+    it('passes all parameters to Aggregator.fetchEvents()', async () => {
+      const dataGroupCode = 'PSSS_Confirmed_WNR';
+      const dataElementCodes = ['PSSS_AFR_Cases', 'PSSS_ILI_Cases'];
+      const organisationUnitCodes = ['PG'];
+      const startDate = '2020-01-05';
+      const endDate = '2020-01-10';
 
-    expect(events).toEqual(expectedEvents);
+      const events = await eventsDataTableService.fetchData({
+        hierarchy: 'psss',
+        organisationUnitCodes,
+        dataGroupCode,
+        dataElementCodes,
+        startDate,
+        endDate,
+      });
+
+      const expectedEvents = fetchFakeEvents(dataGroupCode, {
+        dataElementCodes,
+        organisationUnitCodes,
+        startDate,
+        endDate,
+      }).map(flattenEvent);
+
+      expect(events).toEqual(expectedEvents);
+    });
   });
 });

--- a/packages/data-table-server/src/app/createApp.ts
+++ b/packages/data-table-server/src/app/createApp.ts
@@ -5,8 +5,9 @@
 import { ForwardingAuthHandler } from '@tupaia/api-client';
 import { TupaiaDatabase } from '@tupaia/database';
 import { handleWith, MicroServiceApiBuilder } from '@tupaia/server-boilerplate';
+import { attachDataTableToContext } from '../middleware';
 
-import { FetchDataRequest, FetchDataRoute } from '../routes';
+import { FetchDataRequest, FetchDataRoute, ParametersRequest, ParametersRoute } from '../routes';
 
 /**
  * Set up express server with middleware,
@@ -16,7 +17,16 @@ export function createApp(database = new TupaiaDatabase()) {
     .attachApiClientToContext(req => new ForwardingAuthHandler(req.headers.authorization))
     .useBasicBearerAuth()
     // Use POST for this route as we often need to pass long query arguments
-    .post<FetchDataRequest>('dataTable/:dataTableCode/fetchData', handleWith(FetchDataRoute))
+    .post<FetchDataRequest>(
+      'dataTable/:dataTableCode/fetchData',
+      attachDataTableToContext,
+      handleWith(FetchDataRoute),
+    )
+    .get<ParametersRequest>(
+      'dataTable/:dataTableCode/parameters',
+      attachDataTableToContext,
+      handleWith(ParametersRoute),
+    )
     .build();
 
   return app;

--- a/packages/data-table-server/src/dataTableService/DataTableService.ts
+++ b/packages/data-table-server/src/dataTableService/DataTableService.ts
@@ -4,11 +4,19 @@
  */
 
 import { yup } from '@tupaia/utils';
+import { DataTableParameter } from './types';
+
+export type ServiceContext<Type> = Type extends DataTableService<infer Context> ? Context : never;
+
+export type ClassOfDataTableService<Service extends DataTableService> = new (
+  context: ServiceContext<Service>,
+  config: unknown,
+) => Service;
 
 export abstract class DataTableService<
   Context extends Record<string, unknown> = Record<string, unknown>,
-  ParamsSchema extends yup.AnySchema = yup.AnySchema,
-  ConfigSchema extends yup.AnySchema = yup.AnySchema,
+  ParamsSchema extends yup.AnyObjectSchema = yup.AnyObjectSchema,
+  ConfigSchema extends yup.AnyObjectSchema = yup.AnyObjectSchema,
   RecordSchema = unknown
 > {
   protected readonly ctx: Context;
@@ -41,4 +49,6 @@ export abstract class DataTableService<
     const validatedParams = this.validateParams(params);
     return this.pullData(validatedParams);
   }
+
+  public abstract getParameters(): DataTableParameter[];
 }

--- a/packages/data-table-server/src/dataTableService/DataTableServiceBuilder.ts
+++ b/packages/data-table-server/src/dataTableService/DataTableServiceBuilder.ts
@@ -4,9 +4,8 @@
  */
 
 import { DataTableType } from '../models';
-import { DataTableService } from './DataTableService';
+import { DataTableService, ClassOfDataTableService, ServiceContext } from './DataTableService';
 import { AnalyticsDataTableService, EventsDataTableService } from './internal';
-import { ClassOfDataTableService, ServiceContext } from './types';
 
 /**
  * Generic builder class that allows us to configure the context for a specific DataTableService

--- a/packages/data-table-server/src/dataTableService/DataTableServiceBuilder.ts
+++ b/packages/data-table-server/src/dataTableService/DataTableServiceBuilder.ts
@@ -5,7 +5,12 @@
 
 import { DataTableType } from '../models';
 import { DataTableService, ClassOfDataTableService, ServiceContext } from './DataTableService';
-import { AnalyticsDataTableService, EventsDataTableService } from './internal';
+import {
+  AnalyticsDataTableService,
+  EntitiesDataTableService,
+  EntityRelationsDataTableService,
+  EventsDataTableService,
+} from './internal';
 
 /**
  * Generic builder class that allows us to configure the context for a specific DataTableService
@@ -42,6 +47,8 @@ class DataTableServiceBuilderForType<Service extends DataTableService> {
 const internalDataTableServiceBuilders = {
   analytics: () => new DataTableServiceBuilderForType(AnalyticsDataTableService),
   events: () => new DataTableServiceBuilderForType(EventsDataTableService),
+  entities: () => new DataTableServiceBuilderForType(EntitiesDataTableService),
+  entity_relations: () => new DataTableServiceBuilderForType(EntityRelationsDataTableService),
 };
 
 const userDefinedDataTableServiceBuilders = {};

--- a/packages/data-table-server/src/dataTableService/index.ts
+++ b/packages/data-table-server/src/dataTableService/index.ts
@@ -4,3 +4,5 @@
  */
 
 export { DataTableServiceBuilder, getDataTableServiceType } from './DataTableServiceBuilder';
+export { DataTableService } from './DataTableService';
+export { DataTableParameter } from './types';

--- a/packages/data-table-server/src/dataTableService/internal/EntitiesDataTableService.ts
+++ b/packages/data-table-server/src/dataTableService/internal/EntitiesDataTableService.ts
@@ -1,0 +1,87 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import { TupaiaApiClient } from '@tupaia/api-client';
+import { yup } from '@tupaia/utils';
+import { DataTableService } from '../DataTableService';
+import { yupSchemaToDataTableParams } from '../utils';
+
+const paramsSchema = yup.object().shape({
+  hierarchy: yup.string().default('explore'),
+  entityCodes: yup.array().of(yup.string().required()).required(),
+  filter: yup.object(),
+  fields: yup.array().of(yup.string().required()).default(['code']),
+  includeDescendants: yup.boolean().default(false),
+});
+
+const configSchema = yup.object();
+
+type EntitiesDataTableContext = { apiClient: TupaiaApiClient };
+type Entity = Record<string, unknown>;
+
+/**
+ * DataTableService for pulling data entityApi.getEntities() and entityApi.getDescendantsOfEntities()
+ */
+export class EntitiesDataTableService extends DataTableService<
+  EntitiesDataTableContext,
+  typeof paramsSchema,
+  typeof configSchema,
+  Entity
+> {
+  public constructor(context: EntitiesDataTableContext, config: unknown) {
+    super(context, paramsSchema, configSchema, config);
+  }
+
+  protected async pullData(params: {
+    hierarchy: string;
+    entityCodes: string[];
+    filter?: Record<string, unknown>;
+    fields: string[];
+    includeDescendants: boolean;
+  }) {
+    const { hierarchy, entityCodes, filter, fields, includeDescendants } = params;
+
+    const entities = await this.ctx.apiClient.entity.getEntities(hierarchy, entityCodes, {
+      fields,
+      filter,
+    });
+
+    if (!includeDescendants) {
+      return entities;
+    }
+
+    const descendants = await this.ctx.apiClient.entity.getDescendantsOfEntities(
+      hierarchy,
+      entityCodes,
+      {
+        fields,
+        filter,
+      },
+    );
+
+    return entities.concat(descendants);
+  }
+
+  public getParameters() {
+    const {
+      hierarchy,
+      entityCodes,
+      filter,
+      fields,
+      includeDescendants,
+    } = yupSchemaToDataTableParams(paramsSchema);
+
+    return [
+      { name: 'hierarchy', config: hierarchy },
+      {
+        name: 'entityCodes',
+        config: entityCodes,
+      },
+      { name: 'filter', config: filter },
+      { name: 'fields', config: fields },
+      { name: 'includeDescendants', config: includeDescendants },
+    ];
+  }
+}

--- a/packages/data-table-server/src/dataTableService/internal/EntityRelationsDataTableService.ts
+++ b/packages/data-table-server/src/dataTableService/internal/EntityRelationsDataTableService.ts
@@ -1,0 +1,76 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import { TupaiaApiClient } from '@tupaia/api-client';
+import { yup } from '@tupaia/utils';
+import { DataTableService } from '../DataTableService';
+import { yupSchemaToDataTableParams } from '../utils';
+
+const paramsSchema = yup.object().shape({
+  hierarchy: yup.string().default('explore'),
+  entityCodes: yup.array().of(yup.string().required()).required(),
+  ancestorType: yup.string().required(),
+  descendantType: yup.string().required(),
+});
+
+const configSchema = yup.object();
+
+type EntityRelationsDataTableContext = { apiClient: TupaiaApiClient };
+type EntityRelation = { ancestor: string; descendant: string };
+
+/**
+ * DataTableService for pulling data entityApi.getRelations()
+ */
+export class EntityRelationsDataTableService extends DataTableService<
+  EntityRelationsDataTableContext,
+  typeof paramsSchema,
+  typeof configSchema,
+  EntityRelation
+> {
+  public constructor(context: EntityRelationsDataTableContext, config: unknown) {
+    super(context, paramsSchema, configSchema, config);
+  }
+
+  protected async pullData(params: {
+    hierarchy: string;
+    entityCodes: string[];
+    ancestorType: string;
+    descendantType: string;
+  }) {
+    const { hierarchy, entityCodes, ancestorType, descendantType } = params;
+    const relations = await this.ctx.apiClient.entity.getRelationshipsOfEntities(
+      hierarchy,
+      entityCodes,
+      'descendant',
+      {},
+      { filter: { type: ancestorType } },
+      { filter: { type: descendantType } },
+    );
+
+    return Object.entries(relations).map(([descendant, ancestor]) => ({
+      ancestor,
+      descendant,
+    })) as EntityRelation[];
+  }
+
+  public getParameters() {
+    const { hierarchy, entityCodes, ancestorType, descendantType } = yupSchemaToDataTableParams(
+      paramsSchema,
+    );
+
+    return [
+      { name: 'hierarchy', config: hierarchy },
+      {
+        name: 'entityCodes',
+        config: entityCodes,
+      },
+      { name: 'ancestorType', config: ancestorType },
+      {
+        name: 'descendantType',
+        config: descendantType,
+      },
+    ];
+  }
+}

--- a/packages/data-table-server/src/dataTableService/internal/index.ts
+++ b/packages/data-table-server/src/dataTableService/internal/index.ts
@@ -5,3 +5,5 @@
 
 export { AnalyticsDataTableService } from './AnalyticsDataTableService';
 export { EventsDataTableService } from './EventsDataTableService';
+export { EntityRelationsDataTableService } from './EntityRelationsDataTableService';
+export { EntitiesDataTableService } from './EntitiesDataTableService';

--- a/packages/data-table-server/src/dataTableService/types.ts
+++ b/packages/data-table-server/src/dataTableService/types.ts
@@ -3,11 +3,15 @@
  * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
  */
 
-import { DataTableService } from './DataTableService';
+export interface DataTableParameter {
+  name: string;
+  config: DataTableParameterConfig;
+}
 
-export type ServiceContext<Type> = Type extends DataTableService<infer Context> ? Context : never;
-
-export type ClassOfDataTableService<Service extends DataTableService> = new (
-  context: ServiceContext<Service>,
-  config: unknown,
-) => Service;
+export interface DataTableParameterConfig {
+  type: string;
+  defaultValue?: unknown;
+  innerType?: DataTableParameterConfig;
+  oneOf?: unknown[];
+  required?: boolean;
+}

--- a/packages/data-table-server/src/dataTableService/utils/index.ts
+++ b/packages/data-table-server/src/dataTableService/utils/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+export { yupSchemaToDataTableParams } from './yupSchemaToDataTableParams';

--- a/packages/data-table-server/src/dataTableService/utils/yupSchemaToDataTableParams.ts
+++ b/packages/data-table-server/src/dataTableService/utils/yupSchemaToDataTableParams.ts
@@ -1,0 +1,61 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import { yup } from '@tupaia/utils';
+import { DataTableParameterConfig } from '../types';
+
+interface YupDescription {
+  type: string;
+  defaultValue?: unknown;
+  innerType?: YupDescription;
+  oneOf?: unknown[];
+  tests?: { name?: string }[];
+}
+
+const yupDescriptionToDataTableParam = (description: YupDescription): DataTableParameterConfig => {
+  const { type, defaultValue, innerType, oneOf, tests } = description;
+  const isRequired = tests && tests.some(({ name }) => name === 'required');
+  const paramOfInnerType = innerType ? yupDescriptionToDataTableParam(innerType) : undefined;
+  const param: DataTableParameterConfig = {
+    type,
+  };
+
+  if (defaultValue !== undefined) {
+    param.defaultValue = defaultValue;
+  }
+
+  if (innerType) {
+    param.innerType = paramOfInnerType;
+  }
+
+  if (oneOf && oneOf.length > 0) {
+    param.oneOf = oneOf;
+  }
+
+  if (isRequired) {
+    param.required = true;
+  }
+
+  return param;
+};
+
+export const yupSchemaToDataTableParams = (
+  schema: yup.AnyObjectSchema,
+): Record<string, DataTableParameterConfig> => {
+  const descriptions = schema.describe().fields;
+  return Object.fromEntries(
+    Object.entries(descriptions).map(([name, description]) => {
+      const { type } = description;
+      const innerType = 'innerType' in description ? description.innerType : undefined;
+      const oneOf = 'oneOf' in description ? description.oneOf : undefined;
+      const tests = 'tests' in description ? description.tests : undefined;
+      const defaultValue = schema.fields[name].getDefault();
+      return [
+        name,
+        yupDescriptionToDataTableParam({ type, innerType, oneOf, tests, defaultValue }),
+      ];
+    }),
+  );
+};

--- a/packages/data-table-server/src/middleware/attachDataTableToContext.ts
+++ b/packages/data-table-server/src/middleware/attachDataTableToContext.ts
@@ -1,0 +1,46 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import { NextFunction, Request, Response } from 'express';
+import { DataTableServiceBuilder, getDataTableServiceType } from '../dataTableService';
+
+/**
+ * Finds the requested dataTable and attaches it to the context
+ * Checks for permissions
+ */
+export const attachDataTableToContext = async (
+  req: Request<{ dataTableCode: string }, any, any, any>,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const { accessPolicy, models, params, ctx } = req;
+    const { dataTableCode } = params;
+    const dataTable = await models.dataTable.findOne({ code: dataTableCode });
+    if (!dataTable) {
+      throw new Error(`No data-table found with code ${dataTableCode}`);
+    }
+
+    const permissionGroups = dataTable.permission_groups;
+
+    if (!(permissionGroups.includes('*') || permissionGroups.some(accessPolicy.allowsAnywhere))) {
+      throw new Error(`User does not have permission to access data table ${dataTable.code}`);
+    }
+
+    const serviceType = getDataTableServiceType(dataTable);
+    const dataTableService = new DataTableServiceBuilder()
+      .setServiceType(serviceType)
+      .setContext({ apiClient: ctx.services, accessPolicy })
+      .setConfig(dataTable.config)
+      .build();
+
+    req.ctx.dataTable = dataTable;
+    req.ctx.dataTableService = dataTableService;
+
+    next();
+  } catch (error) {
+    next(error);
+  }
+};

--- a/packages/data-table-server/src/middleware/index.ts
+++ b/packages/data-table-server/src/middleware/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+export { attachDataTableToContext } from './attachDataTableToContext';

--- a/packages/data-table-server/src/routes/Parameters.ts
+++ b/packages/data-table-server/src/routes/Parameters.ts
@@ -6,20 +6,17 @@
 import { Request } from 'express';
 
 import { Route } from '@tupaia/server-boilerplate';
+import { DataTableParameter } from '../dataTableService';
 
-export type FetchDataRequest = Request<
+export type ParametersRequest = Request<
   { dataTableCode: string },
-  { data: unknown[] },
+  { parameters: DataTableParameter[] },
   Record<string, unknown>,
   Record<string, unknown>
 >;
 
-export class FetchDataRoute extends Route<FetchDataRequest> {
+export class ParametersRoute extends Route<ParametersRequest> {
   public async buildResponse() {
-    const { body, ctx } = this.req;
-
-    const requestParams = { ...body };
-    const data = await ctx.dataTableService.fetchData(requestParams);
-    return { data };
+    return { parameters: this.req.ctx.dataTableService.getParameters() };
   }
 }

--- a/packages/data-table-server/src/routes/index.ts
+++ b/packages/data-table-server/src/routes/index.ts
@@ -4,3 +4,4 @@
  */
 
 export { FetchDataRequest, FetchDataRoute } from './FetchData';
+export { ParametersRequest, ParametersRoute } from './Parameters';

--- a/packages/database/src/migrations/20221006004520-AddEntityRelationsDataTable-modifies-data.js
+++ b/packages/database/src/migrations/20221006004520-AddEntityRelationsDataTable-modifies-data.js
@@ -1,0 +1,38 @@
+'use strict';
+
+import { insertObject, generateId } from '../utilities';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = async function (db) {
+  return insertObject(db, 'data_table', {
+    id: generateId(),
+    code: 'entity_relations',
+    description: 'Fetches data for entity relations',
+    type: 'internal',
+    permission_groups: '{*}',
+  });
+};
+
+exports.down = async function (db) {
+  return db.runSql(`
+    DELETE FROM data_table
+    WHERE code = 'entity_relations'
+  `);
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/packages/database/src/migrations/20221006010514-AddEntitiesDataTable-modifies-data.js
+++ b/packages/database/src/migrations/20221006010514-AddEntitiesDataTable-modifies-data.js
@@ -1,0 +1,38 @@
+'use strict';
+
+import { insertObject, generateId } from '../utilities';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = async function (db) {
+  return insertObject(db, 'data_table', {
+    id: generateId(),
+    code: 'entities',
+    description: 'Fetches data for entities',
+    type: 'internal',
+    permission_groups: '{*}',
+  });
+};
+
+exports.down = async function (db) {
+  return db.runSql(`
+    DELETE FROM data_table
+    WHERE code = 'entities'
+  `);
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -5233,6 +5233,7 @@ __metadata:
     "@tupaia/utils": 1.0.0
     dotenv: ^8.2.0
     express: ^4.16.2
+    mockdate: ^3.0.5
     winston: ^3.2.1
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
### Issue RN-645:

We're adding 2 new data tables in the PR.
`entities` - fetches metadata for entities (useful for getting entity names from codes for instance)
`entity_relations` - fetches relations within an entity hierarchy (useful for entity aggregation)

Also adding the `Parameters` route for fetching the parameters required by a given data-table. It's not entirely needed, but there's been some rebasing shenanigans going on and I'd rather not have to create a separate PR for it 👍  