### PR TITLE
RN-708: Fix Kobo Sync Groups being stuck in a 'Syncing' state

### DIFF
--- a/packages/central-server/src/kobo/startSyncWithKoBo.js
+++ b/packages/central-server/src/kobo/startSyncWithKoBo.js
@@ -170,6 +170,10 @@ export async function startSyncWithKoBo(models) {
     const koboDataServiceSyncGroups = await models.dataServiceSyncGroup.find({
       service_type: SERVICE_TYPE,
     });
+
+    // Put all kobo sync groups in an idle state, just in case they're stuck in an 'syncing' state due to a server shutdown
+    await Promise.all(koboDataServiceSyncGroups.map(async syncGroup => syncGroup.setSyncIdle()));
+
     koboDataServiceSyncGroups.forEach(dssg =>
       setInterval(() => syncWithKoBo(models, dataBroker, dssg.code), PERIOD_BETWEEN_SYNCS),
     );

--- a/packages/database/src/modelClasses/DataServiceSyncGroup.js
+++ b/packages/database/src/modelClasses/DataServiceSyncGroup.js
@@ -22,6 +22,10 @@ const syncStatuses = {
 class DataServiceSyncGroupType extends DatabaseType {
   static databaseType = TYPES.DATA_SERVICE_SYNC_GROUP;
 
+  async setSyncIdle() {
+    return this.model.update({ id: this.id }, { sync_status: syncStatuses.idle });
+  }
+
   async setSyncStarted() {
     return this.model.update({ id: this.id }, { sync_status: syncStatuses.syncing });
   }


### PR DESCRIPTION
### Issue RN-708:

Flag all kobo sync groups as being in an IDLE sync state upon server startup