### PR TITLE
RN-743 Fix maximum call stack size in viz builder

### DIFF
--- a/packages/data-broker/src/services/dhis/pullers/AnalyticsPuller.ts
+++ b/packages/data-broker/src/services/dhis/pullers/AnalyticsPuller.ts
@@ -104,7 +104,7 @@ export class AnalyticsPuller {
       pullOptions: PullAnalyticsOptions,
     ) => {
       const { results, metadata } = await pullAnalyticsForApi(api, dataSourceList, pullOptions);
-      response.results.push(...results);
+      response.results = [...response.results].concat(results);
       response.metadata = {
         dataElementCodeToName: {
           ...(response.metadata?.dataElementCodeToName || {}),
@@ -279,7 +279,7 @@ export class AnalyticsPuller {
         options,
         dhisDataType,
       );
-      response.results.push(...results);
+      response.results = [...response.results].concat(results);
       response.metadata = {
         dataElementCodeToName: {
           ...(response.metadata?.dataElementCodeToName || {}),


### PR DESCRIPTION
Spreading a long results to parameters list will cause oversize error, since the maximum size is 255

### Issue #:

### Changes:

- Example

---

### Screenshots:
