### PR TITLE
Fix validation too strict on fetchDataGroup result

### DIFF
--- a/packages/report-server/src/aggregator/ReportServerAggregator.ts
+++ b/packages/report-server/src/aggregator/ReportServerAggregator.ts
@@ -95,7 +95,8 @@ export class ReportServerAggregator {
         .of(
           yup.object().shape({
             code: yup.string().required(),
-            text: yup.string().required(),
+            text: yup.string(),
+            name: yup.string(),
           }),
         )
         .required(),

--- a/packages/report-server/src/reportBuilder/output/functions/rawDataExport/rawDataExportBuilder.ts
+++ b/packages/report-server/src/reportBuilder/output/functions/rawDataExport/rawDataExportBuilder.ts
@@ -50,7 +50,7 @@ export class RawDataExportBuilder {
           const { dataElements } = await this.aggregator.fetchDataGroup(surveyCode);
           return dataElements.map(dataElement => ({
             key: dataElement.code,
-            title: dataElement.text,
+            title: dataElement.text || dataElement.name || '',
           }));
         }),
       )


### PR DESCRIPTION
### Issue #:
When doing raw data download, it throws yup validation error with DHIS data group result because validation is too strict.

This needs to be a hot fix. Slack thread: https://beyondessential.slack.com/archives/C04QFLD87E3/p1680130358072369
 