### PR TITLE
No issue: Accept permissionGroupName as undefined

### DIFF
--- a/packages/central-server/src/apiV2/dashboardVisualisations/EditDashboardVisualisation.js
+++ b/packages/central-server/src/apiV2/dashboardVisualisations/EditDashboardVisualisation.js
@@ -84,7 +84,10 @@ export class EditDashboardVisualisation extends EditHandler {
 
   async editRecord() {
     const { report } = this.req.body;
-    await assertPermissionGroupAccess(this.accessPolicy, report.permission_group);
+    // Skip permission check as legacy report has no permission group
+    if (report.permission_group) {
+      assertPermissionGroupAccess(this.accessPolicy, report.permission_group);
+    }
     return this.models.wrapInTransaction(async transactingModels => {
       const dashboardItemRecord = this.getDashboardItemRecord();
       const reportRecord = this.getReportRecord();

--- a/packages/central-server/src/permissions/assertions.js
+++ b/packages/central-server/src/permissions/assertions.js
@@ -116,7 +116,7 @@ export const assertVizBuilderAccess = accessPolicy => {
 };
 
 export const assertPermissionGroupAccess = (accessPolicy, permissionGroupName) => {
-  if (hasPermissionGroupAccess(accessPolicy, permissionGroupName)) {
+  if (!permissionGroupName || hasPermissionGroupAccess(accessPolicy, permissionGroupName)) {
     return true;
   }
 

--- a/packages/central-server/src/permissions/assertions.js
+++ b/packages/central-server/src/permissions/assertions.js
@@ -116,7 +116,7 @@ export const assertVizBuilderAccess = accessPolicy => {
 };
 
 export const assertPermissionGroupAccess = (accessPolicy, permissionGroupName) => {
-  if (!permissionGroupName || hasPermissionGroupAccess(accessPolicy, permissionGroupName)) {
+  if (hasPermissionGroupAccess(accessPolicy, permissionGroupName)) {
     return true;
   }
 


### PR DESCRIPTION
### Issue #:
Issue: https://beyondessential.slack.com/archives/C04QFLD87E3/p1678940272063209

Legacy report doesn't have permission group, it throws error in this permission check. It is only used in EditDashboardVisualisation handler, so I think it is safe not to test. 