### PR TITLE
RN-783 [fix]: Fix data element names not being consistent when pulling from DHIS2

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -47,7 +47,8 @@
         "packages/report-server/**",
         "packages/server-boilerplate/**",
         "packages/supserset-api/**",
-        "packages/tsutils/**"
+        "packages/tsutils/**",
+        "packages/types/**"
       ],
       "extends": "@beyondessential/ts",
       "parserOptions": {

--- a/packages/data-broker/package.json
+++ b/packages/data-broker/package.json
@@ -28,6 +28,7 @@
     "@tupaia/indicators": "1.0.0",
     "@tupaia/kobo-api": "1.0.0",
     "@tupaia/superset-api": "1.0.0",
+    "@tupaia/tsutils": "1.0.0",
     "@tupaia/utils": "1.0.0",
     "@tupaia/weather-api": "1.0.0",
     "case": "^1.5.5",

--- a/packages/data-broker/src/__tests__/services/dhis/translators/DhisTranslator.test.ts
+++ b/packages/data-broker/src/__tests__/services/dhis/translators/DhisTranslator.test.ts
@@ -7,6 +7,7 @@ import { createJestMockInstance } from '@tupaia/utils';
 import { DhisTranslator } from '../../../../services/dhis/translators/DhisTranslator';
 import { DATA_ELEMENT_DESCRIPTORS } from './DhisTranslator.fixtures';
 import * as ParseValueFromDhis from '../../../../services/dhis/translators/parseValueForDhis';
+import { DataElement } from '../../../../types';
 
 describe('DhisTranslator', () => {
   const mockModels = createJestMockInstance('@tupaia/database', 'ModelRegistry');
@@ -53,6 +54,11 @@ describe('DhisTranslator', () => {
       { code: 'codeC', name: 'C', id: 'id_c' },
     ];
 
+    const baseDhisCategoryOptionComboMetadata = [
+      { code: 'SEX_Male', name: 'Male', id: 'id_d' },
+      { code: 'SEX_Female', name: 'Female', id: 'id_e' },
+    ];
+
     const dhisServiceType = 'dhis' as const;
 
     it('translates data element metadata code to data element code', () => {
@@ -87,7 +93,11 @@ describe('DhisTranslator', () => {
       ];
 
       expect(
-        translator.translateInboundDataElements(baseDhisDataElementMetadata, dataElements),
+        translator.translateInboundDataElements(
+          baseDhisDataElementMetadata,
+          baseDhisCategoryOptionComboMetadata,
+          dataElements,
+        ),
       ).toStrictEqual(expect.arrayContaining(expectResults));
     });
 
@@ -97,19 +107,23 @@ describe('DhisTranslator', () => {
         { code: 'codeA_B', name: 'A_B', id: 'id_a_b' },
       ];
 
-      const dataElements = [
+      const dataElements: DataElement[] = [
         {
           code: 'dataElementCodeA',
           dataElementCode: 'codeA_B',
           service_type: dhisServiceType,
-          config: {},
+          config: {
+            categoryOptionCombo: 'SEX_Male',
+          },
           permission_groups: [],
         },
         {
           code: 'dataElementCodeB',
           dataElementCode: 'codeA_B',
           service_type: dhisServiceType,
-          config: {},
+          config: {
+            categoryOptionCombo: 'SEX_Female',
+          },
           permission_groups: [],
         },
         {
@@ -122,13 +136,17 @@ describe('DhisTranslator', () => {
       ];
 
       const expectResults = [
-        { code: 'dataElementCodeA', name: 'A_B', id: 'id_a_b' },
-        { code: 'dataElementCodeB', name: 'A_B', id: 'id_a_b' },
+        { code: 'dataElementCodeA', name: 'A_B - Male', id: 'id_a_b' },
+        { code: 'dataElementCodeB', name: 'A_B - Female', id: 'id_a_b' },
         { code: 'dataElementCodeC', name: 'C', id: 'id_c' },
       ];
 
       expect(
-        translator.translateInboundDataElements(dhisDataElementMetadata, dataElements),
+        translator.translateInboundDataElements(
+          dhisDataElementMetadata,
+          baseDhisCategoryOptionComboMetadata,
+          dataElements,
+        ),
       ).toStrictEqual(expect.arrayContaining(expectResults));
     });
 
@@ -150,7 +168,11 @@ describe('DhisTranslator', () => {
       ];
 
       expect(
-        translator.translateInboundDataElements(baseDhisDataElementMetadata, dataElements),
+        translator.translateInboundDataElements(
+          baseDhisDataElementMetadata,
+          baseDhisCategoryOptionComboMetadata,
+          dataElements,
+        ),
       ).toStrictEqual(expectResults);
     });
   });

--- a/packages/data-broker/src/services/dhis/pullers/DataElementsMetadataPuller.ts
+++ b/packages/data-broker/src/services/dhis/pullers/DataElementsMetadataPuller.ts
@@ -6,6 +6,7 @@
 import groupBy from 'lodash.groupby';
 
 import type { DhisApi } from '@tupaia/dhis-api';
+import { isNotNullish } from '@tupaia/tsutils';
 import { DataElementModel } from '../../../types';
 import { DataElement } from '../types';
 import { DhisTranslator } from '../translators';
@@ -49,13 +50,21 @@ export class DataElementsMetadataPuller {
           ...this.translator.translateInboundIndicators(indicators, groupedDataSources),
         );
       } else {
+        const categoryOptionComboCodes = groupedDataSources
+          .map(ds => ds.config?.categoryOptionCombo)
+          .filter(isNotNullish);
         const { additionalFields, includeOptions } = options;
         const dataElements = await api.fetchDataElements(dataElementCodes, {
           additionalFields,
           includeOptions,
         });
+        const categoryOptionCombos = await api.fetchCategoryOptionCombos(categoryOptionComboCodes);
         metadata.push(
-          ...this.translator.translateInboundDataElements(dataElements, groupedDataSources),
+          ...this.translator.translateInboundDataElements(
+            dataElements,
+            categoryOptionCombos,
+            groupedDataSources,
+          ),
         );
       }
     }

--- a/packages/data-broker/src/services/dhis/translators/InboundAnalyticsTranslator.ts
+++ b/packages/data-broker/src/services/dhis/translators/InboundAnalyticsTranslator.ts
@@ -10,6 +10,7 @@ import keyBy from 'lodash.keyby';
 import pickBy from 'lodash.pickby';
 import { DataElement, DhisAnalyticDimension, DhisAnalytics } from '../types';
 import { Values } from '../../../types';
+import { formatInboundDataElementName } from './formatDataElementName';
 
 const DIMENSIONS: Record<string, DhisAnalyticDimension> = {
   DATA_ELEMENT: 'dx',
@@ -171,7 +172,7 @@ export class InboundAnalyticsTranslator {
         ...item,
         uid: translatedId,
         code: this.dataElementKeyToSourceCode![dataElementKey],
-        name: name + (coComboName ? ` - ${coComboName}` : ''),
+        name: formatInboundDataElementName(name, coComboName),
       };
     });
 

--- a/packages/data-broker/src/services/dhis/translators/formatDataElementName.ts
+++ b/packages/data-broker/src/services/dhis/translators/formatDataElementName.ts
@@ -1,0 +1,11 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+export const formatInboundDataElementName = (
+  dataElementName: string,
+  categoryOptionComboName?: string,
+) => {
+  return dataElementName + (categoryOptionComboName ? ` - ${categoryOptionComboName}` : '');
+};

--- a/packages/dhis-api/src/DhisApi.js
+++ b/packages/dhis-api/src/DhisApi.js
@@ -571,6 +571,21 @@ export class DhisApi {
     return dataGroupMetadata;
   }
 
+  async fetchCategoryOptionCombos(categoryOptionComboCodes, { additionalFields = [] } = {}) {
+    if (categoryOptionComboCodes.length === 0) {
+      return [];
+    }
+
+    const fields = ['id', 'code', 'name', ...additionalFields];
+    const categoryOptionCombos = await this.getRecords({
+      type: CATEGORY_OPTION_COMBO,
+      codes: categoryOptionComboCodes,
+      fields,
+    });
+
+    return categoryOptionCombos;
+  }
+
   buildFetchIndicatorsQuery = queryInput => {
     const { dataElementIds, dataElementCodes } = queryInput;
 

--- a/packages/entity-server/src/routes/hierarchy/format/formatEntityForResponse.ts
+++ b/packages/entity-server/src/routes/hierarchy/format/formatEntityForResponse.ts
@@ -3,7 +3,6 @@
  * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
  */
 
-import { reduceToDictionary, reduceToArrayDictionary } from '@tupaia/utils';
 import { EntityType } from '../../../models';
 import { EntityServerModelRegistry } from '../../../types';
 import {

--- a/packages/entity-server/src/routes/hierarchy/middleware/attachEntityContext.ts
+++ b/packages/entity-server/src/routes/hierarchy/middleware/attachEntityContext.ts
@@ -4,9 +4,9 @@
  */
 import { Request, NextFunction, Response } from 'express';
 import { PermissionsError } from '@tupaia/utils';
+import { ajvValidate } from '@tupaia/tsutils';
 import { EntityType, EntityFilter } from '../../../models';
 import { extractFilterFromQuery } from './filter';
-import { ajvValidate } from '@tupaia/tsutils';
 import { MultiEntityRequestBodySchema } from '../types';
 
 const notNull = <T>(value: T): value is Exclude<T, null> => value !== null;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5255,6 +5255,7 @@ __metadata:
     "@tupaia/indicators": 1.0.0
     "@tupaia/kobo-api": 1.0.0
     "@tupaia/superset-api": 1.0.0
+    "@tupaia/tsutils": 1.0.0
     "@tupaia/utils": 1.0.0
     "@tupaia/weather-api": 1.0.0
     "@types/lodash.flatten": ^4.4.0


### PR DESCRIPTION
### Issue RN-783:
Issues: 8, 9, 14, 16

Reworked fetchDataElementMetadata in DhisService to pull category option combos and combine with data element name. This is the behaviour of pulling data element metadata with fetchAnalytics, so keeping it consistent. Might have to do some regression on the `tableOfEvents` and `tableOfDataValues` legacy reports, but they seemed to still work fine when I took a look at them.