### PR TITLE
WAITP-1194 fix type of response expected for events

### DIFF
--- a/packages/central-server/src/database/models/SurveyResponse.js
+++ b/packages/central-server/src/database/models/SurveyResponse.js
@@ -71,7 +71,7 @@ export class SurveyResponseModel extends MaterializedViewLogDatabaseModel {
   };
 
   /**
-   * Returns the SQL to inclue only event based survey responses from a statement that has
+   * Returns the SQL to include only event based survey responses from a statement that has
    * already JOINed both survey and entity
    */
   getOnlyEventsQueryClause = () => `
@@ -99,7 +99,7 @@ export class SurveyResponseModel extends MaterializedViewLogDatabaseModel {
       [surveyResponseId],
     );
     if (result.length === 0) return false;
-    return result[0].count === '1';
+    return result[0].count === 1;
   }
 
   approvalStatusTypes = SURVEY_RESPONSE_APPROVAL_STATUS;

--- a/packages/central-server/src/tests/database/models/SurveyResponse.test.js
+++ b/packages/central-server/src/tests/database/models/SurveyResponse.test.js
@@ -1,0 +1,67 @@
+import { expect } from 'chai';
+import { SurveyResponseModel } from '../../../database/models/SurveyResponse';
+
+describe('SurveyResponse', () => {
+  describe('checkIsEventBased', () => {
+    const otherModels = {
+      entity: {
+        orgUnitEntityTypes: ['country', 'district', 'facility', 'sub_district', 'village'],
+      },
+    };
+
+    const createModel = (executeSqlResults = []) => {
+      const model = new SurveyResponseModel({
+        fetchSchemaForTable: () => {},
+        executeSql: () => executeSqlResults,
+      });
+      model.otherModels = otherModels;
+      return model;
+    };
+
+    it('checkIsEventBased should return false if there are no results from the database query', async () => {
+      const model = createModel([]);
+      const result = await model.checkIsEventBased(1);
+      expect(result).to.equal(false);
+    });
+
+    it('checkIsEventBased should return true if results[0].count === 1', async () => {
+      const model = createModel([
+        {
+          count: 1,
+        },
+      ]);
+      const result = await model.checkIsEventBased(1);
+      expect(result).to.equal(true);
+    });
+
+    it('checkIsEventBased should return false if results[0].count === "1"', async () => {
+      const model = createModel([
+        {
+          count: '1',
+        },
+      ]);
+      const result = await model.checkIsEventBased(1);
+      expect(result).to.equal(false);
+    });
+
+    it('checkIsEventBased should return false if results[0].count > 1', async () => {
+      const model = createModel([
+        {
+          count: 2,
+        },
+      ]);
+      const result = await model.checkIsEventBased(1);
+      expect(result).to.equal(false);
+    });
+
+    it('checkIsEventBased should return false if results[0].count < 1', async () => {
+      const model = createModel([
+        {
+          count: 0,
+        },
+      ]);
+      const result = await model.checkIsEventBased(1);
+      expect(result).to.equal(false);
+    });
+  });
+});


### PR DESCRIPTION
### Issue WAITP-1194: DHIS2 sometimes fails to sync

### Changes:
- Updated the type that is expected from the event check query to be number, not string
- Added tests for `checkIsEventBased` in `SurveyResponse`
