### PR TITLE
RN-702: Re-instate excluding columns when using the 'exclude' merge function

### DIFF
--- a/packages/report-server/src/__tests__/reportBuilder/transform/mergeRows.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/transform/mergeRows.test.ts
@@ -283,10 +283,11 @@ describe('mergeRows', () => {
         },
       ]);
       expect(transform(TransformTable.fromRows(MERGEABLE_ANALYTICS))).toStrictEqual(
-        TransformTable.fromRows(
-          [{ period: '20200101' }, { period: '20200102' }, { period: '20200103' }],
-          ['period', 'organisationUnit', 'BCD1', 'BCD2'], // excludes values, but keeps columns
-        ),
+        TransformTable.fromRows([
+          { period: '20200101' },
+          { period: '20200102' },
+          { period: '20200103' },
+        ]),
       );
     });
 

--- a/packages/report-server/src/__tests__/reportBuilder/transform/parser/parser.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/transform/parser/parser.test.ts
@@ -121,31 +121,6 @@ describe('parser', () => {
   });
 
   describe('in transforms', () => {
-    it('mergeRows supports parser lookups on where', () => {
-      const transform = buildTransform([
-        {
-          transform: 'mergeRows',
-          using: {
-            organisationUnit: 'exclude',
-            period: 'exclude',
-            '*': 'sum',
-          },
-          where: "=eq($organisationUnit, 'TO')",
-        },
-      ]);
-      expect(transform(TransformTable.fromRows(PARSABLE_ANALYTICS))).toStrictEqual(
-        TransformTable.fromRows(
-          [
-            { BCD1: 11 },
-            { period: '20200101', organisationUnit: 'PG', BCD1: 7 },
-            { period: '20200102', organisationUnit: 'PG', BCD1: 8 },
-            { period: '20200103', organisationUnit: 'PG', BCD1: 2 },
-          ],
-          ['period', 'organisationUnit', 'BCD1'],
-        ),
-      );
-    });
-
     it('excludeRows supports parser lookups on where', () => {
       const transform = buildTransform([
         {


### PR DESCRIPTION
### Issue RN-702:

Just re-introducing some behaviour that got removed as part of RN-175.

Also scrapped the `where` clause support on `mergeRows`, as it's never been used and makes the code more complex than needed