### PR TITLE
[no-issue]: Fix upserting dynamic columns

### DIFF
--- a/packages/report-server/src/__tests__/reportBuilder/transform/updateColumns.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/transform/updateColumns.test.ts
@@ -186,4 +186,24 @@ describe('updateColumns', () => {
       ]),
     );
   });
+
+  it('can upsert a column dynamically', () => {
+    const transform = buildTransform([
+      {
+        transform: 'updateColumns',
+        insert: {
+          '=$name': '=$value',
+        },
+        exclude: '*',
+      },
+    ]);
+    expect(
+      transform(
+        TransformTable.fromRows([
+          { name: 'value', value: 7 },
+          { name: 'total', value: 10 },
+        ]),
+      ),
+    ).toStrictEqual(TransformTable.fromRows([{ value: 7 }, { total: 10 }]));
+  });
 });

--- a/packages/report-server/src/reportBuilder/transform/functions/updateColumns.ts
+++ b/packages/report-server/src/reportBuilder/transform/functions/updateColumns.ts
@@ -46,9 +46,7 @@ const updateColumns = (table: TransformTable, params: UpdateColumnsParams, conte
       const columnName = parser.evaluate(key);
       const columnValue = parser.evaluate(expression);
       if (!newColumns[columnName]) {
-        newColumns[columnName] = table.hasColumn(columnName)
-          ? table.getColumnValues(columnName) // Upserting a column, so fill with current column values
-          : new Array(table.length()).fill(undefined); // Creating a new column, so fill with undefined
+        newColumns[columnName] = new Array(table.length()).fill(undefined);
       }
       newColumns[columnName].splice(rowIndex, 1, columnValue);
     });


### PR DESCRIPTION
### Issue https://beyondessential.slack.com/archives/C01MAA3NKM1/p1665977231627499:

This issue is a bit rare, but when we're using dynamic columns to override an existing column, the old values from the existing column are kept.