### PR TITLE
Add dashboard item edit options

### DIFF
--- a/packages/web-config-server/src/apiV1/dashboardItems.js
+++ b/packages/web-config-server/src/apiV1/dashboardItems.js
@@ -1,0 +1,21 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+
+import { RouteHandler } from './RouteHandler';
+import { NoPermissionRequiredChecker } from './permissions';
+
+export default class extends RouteHandler {
+  static PermissionsChecker = NoPermissionRequiredChecker;
+
+  buildResponse = async () => {
+    const dashboardItems = await this.models.dashboardItem.all();
+
+    const dashboardItemOptions = dashboardItems.map(({ id, code }) => {
+      return { id, code };
+    });
+
+    return dashboardItemOptions;
+  };
+}

--- a/packages/web-config-server/src/apiV1/index.js
+++ b/packages/web-config-server/src/apiV1/index.js
@@ -27,6 +27,7 @@ import MeasuresDataHandler from './measureData';
 import OrgUnitSearchHandler from './organisationUnitSearch';
 import OrganisationUnitHandler from './organisationUnit';
 import DashboardsHandler from './dashboards';
+import DashboardItemsHandler from './dashboardItems';
 import { ReportHandler } from './report';
 import { disasters } from './disasters';
 
@@ -61,6 +62,7 @@ export const getRoutesForApiV1 = () => {
   api.get('/dashboards', handleWith(DashboardsHandler)); // New style dashboards
   api.get('/report/:reportCode', handleWith(ReportHandler));
   api.post('/pdf', catchAsyncErrors(PDFExportHandler));
+  api.get('/dashboardItems', handleWith(DashboardItemsHandler));
 
   return api;
 };

--- a/packages/web-frontend/package.json
+++ b/packages/web-frontend/package.json
@@ -45,6 +45,7 @@
     "history": "^4.7.2",
     "is-mobile": "^0.2.2",
     "lodash": "^4.17.4",
+    "lodash.throttle": "^4.1.1",
     "markdown-to-jsx": "^6.4.1",
     "material-ui": "^0.18.3",
     "material-ui-datetimepicker": "^1.0.7",
@@ -71,6 +72,7 @@
     "sanitize-filename": "^1.6.3",
     "shallowequal": "^1.0.2",
     "styled-components": "^5.1.0",
+    "uuid": "^9.0.0",
     "whatwg-fetch": "2.0.3"
   },
   "devDependencies": {

--- a/packages/web-frontend/src/actions.js
+++ b/packages/web-frontend/src/actions.js
@@ -132,6 +132,15 @@ export const UPDATE_HISTORY_LOCATION = 'UPDATE_HISTORY_LOCATION';
 export const SET_MAP_OVERLAYS_ONCE_HIERARCHY_LOADS = 'SET_MAP_OVERLAYS_ONCE_HIERARCHY_LOADS';
 export const LOCATION_CHANGE = 'LOCATION_CHANGE';
 export const SET_MAX_SELECTED_OVERLAYS = 'SET_MAX_SELECTED_OVERLAYS';
+export const FETCH_DASHBOARD_ITEM_EDIT_OPTIONS = 'FETCH_DASHBOARD_ITEM_EDIT_OPTIONS';
+export const FETCH_DASHBOARD__ITEM_EDIT_OPTIONS_SUCCESS =
+  'FETCH_DASHBOARD_ITEM_EDIT_OPTIONS_SUCCESS';
+export const AUTOCOMPLETE_INPUT_CHANGE = 'AUTOCOMPLETE_INPUT_CHANGE';
+export const AUTOCOMPLETE_RESULTS_CHANGE = 'AUTOCOMPLETE_RESULTS_CHANGE';
+export const AUTOCOMPLETE_SEARCH_FAILURE = 'AUTOCOMPLETE_SEARCH_FAILURE';
+export const AUTOCOMPLETE_SELECTION_CHANGE = 'AUTOCOMPLETE_SELECTION_CHANGE';
+export const AUTOCOMPLETE_RESET = 'AUTOCOMPLETE_RESET';
+export const MAX_AUTOCOMPLETE_RESULTS = 'MAX_AUTOCOMPLETE_RESULTS';
 
 /**
  * Attempt password change using old password, new password and new password
@@ -487,6 +496,23 @@ export function fetchOrgUnit(organisationUnitCode) {
   return {
     type: FETCH_ORG_UNIT,
     organisationUnitCode,
+  };
+}
+
+/**
+ * Fetches all dashboard item codes and ids for adding a new dashboard relation.
+ *
+ */
+export function fetchDashboardItemEditOptions() {
+  return {
+    type: FETCH_DASHBOARD_ITEM_EDIT_OPTIONS,
+  };
+}
+
+export function fetchDashboardItemEditOptionsSuccess(dashboardItemEditOptionsData) {
+  return {
+    type: FETCH_DASHBOARD__ITEM_EDIT_OPTIONS_SUCCESS,
+    dashboardItemEditOptionsData,
   };
 }
 

--- a/packages/web-frontend/src/autocomplete/actions.js
+++ b/packages/web-frontend/src/autocomplete/actions.js
@@ -1,0 +1,20 @@
+/**
+ * Tupaia Web
+ * Copyright (c) 2019 Beyond Essential Systems Pty Ltd.
+ * This source code is licensed under the AGPL-3.0 license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+// import { v1 as generateId } from 'uuid';
+// import { convertSearchTermToFilter, makeSubstitutionsInString } from '../utils';
+import { AUTOCOMPLETE_SELECTION_CHANGE, AUTOCOMPLETE_RESET } from '../actions';
+
+export const changeSelection = (reduxId, selection) => ({
+  type: AUTOCOMPLETE_SELECTION_CHANGE,
+  selection,
+  reduxId,
+});
+
+export const clearState = reduxId => ({
+  type: AUTOCOMPLETE_RESET,
+  reduxId,
+});

--- a/packages/web-frontend/src/autocomplete/constants.js
+++ b/packages/web-frontend/src/autocomplete/constants.js
@@ -1,0 +1,7 @@
+export const DEFAULT_AUTOCOMPLETE_STATE = {
+  selection: [],
+  searchTerm: '',
+  results: [],
+  isLoading: false,
+  fetchId: null,
+};

--- a/packages/web-frontend/src/autocomplete/index.js
+++ b/packages/web-frontend/src/autocomplete/index.js
@@ -1,0 +1,9 @@
+/**
+ * Tupaia MediTrak
+ * Copyright (c) 2018 Beyond Essential Systems Pty Ltd
+ */
+
+export { changeSelection, clearState } from './actions';
+// TODO: add changeSearchTerm to actions
+export { autocomplete } from './reducers';
+export { DEFAULT_AUTOCOMPLETE_STATE } from './constants';

--- a/packages/web-frontend/src/autocomplete/reducers.js
+++ b/packages/web-frontend/src/autocomplete/reducers.js
@@ -1,0 +1,52 @@
+/**
+ * Tupaia MediTrak
+ * Copyright (c) 2018 Beyond Essential Systems Pty Ltd
+ */
+
+import {
+  AUTOCOMPLETE_INPUT_CHANGE,
+  AUTOCOMPLETE_RESULTS_CHANGE,
+  AUTOCOMPLETE_SEARCH_FAILURE,
+  AUTOCOMPLETE_SELECTION_CHANGE,
+  AUTOCOMPLETE_RESET,
+} from '../actions';
+import { DEFAULT_AUTOCOMPLETE_STATE } from './constants';
+import { getFetchId } from '../selectors';
+
+export function autocomplete(state = DEFAULT_AUTOCOMPLETE_STATE, action) {
+  switch (action.type) {
+    case AUTOCOMPLETE_INPUT_CHANGE:
+      return {
+        ...state,
+        isLoading: true,
+      };
+    case AUTOCOMPLETE_RESULTS_CHANGE: {
+      const currentFetchId = getFetchId(state);
+      if (action.fetchId !== currentFetchId) return {}; // From a previous fetch request, ignore it
+      return {
+        ...state,
+        isLoading: false,
+        fetchId: null,
+      };
+    }
+    case AUTOCOMPLETE_SELECTION_CHANGE:
+      return {
+        ...state,
+        searchTerm: '',
+        [action.reduxId]: action.selection,
+      };
+    case AUTOCOMPLETE_SEARCH_FAILURE: {
+      const currentFetchId = getFetchId(state);
+      if (action.fetchId !== currentFetchId) return {}; // From a previous fetch request, ignore it
+      return {
+        results: DEFAULT_AUTOCOMPLETE_STATE.results,
+        isLoading: false,
+        fetchId: null,
+      };
+    }
+    case AUTOCOMPLETE_RESET:
+      return DEFAULT_AUTOCOMPLETE_STATE;
+    default:
+      return state;
+  }
+}

--- a/packages/web-frontend/src/components/Autocomplete.js
+++ b/packages/web-frontend/src/components/Autocomplete.js
@@ -1,0 +1,113 @@
+/**
+ * Tupaia Web
+ * Copyright (c) 2019 Beyond Essential Systems Pty Ltd.
+ * This source code is licensed under the AGPL-3.0 license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+// import throttle from 'lodash.throttle';
+import { connect } from 'react-redux';
+import styled from 'styled-components';
+import { Autocomplete as AutocompleteUi } from '@tupaia/ui-components';
+import { getAutocompleteState } from '../selectors';
+import { changeSelection } from '../autocomplete';
+
+const AutocompleteBase = styled(AutocompleteUi)`
+  margin: 5px 10px 5px 10px;
+  color: white;
+
+  .MuiInputBase-root {
+    background-color: transparent;
+  }
+`;
+
+const AutocompleteComponent = React.memo(
+  ({ onChangeSelection, selection, isLoading, options, label, optionLabelKey, searchTerm }) => {
+    // React.useEffect(() => {
+    //   onChangeSearchTerm('');
+
+    //   return () => {
+    //     onClearState();
+    //   };
+    // }, []);
+
+    const value = selection;
+
+    return (
+      <AutocompleteBase
+        value={value}
+        label={label}
+        options={options}
+        getOptionSelected={(option, selected) =>
+          option[optionLabelKey] === selected[optionLabelKey]
+        }
+        getOptionLabel={option => (option && option[optionLabelKey] ? option[optionLabelKey] : '')}
+        loading={isLoading}
+        onChange={onChangeSelection}
+        // onInputChange={throttle((event, newValue) => onChangeSearchTerm(newValue), 50)}
+        inputValue={searchTerm}
+        placeholder="Start typing to search"
+      />
+    );
+  },
+);
+
+AutocompleteComponent.propTypes = {
+  isLoading: PropTypes.bool.isRequired,
+  // onChangeSearchTerm: PropTypes.func.isRequired,
+  onChangeSelection: PropTypes.func.isRequired,
+  // onClearState: PropTypes.func.isRequired,
+  optionLabelKey: PropTypes.string.isRequired,
+  options: PropTypes.arrayOf(PropTypes.object),
+  searchTerm: PropTypes.string,
+  placeholder: PropTypes.oneOfType([PropTypes.array, PropTypes.string]),
+  label: PropTypes.string,
+  selection: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
+};
+
+AutocompleteComponent.defaultProps = {
+  selection: [],
+  options: [],
+  searchTerm: null,
+  placeholder: null,
+  label: null,
+};
+
+const mapStateToProps = (state, { reduxId }) => {
+  const { selection, searchTerm, results, isLoading, fetchId } = getAutocompleteState(
+    state,
+    reduxId,
+  );
+  return { selection, searchTerm, results, isLoading, fetchId };
+};
+
+const mapDispatchToProps = (
+  dispatch,
+  { endpoint, optionLabelKey, optionValueKey, reduxId, onChange, baseFilter },
+) => ({
+  onChangeSelection: (event, newSelection) => {
+    if (newSelection === null) {
+      onChange(null);
+    } else {
+      onChange(newSelection[optionValueKey]);
+    }
+
+    dispatch(changeSelection(reduxId, newSelection));
+  },
+  // onChangeSearchTerm: newSearchTerm =>
+  //   dispatch(
+  //     changeSearchTerm(
+  //       reduxId,
+  //       endpoint,
+  //       optionLabelKey,
+  //       optionValueKey,
+  //       newSearchTerm,
+  //       baseFilter,
+  //     ),
+  //   ),
+  // onClearState: () => dispatch(clearState(reduxId)),
+});
+
+export const Autocomplete = connect(mapStateToProps, mapDispatchToProps)(AutocompleteComponent);

--- a/packages/web-frontend/src/components/DashboardEditButton.js
+++ b/packages/web-frontend/src/components/DashboardEditButton.js
@@ -8,17 +8,25 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import MuiIconButton from '@material-ui/core/Button';
+import EditIcon from '@material-ui/icons/Edit';
 
-import EditIcon from 'material-ui/svg-icons/action/info';
-
-const EditButton = styled.div`
-  outline: 1px solid yellow;
+const EditButton = styled(MuiIconButton)`
+  font-size: 10px;
+  margin: 5px 5px 0px 10px;
+  background-color: transparent;
+  color: white;
 `;
 
-export const DashboardEditButton = ({ onEdit }) => (
-  <EditButton onClick={onEdit} role="button" tabIndex={0}>
-    edit dashboard
-    <EditIcon />
+export const DashboardEditButton = ({ onClick }) => (
+  <EditButton
+    startIcon={<EditIcon style={{ fontSize: 16 }} />}
+    variant="outlined"
+    disableElevation
+    onClick={onClick}
+    tabIndex={0}
+  >
+    Edit
   </EditButton>
 );
 

--- a/packages/web-frontend/src/components/EditDashboardModal.js
+++ b/packages/web-frontend/src/components/EditDashboardModal.js
@@ -7,6 +7,7 @@ import styled from 'styled-components';
 import { cloneDeep } from 'lodash';
 import EditIcon from 'material-ui/svg-icons/action/info';
 import CloseIcon from 'material-ui/svg-icons/navigation/close';
+import { Autocomplete } from './Autocomplete';
 
 const DialogTitleWrapper = ({ titleText }) => {
   const styles = {
@@ -52,14 +53,24 @@ const EditRowActions = styled.div`
 
 const dialogTitle = 'Edit Dashboard';
 
-export const EditDashboardModal = ({ dashboardSpec, isOpen, onClose, onSave }) => {
+export const EditDashboardModal = ({
+  dashboardSpec,
+  isOpen,
+  onClose,
+  onSave,
+  dashboardItemEditOptions,
+}) => {
   const [newDashboardSpec, setNewDashboardSpec] = useState(cloneDeep(dashboardSpec));
-
-  console.log('dashboardSpec', dashboardSpec);
 
   return (
     <Dialog open={isOpen} onClose={onClose}>
       <DialogTitleWrapper titleText={dialogTitle} />
+      <Autocomplete
+        options={dashboardItemEditOptions}
+        optionLabelKey="code"
+        optionValueKey="id"
+        placeholder="Search for a dashboard item"
+      />
       <div>
         {dashboardSpec &&
           dashboardSpec.items.map(item => (
@@ -85,4 +96,5 @@ EditDashboardModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
   onSave: PropTypes.func.isRequired,
+  dashboardItemEditOptions: PropTypes.arrayOf(PropTypes.object).isRequired,
 };

--- a/packages/web-frontend/src/containers/Dashboard.js
+++ b/packages/web-frontend/src/containers/Dashboard.js
@@ -21,7 +21,12 @@ import styled from 'styled-components';
 import { FlexSpaceBetween } from '@tupaia/ui-components';
 import StaticMap from '../components/StaticMap';
 import { DASHBOARD_STYLES, DASHBOARD_META_MARGIN } from '../styles';
-import { setDashboardGroup, closeDropdownOverlays, setOrgUnit } from '../actions';
+import {
+  setDashboardGroup,
+  closeDropdownOverlays,
+  setOrgUnit,
+  fetchDashboardItemEditOptions,
+} from '../actions';
 import { DashboardGroup } from './DashboardGroup';
 import { getOrgUnitPhotoUrl } from '../utils';
 import { DropDownMenu } from '../components/DropDownMenu';
@@ -42,7 +47,7 @@ const IMAGE_HEIGHT_RATIO = 0.5;
 
 const MuiButton = styled(MuiIconButton)`
   font-size: 10px;
-  margin: 5px 10px 0px 10px;
+  margin: 5px 10px 0px 5px;
   background-color: transparent;
   color: white;
 `;
@@ -255,14 +260,17 @@ export class Dashboard extends Component {
         {this.renderMetaMedia()}
         <FlexSpaceBetween>
           <h2 style={DASHBOARD_STYLES.title}>{currentOrganisationUnit.name}</h2>
-          <MuiButton
-            startIcon={<DownloadIcon style={{ fontSize: 16 }} />}
-            variant="outlined"
-            onClick={() => this.setState({ isOpen: true })}
-            disableElevation
-          >
-            export
-          </MuiButton>
+          <div>
+            <DashboardEditButton onClick={() => this.setIsEditingDashboard(true)} />
+            <MuiButton
+              startIcon={<DownloadIcon style={{ fontSize: 16 }} />}
+              variant="outlined"
+              onClick={() => this.setState({ isOpen: true })}
+              disableElevation
+            >
+              export
+            </MuiButton>
+          </div>
         </FlexSpaceBetween>
       </div>
     );
@@ -275,11 +283,12 @@ export class Dashboard extends Component {
       currentGroupDashboard,
       currentOrganisationUnit,
       currentProjectName,
+      dashboardItemEditOptions,
     } = this.props;
     const exportFileName =
       currentGroupDashboard &&
       `${currentProjectName}-${currentOrganisationUnit.name}-${currentGroupDashboard.dashboardName}-dashboard-export`;
-
+    console.log('dashboardItemEditOptions', dashboardItemEditOptions);
     return (
       <>
         <div
@@ -295,7 +304,6 @@ export class Dashboard extends Component {
             {this.renderGroupsDropdown()}
             {this.renderGroup(currentGroupDashboard)}
           </div>
-          <DashboardEditButton onEdit={() => this.setIsEditingDashboard(true)} />
           {this.renderFloatingHeader()}
           {this.renderEnlargePopup()}
         </div>
@@ -310,6 +318,7 @@ export class Dashboard extends Component {
           onClose={() => this.setState({ isEditingDashboard: false })}
           onSave={() => this.onSaveDashboard}
           dashboardSpec={this.props.currentGroupDashboard}
+          dashboardItemEditOptions={dashboardItemEditOptions}
         />
       </>
     );
@@ -336,6 +345,7 @@ Dashboard.propTypes = {
     }),
   ).isRequired,
   onChangeOrgUnit: PropTypes.func.isRequired,
+  dashboardItemEditOptions: PropTypes.array.isRequired,
 };
 
 Dashboard.defaultProps = {
@@ -358,7 +368,7 @@ const mapStateToProps = state => {
   const currentDashboardName = selectCurrentDashboardName(state);
   const currentProject = selectCurrentProject(state);
   const breadcrumbs = selectCurrentBreadcrumbs(state);
-
+  const dashboardItemEditOptions = state.global.editOptions.dashboardItems;
   const dashboardNames = [];
   // sort group names based on current project
   dashboards.forEach(({ dashboardName, project: dashboardProject }) => {
@@ -388,6 +398,7 @@ const mapStateToProps = state => {
     isLoading: isLoadingOrganisationUnit,
     isSidePanelExpanded,
     contractedWidth,
+    dashboardItemEditOptions,
   };
 };
 
@@ -398,6 +409,7 @@ const mapDispatchToProps = dispatch => {
     onChangeOrgUnit: (organisationUnitCode, shouldChangeMapBounds = true) => {
       dispatch(setOrgUnit(organisationUnitCode, shouldChangeMapBounds));
     },
+    fetchDashboardItemEditOptions: () => dispatch(fetchDashboardItemEditOptions()),
   };
 };
 

--- a/packages/web-frontend/src/reducers.js
+++ b/packages/web-frontend/src/reducers.js
@@ -19,6 +19,7 @@ import { combineReducers } from 'redux';
 import map from './reducers/mapReducers';
 import disaster from './disaster/reducers';
 import project from './projects/reducers';
+import { autocomplete } from './autocomplete';
 import orgUnits from './reducers/orgUnitReducers';
 import { isMobile, getUniqueViewId } from './utils';
 import { LANDING } from './containers/OverlayDiv/constants';
@@ -74,6 +75,7 @@ import {
   FINISH_USER_SESSION,
   FIND_USER_LOGGEDIN,
   FIND_USER_LOGIN_FAILED,
+  FETCH_ALL_MEASURE_DATA_SUCCESS,
   GO_HOME,
   CLOSE_DROPDOWN_OVERLAYS,
   SHOW_SERVER_UNREACHABLE_ERROR,
@@ -98,6 +100,8 @@ import {
   FETCH_RESET_TOKEN_LOGIN_ERROR,
   SET_ENLARGED_DIALOG_DATE_RANGE,
   SET_OVERLAY_CONFIGS,
+  FETCH_DASHBOARD_ITEM_EDIT_OPTIONS,
+  FETCH_DASHBOARD__ITEM_EDIT_OPTIONS_SUCCESS,
 } from './actions';
 import { LOGIN_TYPES } from './constants';
 import { updateOverlayConfigs } from './utils/mapOverlays';
@@ -629,6 +633,7 @@ function global(
     dashboards: [],
     viewConfigs: {},
     isLoadingOrganisationUnit: false,
+    editOptions: { dashboardItems: [] },
   },
   action,
 ) {
@@ -671,6 +676,10 @@ function global(
       return { ...state, overlay: action.component };
     case SET_PROJECT:
       return { ...state, dashboards: [], viewConfigs: {} };
+    case FETCH_DASHBOARD_ITEM_EDIT_OPTIONS:
+      return state;
+    case FETCH_DASHBOARD__ITEM_EDIT_OPTIONS_SUCCESS:
+      return { ...state, editOptions: { dashboardItems: action.dashboardItemEditOptionsData } };
     default:
       return state;
   }
@@ -802,4 +811,5 @@ export default combineReducers({
   project,
   orgUnits,
   routing,
+  autocomplete,
 });

--- a/packages/web-frontend/src/sagas/handlers/fetchDashboardItemEditOptions.js
+++ b/packages/web-frontend/src/sagas/handlers/fetchDashboardItemEditOptions.js
@@ -1,0 +1,32 @@
+import { call, put } from 'redux-saga/effects';
+import { fetchDashboardItemEditOptions, fetchDashboardItemEditOptionsSuccess } from '../../actions';
+import { request } from '../../utils';
+
+/**
+ * fetchDashboardItemEditOptions
+ *
+ * Fetch all dashboard items from database.
+ *
+ */
+export function* fetchDashboardItemEditOptionsData() {
+  try {
+    console.log('starting the try for fetching dashboard item info');
+    yield put(fetchDashboardItemEditOptions());
+    // Build the request url
+    const requestResourceUrl = 'dashboardItems';
+    const dashboardItemData = yield call(request, requestResourceUrl);
+    console.log('dashboardItemdata', dashboardItemData);
+    // TODO: add fetch success action and reducer
+    yield put(fetchDashboardItemEditOptionsSuccess(dashboardItemData));
+    console.log('about to return dashboardItemData');
+    return;
+  } catch (error) {
+    if (error.errorFunction) {
+      yield put(error.errorFunction(error));
+    }
+    // TODO: add fetch success action and reducer
+    // e.g. yield put(fetchOrgUnitError(organisationUnitCode, error.message));
+
+    throw error;
+  }
+}

--- a/packages/web-frontend/src/sagas/handlers/index.js
+++ b/packages/web-frontend/src/sagas/handlers/index.js
@@ -8,3 +8,4 @@ export * from './fetchSearchData';
 export * from './fetchViewData';
 export * from './fetchMeasureInfo';
 export * from './fetchCurrentMeasureInfo';
+export * from './fetchDashboardItemEditOptions';

--- a/packages/web-frontend/src/sagas/watchUser/watchFetchInitialData.js
+++ b/packages/web-frontend/src/sagas/watchUser/watchFetchInitialData.js
@@ -5,7 +5,7 @@ import { getInitialLocation } from '../../historyNavigation';
 import { clearLocation } from '../../historyNavigation/historyNavigation';
 import { fetchProjectData } from '../../projects/sagas';
 import request from '../../utils/request';
-import { handleLocationChange } from '../handlers';
+import { handleLocationChange, fetchDashboardItemEditOptionsData } from '../handlers';
 
 export function* watchFetchInitialData() {
   yield take(FETCH_INITIAL_DATA);
@@ -13,6 +13,8 @@ export function* watchFetchInitialData() {
   // Login must happen first so that projects return the correct access flags
   yield call(findUserLoggedIn, LOGIN_TYPES.AUTO);
   yield call(fetchProjectData);
+  yield call(fetchDashboardItemEditOptionsData);
+  console.log('about to call handleLocationChange');
   yield call(handleLocationChange, {
     location: getInitialLocation(),
     previousLocation: clearLocation(),

--- a/packages/web-frontend/src/selectors/autocompleteSelectors.js
+++ b/packages/web-frontend/src/selectors/autocompleteSelectors.js
@@ -1,0 +1,11 @@
+/**
+ * Tupaia MediTrak
+ * Copyright (c) 2018 Beyond Essential Systems Pty Ltd
+ */
+
+import { DEFAULT_AUTOCOMPLETE_STATE } from '../autocomplete';
+
+export const getAutocompleteState = (state, reduxId) =>
+  state.autocomplete[reduxId] || DEFAULT_AUTOCOMPLETE_STATE;
+
+export const getFetchId = autocompleteState => autocompleteState.fetchId;

--- a/packages/web-frontend/src/selectors/dashboardSelectors.js
+++ b/packages/web-frontend/src/selectors/dashboardSelectors.js
@@ -39,6 +39,7 @@ export const selectCurrentExpandedDates = createSelector([selectLocation], locat
 export const selectCurrentDashboardName = createSelector(
   [state => state.global.dashboards, selectCurrentDashboardNameFromLocation],
   (dashboards, currentDashboardName) => {
+    console.log('dashboards in selector', dashboards);
     if (dashboards.find(d => d.dashboardName === currentDashboardName)) {
       return currentDashboardName;
     }
@@ -77,6 +78,13 @@ export const selectCurrentExpandedViewContent = createSelector(
   [selectCurrentInfoViewKey, state => state.dashboard.viewResponses],
   (infoViewKey, viewResponses) => {
     return viewResponses[infoViewKey];
+  },
+);
+
+export const selectDashboardItemEditOptions = createSelector(
+  [state => state.editOptions],
+  editOptions => {
+    return editOptions.dashboardItems;
   },
 );
 

--- a/packages/web-frontend/src/selectors/index.js
+++ b/packages/web-frontend/src/selectors/index.js
@@ -56,6 +56,7 @@ export {
   selectCurrentExpandedDates,
   selectViewConfig,
   selectCurrentBreadcrumbs,
+  selectDashboardItemEditOptions,
 } from './dashboardSelectors';
 
 export {
@@ -77,5 +78,7 @@ export {
   selectMapOverlayEmptyMessage,
   selectPeriodGranularityByCode,
 } from './mapOverlaySelectors';
+
+export { getAutocompleteState, getFetchId } from './autocompleteSelectors';
 
 export { selectMobileTab } from './navigationSelectors';

--- a/packages/web-frontend/src/utils/convertSearchTermToFilter.js
+++ b/packages/web-frontend/src/utils/convertSearchTermToFilter.js
@@ -1,0 +1,21 @@
+/**
+ * Tupaia MediTrak
+ * Copyright (c) 2018 Beyond Essential Systems Pty Ltd
+ */
+
+export const convertSearchTermToFilter = (unprocessedFilterObject = {}) => {
+  const filterObject = {};
+  Object.entries(unprocessedFilterObject).forEach(([key, value]) => {
+    if (typeof value !== 'string') {
+      filterObject[key] = value;
+      return;
+    }
+
+    filterObject[key] = {
+      comparator: `ilike`,
+      comparisonValue: `%${value}%`,
+      castAs: 'text',
+    };
+  });
+  return filterObject;
+};

--- a/packages/web-frontend/src/utils/createNestedReducer.js
+++ b/packages/web-frontend/src/utils/createNestedReducer.js
@@ -1,0 +1,33 @@
+/**
+ * Tupaia MediTrak
+ * Copyright (c) 2018 Beyond Essential Systems Pty Ltd
+ */
+
+import { createReducer } from './createReducer';
+
+const createNestedStateChanger = (defaultNestedState, handleActionPayload) => (
+  { reduxId: id, ...restOfPayload },
+  currentState,
+) => {
+  const ids = id ? [id] : Object.keys(currentState);
+  const newState = {};
+  ids.forEach(currentId => {
+    const nestedState = currentState[currentId] || defaultNestedState;
+    const stateChanges = handleActionPayload
+      ? handleActionPayload(restOfPayload, nestedState)
+      : restOfPayload;
+    newState[currentId] = {
+      ...nestedState,
+      ...stateChanges,
+    };
+  });
+  return newState;
+};
+
+export const createNestedReducer = (defaultNestedState, nestedStateChanges) => {
+  const stateChanges = {};
+  Object.entries(nestedStateChanges).forEach(([actionType, actionHandler]) => {
+    stateChanges[actionType] = createNestedStateChanger(defaultNestedState, actionHandler);
+  });
+  return createReducer(defaultNestedState, stateChanges);
+};

--- a/packages/web-frontend/src/utils/createReducer.js
+++ b/packages/web-frontend/src/utils/createReducer.js
@@ -1,0 +1,25 @@
+/**
+ * Tupaia MediTrak
+ * Copyright (c) 2017 Beyond Essential Systems Pty Ltd
+ */
+
+/**
+ * Helper function that returns a reducer based on an object that contains an entry for each action
+ * type, with a function that describes what changes to state that action would cause.
+ */
+export const createReducer = (defaultState = {}, stateChanges = {}) => (
+  state = defaultState,
+  action,
+) => {
+  const { type, payload, ...otherProps } = action;
+  // Whether passed through in 'payload' or as a series of extra props, all data for this action
+  // is passed through to state manipulator as one payload argument
+  const fullPayload = { ...payload, ...otherProps };
+  if (type && stateChanges && Object.prototype.hasOwnProperty.call(stateChanges, type)) {
+    return {
+      ...state,
+      ...stateChanges[type](fullPayload, state),
+    };
+  }
+  return state; // Action type didn't match a change or a manipulator, return original state
+};

--- a/packages/web-frontend/src/utils/index.js
+++ b/packages/web-frontend/src/utils/index.js
@@ -36,3 +36,6 @@ export {
 } from './getUniqueViewId';
 export { sleep } from './sleep';
 export { getLayeredOpacity } from './opacity';
+export { convertSearchTermToFilter } from './convertSearchTermToFilter';
+export { makeSubstitutionsInString } from './makeSubstitutionsInString';
+export { createNestedReducer } from './createNestedReducer';

--- a/packages/web-frontend/src/utils/makeSubstitutionsInString.js
+++ b/packages/web-frontend/src/utils/makeSubstitutionsInString.js
@@ -1,0 +1,12 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
+ */
+
+const extractParams = template =>
+  [...template.matchAll(/\{(\w+)\}/gi)].map(matchArray => matchArray[1]);
+
+export const makeSubstitutionsInString = (template, variables) => {
+  const params = extractParams(template);
+  return params.reduce((str, param) => str.replace(`{${param}}`, variables[param]), template);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -5793,6 +5793,7 @@ __metadata:
     jest: ^27.0.6
     js-beautify: ^1.13.0
     lodash: ^4.17.4
+    lodash.throttle: ^4.1.1
     markdown-to-jsx: ^6.4.1
     material-ui: ^0.18.3
     material-ui-datetimepicker: ^1.0.7
@@ -5826,6 +5827,7 @@ __metadata:
     shallowequal: ^1.0.2
     sinon: ^9.0.2
     styled-components: ^5.1.0
+    uuid: ^9.0.0
     whatwg-fetch: 2.0.3
   languageName: unknown
   linkType: soft
@@ -34670,6 +34672,15 @@ __metadata:
   bin:
     uuid: dist/bin/uuid
   checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "uuid@npm:9.0.0"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 8dd2c83c43ddc7e1c71e36b60aea40030a6505139af6bee0f382ebcd1a56f6cd3028f7f06ffb07f8cf6ced320b76aea275284b224b002b289f89fe89c389b028
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Changes:

- Add route in web-config-server for returning dashboard item edit options (id and code)
- Add redux actions, reducers, sagas for storing these items to state.
- Style edit button in dashboard.
- Add search bar for dashboard item in modal.
