### PR TITLE
[no-issue]: Move datetime to tsutils

### DIFF
--- a/packages/central-server/package.json
+++ b/packages/central-server/package.json
@@ -33,6 +33,7 @@
     "@tupaia/database": "1.0.0",
     "@tupaia/dhis-api": "1.0.0",
     "@tupaia/expression-parser": "1.0.0",
+    "@tupaia/tsutils": "1.0.0",
     "@tupaia/utils": "1.0.0",
     "adm-zip": "^0.5.5",
     "api-error-handler": "^1.0.0",

--- a/packages/central-server/src/apiV2/surveyResponse.js
+++ b/packages/central-server/src/apiV2/surveyResponse.js
@@ -4,8 +4,8 @@
  */
 
 import keyBy from 'lodash.keyby';
+import { getTimezoneNameFromTimestamp } from '@tupaia/tsutils';
 import {
-  getTimezoneNameFromTimestamp,
   ValidationError,
   MultiValidationError,
   ObjectValidator,

--- a/packages/tsutils/package.json
+++ b/packages/tsutils/package.json
@@ -22,7 +22,12 @@
   "dependencies": {
     "@tupaia/utils": "1.0.0",
     "cookie": "^0.5.0",
+    "moment": "^2.24.0",
+    "moment-timezone": "^0.5.25",
     "puppeteer": "^15.4.0",
     "yup": "^0.32.9"
+  },
+  "devDependencies": {
+    "@types/moment-timezone": "0.5.13"
   }
 }

--- a/packages/tsutils/src/__tests__/datetime.test.ts
+++ b/packages/tsutils/src/__tests__/datetime.test.ts
@@ -1,6 +1,6 @@
 /**
  * Tupaia
- * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
  */
 
 import moment from 'moment';

--- a/packages/tsutils/src/datetime.ts
+++ b/packages/tsutils/src/datetime.ts
@@ -1,0 +1,22 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import moment from 'moment';
+import momentTimezone from 'moment-timezone';
+
+/**
+ * @returns utcOffset in format: "+05:00"
+ */
+const getUtcOffsetFromTimestamp = (timestamp: string) => moment.parseZone(timestamp).format('Z');
+
+/**
+ * @returns timezone name in format: "Pacific/Fiji".
+ */
+export const getTimezoneNameFromTimestamp = (timestamp: string) =>
+  momentTimezone.tz
+    .names()
+    .find(name => getUtcOffsetFromTimestamp(timestamp) === momentTimezone.tz(name).format('Z'));
+
+export const utcMoment = (...args: Parameters<typeof moment['utc']>) => moment.utc(...args);

--- a/packages/tsutils/src/index.ts
+++ b/packages/tsutils/src/index.ts
@@ -1,3 +1,4 @@
+export * from './datetime';
 export * from './downloadPageAsPDF';
 export * from './hashStringToInt';
 export * from './typeGuards';

--- a/packages/utils/src/datetime.js
+++ b/packages/utils/src/datetime.js
@@ -4,24 +4,6 @@
  */
 
 import moment from 'moment';
-import momentTimezone from 'moment-timezone';
-
-/**
- * @param {string} timestamp timestamp to get utcOffset from
- *
- * @returns {string} utcOffset in format: "+05:00"
- */
-const getUtcOffsetFromTimestamp = timestamp => moment.parseZone(timestamp).format('Z');
-
-/**
- * @param {string} utcOffset utcOffset to match to timezone name
- *
- * @returns {string} timezone name in format: "Pacific/Fiji".
- */
-export const getTimezoneNameFromTimestamp = timestamp =>
-  momentTimezone.tz
-    .names()
-    .find(name => getUtcOffsetFromTimestamp(timestamp) === momentTimezone.tz(name).format('Z'));
 
 /**
  * @param  {...any} args

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -8,7 +8,7 @@ export { DEFAULT_BINARY_OPTIONS, DEFAULT_BINARY_OPTIONS_OBJECT } from './constan
 export * from './compare';
 export * from './authHeaderBuilders';
 export * from './cypress';
-export { getTimezoneNameFromTimestamp, utcMoment } from './datetime';
+export { utcMoment } from './datetime';
 export * from './legacyDhis';
 export * from './errors';
 export { Multilock } from './Multilock';

--- a/tupaia-packages.code-workspace
+++ b/tupaia-packages.code-workspace
@@ -150,6 +150,7 @@
       "cleanup",
       "Codeship",
       "ctes",
+      "datetime",
       "debouncing",
       "deleters",
       "dhis",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5111,6 +5111,7 @@ __metadata:
     "@tupaia/database": 1.0.0
     "@tupaia/dhis-api": 1.0.0
     "@tupaia/expression-parser": 1.0.0
+    "@tupaia/tsutils": 1.0.0
     "@tupaia/utils": 1.0.0
     adm-zip: ^0.5.5
     api-error-handler: ^1.0.0
@@ -5637,7 +5638,10 @@ __metadata:
   resolution: "@tupaia/tsutils@workspace:packages/tsutils"
   dependencies:
     "@tupaia/utils": 1.0.0
+    "@types/moment-timezone": 0.5.13
     cookie: ^0.5.0
+    moment: ^2.24.0
+    moment-timezone: ^0.5.25
     puppeteer: ^15.4.0
     yup: ^0.32.9
   languageName: unknown
@@ -6352,6 +6356,15 @@ __metadata:
   version: 1.2.0
   resolution: "@types/minimist@npm:1.2.0"
   checksum: 30cbd9acd7ddb60bc3729adcc43a9da4940c90180fa0f08228f1da95ec6c00db2e3fd3af5280fc5345e3fa2637253bb5cf6625f30d571ef9bc3820a531febb7e
+  languageName: node
+  linkType: hard
+
+"@types/moment-timezone@npm:0.5.13":
+  version: 0.5.13
+  resolution: "@types/moment-timezone@npm:0.5.13"
+  dependencies:
+    moment: ">=2.14.0"
+  checksum: 35bd6414b790663e4879e38b4a344526ebe87b3f795929f9bc38f91f7caa373c65dd19a0e836182319f929d0f7fcff9b629efc6dbcef23d386bf0c87597f5b49
   languageName: node
   linkType: hard
 
@@ -24120,6 +24133,13 @@ __metadata:
   version: 2.24.0
   resolution: "moment@npm:2.24.0"
   checksum: 9cd93a251a2b33cb1b532eade0e496a2a7547faa6cfe37a283ee7bf69e202cd7c8ab0673d66883b5b29aed051353176dc0e6684f04073a75b0a155c500be1580
+  languageName: node
+  linkType: hard
+
+"moment@npm:>=2.14.0":
+  version: 2.29.4
+  resolution: "moment@npm:2.29.4"
+  checksum: 0ec3f9c2bcba38dc2451b1daed5daded747f17610b92427bebe1d08d48d8b7bdd8d9197500b072d14e326dd0ccf3e326b9e3d07c5895d3d49e39b6803b76e80e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Just moving the utils in `datetime.js` to `@tupaia/tsutils`

I left a copy of `utcMoment` in `@tupaia/utils` because it's currently used in many places. Will move that later on
