### PR TITLE
MDEV-2: Revert Search Term Filter in Admin Panel

### DIFF
--- a/packages/admin-panel/src/utilities/convertSearchTermToFilter.js
+++ b/packages/admin-panel/src/utilities/convertSearchTermToFilter.js
@@ -13,7 +13,7 @@ export const convertSearchTermToFilter = (unprocessedFilterObject = {}) => {
 
     filterObject[key] = {
       comparator: `ilike`,
-      comparisonValue: `%${value}%`,
+      comparisonValue: `${value}%`,
       castAs: 'text',
     };
   });


### PR DESCRIPTION
### Issue MDEV-2:

### Changes:

- Revert search term filtering to previous behaviour, without wild card symbol at start. This enables easy searching for short names.
