### PR TITLE
RN-689: Fix the world entity not syncing with permission based syncs

### DIFF
--- a/packages/central-server/src/apiV2/utilities/meditrakSync/permissionsBasedMeditrakSyncQuery.js
+++ b/packages/central-server/src/apiV2/utilities/meditrakSync/permissionsBasedMeditrakSyncQuery.js
@@ -18,6 +18,8 @@ import {
 } from './supportsPermissionsBasedSync';
 
 const recordTypesToAlwaysSync = ['country', 'permission_group'];
+const entityTypesToAlwaysSync = ['world', 'country'];
+
 /**
  * Since all countries, permission_groups, and country entities regardless of permissions
  */
@@ -25,8 +27,8 @@ export const permissionsFreeChanges = since => {
   return {
     query: `change_time > ? AND (record_type IN ${SqlQuery.record(
       recordTypesToAlwaysSync,
-    )} OR entity_type = ?)`,
-    params: [since, ...recordTypesToAlwaysSync, 'country'],
+    )} OR entity_type IN ${SqlQuery.record(entityTypesToAlwaysSync)})`,
+    params: [since, ...recordTypesToAlwaysSync, ...entityTypesToAlwaysSync],
   };
 };
 


### PR DESCRIPTION
### Issue RN-689:

World wasn't syncing sync technically no users have permissions for it. We should always sync it.

#### Merge tasks:
- [ ] Bump the change_time of the world entity record to force a resync for all users