### PR TITLE
Hotfix: Pg types parser errors

### DIFF
--- a/packages/central-server/src/database/models/SurveyResponse.js
+++ b/packages/central-server/src/database/models/SurveyResponse.js
@@ -99,7 +99,7 @@ export class SurveyResponseModel extends MaterializedViewLogDatabaseModel {
       [surveyResponseId],
     );
     if (result.length === 0) return false;
-    return result[0].count === '1';
+    return parseInt(result[0].count) === 1;
   }
 
   approvalStatusTypes = SURVEY_RESPONSE_APPROVAL_STATUS;

--- a/packages/database/src/TupaiaDatabase.js
+++ b/packages/database/src/TupaiaDatabase.js
@@ -67,6 +67,7 @@ const HANDLER_DEBOUNCE_DURATION = 250;
 // string, independent of timezones, rather than being converted to local time
 pgTypes.setTypeParser(pgTypes.builtins.TIMESTAMP, val => val);
 pgTypes.setTypeParser(pgTypes.builtins.NUMERIC, parseFloat);
+pgTypes.setTypeParser(20, parseInt); // bigInt type to Integer
 
 export class TupaiaDatabase {
   /**

--- a/packages/database/src/TupaiaDatabase.js
+++ b/packages/database/src/TupaiaDatabase.js
@@ -62,9 +62,11 @@ const COMPARATORS = {
 // keeping all the tests passing
 const HANDLER_DEBOUNCE_DURATION = 250;
 
+// Danger: pgTypes is a global variable, so it will be shared between all instances of TupaiaDatabase
 // turn off parsing of timestamp (not timestamptz), so that it stays as a sort of "universal time"
 // string, independent of timezones, rather than being converted to local time
 pgTypes.setTypeParser(pgTypes.builtins.TIMESTAMP, val => val);
+pgTypes.setTypeParser(pgTypes.builtins.NUMERIC, parseFloat);
 
 export class TupaiaDatabase {
   /**

--- a/packages/database/src/modelClasses/ExternalDatabaseConnection.js
+++ b/packages/database/src/modelClasses/ExternalDatabaseConnection.js
@@ -5,16 +5,12 @@
 
 import { getEnvVarOrDefault, requireEnv } from '@tupaia/utils';
 import knex from 'knex';
-import { types as pgTypes } from 'pg';
 
 import { DatabaseModel } from '../DatabaseModel';
 import { DatabaseType } from '../DatabaseType';
 import { TYPES } from '../types';
 
 const EXT_DB_CONNECTION_ENV_VAR_PREFIX = 'EXT_DB';
-
-pgTypes.setTypeParser(pgTypes.builtins.NUMERIC, parseFloat);
-pgTypes.setTypeParser(20, parseInt); // bigInt type to Integer
 
 export class ExternalDatabaseConnectionType extends DatabaseType {
   static databaseType = TYPES.EXTERNAL_DATABASE_CONNECTION;


### PR DESCRIPTION
### Issue #:
Since we added `pg.setTypeParser()` for parsing bigInt type to integer ([PR](https://github.com/beyondessential/tupaia/pull/4436#discussion_r1179883239)), a bug created in sync queue because originally we treated bigInt type data as string. 

Summary:
1. There is only one place in Tupaia database use bigInt, which is `access_token_expiry`, they got used to compare with Date.now(), this is fine as string and integer types can be used to do this comparsion.
2. Have check all sql queries in Tupaia to see if any mathematic functions would be broken, like count, sum, min, max.. 
3. most count are captured and parsed to Int in the codebase except one.
4. coconuts, pigs got changed from string to int, they are fine for displaying purpose on frontend.

- Example

---

### Screenshots:
