### PR TITLE
Remove build non internal dependencies in ci for testing service

### DIFF
--- a/packages/admin-panel-server/package.json
+++ b/packages/admin-panel-server/package.json
@@ -29,7 +29,6 @@
     "@tupaia/access-policy": "3.0.0",
     "@tupaia/api-client": "3.1.0",
     "@tupaia/database": "1.0.0",
-    "@tupaia/report-server": "0.0.0",
     "@tupaia/server-boilerplate": "1.0.0",
     "@tupaia/utils": "1.0.0",
     "api-error-handler": "^1.0.0",

--- a/packages/admin-panel-server/src/viz-builder/types.ts
+++ b/packages/admin-panel-server/src/viz-builder/types.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
  */
 
-import { StandardOrCustomReportConfig } from '@tupaia/report-server';
+import type { StandardOrCustomReportConfig } from '@tupaia/types';
 import { Report as BaseReportType } from '@tupaia/types';
 
 export type VizData = {

--- a/packages/devops/ci/tupaia-ci-cd.Dockerfile
+++ b/packages/devops/ci/tupaia-ci-cd.Dockerfile
@@ -132,6 +132,3 @@ RUN yarn build:internal-dependencies
 
 # copy everything else from the repo
 COPY . ./
-
-# Make sure all packages build
-RUN yarn build:non-internal-dependencies

--- a/packages/report-server/src/reportBuilder/reportBuilder.ts
+++ b/packages/report-server/src/reportBuilder/reportBuilder.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
-import { StandardOrCustomReportConfig } from '../types';
+import type { StandardOrCustomReportConfig } from '@tupaia/types';
 import { configValidator } from './configValidator';
 import { buildContext, ReqContext } from './context';
 import { buildTransform, TransformTable } from './transform';

--- a/packages/report-server/src/types.ts
+++ b/packages/report-server/src/types.ts
@@ -5,7 +5,6 @@
 
 import { TupaiaApiClient } from '@tupaia/api-client';
 import { ModelRegistry } from '@tupaia/database';
-import { Report } from '@tupaia/types';
 import { ReportModel } from './models';
 
 export type RequestContext = {
@@ -33,12 +32,6 @@ export type AggregationObject = {
 };
 
 export type Aggregation = string | AggregationObject;
-
-type CustomReportConfig = {
-  customReport: string;
-};
-
-export type StandardOrCustomReportConfig = Report['config'] | CustomReportConfig;
 
 export interface Event {
   event: string;

--- a/packages/types/src/types/models-extra/index.ts
+++ b/packages/types/src/types/models-extra/index.ts
@@ -3,5 +3,5 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
-export type { ReportConfig } from './report';
+export type { ReportConfig, StandardOrCustomReportConfig } from './report';
 export type { DashboardItemConfig } from './dashboard-item';

--- a/packages/types/src/types/models-extra/report.ts
+++ b/packages/types/src/types/models-extra/report.ts
@@ -9,3 +9,9 @@ export type ReportConfig = {
   transform: Transform[];
   output?: Record<string, unknown>;
 };
+
+type CustomReportConfig = {
+  customReport: string;
+};
+
+export type StandardOrCustomReportConfig = ReportConfig | CustomReportConfig;

--- a/packages/types/src/types/models.ts
+++ b/packages/types/src/types/models.ts
@@ -10,6 +10,8 @@
 import { ReportConfig } from './models-extra';
 import { DashboardItemConfig } from './models-extra';
 
+export { StandardOrCustomReportConfig } from './models-extra';
+
 export interface AccessRequest {
   'approved'?: boolean | null;
   'created_time'?: Date;
@@ -619,6 +621,8 @@ export enum EntityType {
   'asset' = 'asset',
   'institute' = 'institute',
   'msupply_store' = 'msupply_store',
+  'complaint' = 'complaint',
+  'water_sample' = 'water_sample',
 }
 export enum DisasterType {
   'cyclone' = 'cyclone',

--- a/yarn.lock
+++ b/yarn.lock
@@ -5053,7 +5053,6 @@ __metadata:
     "@tupaia/access-policy": 3.0.0
     "@tupaia/api-client": 3.1.0
     "@tupaia/database": 1.0.0
-    "@tupaia/report-server": 0.0.0
     "@tupaia/server-boilerplate": 1.0.0
     "@tupaia/types": 1.0.0
     "@tupaia/utils": 1.0.0
@@ -5649,7 +5648,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@tupaia/report-server@0.0.0, @tupaia/report-server@workspace:packages/report-server":
+"@tupaia/report-server@workspace:packages/report-server":
   version: 0.0.0-use.local
   resolution: "@tupaia/report-server@workspace:packages/report-server"
   dependencies:


### PR DESCRIPTION
### Issue #:
It is not necessary to run `yarn build:non-internal-dependencies` in testing service because non internal packages are not relied on others anymore.  

1. This will save us ~6 mins to build testing service
2. Easier to migrate to GHA 

### Changes:
  Remove report-server dependency in admin-panel-server (tiny)
