### PR TITLE
Add options back to metadata

### DIFF
--- a/packages/data-broker/src/services/dhis/translators/DhisTranslator.ts
+++ b/packages/data-broker/src/services/dhis/translators/DhisTranslator.ts
@@ -228,12 +228,17 @@ export class DhisTranslator {
             item => item.code === categoryOptionComboCode,
           );
           const dataElementName = formatInboundDataElementName(name, categoryOptionCombo?.name);
-          return {
+          const metadataResults: DhisMetadataObject = {
             id,
             name: dataElementName,
-            options,
             code,
           };
+
+          if (options) {
+            metadataResults.options = options;
+          }
+
+          return metadataResults;
         });
 
       if (translatedMetadata.length > 0) {

--- a/packages/data-broker/src/services/dhis/translators/DhisTranslator.ts
+++ b/packages/data-broker/src/services/dhis/translators/DhisTranslator.ts
@@ -222,7 +222,7 @@ export class DhisTranslator {
       const translatedMetadata = dataElements
         .filter(dataSource => dataSource.dataElementCode === mData.code)
         .map(({ code, dataElementCode, config }) => {
-          const { id, name } = metadataGroupedByCode[dataElementCode];
+          const { id, name, options } = metadataGroupedByCode[dataElementCode];
           const { categoryOptionCombo: categoryOptionComboCode } = config;
           const categoryOptionCombo = categoryOptionCombos.find(
             item => item.code === categoryOptionComboCode,
@@ -231,6 +231,7 @@ export class DhisTranslator {
           return {
             id,
             name: dataElementName,
+            options,
             code,
           };
         });

--- a/packages/data-broker/src/types/results.ts
+++ b/packages/data-broker/src/types/results.ts
@@ -17,6 +17,7 @@ export interface DataElementMetadata {
 
 export interface DhisMetadataObject extends DataElementMetadata {
   id: string;
+  options?: Record<string, string>;
 }
 
 export interface DataGroupMetadata {


### PR DESCRIPTION
### Issue #:
Issue found in regression, https://beyondessential.slack.com/archives/C01MAA3NKM1/p1680664696247249

Basically options are missing so legacy report can't translate value to option name.