### PR TITLE
RN-782: dataTableCode Migration Checks Against Wrong Data Group Key

### DIFF
--- a/packages/database/src/migrations/20230216141720-ConvertReportsToPullFromDataTables-modifies-schema.js
+++ b/packages/database/src/migrations/20230216141720-ConvertReportsToPullFromDataTables-modifies-schema.js
@@ -17,7 +17,7 @@ exports.setup = function (options, seedLink) {
 const convertFetchDataTransformToUseDataTables = transform => {
   const { parameters } = transform;
   // If passing both data group as param, then fetching events
-  if (parameters.dataGroup) {
+  if (parameters.dataGroupCode) {
     return { ...transform, dataTableCode: 'events' };
   }
 


### PR DESCRIPTION
### Issue RN-782:

### Changes:

- Look for 'dataGroupCode' instead of 'dataGroup' in parameters to determine 'events' data table.
