### PR TITLE
RN-850 Date param use client local timezone

### DIFF
--- a/packages/admin-panel/src/dataTables/components/PreviewFilters/filters/DatePicker.js
+++ b/packages/admin-panel/src/dataTables/components/PreviewFilters/filters/DatePicker.js
@@ -31,11 +31,21 @@ const getDateValue = value => {
 export const DatePicker = ({ name, value, onChange, config }) => {
   const dateValue = getDateValue(value);
   const defaultDateValue = getDateValue(config?.hasDefaultValue && config?.defaultValue);
+  // Convert date to UTC as server uses UTC timezone
+  const onChangeDate = localDate => {
+    if (!localDate) {
+      return;
+    }
+    const UTCDate = new Date(
+      Date.UTC(localDate.getFullYear(), localDate.getMonth(), localDate.getDate()),
+    );
+    onChange(UTCDate);
+  };
 
   return (
     <BaseDatePicker
       label={name || ''}
-      onChange={onChange}
+      onChange={onChangeDate}
       value={dateValue}
       placeholder={defaultDateValue && format(defaultDateValue, 'dd/MM/yyyy')}
     />


### PR DESCRIPTION
### Issue #:
RN-850

### Changes:
This happens in SQL data table, and it really depends on user's machine. When adding a new date param and pick a date, some clients will set date in UTC format instead of local time zone, which makes it inconsistent when compare with data period.