### PR TITLE
Hotfix: move extra pg flags to callable method

### DIFF
--- a/packages/data-table-server/src/index.ts
+++ b/packages/data-table-server/src/index.ts
@@ -16,6 +16,7 @@ configureWinston();
 dotenv.config(); // Load the environment variables into process.env
 
 const database = new TupaiaDatabase();
+database.configurePgGlobals(true);
 
 /**
  * Set up app with routes etc.

--- a/packages/database/src/modelClasses/ExternalDatabaseConnection.js
+++ b/packages/database/src/modelClasses/ExternalDatabaseConnection.js
@@ -5,16 +5,12 @@
 
 import { getEnvVarOrDefault, requireEnv } from '@tupaia/utils';
 import knex from 'knex';
-import { types as pgTypes } from 'pg';
 
 import { DatabaseModel } from '../DatabaseModel';
 import { DatabaseType } from '../DatabaseType';
 import { TYPES } from '../types';
 
 const EXT_DB_CONNECTION_ENV_VAR_PREFIX = 'EXT_DB';
-
-pgTypes.setTypeParser(pgTypes.builtins.NUMERIC, parseFloat);
-pgTypes.setTypeParser(20, parseInt); // bigInt type to Integer
 
 export class ExternalDatabaseConnectionType extends DatabaseType {
   static databaseType = TYPES.EXTERNAL_DATABASE_CONNECTION;


### PR DESCRIPTION
### Issue #: WAITP-1194

Replaces PRs #4503 and #4507

Discussed rolling back vs rolling forward. Went with a fix that rolls back everything but data-table-server using a conditional. This lets us release safely today and in clean up in the next few days.

Tested:
- data-tables still work ✅ (data coming back from data lake as numeric)
- [rolled back] big int converted to string as before in web-config server ✅ 
- [rolled back] dhis sync queue the count is coming back as a string, as before ✅ 
