### PR TITLE
Mdev-89 warn user if a question code is existed

### DIFF
--- a/packages/admin-panel/src/widgets/ModalContentProvider.js
+++ b/packages/admin-panel/src/widgets/ModalContentProvider.js
@@ -18,19 +18,40 @@ const Heading = styled(Typography)`
   margin-bottom: 18px;
 `;
 
-export const ModalContentProvider = ({ isLoading, errorMessage, children }) => {
+const StyledAlert = styled(SmallAlert)`
+  &.MuiAlert-standardWarning {
+    color: #8b6e37;
+    background: #fcf8e2;
+    border: 1px solid #faecca;
+
+    .MuiAlert-icon {
+      color: #8b6e37;
+    }
+  }
+`;
+
+export const ModalContentProvider = ({
+  isLoading,
+  errorMessage,
+  warningMessage,
+  children,
+  severity,
+}) => {
+  const message = errorMessage || warningMessage;
+  const header = severity === 'error' ? 'An error has occurred.' : 'Warning';
+
   return (
     <Content>
       {isLoading && 'Please be patient, this can take some time...'}
-      {!!errorMessage && (
+      {!!message && (
         <>
-          <Heading variant="h6">An error has occurred.</Heading>
-          <SmallAlert severity="error" variant="standard">
-            {errorMessage}
-          </SmallAlert>
+          <Heading variant="h6">{header}</Heading>
+          <StyledAlert severity={severity} variant="standard">
+            {message}
+          </StyledAlert>
         </>
       )}
-      <span style={isLoading || !!errorMessage ? { display: 'none' } : {}}>{children}</span>
+      <span style={isLoading || !!message ? { display: 'none' } : {}}>{children}</span>
     </Content>
   );
 };
@@ -38,10 +59,14 @@ export const ModalContentProvider = ({ isLoading, errorMessage, children }) => {
 ModalContentProvider.propTypes = {
   isLoading: PropTypes.bool.isRequired,
   errorMessage: PropTypes.string,
+  warningMessage: PropTypes.string,
+  severity: PropTypes.string,
   children: PropTypes.node,
 };
 
 ModalContentProvider.defaultProps = {
   errorMessage: null,
+  warningMessage: null,
   children: null,
+  severity: 'error',
 };

--- a/packages/central-server/src/apiV2/import/importSurveys/importSurveyQuestions.js
+++ b/packages/central-server/src/apiV2/import/importSurveys/importSurveyQuestions.js
@@ -66,11 +66,21 @@ const updateOrCreateDataElementInGroup = async (
  * @param models
  * @param {File} file
  * @param {Survey} survey
+ * @param {boolean} isNewSurvey
  * @param {DataGroup} dataGroup
  * @param {PermissionGroup} permissionGroup
+ * @param {boolean} [strictValidationMode]
  * @return {Promise<void>}
  */
-export async function importSurveysQuestions({ models, file, survey, dataGroup, permissionGroup }) {
+export async function importSurveysQuestions({
+  models,
+  file,
+  survey,
+  isNewSurvey,
+  dataGroup,
+  permissionGroup,
+  strictValidationMode = true,
+}) {
   if (!file) {
     throw new UploadError();
   }
@@ -106,7 +116,9 @@ export async function importSurveysQuestions({ models, file, survey, dataGroup, 
   let hasSeenDateOfDataQuestion = false;
   const questionCodes = []; // An array to hold all qustion codes, allowing duplicate checking
   const configImporter = new ConfigImporter(models, rows);
-  const objectValidator = new ObjectValidator(constructQuestionValidators(models));
+  const objectValidator = new ObjectValidator(
+    constructQuestionValidators(models, isNewSurvey, strictValidationMode),
+  );
   let hasPrimaryEntityQuestion = false;
   for (let rowIndex = 0; rowIndex < rows.length; rowIndex++) {
     const row = rows[rowIndex];

--- a/packages/central-server/src/apiV2/surveys/CreateSurvey.js
+++ b/packages/central-server/src/apiV2/surveys/CreateSurvey.js
@@ -18,6 +18,10 @@ export class CreateSurvey extends CreateHandler {
 
     const convertedFields = await convertNamesToIds(this.models, this.newRecordData);
 
+    if (this.req.query.strictValidationMode === 'false') {
+      surveyEditor.setStrictValidationMode(false);
+    }
+
     return surveyEditor.create(convertedFields);
   }
 }

--- a/packages/central-server/src/apiV2/surveys/EditSurvey.js
+++ b/packages/central-server/src/apiV2/surveys/EditSurvey.js
@@ -18,6 +18,10 @@ export class EditSurvey extends EditHandler {
 
     const convertedFields = await convertNamesToIds(this.models, this.updatedFields);
 
+    if (this.req.query.strictValidationMode === 'false') {
+      surveyEditor.setStrictValidationMode(false);
+    }
+
     return surveyEditor.edit(this.recordId, convertedFields);
   }
 }

--- a/packages/central-server/src/apiV2/surveys/SurveyEditor.js
+++ b/packages/central-server/src/apiV2/surveys/SurveyEditor.js
@@ -81,9 +81,18 @@ const updateOrCreateDataGroup = async (
 };
 
 export class SurveyEditor {
+  strictValidationMode = true;
+
   constructor(models, assertPermissions) {
     this.models = models;
     this.assertPermissions = assertPermissions;
+  }
+
+  /**
+   * @param {boolean} strict
+   */
+  setStrictValidationMode(strict) {
+    this.strictValidationMode = strict;
   }
 
   /**
@@ -253,8 +262,10 @@ export class SurveyEditor {
         models: transactingModels,
         file: surveyQuestions,
         survey,
+        isNewSurvey: !existingSurvey,
         dataGroup,
         permissionGroup,
+        strictValidationMode: this.strictValidationMode,
       });
     }
 

--- a/packages/utils/src/errors.js
+++ b/packages/utils/src/errors.js
@@ -136,9 +136,15 @@ export class UploadError extends RespondingError {
   }
 }
 
-export class ValidationError extends RespondingError {
+export class StrictValidationError extends RespondingError {
   constructor(message) {
-    super(message, 400);
+    super(message, 400, { isStrictValidationModeError: true });
+  }
+}
+
+export class ValidationError extends RespondingError {
+  constructor(message, extraFields = {}) {
+    super(message, 400, extraFields);
   }
 }
 
@@ -163,14 +169,20 @@ export class TypeValidationError extends ValidationError {
 }
 
 export class ImportValidationError extends ValidationError {
-  constructor(message, rowNumber = undefined, field = undefined, tabName = undefined) {
+  constructor(
+    message,
+    rowNumber = undefined,
+    field = undefined,
+    tabName = undefined,
+    extraFields = {},
+  ) {
     const errorMessage =
       'Import failed' +
       `${tabName !== undefined ? ` in tab ${tabName}` : ''}` +
       `${rowNumber !== undefined ? ` at row ${rowNumber}` : ''}` +
       `${field !== undefined ? ` on the field '${field}'` : ''}` +
       ` with the message '${message}'`;
-    super(errorMessage);
+    super(errorMessage, extraFields);
   }
 }
 
@@ -200,10 +212,15 @@ export class CustomError extends RespondingError {
       ...jsonFields,
       ...extraJsonFields,
     };
-    const { responseText, responseStatus, description } = json;
+    const { responseText, responseStatus, description, isStrictValidationModeError } = json;
     const { status, details } = responseText;
     const errorMessage = status || responseText;
-    super(errorMessage, responseStatus, { description, status, details });
+    super(errorMessage, responseStatus, {
+      description,
+      status,
+      details,
+      isStrictValidationModeError,
+    });
   }
 }
 

--- a/packages/utils/src/request.js
+++ b/packages/utils/src/request.js
@@ -92,11 +92,12 @@ export const asynchronouslyFetchValuesForObject = async objectSpecification => {
   return returnObject;
 };
 
-const throwCustomError = (status, errorMessage) => {
+const throwCustomError = (status, errorMessage, errorBody) => {
   const statusCode = status || 500;
   throw new CustomError({
     responseStatus: statusCode,
     responseText: errorMessage,
+    isStrictValidationModeError: !!errorBody.isStrictValidationModeError,
   });
 };
 
@@ -116,7 +117,7 @@ export const verifyResponseStatus = async response => {
       throwCustomError(response.status, responseJson.message);
     }
     if (responseJson.error) {
-      throwCustomError(response.status, responseJson.error);
+      throwCustomError(response.status, responseJson.error, responseJson);
     }
   }
 };

--- a/packages/utils/src/validation/ObjectValidator.js
+++ b/packages/utils/src/validation/ObjectValidator.js
@@ -68,7 +68,7 @@ async function runValidators(validators, object, fieldKey, constructError) {
       await validators[j](object[fieldKey], object, fieldKey);
     } catch (error) {
       throw constructError
-        ? constructError(error.message, fieldKey)
+        ? constructError(error.message, fieldKey, { ...error?.extraFields })
         : new ValidationError(
             `Invalid content for field "${fieldKey}" causing message "${error.message}"`,
           );


### PR DESCRIPTION
### Issue #:
mdev-89

### Change 
- Add a flag `confirmRequest` from frontend to backend to handle the warning status 
- If an existing question code is found, throw a warning to request confirm, if client wants to import it anyway, overwrite the existing question.