### PR TITLE
Release 2023 17

### DIFF
--- a/packages/admin-panel-server/package.json
+++ b/packages/admin-panel-server/package.json
@@ -29,7 +29,6 @@
     "@tupaia/access-policy": "3.0.0",
     "@tupaia/api-client": "3.1.0",
     "@tupaia/database": "1.0.0",
-    "@tupaia/report-server": "0.0.0",
     "@tupaia/server-boilerplate": "1.0.0",
     "@tupaia/utils": "1.0.0",
     "api-error-handler": "^1.0.0",

--- a/packages/admin-panel-server/src/viz-builder/types.ts
+++ b/packages/admin-panel-server/src/viz-builder/types.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
  */
 
-import { StandardOrCustomReportConfig } from '@tupaia/report-server';
+import type { StandardOrCustomReportConfig } from '@tupaia/types';
 import { Report as BaseReportType } from '@tupaia/types';
 
 export type VizData = {

--- a/packages/central-server/src/apiV2/export/exportSurveys/cellBuilders/AutocompleteConfigCellBuilder.js
+++ b/packages/central-server/src/apiV2/export/exportSurveys/cellBuilders/AutocompleteConfigCellBuilder.js
@@ -6,11 +6,42 @@
 import { KeyValueCellBuilder } from './KeyValueCellBuilder';
 
 export class AutocompleteConfigCellBuilder extends KeyValueCellBuilder {
+  individualFieldProcessors = {
+    attributes: AutocompleteConfigCellBuilder.processAttributesField,
+  };
+
   async processValue(value, key) {
     if (key === 'createNew') {
       return value ? 'Yes' : 'No';
     }
     return value;
+  }
+
+  /**
+   * Currently we only actually support parent_project as an attribute
+   * But this processor function processes all keys for future proofing
+   * Since it's not a one to one relationship we can't run it through the generic handlers
+   *
+   * Input:
+   * attibutes: {
+   *   parent_project: {
+   *    questionId: <guid>
+   *   }
+   * }
+   * Converted to Excel config:
+   * attributes.parent_project: <questionCode>
+   */
+  static async processAttributesField(models, attributesObject = {}) {
+    const processedAttributes = await Promise.all(
+      Object.entries(attributesObject).map(async ([key, value]) => {
+        const question = await models.question.findById(value?.questionId);
+        if (!question) {
+          throw new Error(`Could not find a question with id matching ${value?.questionId}`);
+        }
+        return `attributes.${key}: ${question.code}`;
+      }),
+    );
+    return processedAttributes.join('\r\n');
   }
 
   extractRelevantObject({ autocomplete }) {

--- a/packages/central-server/src/apiV2/export/exportSurveys/cellBuilders/KeyValueCellBuilder.js
+++ b/packages/central-server/src/apiV2/export/exportSurveys/cellBuilders/KeyValueCellBuilder.js
@@ -8,6 +8,10 @@ export class KeyValueCellBuilder {
     this.models = models;
   }
 
+  // Override handlers for specific fields that can't run through generic handlers
+  // e.g. object fields that map one to many in our excel format
+  individualFieldProcessors = {};
+
   fetchQuestionCode = async ({ questionId }) => {
     const question = await this.models.question.findById(questionId);
     if (!question) {
@@ -37,6 +41,9 @@ export class KeyValueCellBuilder {
     const object = this.extractRelevantObject(fullObject) || {};
     const processedFields = await Promise.all(
       Object.entries(object).map(async ([key, value]) => {
+        if (this.individualFieldProcessors[key]) {
+          return this.individualFieldProcessors[key](this.models, value);
+        }
         const processedKey = await this.processKey(key);
         const processedValue = await this.processValue(value, key);
         return `${processedKey}: ${processedValue}`;

--- a/packages/devops/ci/tupaia-ci-cd.Dockerfile
+++ b/packages/devops/ci/tupaia-ci-cd.Dockerfile
@@ -132,6 +132,3 @@ RUN yarn build:internal-dependencies
 
 # copy everything else from the repo
 COPY . ./
-
-# Make sure all packages build
-RUN yarn build:non-internal-dependencies

--- a/packages/report-server/src/reportBuilder/reportBuilder.ts
+++ b/packages/report-server/src/reportBuilder/reportBuilder.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
-import { StandardOrCustomReportConfig } from '../types';
+import type { StandardOrCustomReportConfig } from '@tupaia/types';
 import { configValidator } from './configValidator';
 import { buildContext, ReqContext } from './context';
 import { buildTransform, TransformTable } from './transform';

--- a/packages/report-server/src/types.ts
+++ b/packages/report-server/src/types.ts
@@ -5,7 +5,6 @@
 
 import { TupaiaApiClient } from '@tupaia/api-client';
 import { ModelRegistry } from '@tupaia/database';
-import { Report } from '@tupaia/types';
 import { ReportModel } from './models';
 
 export type RequestContext = {
@@ -33,12 +32,6 @@ export type AggregationObject = {
 };
 
 export type Aggregation = string | AggregationObject;
-
-type CustomReportConfig = {
-  customReport: string;
-};
-
-export type StandardOrCustomReportConfig = Report['config'] | CustomReportConfig;
 
 export interface Event {
   event: string;

--- a/packages/types/src/types/models-extra/index.ts
+++ b/packages/types/src/types/models-extra/index.ts
@@ -3,5 +3,5 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
-export type { ReportConfig } from './report';
+export type { ReportConfig, StandardOrCustomReportConfig } from './report';
 export type { DashboardItemConfig } from './dashboard-item';

--- a/packages/types/src/types/models-extra/report.ts
+++ b/packages/types/src/types/models-extra/report.ts
@@ -9,3 +9,9 @@ export type ReportConfig = {
   transform: Transform[];
   output?: Record<string, unknown>;
 };
+
+type CustomReportConfig = {
+  customReport: string;
+};
+
+export type StandardOrCustomReportConfig = ReportConfig | CustomReportConfig;

--- a/packages/types/src/types/models.ts
+++ b/packages/types/src/types/models.ts
@@ -10,6 +10,8 @@
 import { ReportConfig } from './models-extra';
 import { DashboardItemConfig } from './models-extra';
 
+export { StandardOrCustomReportConfig } from './models-extra';
+
 export interface AccessRequest {
   'approved'?: boolean | null;
   'created_time'?: Date;
@@ -619,6 +621,8 @@ export enum EntityType {
   'asset' = 'asset',
   'institute' = 'institute',
   'msupply_store' = 'msupply_store',
+  'complaint' = 'complaint',
+  'water_sample' = 'water_sample',
 }
 export enum DisasterType {
   'cyclone' = 'cyclone',

--- a/yarn.lock
+++ b/yarn.lock
@@ -5053,7 +5053,6 @@ __metadata:
     "@tupaia/access-policy": 3.0.0
     "@tupaia/api-client": 3.1.0
     "@tupaia/database": 1.0.0
-    "@tupaia/report-server": 0.0.0
     "@tupaia/server-boilerplate": 1.0.0
     "@tupaia/types": 1.0.0
     "@tupaia/utils": 1.0.0
@@ -5649,7 +5648,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@tupaia/report-server@0.0.0, @tupaia/report-server@workspace:packages/report-server":
+"@tupaia/report-server@workspace:packages/report-server":
   version: 0.0.0-use.local
   resolution: "@tupaia/report-server@workspace:packages/report-server"
   dependencies:


### PR DESCRIPTION
## Features ⭐
 - WAITP-1122 Add more functionality to user imports in admin panel

## Visualisations 📊 


## Bug fixes 🐛
- RN-864: Added missing 'Delete' button for data-tables 
- WAITP-1146 When deleting map overlays, delete the underlying report too
- RN-832: Raw data exports treat numbers as text
- RN-828: Fix error message seen when viewing user permissions
- RN-855: Allow selecting non 'Explore' entities for default values of Organisation Unit Codes parameters
- WAITP-92: Fetch projects after one time login
- WAITP-1144: Redirect user to 'Explore' when dismissing welcome modal after email verification
- WAITP-1121: Show loading indicator when changing dates in a visualisation
- WAITP-1120: Fix bar chart alignment for time series charts when not expanded
- WAITP-1123: Sort tables with dates by default
- WAITP-1176: Bug fix to mass approving access requests

## Infrastructure and maintenance 🛠️
- WAITP-1145: create commands for reloading on dev 
- WAITP-1186: Add example.http file to dhis-api
- [no-issue]: Updated test database schema