### PR TITLE
WAITP-1144 verify email view also loads explore

### DIFF
--- a/packages/web-frontend/src/sagas/watchUser/watchSetVerifyEmailToken.js
+++ b/packages/web-frontend/src/sagas/watchUser/watchSetVerifyEmailToken.js
@@ -4,6 +4,7 @@ import {
   openEmailVerifiedPage,
   setOverlayComponent,
   SET_VERIFY_EMAIL_TOKEN,
+  goHome,
 } from '../../actions';
 import { request } from '../../utils';
 
@@ -13,10 +14,10 @@ function* attemptVerifyToken(action) {
   try {
     yield call(request, requestResourceUrl);
     yield put(openEmailVerifiedPage());
-    yield put(setOverlayComponent('landing'));
   } catch (error) {
     yield put(fetchEmailVerifyError());
-    yield put(setOverlayComponent('landing'));
+  } finally {
+    yield put(goHome());
   }
 }
 


### PR DESCRIPTION
### Issue WAITP-1144

### Changes:
- Update verify email view to load the explore view behind the modal as well as showing the landing modal. Should work for both success and error cases of verifying emails.