### PR TITLE
Run Postgres using docker compose in development

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,6 +15,7 @@
 *.pem
 codeship_deploy_key.pub
 codeship_deploy_key
+data/
 dump.sql
 *.todo
 **/cypress/screenshots

--- a/.dockerignore
+++ b/.dockerignore
@@ -15,7 +15,6 @@
 *.pem
 codeship_deploy_key.pub
 codeship_deploy_key
-data/
 dump.sql
 *.todo
 **/cypress/screenshots

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,10 +4,13 @@ services:
   db:
     image: "postgis/postgis:13-3.3"
     volumes:
-      - ./data/db:/var/lib/postgresql/data
+      - db:/var/lib/postgresql/data
     environment:
       - POSTGRES_DB=postgres
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
     ports:
       - "5432:5432"
+
+volumes:
+  db:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
     ports:
-      - "5432:5432"
+      - "${PG_PORT:-5432}:5432"
 
 volumes:
   db:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,13 @@
+---
+version: "3.9"
+services:
+  db:
+    image: "postgis/postgis:13-3.3"
+    volumes:
+      - ./data/db:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_DB=postgres
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+    ports:
+      - "5432:5432"

--- a/packages/database/scripts/refreshDatabase.js
+++ b/packages/database/scripts/refreshDatabase.js
@@ -62,8 +62,9 @@ class RefreshDatabaseScript extends Script {
     const dbArgs = { user: dbPgUser, port: dbPort, host: dbHost };
     this.execDbCommand(`DROP DATABASE IF EXISTS ${dbName}`, dbArgs);
     this.execDbCommand(`CREATE DATABASE ${dbName} WITH OWNER ${dbUser}`, dbArgs);
-    // Loading GIS extension is optional - it's already loaded when using
-    // postgis/postgis Docker container
+    // Loading GIS extension is optional. Its already loaded in the
+    // postgis/postgis Docker image. Loading an extension thats already loaded
+    // fails.
     if (this.args.gis) {
       this.execDbCommand('CREATE EXTENSION postgis', dbArgs);
     }

--- a/packages/database/scripts/refreshDatabase.js
+++ b/packages/database/scripts/refreshDatabase.js
@@ -10,7 +10,7 @@ require('dotenv/config');
 const fs = require('fs');
 const path = require('path');
 
-const { requireEnv, Script } = require('@tupaia/utils');
+const { requireEnv, Script, getEnvVarOrDefault } = require('@tupaia/utils');
 
 class RefreshDatabaseScript extends Script {
   config = {
@@ -25,6 +25,12 @@ class RefreshDatabaseScript extends Script {
         alias: 'r',
         type: 'string',
         description: 'Root for provided paths (relative to packages/database)',
+      },
+      gis: {
+        alias: 'g',
+        default: true,
+        type: 'boolean',
+        description: 'Create postgis extension',
       },
     },
     version: '1.0.0',
@@ -41,6 +47,9 @@ class RefreshDatabaseScript extends Script {
     const dbName = requireEnv('DB_NAME');
     const dbUser = requireEnv('DB_USER');
     const dbPgUser = requireEnv('DB_PG_USER');
+    const dbPort = getEnvVarOrDefault('DB_PORT', 5432);
+    const dbHost = getEnvVarOrDefault('DB_HOST', 'localhost');
+
 
     this.logInfo(`Refreshing the ${dbName} database (owner: ${dbUser})...`);
 
@@ -50,18 +59,23 @@ class RefreshDatabaseScript extends Script {
     }
 
     this.verifyPsql();
-    this.execDbCommand(`DROP DATABASE IF EXISTS ${dbName}`, { user: dbPgUser });
-    this.execDbCommand(`CREATE DATABASE ${dbName} WITH OWNER ${dbUser}`, { user: dbPgUser });
-    this.execDbCommand('CREATE EXTENSION postgis', { db: dbName, user: dbPgUser });
-    this.execDbCommand(`ALTER USER ${dbUser} WITH SUPERUSER`, { user: dbPgUser });
-    this.exec(`psql -U ${dbUser} -d ${dbName} -f "${dumpPath}"`);
-    this.execDbCommand(`ALTER USER ${dbUser} WITH NOSUPERUSER`, { user: dbPgUser });
+    const dbArgs = { user: dbPgUser, port: dbPort, host: dbHost };
+    this.execDbCommand(`DROP DATABASE IF EXISTS ${dbName}`, dbArgs);
+    this.execDbCommand(`CREATE DATABASE ${dbName} WITH OWNER ${dbUser}`, dbArgs);
+    // Loading GIS extension is optional - it's already loaded when using
+    // postgis/postgis Docker container
+    if (this.args.gis) {
+      this.execDbCommand('CREATE EXTENSION postgis', dbArgs);
+    }
+    this.execDbCommand(`ALTER USER ${dbUser} WITH SUPERUSER`, dbArgs);
+    this.exec(`psql -U ${dbUser} -d ${dbName} -h "${dbHost}" -p ${dbPort} -f "${dumpPath}"`);
+    this.execDbCommand(`ALTER USER ${dbUser} WITH NOSUPERUSER`, dbArgs);
   }
 
   resolvePath = relativePath =>
     path.resolve([this.args.root, relativePath].filter(x => !!x).join('/'));
 
-  execDbCommand = (dbCommand, { user, db } = {}) => {
+  execDbCommand = (dbCommand, { user, db, host, port } = {}) => {
     const parts = ['psql'];
     if (user) {
       parts.push('-U', user);
@@ -71,6 +85,13 @@ class RefreshDatabaseScript extends Script {
     }
     if (db) {
       parts.push('-d', db);
+    }
+
+    if (host) {
+      parts.push('-h', host);
+    }
+    if (port) {
+      parts.push('-p', port);
     }
     parts.push('-c', `"${dbCommand}"`);
 

--- a/packages/database/scripts/refreshDatabase.js
+++ b/packages/database/scripts/refreshDatabase.js
@@ -48,7 +48,7 @@ class RefreshDatabaseScript extends Script {
     const dbUser = requireEnv('DB_USER');
     const dbPgUser = requireEnv('DB_PG_USER');
     const dbPort = getEnvVarOrDefault('DB_PORT', '');
-    const dbHost = getEnvVarOrDefault('DB_HOST', '');
+    const dbHost = getEnvVarOrDefault('DB_URL', '');
 
 
     this.logInfo(`Refreshing the ${dbName} database (owner: ${dbUser})...`);

--- a/packages/database/scripts/refreshDatabase.js
+++ b/packages/database/scripts/refreshDatabase.js
@@ -47,8 +47,8 @@ class RefreshDatabaseScript extends Script {
     const dbName = requireEnv('DB_NAME');
     const dbUser = requireEnv('DB_USER');
     const dbPgUser = requireEnv('DB_PG_USER');
-    const dbPort = getEnvVarOrDefault('DB_PORT', 5432);
-    const dbHost = getEnvVarOrDefault('DB_HOST', 'localhost');
+    const dbPort = getEnvVarOrDefault('DB_PORT', '');
+    const dbHost = getEnvVarOrDefault('DB_HOST', '');
 
 
     this.logInfo(`Refreshing the ${dbName} database (owner: ${dbUser})...`);


### PR DESCRIPTION
Avoid having to install specific versions of Postgres locally. Following starts postgres 13 with the postgis extension installed:

    $ docker-compose up 

Port can be overriden:

     $ PG_PORT=8765 docker-compose up

The database is stored as a docker volume.

```
$ docker volume ls

DRIVER    VOLUME NAME
local          tupaia_db
 ```
 To clean it up

    $ docker volume rm tuapai_db


Main motivation for using a volume is not to pollute the working dir with the db files. I  guess .gitignore + .dockerignore  works too, so happy to change this to a bind mount inside the working dir if preferred  :shrug:  


The `refreshDatabase.js` script has been updated to respect `DB_URL` and `DB_PORT` variables so it can connect to the compose db. There is a --no-gis (or --gis=false) option so that the postgis extension install isn't attempted. This is need as extension installation will fail on the postgis image, and isn't possible using the postgres image (at least without some hacks)


   $ yarn refresh-database --no-gis  dump.sql


I guess if approved,  I should document this somewhere.. is [tupaia-mono-repo-setup](https://beyond-essential.slab.com/posts/tupaia-monorepo-setup-v5egpdpq) the right place ??


