### PR TITLE
[no-issue]: Prevent noisy api client auth error in server-boilerplate

### DIFF
--- a/packages/database/src/modelClasses/index.js
+++ b/packages/database/src/modelClasses/index.js
@@ -124,6 +124,7 @@ export {
   AncestorDescendantRelationModel,
   AncestorDescendantRelationType,
 } from './AncestorDescendantRelation';
+export { APIClientModel } from './APIClient';
 export { ApiRequestLogModel } from './ApiRequestLog';
 export { CommentModel } from './Comment';
 export { CountryModel } from './Country';

--- a/packages/server-boilerplate/src/microService/@types/express/index.d.ts
+++ b/packages/server-boilerplate/src/microService/@types/express/index.d.ts
@@ -3,15 +3,15 @@
  * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
  */
 import { AccessPolicy } from '@tupaia/access-policy';
-import { ModelRegistry } from '@tupaia/database';
 import { UserType } from '../../../models';
+import { ServerBoilerplateModelRegistry } from '../../../types';
 
 declare global {
   namespace Express {
     export interface Request {
       user: UserType;
       accessPolicy: AccessPolicy;
-      models: ModelRegistry;
+      models: ServerBoilerplateModelRegistry;
       apiRequestLogId: string;
     }
   }

--- a/packages/server-boilerplate/src/types.ts
+++ b/packages/server-boilerplate/src/types.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
-import { ModelRegistry, ApiRequestLogModel } from '@tupaia/database';
+import { ModelRegistry, ApiRequestLogModel, APIClientModel } from '@tupaia/database';
 import { UserModel } from './models';
 
 export type AccessPolicyObject = Record<string, string[]>;
@@ -19,5 +19,6 @@ export type RequestBody = Record<string, unknown> | Record<string, unknown>[];
 
 export interface ServerBoilerplateModelRegistry extends ModelRegistry {
   readonly apiRequestLog: ApiRequestLogModel;
+  readonly apiClient: APIClientModel;
   readonly user: UserModel;
 }


### PR DESCRIPTION
This noisy error can be seen in the logs quite often, and is a real red herring at times. It's not a real error, just that our previous flow did a try/catch on a `LoggedError`, so the error always got logged even though it was being caught and swallowed.

Now we check if user is an api client before attempting to auth, so the error shouldn't appear unless it's meant to.