### PR TITLE
Set defaultValue for entitycodes

### DIFF
--- a/packages/data-table-server/src/__tests__/dataTableService/services/EntitiesDataTableService.test.ts
+++ b/packages/data-table-server/src/__tests__/dataTableService/services/EntitiesDataTableService.test.ts
@@ -16,12 +16,13 @@ const entitiesDataTableService = new DataTableServiceBuilder()
 
 describe('EntitiesDataTableService', () => {
   describe('parameter validation', () => {
-    const testData: [string, unknown, string][] = [
-      ['missing entityCodes', {}, 'entityCodes is a required field'],
-    ];
-
-    it.each(testData)('%s', (_, parameters: unknown, expectedError: string) => {
-      expect(() => entitiesDataTableService.fetchData(parameters)).toThrow(expectedError);
+    it('set entityCodes as default value []', async () => {
+      await expect(
+        entitiesDataTableService.fetchData({
+          ancestorType: 'district',
+          descendantType: 'sub_district',
+        }),
+      ).resolves.toEqual([]);
     });
   });
 
@@ -32,7 +33,7 @@ describe('EntitiesDataTableService', () => {
       {
         config: {
           innerType: { required: true, type: 'string' },
-          required: true,
+          defaultValue: [],
           type: 'organisationUnitCodes',
         },
         name: 'entityCodes',

--- a/packages/data-table-server/src/__tests__/dataTableService/services/EntityRelationsDataTableService.test.ts
+++ b/packages/data-table-server/src/__tests__/dataTableService/services/EntityRelationsDataTableService.test.ts
@@ -18,11 +18,6 @@ describe('EntityRelationsDataTableService', () => {
   describe('parameter validation', () => {
     const testData: [string, unknown, string][] = [
       [
-        'missing entityCodes',
-        { ancestorType: 'district', descendantType: 'sub_district' },
-        'entityCodes is a required field',
-      ],
-      [
         'missing ancestorType',
         { entityCodes: ['TO'], descendantType: 'sub_district' },
         'ancestorType is a required field',
@@ -37,6 +32,15 @@ describe('EntityRelationsDataTableService', () => {
     it.each(testData)('%s', (_, parameters: unknown, expectedError: string) => {
       expect(() => entityRelationsDataTableService.fetchData(parameters)).toThrow(expectedError);
     });
+
+    it('set entityCodes as default value []', async () => {
+      await expect(
+        entityRelationsDataTableService.fetchData({
+          ancestorType: 'district',
+          descendantType: 'sub_district',
+        }),
+      ).resolves.toEqual([]);
+    });
   });
 
   it('getParameters', () => {
@@ -46,7 +50,7 @@ describe('EntityRelationsDataTableService', () => {
       {
         config: {
           innerType: { required: true, type: 'string' },
-          required: true,
+          defaultValue: [],
           type: 'organisationUnitCodes',
         },
         name: 'entityCodes',

--- a/packages/data-table-server/src/dataTableService/services/EntitiesDataTableService.ts
+++ b/packages/data-table-server/src/dataTableService/services/EntitiesDataTableService.ts
@@ -9,7 +9,7 @@ import { DataTableService } from '../DataTableService';
 
 const requiredParamsSchema = yup.object().shape({
   hierarchy: yup.string().default('explore'),
-  entityCodes: yup.array().of(yup.string().required()).required(),
+  entityCodes: yup.array().of(yup.string().required()).default([]),
   filter: yup.object(),
   fields: yup.array().of(yup.string().required()).default(['code']),
   includeDescendants: yup.boolean().default(false),

--- a/packages/data-table-server/src/dataTableService/services/EntityRelationsDataTableService.ts
+++ b/packages/data-table-server/src/dataTableService/services/EntityRelationsDataTableService.ts
@@ -9,7 +9,7 @@ import { DataTableService } from '../DataTableService';
 
 const requiredParamsSchema = yup.object().shape({
   hierarchy: yup.string().default('explore'),
-  entityCodes: yup.array().of(yup.string().required()).required(),
+  entityCodes: yup.array().of(yup.string().required()).default([]),
   ancestorType: yup.string().required(),
   descendantType: yup.string().required(),
 });


### PR DESCRIPTION
 ### Changes:
There are couple of migrations that use `=@all.organisationUnit`, instead of changing them to `'=exists(@all.organisationUnit) ? @all.organisationUnit : []'`, this could fix them without redeploy in data-table-ph1.

- Set defaultValue for entitycodes in entities and entity_relations data tables

 
