### PR TITLE
OSC-10: Admin panel entity hierarchy - Backend

### DIFF
--- a/packages/admin-panel-server/src/app/createApp.ts
+++ b/packages/admin-panel-server/src/app/createApp.ts
@@ -19,6 +19,8 @@ import {
   ExportMapOverlayVisualisationRoute,
   FetchDashboardVisualisationRequest,
   FetchDashboardVisualisationRoute,
+  FetchEntityHierarchyTreeRequest,
+  FetchEntityHierarchyTreeRoute,
   FetchHierarchyEntitiesRequest,
   FetchHierarchyEntitiesRoute,
   FetchMapOverlayVisualisationRequest,
@@ -54,6 +56,16 @@ export function createApp() {
     .useSessionModel(AdminPanelSessionModel)
     .verifyLogin(hasTupaiaAdminPanelAccess)
     .get('user', handleWith(UserRoute))
+    .get<FetchEntityHierarchyTreeRequest>(
+      'entityHierarchyTree',
+      verifyBESAdminAccess,
+      handleWith(FetchEntityHierarchyTreeRoute),
+    )
+    .get<FetchEntityHierarchyTreeRequest>(
+      'entityHierarchyTree/:hierarchyName/:entityCode',
+      verifyBESAdminAccess,
+      handleWith(FetchEntityHierarchyTreeRoute),
+    )
     .get<FetchHierarchyEntitiesRequest>(
       'hierarchy/:hierarchyName/:entityCode',
       verifyBESAdminAccess,

--- a/packages/admin-panel-server/src/routes/FetchEntityHierarchyTreeRoute.ts
+++ b/packages/admin-panel-server/src/routes/FetchEntityHierarchyTreeRoute.ts
@@ -1,0 +1,87 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import { Request } from 'express';
+
+import { Route } from '@tupaia/server-boilerplate';
+import { groupBy } from 'lodash';
+import { getSortByKey } from '@tupaia/utils';
+
+interface EntityNode {
+  code: string;
+  name: string;
+  hierarchyName: string;
+}
+
+export type FetchEntityHierarchyTreeRequest = Request<
+  Record<string, never> | { hierarchyName: string; entityCode: string },
+  (EntityNode & {
+    children: EntityNode[];
+  })[],
+  Record<string, never>,
+  Record<string, never>
+>;
+
+export class FetchEntityHierarchyTreeRoute extends Route<FetchEntityHierarchyTreeRequest> {
+  public async buildResponse() {
+    const { hierarchyName, entityCode } = this.req.params;
+
+    return hierarchyName && entityCode
+      ? this.buildHierarchyEntityTree(hierarchyName, entityCode)
+      : this.buildRootTree();
+  }
+
+  private async buildRootTree() {
+    const { central: centralApi } = this.req.ctx.services;
+
+    const rootEntities: Record<string, string>[] = await centralApi.fetchResources('entities', {
+      filter: { type: 'project' },
+      columns: ['id', 'code', 'name'],
+      sort: ['name'],
+    });
+
+    const childRelations = await centralApi.fetchResources('entityRelations', {
+      filter: { parent_id: rootEntities.map(({ id }) => id) },
+      columns: ['parent_id', 'entity.code', 'entity.name'],
+      sort: ['entity.name'],
+    });
+    const childRelationsByParent = groupBy(childRelations, 'parent_id');
+
+    return rootEntities.map(({ id, code, name }) => ({
+      code,
+      name,
+      hierarchyName: code,
+      children: (childRelationsByParent[id] || []).map(child => ({
+        code: child['entity.code'],
+        name: child['entity.name'],
+        hierarchyName: code,
+      })),
+    }));
+  }
+
+  private async buildHierarchyEntityTree(hierarchyName: string, entityCode: string) {
+    const { entity: entityApi } = this.req.ctx.services;
+
+    const descendants = await entityApi.getDescendantsOfEntity(hierarchyName, entityCode, {
+      filter: { generational_distance: { comparator: '<=', comparisonValue: 2 } },
+      fields: ['code', 'name', 'parent_code'],
+    });
+
+    descendants.sort(getSortByKey('name'));
+    const descendantsByParent = groupBy(descendants, 'parent_code');
+    const children = descendantsByParent[entityCode] || [];
+
+    return children.map(({ code, name }) => ({
+      code,
+      name,
+      hierarchyName,
+      children: (descendantsByParent[code] || []).map(descendant => ({
+        code: descendant.code,
+        name: descendant.name,
+        hierarchyName,
+      })),
+    }));
+  }
+}

--- a/packages/admin-panel-server/src/routes/index.ts
+++ b/packages/admin-panel-server/src/routes/index.ts
@@ -6,6 +6,7 @@
 
 export * from './dashboardVisualisations';
 export * from './mapOverlayVisualisations';
+export * from './FetchEntityHierarchyTreeRoute';
 export * from './FetchHierarchyEntitiesRoute';
 export * from './FetchReportPreviewDataRoute';
 export * from './FetchAggregationOptionsRoute';

--- a/packages/api-client/src/connections/CentralApi.ts
+++ b/packages/api-client/src/connections/CentralApi.ts
@@ -18,10 +18,20 @@ export type Answers = {
   [key: string]: string; // question_code -> value
 };
 
-const stringifyParams = (queryParameters?: Record<string, unknown>) => {
-  const translatedParams = queryParameters?.filter
-    ? { ...queryParameters, filter: JSON.stringify(queryParameters?.filter) }
-    : queryParameters;
+const stringifyParams = (queryParameters: Record<string, unknown> = {}) => {
+  const { filter, columns, sort, ...restOfParameters } = queryParameters;
+
+  const translatedParams = restOfParameters;
+  if (filter) {
+    translatedParams.filter = JSON.stringify(filter);
+  }
+  if (columns) {
+    translatedParams.columns = JSON.stringify(columns);
+  }
+  if (sort) {
+    translatedParams.sort = JSON.stringify(sort);
+  }
+
   return translatedParams as QueryParameters;
 };
 

--- a/packages/api-client/src/connections/EntityApi.ts
+++ b/packages/api-client/src/connections/EntityApi.ts
@@ -14,7 +14,11 @@ const MULTIPLE_VALUES_DELIMITER = ',';
 const comparatorToOperator = {
   '=': '==' as const, // Exact match
   '!=': '!=' as const, // Does not match
-  ilike: '=@' as const, // Contains sub string
+  ilike: '=@' as const, // Contains sub string,
+  '<': '<' as const, // Less than
+  '<=': '<=' as const, // Less than or equal
+  '>': '>' as const, // Greater than
+  '>=': '>=' as const, // Greater than or equal
 };
 
 type ValueOf<T> = T extends Record<string, any> ? T[keyof T] : never;

--- a/packages/central-server/src/apiV2/entityRelations/GETEntityRelations.js
+++ b/packages/central-server/src/apiV2/entityRelations/GETEntityRelations.js
@@ -1,0 +1,21 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import { GETHandler } from '../GETHandler';
+
+export class GETEntityRelations extends GETHandler {
+  // TODO we should allow a table to be joined multiple times (here for child_id and parent_id)
+  customJoinConditions = {
+    entity: ['entity.id', 'entity_relation.child_id'],
+    entity_hierarchy: ['entity_hierarchy.id', 'entity_relation.entity_hierarchy_id'],
+  };
+
+  // TODO add permissions - see GetDashboardRelations
+  async assertUserHasAccess() {
+    await this.assertPermissions(() => true);
+  }
+
+  // TODO add tests if this is going to be used
+}

--- a/packages/central-server/src/apiV2/entityRelations/index.js
+++ b/packages/central-server/src/apiV2/entityRelations/index.js
@@ -1,0 +1,6 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+export { GETEntityRelations } from './GETEntityRelations';

--- a/packages/central-server/src/apiV2/index.js
+++ b/packages/central-server/src/apiV2/index.js
@@ -55,6 +55,7 @@ import {
   CreateDashboardVisualisation,
   EditDashboardVisualisation,
 } from './dashboardVisualisations';
+import { GETEntityRelations } from './entityRelations';
 import { DeleteLegacyReport, EditLegacyReport, GETLegacyReports } from './legacyReports';
 import { DeleteMapOverlays, EditMapOverlays, GETMapOverlays } from './mapOverlays';
 import {
@@ -220,6 +221,7 @@ apiV2.get('/dataTables/:recordId?', useRouteHandler(GETDataTables));
 apiV2.get('/dataElementDataGroups', useRouteHandler(GETDataElementDataGroups));
 apiV2.get('/entities/:recordId?', useRouteHandler(GETEntities));
 apiV2.get('/entities/:parentRecordId/surveyResponses', useRouteHandler(GETSurveyResponses));
+apiV2.get('/entityRelations/:recordId?', useRouteHandler(GETEntityRelations));
 apiV2.get('/countries/:recordId?', useRouteHandler(GETCountries));
 apiV2.get('/clinics/:recordId?', useRouteHandler(GETClinics));
 apiV2.get('/facilities/:recordId?', useRouteHandler(GETClinics));

--- a/packages/entity-server/src/__tests__/__integration__/fieldsAndFilters.test.ts
+++ b/packages/entity-server/src/__tests__/__integration__/fieldsAndFilters.test.ts
@@ -198,6 +198,50 @@ describe('fieldsAndFilters', () => {
       expect(entities).toIncludeSameMembers(['PKMN_MANSION', 'PKMN_TOWER']);
     });
 
+    it('it can filter using <', async () => {
+      const { body: entities } = await app.get('hierarchy/redblue/redblue/descendants', {
+        query: { field: 'code', filter: 'generational_distance<2' },
+      });
+
+      expect(entities).toIncludeSameMembers(['KANTO']);
+    });
+
+    it('it can filter using <=', async () => {
+      const { body: entities } = await app.get('hierarchy/redblue/redblue/descendants', {
+        query: { field: 'code', filter: 'generational_distance<=2' },
+      });
+
+      expect(entities).toIncludeSameMembers([
+        'CELADON',
+        'CERULEAN',
+        'CINNABAR',
+        'FUCHSIA',
+        'KANTO',
+        'LAVENDER',
+        'PALLET',
+        'PEWTER',
+        'SAFFRON',
+        'VERMILLION',
+        'VIRIDIAN',
+      ]);
+    });
+
+    it('it can filter using >', async () => {
+      const { body: entities } = await app.get('hierarchy/redblue/redblue/descendants', {
+        query: { field: 'code', filter: 'name>Saffron City' },
+      });
+
+      expect(entities).toIncludeSameMembers(['BLUE', 'SILPH', 'VERMILLION', 'VIRIDIAN']);
+    });
+
+    it('it can filter using >=', async () => {
+      const { body: entities } = await app.get('hierarchy/redblue/redblue/descendants', {
+        query: { field: 'code', filter: 'name>=Saffron City' },
+      });
+
+      expect(entities).toIncludeSameMembers(['BLUE', 'SAFFRON', 'SILPH', 'VERMILLION', 'VIRIDIAN']);
+    });
+
     it('it can filter on deep properties of object properties', async () => {
       const { body: entities } = await app.get('hierarchy/redblue/redblue/descendants', {
         query: { field: 'code', filter: 'attributes_type==gym' },

--- a/packages/entity-server/src/models/Entity.ts
+++ b/packages/entity-server/src/models/Entity.ts
@@ -21,7 +21,11 @@ export type EntityFields = Readonly<{
   };
 }>;
 
-export type EntityFilter = DbFilter<EntityFields>;
+export type EntityQueryFields = EntityFields & {
+  generational_distance: number;
+};
+
+export type EntityFilter = DbFilter<EntityQueryFields>;
 
 export interface EntityType extends EntityFields, Omit<BaseEntityType, 'id'> {
   getChildren: (hierarchyId: string, criteria?: EntityFilter) => Promise<EntityType[]>;

--- a/packages/entity-server/src/models/index.ts
+++ b/packages/entity-server/src/models/index.ts
@@ -7,5 +7,5 @@ export {
   AncestorDescendantRelationModel,
   AncestorDescendantRelationType,
 } from './AncestorDescendantRelation';
-export { EntityModel, EntityType, EntityFields, EntityFilter } from './Entity';
+export { EntityModel, EntityType, EntityFields, EntityFilter, EntityQueryFields } from './Entity';
 export { EntityHierarchyModel, EntityHierarchyType } from './EntityHierarchy';

--- a/packages/entity-server/src/types.ts
+++ b/packages/entity-server/src/types.ts
@@ -17,6 +17,11 @@ export type ObjectLikeKeys<T> = {
   [K in keyof T]: T[K] extends Record<string, unknown> ? K : never;
 }[keyof T];
 
+// Extracts keys that have numeric values from type T
+export type NumericKeys<T> = {
+  [K in keyof T]: T[K] extends number ? K : never;
+}[keyof T];
+
 export type Writable<T> = { -readonly [field in keyof T]?: T[field] };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/utils/src/object.js
+++ b/packages/utils/src/object.js
@@ -33,7 +33,7 @@ export const getKeysSortedByValues = (object, options = {}) => {
  *
  * @param {string} key
  * @param {{ ascending: boolean }} [options]
- * @returns { (a: Object<string, any>, b: Object<string, any> ) => number }
+ * @returns { (a: any, b: any ) => number }
  */
 export function getSortByKey(key, options) {
   return getSortByExtractedValue(o => o[key], options);


### PR DESCRIPTION
### Issue #:
[OS-10](https://linear.app/bes/team/OSC/active) - just the backend in this PR

### Changes:
* Added a `GET /entityHierarchyTree` endpoint in `admin-panel-server`
* Automatically stringify `columns`,  `sort` in `central-server` requests done with `api-client`
* Add support for `<`, `<=`, `>`, `>=` comparators in `entity-server`
* Add support for filtering on `ancestor_descendant_relation.generational_distance` for entities fetched with `entity-server`
* Add `GET /entityRelations` endpoint in `central-server` (basic version, needs more work)



