### PR TITLE
RN-851 Knex to handle numeric and bigInt type

### DIFF
--- a/packages/database/src/modelClasses/ExternalDatabaseConnection.js
+++ b/packages/database/src/modelClasses/ExternalDatabaseConnection.js
@@ -5,12 +5,17 @@
 
 import { getEnvVarOrDefault, requireEnv } from '@tupaia/utils';
 import knex from 'knex';
+import { types as pgTypes } from 'pg';
 
 import { DatabaseModel } from '../DatabaseModel';
 import { DatabaseType } from '../DatabaseType';
 import { TYPES } from '../types';
 
 const EXT_DB_CONNECTION_ENV_VAR_PREFIX = 'EXT_DB';
+
+pgTypes.setTypeParser(pgTypes.builtins.NUMERIC, value => {
+  return parseFloat(value);
+});
 
 export class ExternalDatabaseConnectionType extends DatabaseType {
   static databaseType = TYPES.EXTERNAL_DATABASE_CONNECTION;

--- a/packages/database/src/modelClasses/ExternalDatabaseConnection.js
+++ b/packages/database/src/modelClasses/ExternalDatabaseConnection.js
@@ -13,9 +13,8 @@ import { TYPES } from '../types';
 
 const EXT_DB_CONNECTION_ENV_VAR_PREFIX = 'EXT_DB';
 
-pgTypes.setTypeParser(pgTypes.builtins.NUMERIC, value => {
-  return parseFloat(value);
-});
+pgTypes.setTypeParser(pgTypes.builtins.NUMERIC, parseFloat);
+pgTypes.setTypeParser(20, parseInt); // bigInt type to Integer
 
 export class ExternalDatabaseConnectionType extends DatabaseType {
   static databaseType = TYPES.EXTERNAL_DATABASE_CONNECTION;


### PR DESCRIPTION
### Issue #:
RN-851 

Checked that type `timestamp without timezone`, `Integer` work fine. 

