### PR TITLE
WAITP-1120 bar chart alignment fix for time series

### DIFF
--- a/packages/ui-components/src/components/Chart/BarChart.js
+++ b/packages/ui-components/src/components/Chart/BarChart.js
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import { Bar, LabelList } from 'recharts';
 import { formatDataValueByType } from '@tupaia/utils';
 import { BLUE, CHART_TYPES } from './constants';
+import { getIsTimeSeries } from './utils';
 
 export const BarChart = ({
   color = BLUE,
@@ -38,6 +39,13 @@ export const BarChart = ({
       if ((chartConfigHasTooManyKeys && stackSize === 0) || chartConfigHasTooManyStacks) {
         return 1;
       }
+    }
+    /*
+      There is a known bug with Recharts where if a bar graph is a time scale, it overflows the bars over the edge of the axes. 
+      As a workaround, until it is fixed, setting the bar size to be a specific value stops this from happening.
+    */
+    if (getIsTimeSeries(data) && !isEnlarged) {
+      return Math.max(1, Math.floor(200 / data.length));
     }
     return undefined;
   };

--- a/packages/ui-components/src/components/Chart/BarChart.js
+++ b/packages/ui-components/src/components/Chart/BarChart.js
@@ -40,8 +40,8 @@ export const BarChart = ({
         return 1;
       }
     }
-    /*
-      There is a known bug with Recharts where if a bar graph is a time scale, it overflows the bars over the edge of the axes. 
+    /* 
+      [There is a known bug with Recharts](https://github.com/recharts/recharts/issues/2711) where if a bar graph is a time scale, it overflows the bars over the edge of the axes. 
       As a workaround, until it is fixed, setting the bar size to be a specific value stops this from happening.
     */
     if (getIsTimeSeries(data) && !isEnlarged) {

--- a/packages/ui-components/src/components/Chart/XAxis.js
+++ b/packages/ui-components/src/components/Chart/XAxis.js
@@ -26,8 +26,8 @@ const X_AXIS_PADDING = {
   },
   preview: {
     dataLengthThreshold: 9,
-    base: 4,
-    offset: 10,
+    base: 8,
+    offset: 16,
     minimum: 10,
   },
 };


### PR DESCRIPTION
### Issue WAITP-1120:

### Changes:

This bug was a result of [a known bug with Recharts](https://github.com/recharts/recharts/issues/2711) where bar graphs with timestamps as the x-axis values cause overlapping of the bars on either side.

Until a fix has been implemented by Recharts, I have added a workaround with setting the bar sizes for time scale charts (when not expanded, as this already seems to have been accounted for when expanded) and changed the values used to calculate x-axis padding on preview charts.

It should not affect bar graphs with large datasets, as this also seems to have been accounted for previously, so it's mainly on smaller datasets on a chart, e.g. [this one here](https://tupaia.org/pacmossi/SB?overlay=PacMosssi_Mosquito_Species_District)

### Screenshots:

Before:
![image](https://user-images.githubusercontent.com/129009580/229385217-1241a0c4-b998-4ca7-b243-bc97f25ca22b.png)

After: 
![image](https://user-images.githubusercontent.com/129009580/229385381-12503c82-6074-497e-8cfd-9d817c284cd5.png)



