### PR TITLE
[no-issue]: Added data-table-api to the tupaia api-client

### DIFF
--- a/packages/api-client/src/MockTupaiaApiClient.ts
+++ b/packages/api-client/src/MockTupaiaApiClient.ts
@@ -6,26 +6,36 @@
 import {
   AuthApiInterface,
   CentralApiInterface,
+  DataTableApiInterface,
   EntityApiInterface,
   ReportApiInterface,
 } from './connections';
 
-import { MockAuthApi, MockCentralApi, MockEntityApi, MockReportApi } from './connections/mocks';
+import {
+  MockAuthApi,
+  MockCentralApi,
+  MockDataTableApi,
+  MockEntityApi,
+  MockReportApi,
+} from './connections/mocks';
 
 export class MockTupaiaApiClient {
-  public readonly entity: EntityApiInterface;
-  public readonly central: CentralApiInterface;
   public readonly auth: AuthApiInterface;
+  public readonly central: CentralApiInterface;
+  public readonly dataTable: DataTableApiInterface;
+  public readonly entity: EntityApiInterface;
   public readonly report: ReportApiInterface;
 
   public constructor({
     auth = new MockAuthApi(),
     central = new MockCentralApi(),
+    dataTable = new MockDataTableApi(),
     entity = new MockEntityApi(),
     report = new MockReportApi(),
   } = {}) {
     this.auth = auth;
     this.central = central;
+    this.dataTable = dataTable;
     this.entity = entity;
     this.report = report;
   }

--- a/packages/api-client/src/TupaiaApiClient.ts
+++ b/packages/api-client/src/TupaiaApiClient.ts
@@ -8,12 +8,14 @@ import { AuthHandler } from './types';
 import {
   ApiConnection,
   AuthApi,
-  EntityApi,
   CentralApi,
+  DataTableApi,
+  EntityApi,
   ReportApi,
-  EntityApiInterface,
-  CentralApiInterface,
   AuthApiInterface,
+  CentralApiInterface,
+  DataTableApiInterface,
+  EntityApiInterface,
   ReportApiInterface,
 } from './connections';
 import { PRODUCTION_BASE_URLS, ServiceBaseUrlSet } from './constants';
@@ -21,6 +23,7 @@ import { PRODUCTION_BASE_URLS, ServiceBaseUrlSet } from './constants';
 export class TupaiaApiClient {
   public readonly entity: EntityApiInterface;
   public readonly central: CentralApiInterface;
+  public readonly dataTable: DataTableApiInterface;
   public readonly auth: AuthApiInterface;
   public readonly report: ReportApiInterface;
 
@@ -29,5 +32,6 @@ export class TupaiaApiClient {
     this.entity = new EntityApi(new ApiConnection(authHandler, baseUrls.entity));
     this.central = new CentralApi(new ApiConnection(authHandler, baseUrls.central));
     this.report = new ReportApi(new ApiConnection(authHandler, baseUrls.report));
+    this.dataTable = new DataTableApi(new ApiConnection(authHandler, baseUrls.dataTable));
   }
 }

--- a/packages/api-client/src/connections/DataTableApi.ts
+++ b/packages/api-client/src/connections/DataTableApi.ts
@@ -1,0 +1,24 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import { BaseApi } from './BaseApi';
+import { PublicInterface } from './types';
+
+export class DataTableApi extends BaseApi {
+  public async fetchData(
+    dataTableCode: string,
+    parameters: Record<string, unknown>,
+  ): Promise<{ data: Record<string, unknown>[] }> {
+    return this.connection.post(`dataTable/${dataTableCode}/fetchData`, null, parameters);
+  }
+
+  public async getParameters(
+    dataTableCode: string,
+  ): Promise<{ parameters: { name: string; config: Record<string, unknown> }[] }> {
+    return this.connection.get(`dataTable/${dataTableCode}/parameters`);
+  }
+}
+
+export interface DataTableApiInterface extends PublicInterface<DataTableApi> {}

--- a/packages/api-client/src/connections/index.ts
+++ b/packages/api-client/src/connections/index.ts
@@ -6,6 +6,7 @@
 
 export { ApiConnection } from './ApiConnection';
 export { AuthApi, AuthApiInterface } from './AuthApi';
+export { DataTableApi, DataTableApiInterface } from './DataTableApi';
 export { EntityApi, EntityApiInterface } from './EntityApi';
 export { CentralApi, CentralApiInterface } from './CentralApi';
 export { ReportApi, ReportApiInterface } from './ReportApi';

--- a/packages/api-client/src/connections/mocks/MockDataTableApi.ts
+++ b/packages/api-client/src/connections/mocks/MockDataTableApi.ts
@@ -1,0 +1,24 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import { DataTableApiInterface } from '..';
+
+export class MockDataTableApi implements DataTableApiInterface {
+  public fetchData(
+    dataTableCode: string,
+    parameters: Record<string, unknown>,
+  ): Promise<{ data: Record<string, unknown>[] }> {
+    throw new Error('Method not implemented.');
+  }
+
+  public getParameters(
+    dataTableCode: string,
+  ): Promise<{
+    parameters: { name: string; config: Record<string, unknown> }[];
+  }> {
+    throw new Error('Method not implemented.');
+  }
+}

--- a/packages/api-client/src/connections/mocks/index.ts
+++ b/packages/api-client/src/connections/mocks/index.ts
@@ -5,5 +5,6 @@
 
 export { MockAuthApi } from './MockAuthApi';
 export { MockCentralApi } from './MockCentralApi';
+export { MockDataTableApi } from './MockDataTableApi';
 export { MockEntityApi } from './MockEntityApi';
 export { MockReportApi } from './MockReportApi';

--- a/packages/api-client/src/constants.ts
+++ b/packages/api-client/src/constants.ts
@@ -5,7 +5,7 @@
 
 export const DATA_TIME_FORMAT = 'YYYY-MM-DD HH:mm:ss';
 
-type ServiceName = 'auth' | 'entity' | 'central' | 'report';
+type ServiceName = 'auth' | 'entity' | 'central' | 'report' | 'dataTable';
 export type ServiceBaseUrlSet = Record<ServiceName, string>;
 
 const productionSubdomains = [
@@ -47,6 +47,11 @@ const SERVICES = {
     version: 'v1',
     localPort: '8030',
   },
+  dataTable: {
+    subdomain: 'data-table-api',
+    version: 'v1',
+    localPort: '8010',
+  },
 };
 
 const getLocalUrl = (service: ServiceName): string =>
@@ -56,6 +61,7 @@ export const LOCALHOST_BASE_URLS: ServiceBaseUrlSet = {
   entity: getLocalUrl('entity'),
   central: getLocalUrl('central'),
   report: getLocalUrl('report'),
+  dataTable: getLocalUrl('dataTable'),
 };
 
 const getServiceUrl = (service: ServiceName, subdomainPrefix?: string): string => {
@@ -69,6 +75,7 @@ export const DEV_BASE_URLS: ServiceBaseUrlSet = {
   entity: getServiceUrl('entity', 'dev'),
   central: getServiceUrl('central', 'dev'),
   report: getServiceUrl('report', 'dev'),
+  dataTable: getServiceUrl('dataTable', 'dev'),
 };
 
 export const PRODUCTION_BASE_URLS: ServiceBaseUrlSet = {
@@ -76,6 +83,7 @@ export const PRODUCTION_BASE_URLS: ServiceBaseUrlSet = {
   entity: getServiceUrl('entity'),
   central: getServiceUrl('central'),
   report: getServiceUrl('report'),
+  dataTable: getServiceUrl('dataTable'),
 };
 
 const getServiceUrlForSubdomain = (service: ServiceName, originalSubdomain: string): string => {
@@ -113,15 +121,17 @@ const getDefaultBaseUrls = (hostname: string): ServiceBaseUrlSet => {
     entity: getServiceUrlForSubdomain('entity', subdomain),
     central: getServiceUrlForSubdomain('central', subdomain),
     report: getServiceUrlForSubdomain('report', subdomain),
+    dataTable: getServiceUrlForSubdomain('dataTable', subdomain),
   };
 };
 
 export const getBaseUrlsForHost = (hostname: string): ServiceBaseUrlSet => {
-  const { auth, entity, central, report } = getDefaultBaseUrls(hostname);
+  const { auth, entity, central, report, dataTable } = getDefaultBaseUrls(hostname);
   return {
     auth: process.env.AUTH_API_URL || auth,
     entity: process.env.ENTITY_API_URL || entity,
     central: process.env.CENTRAL_API_URL || central,
     report: process.env.REPORT_API_URL || report,
+    dataTable: process.env.DATA_TABLE_API_URL || dataTable,
   };
 };


### PR DESCRIPTION
Just adding the `dataTableApi` to the `TupaiaApiClient` to allow for using it from other micro-services.