### PR TITLE
RN-854: Fixed 'exitOnNoData' defaulting to 'null' when creating a fetchData transform

### DIFF
--- a/packages/admin-panel/src/VizBuilderApp/components/DataLibrary/component/TransformSelectedOptionWithJsonEditor.js
+++ b/packages/admin-panel/src/VizBuilderApp/components/DataLibrary/component/TransformSelectedOptionWithJsonEditor.js
@@ -15,6 +15,8 @@ const getDefaultValueByType = type => {
       return [];
     case 'object':
       return {};
+    case 'boolean':
+      return false;
     default:
       return null;
   }
@@ -38,7 +40,7 @@ export const TransformSelectedOptionWithJsonEditor = ({
           (value.oneOf && value.oneOf[0].type) ||
           (value.enum && typeof value.enum[0]) ||
           (value.oneOf && typeof value.oneOf[0].enum[0]);
-        const defaultValue = getDefaultValueByType(type);
+        const defaultValue = value.defaultValue || getDefaultValueByType(type);
 
         return [key, defaultValue];
       }),

--- a/packages/report-server/src/reportBuilder/transform/functions/index.ts
+++ b/packages/report-server/src/reportBuilder/transform/functions/index.ts
@@ -3,6 +3,7 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
+import { yup } from '@tupaia/utils';
 import { Context } from '../../context';
 
 import {
@@ -26,7 +27,7 @@ import {
   paramsValidator as gatherColumnsParamsValidator,
 } from './gatherColumns';
 import { buildFetchData, paramsValidator as fetchDataParamsValidator } from './fetchData';
-import { buildOrderColumns, orderColumnsSchema } from './orderColumns';
+import { buildOrderColumns, paramsValidator as orderColumnsParamsValidator } from './orderColumns';
 import { TransformTable } from '../table';
 
 type TransformBuilder = (
@@ -47,21 +48,15 @@ export const transformBuilders: Record<string, TransformBuilder> = {
   orderColumns: buildOrderColumns,
 };
 
-export const transformSchemas: Record<
-  string,
-  {
-    type: string;
-    fields: Record<string, unknown>;
-  }
-> = {
-  fetchData: fetchDataParamsValidator.describe(),
-  insertColumns: insertColumnsParamsValidator.describe(),
-  excludeColumns: excludeColumnsParamsValidator.describe(),
-  updateColumns: updateColumnsParamsValidator.describe(),
-  mergeRows: mergeRowsParamsValidator.describe(),
-  sortRows: sortRowsParamsValidator.describe(),
-  excludeRows: excludeRowsParamsValidator.describe(),
-  insertRows: insertRowsParamsValidator.describe(),
-  gatherColumns: gatherColumnsParamsValidator.describe(),
-  orderColumns: orderColumnsSchema,
+export const transformSchemas: Record<string, yup.AnyObjectSchema> = {
+  fetchData: fetchDataParamsValidator,
+  insertColumns: insertColumnsParamsValidator,
+  excludeColumns: excludeColumnsParamsValidator,
+  updateColumns: updateColumnsParamsValidator,
+  mergeRows: mergeRowsParamsValidator,
+  sortRows: sortRowsParamsValidator,
+  excludeRows: excludeRowsParamsValidator,
+  insertRows: insertRowsParamsValidator,
+  gatherColumns: gatherColumnsParamsValidator,
+  orderColumns: orderColumnsParamsValidator,
 };

--- a/packages/report-server/src/reportBuilder/transform/functions/orderColumns/index.ts
+++ b/packages/report-server/src/reportBuilder/transform/functions/orderColumns/index.ts
@@ -3,4 +3,4 @@
  * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
  */
 
-export { buildOrderColumns, orderColumnsSchema } from './orderColumns';
+export { buildOrderColumns, paramsValidator } from './orderColumns';

--- a/packages/report-server/src/routes/FetchTransformSchemaRoute.ts
+++ b/packages/report-server/src/routes/FetchTransformSchemaRoute.ts
@@ -6,6 +6,7 @@
 import { Request } from 'express';
 
 import { Route } from '@tupaia/server-boilerplate';
+import { yup } from '@tupaia/utils';
 
 import { TransformSchema } from '../types';
 import { transformSchemas } from '../reportBuilder/transform/functions';
@@ -18,34 +19,49 @@ export type FetchTransformSchemaRequest = Request<
   Record<string, never>
 >;
 
+const removeRedundantConfigs = (fields: Record<string, any | any[]> | any[]) => {
+  if (typeof fields !== 'object' || Array.isArray(fields)) {
+    return fields;
+  }
+  const updatedFields = { ...fields };
+  Object.entries(fields).forEach(([key, value]) => {
+    if (typeof value === 'object') {
+      updatedFields[key] = removeRedundantConfigs(value);
+    }
+    const isEmptyArray = Array.isArray(value) && value.length === 0;
+    if (isEmptyArray) {
+      delete updatedFields[key];
+    }
+  });
+  return updatedFields;
+};
+
+const formatYupSchema = (yupSchema: yup.AnyObjectSchema) => {
+  const { fields } = yupSchema.describe();
+  const schema = Object.fromEntries(
+    Object.entries(fields).map(([field, description]) => {
+      const formattedDescription = removeRedundantConfigs(description);
+      // 'getDefault' is not supported on lazy schemas
+      if (yupSchema.fields[field].getDefault) {
+        formattedDescription.defaultValue = yupSchema.fields[field].getDefault();
+      }
+      return [field, formattedDescription];
+    }),
+  );
+  return schema;
+};
+
 export class FetchTransformSchemaRoute extends Route<FetchTransformSchemaRequest> {
   public async buildResponse() {
-    const removeRedundantConfigs = (fields: Record<string, any | any[]> | any[]) => {
-      if (typeof fields !== 'object' || Array.isArray(fields)) {
-        return fields;
-      }
-      const updatedFields = { ...fields };
-      Object.entries(fields).forEach(([key, value]) => {
-        if (typeof value === 'object') {
-          updatedFields[key] = removeRedundantConfigs(value);
-        }
-        const isEmptyArray = Array.isArray(value) && value.length === 0;
-        if (isEmptyArray) {
-          delete updatedFields[key];
-        }
-      });
-      return updatedFields;
-    };
-
     const formattedTransformSchema = Object.entries(transformSchemas).map(
-      ([transformKey, config]) => {
-        const { fields } = config;
+      ([transformKey, schema]) => {
+        const formattedSchema = formatYupSchema(schema);
         return {
           code: transformKey,
           schema: {
             properties: {
               transform: { type: 'string', const: transformKey },
-              ...removeRedundantConfigs(fields),
+              ...formattedSchema,
             },
           },
         };


### PR DESCRIPTION
### Issue RN-854:

Change made to allow passing in the yup validator default as part of the transform schema. `exitOnNoData` has a default of `true`