### PR TITLE
WAITP-1184 field grouping support for admin panel

### DIFF
--- a/packages/admin-panel/src/editor/EditModal.js
+++ b/packages/admin-panel/src/editor/EditModal.js
@@ -47,6 +47,7 @@ export const EditModalComponent = ({
   cancelButtonText,
   saveButtonText,
   extraDialogProps,
+  sections,
 }) => {
   const fieldsBySource = keyBy(fields, 'source');
 
@@ -63,6 +64,7 @@ export const EditModalComponent = ({
                 const fieldSourceToEdit = getFieldSourceToEdit(fieldsBySource[fieldSource]);
                 return onEditField(fieldSourceToEdit, newValue);
               }}
+              sections={sections}
             />
           )}
           {FieldsComponent && (
@@ -112,6 +114,13 @@ EditModalComponent.propTypes = {
   cancelButtonText: PropTypes.string,
   saveButtonText: PropTypes.string,
   extraDialogProps: PropTypes.object,
+  sections: PropTypes.arrayOf(
+    PropTypes.shape({
+      title: PropTypes.string,
+      description: PropTypes.string,
+      fields: PropTypes.arrayOf(PropTypes.string),
+    }),
+  ),
 };
 
 EditModalComponent.defaultProps = {
@@ -126,6 +135,7 @@ EditModalComponent.defaultProps = {
   cancelButtonText: 'Cancel',
   saveButtonText: 'Save',
   extraDialogProps: null,
+  sections: [],
 };
 
 const mapStateToProps = state => ({

--- a/packages/admin-panel/src/editor/EditModal.js
+++ b/packages/admin-panel/src/editor/EditModal.js
@@ -13,6 +13,7 @@ import { getEditorState, getIsUnchanged } from './selectors';
 import { Editor } from './Editor';
 import { ModalContentProvider } from '../widgets';
 import { UsedBy } from '../usedBy/UsedBy';
+import { getExplodedFields } from '../utilities';
 
 const getFieldSourceToEdit = field => {
   const { source, editConfig = {} } = field;
@@ -47,9 +48,9 @@ export const EditModalComponent = ({
   cancelButtonText,
   saveButtonText,
   extraDialogProps,
-  sections,
 }) => {
-  const fieldsBySource = keyBy(fields, 'source');
+  // key the fields by their source so we can easily find the field to edit. Use the exploded fields so that any subfields are placed into the top level of the array
+  const fieldsBySource = keyBy(getExplodedFields(fields), 'source');
 
   return (
     <Dialog onClose={onDismiss} open={isOpen} disableBackdropClick {...extraDialogProps}>
@@ -64,7 +65,6 @@ export const EditModalComponent = ({
                 const fieldSourceToEdit = getFieldSourceToEdit(fieldsBySource[fieldSource]);
                 return onEditField(fieldSourceToEdit, newValue);
               }}
-              sections={sections}
             />
           )}
           {FieldsComponent && (
@@ -114,13 +114,6 @@ EditModalComponent.propTypes = {
   cancelButtonText: PropTypes.string,
   saveButtonText: PropTypes.string,
   extraDialogProps: PropTypes.object,
-  sections: PropTypes.arrayOf(
-    PropTypes.shape({
-      title: PropTypes.string,
-      description: PropTypes.string,
-      fields: PropTypes.arrayOf(PropTypes.string),
-    }),
-  ),
 };
 
 EditModalComponent.defaultProps = {
@@ -135,7 +128,6 @@ EditModalComponent.defaultProps = {
   cancelButtonText: 'Cancel',
   saveButtonText: 'Save',
   extraDialogProps: null,
-  sections: [],
 };
 
 const mapStateToProps = state => ({

--- a/packages/admin-panel/src/editor/Editor.js
+++ b/packages/admin-panel/src/editor/Editor.js
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import { InputGroup } from '@tupaia/ui-components';
 import { InputField } from '../widgets';
 import { checkVisibilityCriteriaAreMet, labelToId } from '../utilities';
+import { SECTION_FIELD_TYPE } from './constants';
 
 export const Editor = ({ fields, recordData, onEditField }) => {
   const onInputChange = (inputKey, inputValue, editConfig = {}) => {
@@ -70,7 +71,7 @@ export const Editor = ({ fields, recordData, onEditField }) => {
 
   // Get the form fields and sections that are visible from the fields prop, handling nested sections
   const visibleFormItems = filterVisibleFields(fields).reduce((result, field) => {
-    if (field.type === 'section') {
+    if (field.type === SECTION_FIELD_TYPE) {
       const visibleSubfields = filterVisibleFields(field.fields);
       if (!visibleSubfields.length) return result;
       return [
@@ -87,7 +88,7 @@ export const Editor = ({ fields, recordData, onEditField }) => {
   return (
     <div>
       {visibleFormItems.map(item =>
-        item.type === 'section' ? (
+        item.type === SECTION_FIELD_TYPE ? (
           <InputGroup
             key={item.title}
             title={item.title}

--- a/packages/admin-panel/src/editor/Editor.js
+++ b/packages/admin-panel/src/editor/Editor.js
@@ -5,10 +5,11 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { InputGroup } from '@tupaia/ui-components';
 import { InputField } from '../widgets';
 import { checkVisibilityCriteriaAreMet, labelToId } from '../utilities';
 
-export const Editor = ({ fields, recordData, onEditField }) => {
+export const Editor = ({ fields, recordData, onEditField, sections }) => {
   const onInputChange = (inputKey, inputValue, editConfig = {}) => {
     const { setFieldsOnChange } = editConfig;
     if (setFieldsOnChange) {
@@ -31,36 +32,74 @@ export const Editor = ({ fields, recordData, onEditField }) => {
     return recordData[source];
   };
 
+  // Get the fields that are visible from an array
+  const filterVisibleFields = allFields => {
+    return allFields.filter(({ show = true, editConfig = {} }) => {
+      const { visibilityCriteria } = editConfig;
+
+      if (!show) {
+        return false;
+      }
+
+      // show or hide a field based on another field's value
+      if (visibilityCriteria) {
+        return checkVisibilityCriteriaAreMet(visibilityCriteria, recordData);
+      }
+
+      return true;
+    });
+  };
+
+  // Get the input field
+  const getFieldInput = field => {
+    const { editable = true, editConfig = {}, source, Header, accessor } = field;
+    return (
+      <InputField
+        key={source}
+        inputKey={source}
+        label={Header}
+        onChange={(inputKey, inputValue) => onInputChange(inputKey, inputValue, editConfig)}
+        value={selectValue(editConfig, accessor, source)}
+        disabled={!editable}
+        recordData={recordData}
+        id={`inputField-${labelToId(source)}`}
+        {...editConfig}
+      />
+    );
+  };
+
+  // The sections that are visible, and their associated input fields
+  const visibleSections = sections.reduce((result, section) => {
+    const visibleFields = filterVisibleFields(section.fields);
+    // If none of the fields are visible, don't show the section
+    if (!visibleFields.length) return result;
+    return [
+      ...result,
+      {
+        ...section,
+        fields: visibleFields.reduce((fieldResult, fieldName) => {
+          const fieldInfo = fields.find(f => f.source === fieldName);
+          if (!fieldInfo) return fieldResult;
+          return [...fieldResult, getFieldInput(fieldInfo)];
+        }, []),
+      },
+    ];
+  }, []);
+
+  // The fields that are not part of a larger subsection
+  const standaloneFields = fields.filter(field => {
+    if (!sections.length) return true;
+    const { source } = field;
+    return !sections.find(section => section.fields.includes(source));
+  });
+
   return (
     <div>
-      {fields
-        .filter(({ show = true, editConfig = {} }) => {
-          const { visibilityCriteria } = editConfig;
-
-          if (!show) {
-            return false;
-          }
-
-          // show or hide a field based on another field's value
-          if (visibilityCriteria) {
-            return checkVisibilityCriteriaAreMet(visibilityCriteria, recordData);
-          }
-
-          return true;
-        })
-        .map(({ editable = true, editConfig = {}, source, Header, accessor }) => (
-          <InputField
-            key={source}
-            inputKey={source}
-            label={Header}
-            onChange={(inputKey, inputValue) => onInputChange(inputKey, inputValue, editConfig)}
-            value={selectValue(editConfig, accessor, source)}
-            disabled={!editable}
-            recordData={recordData}
-            id={`inputField-${labelToId(source)}`}
-            {...editConfig}
-          />
-        ))}
+      {/** Display the sections first, then the standalone fields */}
+      {visibleSections.map(({ title, fields: sectionFields, description }) => (
+        <InputGroup title={title} description={description} fields={sectionFields} />
+      ))}
+      {filterVisibleFields(standaloneFields).map(field => getFieldInput(field))}
     </div>
   );
 };
@@ -69,4 +108,18 @@ Editor.propTypes = {
   fields: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   recordData: PropTypes.object.isRequired,
   onEditField: PropTypes.func.isRequired,
+  sections: PropTypes.arrayOf(
+    PropTypes.shape({
+      /** the section heading */
+      title: PropTypes.string,
+      /** the section description */
+      description: PropTypes.string,
+      /** an array of field names */
+      fields: PropTypes.arrayOf(PropTypes.string),
+    }),
+  ),
+};
+
+Editor.defaultProps = {
+  sections: [],
 };

--- a/packages/admin-panel/src/editor/actions.js
+++ b/packages/admin-panel/src/editor/actions.js
@@ -13,7 +13,11 @@ import {
   EDITOR_FIELD_EDIT,
   EDITOR_OPEN,
 } from './constants';
-import { convertSearchTermToFilter, makeSubstitutionsInString } from '../utilities';
+import {
+  convertSearchTermToFilter,
+  makeSubstitutionsInString,
+  getExplodedFields,
+} from '../utilities';
 
 const STATIC_FIELD_TYPES = ['link'];
 
@@ -22,6 +26,8 @@ export const openBulkEditModal = (
   recordId,
   rowData,
 ) => async (dispatch, getState, { api }) => {
+  // explode the fields from any subsections
+  const explodedFields = getExplodedFields(fields);
   if (recordId) {
     dispatch({
       type: EDITOR_DATA_FETCH_BEGIN,
@@ -36,7 +42,7 @@ export const openBulkEditModal = (
       const response = await api.get(makeSubstitutionsInString(bulkGetEndpoint, rowData), {
         filter: filterString.length > 0 ? filterString : undefined,
         columns: JSON.stringify(
-          fields
+          explodedFields
             .filter(field => !field.hideValue && !STATIC_FIELD_TYPES.includes(field.type)) // Ignore any that will be hidden, e.g. passwords
             .map(field => field.source),
         ), // Fetch fields based on their source
@@ -59,7 +65,7 @@ export const openBulkEditModal = (
     }
   } else {
     // set default values
-    fields.forEach(field => {
+    explodedFields.forEach(field => {
       if (field.editConfig && field.editConfig.default) {
         const {
           source: fieldKey,
@@ -87,6 +93,8 @@ export const openEditModal = (
   { editEndpoint, title, fields, FieldsComponent, extraDialogProps = {}, isLoading = false },
   recordId,
 ) => async (dispatch, getState, { api }) => {
+  // explode the fields from any subsections
+  const explodedFields = getExplodedFields(fields);
   // Open the modal instantly
   dispatch({
     type: EDITOR_OPEN,
@@ -113,7 +121,7 @@ export const openEditModal = (
     try {
       const response = await api.get(endpoint, {
         columns: JSON.stringify(
-          fields
+          explodedFields
             .filter(field => !field.hideValue && !STATIC_FIELD_TYPES.includes(field.type)) // Ignore any that will be hidden, e.g. passwords
             .map(field => field.source),
         ), // Fetch fields based on their source
@@ -130,7 +138,7 @@ export const openEditModal = (
     }
   } else {
     // set default values
-    fields.forEach(field => {
+    explodedFields.forEach(field => {
       if (field.editConfig && field.editConfig.default) {
         const {
           source: fieldKey,

--- a/packages/admin-panel/src/editor/constants.js
+++ b/packages/admin-panel/src/editor/constants.js
@@ -17,3 +17,5 @@ export const DATA_CHANGE_ACTIONS = {
   finish: EDITOR_DATA_EDIT_SUCCESS,
   error: EDITOR_ERROR,
 };
+
+export const SECTION_FIELD_TYPE = 'section';

--- a/packages/admin-panel/src/pages/resources/ResourcePage.js
+++ b/packages/admin-panel/src/pages/resources/ResourcePage.js
@@ -9,7 +9,7 @@ import styled from 'styled-components';
 import { DataFetchingTable } from '../../table';
 import { EditModal } from '../../editor';
 import { Header, PageBody } from '../../widgets';
-import { usePortalWithCallback } from '../../utilities';
+import { getExplodedFields, usePortalWithCallback } from '../../utilities';
 import { LogsModal } from '../../logsTable';
 
 const Container = styled(PageBody)`
@@ -34,7 +34,6 @@ export const ResourcePage = ({
   defaultSorting,
   deleteConfig,
   editorConfig,
-  sections,
 }) => {
   const HeaderPortal = usePortalWithCallback(
     <Header
@@ -52,7 +51,7 @@ export const ResourcePage = ({
       {HeaderPortal}
       <Container>
         <DataFetchingTable
-          columns={columns}
+          columns={getExplodedFields(columns)} // Explode columns to support nested fields, since the table doesn't want to nest these
           endpoint={endpoint}
           expansionTabs={expansionTabs}
           reduxId={reduxId || endpoint}
@@ -62,11 +61,7 @@ export const ResourcePage = ({
           deleteConfig={deleteConfig}
         />
       </Container>
-      <EditModal
-        onProcessDataForSave={onProcessDataForSave}
-        {...editorConfig}
-        sections={sections}
-      />
+      <EditModal onProcessDataForSave={onProcessDataForSave} {...editorConfig} />
       <LogsModal />
     </>
   );
@@ -97,13 +92,6 @@ ResourcePage.propTypes = {
   defaultSorting: PropTypes.array,
   defaultFilters: PropTypes.array,
   editorConfig: PropTypes.object,
-  sections: PropTypes.arrayOf(
-    PropTypes.shape({
-      title: PropTypes.string,
-      description: PropTypes.string,
-      fields: PropTypes.arrayOf(PropTypes.string),
-    }),
-  ),
 };
 
 ResourcePage.defaultProps = {
@@ -120,5 +108,4 @@ ResourcePage.defaultProps = {
   defaultFilters: [],
   reduxId: null,
   editorConfig: {},
-  sections: [],
 };

--- a/packages/admin-panel/src/pages/resources/ResourcePage.js
+++ b/packages/admin-panel/src/pages/resources/ResourcePage.js
@@ -34,6 +34,7 @@ export const ResourcePage = ({
   defaultSorting,
   deleteConfig,
   editorConfig,
+  sections,
 }) => {
   const HeaderPortal = usePortalWithCallback(
     <Header
@@ -61,7 +62,11 @@ export const ResourcePage = ({
           deleteConfig={deleteConfig}
         />
       </Container>
-      <EditModal onProcessDataForSave={onProcessDataForSave} {...editorConfig} />
+      <EditModal
+        onProcessDataForSave={onProcessDataForSave}
+        {...editorConfig}
+        sections={sections}
+      />
       <LogsModal />
     </>
   );
@@ -92,6 +97,13 @@ ResourcePage.propTypes = {
   defaultSorting: PropTypes.array,
   defaultFilters: PropTypes.array,
   editorConfig: PropTypes.object,
+  sections: PropTypes.arrayOf(
+    PropTypes.shape({
+      title: PropTypes.string,
+      description: PropTypes.string,
+      fields: PropTypes.arrayOf(PropTypes.string),
+    }),
+  ),
 };
 
 ResourcePage.defaultProps = {
@@ -108,4 +120,5 @@ ResourcePage.defaultProps = {
   defaultFilters: [],
   reduxId: null,
   editorConfig: {},
+  sections: [],
 };

--- a/packages/admin-panel/src/utilities/getFields.js
+++ b/packages/admin-panel/src/utilities/getFields.js
@@ -1,0 +1,14 @@
+/*
+ * Tupaia
+ *  Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+import { SECTION_FIELD_TYPE } from '../editor/constants';
+
+// This function is used to explode fields that are nested in sections
+export const getExplodedFields = items => {
+  return items.reduce((result, item) => {
+    if (item.type === SECTION_FIELD_TYPE) return [...result, ...item.fields];
+    return [...result, item];
+  }, []);
+};

--- a/packages/admin-panel/src/utilities/index.js
+++ b/packages/admin-panel/src/utilities/index.js
@@ -13,3 +13,4 @@ export * from './useDebounce';
 export { checkVisibilityCriteriaAreMet } from './visibilityCriteria';
 export { labelToId } from './labelToId';
 export { getColumns } from './getColumns';
+export { getExplodedFields } from './getFields';

--- a/packages/ui-components/src/components/Inputs/InputGroup.js
+++ b/packages/ui-components/src/components/Inputs/InputGroup.js
@@ -1,0 +1,45 @@
+/*
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+import React from 'react';
+import styled from 'styled-components';
+
+const InputGroupWrapper = styled.section``;
+const InputGroupHeading = styled.h2`
+  padding-inline-start: 0;
+  margin: 0;
+  font-weight: ${props => props.theme.typography.fontWeightMedium};
+  font-size: 1.2rem;
+  line-height: 1.4;
+`;
+const FieldsWrapper = styled.div`
+  margin-left: 2rem;
+  margin-bottom: 1.2rem;
+  ${InputGroupWrapper}:not(:last-child) & {
+    border-bottom: 1px solid ${props => props.theme.palette.grey['400']};
+  }
+`;
+
+const InputGroupHelperText = styled.p`
+  font-size: 0.9375rem;
+  margin: 0;
+  line-height: 1.2;
+`;
+
+const InputGroupHeaderWrapper = styled.div`
+  margin-bottom: 1rem;
+`;
+
+export const InputGroup = ({ title, description, fields }) => {
+  return (
+    <InputGroupWrapper>
+      <InputGroupHeaderWrapper>
+        {title && <InputGroupHeading>{title}</InputGroupHeading>}
+        {description && <InputGroupHelperText>{description}</InputGroupHelperText>}
+      </InputGroupHeaderWrapper>
+      <FieldsWrapper>{fields}</FieldsWrapper>
+    </InputGroupWrapper>
+  );
+};

--- a/packages/ui-components/src/components/Inputs/index.js
+++ b/packages/ui-components/src/components/Inputs/index.js
@@ -16,3 +16,4 @@ export * from './RadioGroup';
 export * from './FileUploadField';
 export * from './ProfileImageField';
 export * from './SQLQueryEditor';
+export * from './InputGroup';

--- a/packages/ui-components/stories/inputs/inputGroup.stories.js
+++ b/packages/ui-components/stories/inputs/inputGroup.stories.js
@@ -1,0 +1,72 @@
+/*
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { InputGroup, TextField } from '../../src';
+
+export default {
+  title: 'Inputs/InputGroup',
+};
+
+const Container = styled.div`
+  max-width: 380px;
+  padding: 2rem;
+`;
+
+export const inputGroup = () => {
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [bio, setBio] = useState('');
+  const [website, setWebsite] = useState('');
+  const [companyName, setCompanyName] = useState('');
+
+  return (
+    <Container>
+      <InputGroup
+        title="Your details"
+        description="Please enter your details"
+        fields={[
+          <TextField
+            label="First name"
+            id="first-name"
+            value={firstName}
+            onChange={e => setFirstName(e.target.value)}
+          />,
+          <TextField
+            label="Last name"
+            id="last-name"
+            value={lastName}
+            onChange={e => setLastName(e.target.value)}
+          />,
+        ]}
+      />
+      <InputGroup
+        title="About you"
+        fields={[
+          <TextField label="Bio" id="bio" value={bio} onChange={e => setBio(e.target.value)} />,
+        ]}
+      />
+      <InputGroup
+        title="Your work"
+        description="About your work"
+        fields={[
+          <TextField
+            label="Company name"
+            id="company-name"
+            value={companyName}
+            onChange={e => setCompanyName(e.target.value)}
+          />,
+          <TextField
+            label="Website"
+            id="website"
+            value={website}
+            onChange={e => setWebsite(e.target.value)}
+          />,
+        ]}
+      />
+    </Container>
+  );
+};


### PR DESCRIPTION
### Issue WAITP-1184: Support field groupings in admin panel

### Changes:
- Created a `ui-component` called `InputGroup` that displays a title, description, and an array of fields
- Updated `admin-panel` edit files to handle groups of fields. To maintain backwards compatibility, this is done by passing in an optional array of `sections` to the `ResourcePage` component. Each item in the array will have an array of field names, which must be defined as fields are currently, as well as an optional title and description. The `Editor` will group the fields accordingly. This seemed the simplest way to handle these without needing to refactor everything else? 

Note: if sections are defined together with fields that don't belong to a section, the sections will appear first, and then the standalone fields. 
Also note that designs are not set in stone, so some of the styling may change.

### Screenshots:
![image](https://user-images.githubusercontent.com/129009580/233903731-f56f6a8e-7f34-4c29-abd5-85e12afdff9c.png)

