### PR TITLE
Fix data table content overflow

### DIFF
--- a/packages/admin-panel/src/VizBuilderApp/views/Main.js
+++ b/packages/admin-panel/src/VizBuilderApp/views/Main.js
@@ -31,6 +31,8 @@ const Container = styled(MuiContainer)`
 const RightCol = styled(FlexColumn)`
   padding-left: 30px;
   flex: 1;
+  // To solve overflow problem of data table content, use min-width: 0 https://stackoverflow.com/a/66689926
+  min-width: 0;
 `;
 
 const StyledAlert = styled(SmallAlert)`


### PR DESCRIPTION
### Issue NO-ISSUE:

The problem is that when there are lots of columns of data, the preview component flows way over and also breaks the json editor when toggled.

### Changes:

- Add min-width property equal to 0, which fixes data table content overflow problem.
