### PR TITLE
WAITP-1146 Delete report alongside map overlay

### DIFF
--- a/packages/central-server/src/apiV2/mapOverlays/DeleteMapOverlays.js
+++ b/packages/central-server/src/apiV2/mapOverlays/DeleteMapOverlays.js
@@ -10,4 +10,11 @@ export class DeleteMapOverlays extends DeleteHandler {
   async assertUserHasAccess() {
     await this.assertPermissions(assertBESAdminAccess);
   }
+
+  async deleteRecord() {
+    const mapOverlay = await this.resourceModel.findById(this.recordId);
+    const reportModel = mapOverlay.legacy ? this.models.legacyReport : this.models.report;
+    await reportModel.delete({ code: mapOverlay.report_code });
+    return super.deleteRecord();
+  }
 }


### PR DESCRIPTION
### Issue #: WAITP-1146

### Changes:

- Delete report entry from relevant model when deleting a map overlay
  - Uses the same logic as the equivalent behaviour for dashboard items
