### PR TITLE
WAITP-1151: Custom landing pages login flow

### DIFF
--- a/packages/web-frontend/src/containers/OverlayDiv/components/LandingPage/index.js
+++ b/packages/web-frontend/src/containers/OverlayDiv/components/LandingPage/index.js
@@ -5,16 +5,16 @@
  * found in the LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import Button from '@material-ui/core/Button';
 import ExploreIcon from '@material-ui/icons/ExploreOutlined';
-
 import { LoginPage } from './LoginPage';
 import { ProjectPage } from '../ProjectPage';
 import { OVERLAY_PADDING } from '../../constants';
 import { TUPAIA_LIGHT_LOGO_SRC } from '../../../../constants';
+import { useCustomLandingPages } from '../../../../screens/LandingPage/useCustomLandingPages';
 
 const Container = styled.div`
   display: grid;
@@ -45,9 +45,10 @@ const ViewProjectsButton = styled(Button)`
 `;
 
 export const LandingPage = ({ isUserLoggedIn, isViewingProjects }) => {
-  const [isProjectsPageVisible, setIsProjectsPageVisible] = React.useState(isViewingProjects);
-  const showProjects = React.useCallback(() => setIsProjectsPageVisible(true));
-  const hideProjects = React.useCallback(() => setIsProjectsPageVisible(false));
+  const [isProjectsPageVisible, setIsProjectsPageVisible] = useState(isViewingProjects);
+  const showProjects = useCallback(() => setIsProjectsPageVisible(true));
+  const hideProjects = useCallback(() => setIsProjectsPageVisible(false));
+  const { isCustomLandingPage } = useCustomLandingPages();
 
   const isLoginPageVisible = !isUserLoggedIn && !isProjectsPageVisible;
 
@@ -58,7 +59,7 @@ export const LandingPage = ({ isUserLoggedIn, isViewingProjects }) => {
         <TagLine>
           Data aggregation, analysis, and visualisation for the most remote settings in the world
         </TagLine>
-        {isLoginPageVisible && (
+        {!isCustomLandingPage && isLoginPageVisible && (
           <ViewProjectsButton onClick={showProjects} variant="outlined">
             <ExploreIcon /> View projects
           </ViewProjectsButton>

--- a/packages/web-frontend/src/containers/OverlayDiv/components/ProjectPage/ProjectCardList.js
+++ b/packages/web-frontend/src/containers/OverlayDiv/components/ProjectPage/ProjectCardList.js
@@ -1,0 +1,30 @@
+/*
+ * Tupaia
+ *  Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+
+import React from 'react';
+import { ProjectCard } from './ProjectCard';
+
+const EXPLORE_CODE = 'explore';
+
+export const ProjectCardList = ({ projects, accessType, action, actionText }) => {
+  const hasPendingType = accessType === 'pending';
+  const hasAccessType = hasPendingType ? false : accessType;
+  return projects
+    .filter(
+      ({ code, hasAccess, hasPendingAccess = false }) =>
+        code !== EXPLORE_CODE && hasAccess === hasAccessType && hasPendingAccess === hasPendingType,
+    )
+    .sort((a, b) => a.sortOrder - b.sortOrder)
+    .map(project => (
+      <ProjectCard
+        key={project.name}
+        projectAction={() => action(project)}
+        actionText={actionText}
+        accessType={hasAccessType}
+        hasAccessPending={hasPendingType}
+        {...project}
+      />
+    ));
+};

--- a/packages/web-frontend/src/containers/OverlayDiv/components/ProjectPage/index.js
+++ b/packages/web-frontend/src/containers/OverlayDiv/components/ProjectPage/index.js
@@ -17,7 +17,7 @@ import {
 } from '../../constants';
 import { setProject, setRequestingAccess } from '../../../../projects/actions';
 import { setOverlayComponent } from '../../../../actions';
-import { ProjectCard } from './ProjectCard';
+import { ProjectCardList } from './ProjectCardList';
 
 // code for general explore mode project.
 const EXPLORE_CODE = 'explore';
@@ -45,27 +45,6 @@ const ExploreButton = styled(Button)`
   }
 `;
 
-export const renderProjectsWithFilter = (projects, accessType, action, actionText) => {
-  const hasPendingType = accessType === 'pending';
-  const hasAccessType = hasPendingType ? false : accessType;
-  return projects
-    .filter(
-      ({ code, hasAccess, hasPendingAccess = false }) =>
-        code !== EXPLORE_CODE && hasAccess === hasAccessType && hasPendingAccess === hasPendingType,
-    )
-    .sort((a, b) => a.sortOrder - b.sortOrder)
-    .map(project => (
-      <ProjectCard
-        key={project.name}
-        projectAction={() => action(project)}
-        actionText={actionText}
-        accessType={hasAccessType}
-        hasAccessPending={hasPendingType}
-        {...project}
-      />
-    ));
-};
-
 const ProjectPageComponent = ({
   onSelectProject,
   onRequestProjectAccess,
@@ -79,38 +58,30 @@ const ProjectPageComponent = ({
     exploreProject,
   ]);
 
-  const projectsWithAccess = renderProjectsWithFilter(
-    projects,
-    true,
-    onSelectProject,
-    'View project',
-  );
-
-  const projectsPendingAccess = renderProjectsWithFilter(
-    projects,
-    'pending',
-    onRequestProjectAccess,
-    'Approval in progress',
-  );
-
-  const noAccessAction = isUserLoggedIn ? onRequestProjectAccess : openLoginDialog;
-  const noAccessText = isUserLoggedIn ? 'Request access' : 'Log in';
-  const projectsWithoutAccess = renderProjectsWithFilter(
-    projects,
-    false,
-    noAccessAction,
-    noAccessText,
-  );
-
   return (
     <div>
       <ExploreButton onClick={selectExploreProject} variant="outlined">
         <ExploreIcon /> I just want to explore
       </ExploreButton>
       <Container>
-        {projectsWithAccess}
-        {projectsPendingAccess}
-        {projectsWithoutAccess}
+        <ProjectCardList
+          projects={projects}
+          accessType
+          action={onSelectProject}
+          actionText="View project"
+        />
+        <ProjectCardList
+          projects={projects}
+          accessType="pending"
+          action={onRequestProjectAccess}
+          actionText="Approval in progress"
+        />
+        <ProjectCardList
+          projects={projects}
+          accessType={false}
+          action={isUserLoggedIn ? onRequestProjectAccess : openLoginDialog}
+          actionText={isUserLoggedIn ? 'Request access' : 'Log in'}
+        />
       </Container>
     </div>
   );

--- a/packages/web-frontend/src/containers/OverlayDiv/components/ProjectPage/index.js
+++ b/packages/web-frontend/src/containers/OverlayDiv/components/ProjectPage/index.js
@@ -45,7 +45,7 @@ const ExploreButton = styled(Button)`
   }
 `;
 
-const renderProjectsWithFilter = (projects, accessType, action, actionText) => {
+export const renderProjectsWithFilter = (projects, accessType, action, actionText) => {
   const hasPendingType = accessType === 'pending';
   const hasAccessType = hasPendingType ? false : accessType;
   return projects

--- a/packages/web-frontend/src/containers/OverlayDiv/components/RequestProjectAccessDialog.js
+++ b/packages/web-frontend/src/containers/OverlayDiv/components/RequestProjectAccessDialog.js
@@ -27,6 +27,7 @@ import {
 import { LANDING } from '../constants';
 import { TUPAIA_LIGHT_LOGO_SRC } from '../../../constants';
 import { BLUE, WHITE, GREY } from '../../../styles';
+import { useCustomLandingPages } from '../../../screens/LandingPage/useCustomLandingPages';
 
 const leftPadding = '40px';
 
@@ -196,6 +197,7 @@ export const RequestProjectAccessComponent = React.memo(
     success,
     errorMessage,
   }) => {
+    const { isCustomLandingPage } = useCustomLandingPages();
     const requestedCountries = countries.filter(c => c.accessRequests.includes(project.code));
     const availableCountries = countries.filter(c => !c.accessRequests.includes(project.code));
 
@@ -204,15 +206,42 @@ export const RequestProjectAccessComponent = React.memo(
       hideForm = true;
 
     const modalMessage = success ? (
-      <SuccessMessage projectName={project.name} onBackToProjects={onBackToProjects} />
+      <>
+        <Alert severity="success">
+          Thank you for your access request to {project.name}. We will review your application and
+          respond by email shortly.
+        </Alert>
+        <Note>
+          Note: This can take some time to process, as requests require formal permission to be
+          granted.
+        </Note>
+        {!isCustomLandingPage && (
+          <BackButton onClick={onBackToProjects}>Back to Projects</BackButton>
+        )}
+      </>
     ) : (
-      <RequestPendingMessage
-        requestedCountries={requestedCountries}
-        availableCountries={availableCountries}
-        setRequestingAdditionalCountryAccess={setRequestingAdditionalCountryAccess}
-        handleRequest={onRequestProjectAdditionalAccess}
-        onBackToProjects={onBackToProjects}
-      />
+      <>
+        <p>
+          <b>You have already requested access to this project</b>
+        </p>
+        <RequestedProjectCountryAccessList
+          requestedCountries={requestedCountries}
+          availableCountries={availableCountries}
+          handleRequest={onRequestProjectAdditionalAccess}
+        />
+        <p>
+          This can take some time to process, as requests require formal permission to be granted.
+        </p>
+        <p>
+          {`If you have any questions, please email: `}
+          <a style={styles.contactLink} href="mailto:admin@tupaia.org">
+            admin@tupaia.org
+          </a>
+        </p>
+        {!isCustomLandingPage && (
+          <BackButton onClick={onBackToProjects}>Back to Projects</BackButton>
+        )}
+      </>
     );
 
     return (
@@ -225,10 +254,12 @@ export const RequestProjectAccessComponent = React.memo(
               world
             </TagLine>
           </div>
-          <ExploreButton onClick={onBackToProjects} variant="outlined">
-            <ExploreIcon />
-            &nbsp; View other projects
-          </ExploreButton>
+          {!isCustomLandingPage && (
+            <ExploreButton onClick={onBackToProjects} variant="outlined">
+              <ExploreIcon />
+              &nbsp; View other projects
+            </ExploreButton>
+          )}
         </Header>
         <Title>Requesting Project Access</Title>
         <HeroImage src={project.imageUrl}>
@@ -280,45 +311,6 @@ export const RequestProjectAccessComponent = React.memo(
   },
 );
 
-export const SuccessMessage = ({ projectName, onBackToProjects }) => (
-  <>
-    <Alert severity="success">
-      Thank you for your access request to {projectName}. We will review your application and
-      respond by email shortly.
-    </Alert>
-    <Note>
-      Note: This can take some time to process, as requests require formal permission to be granted.
-    </Note>
-    <BackButton onClick={onBackToProjects}>Back to Projects</BackButton>
-  </>
-);
-
-export const RequestPendingMessage = ({
-  requestedCountries,
-  availableCountries,
-  handleRequest,
-  onBackToProjects,
-}) => (
-  <>
-    <p>
-      <b>You have already requested access to this project</b>
-    </p>
-    <RequestedProjectCountryAccessList
-      requestedCountries={requestedCountries}
-      availableCountries={availableCountries}
-      handleRequest={handleRequest}
-    />
-    <p>This can take some time to process, as requests require formal permission to be granted.</p>
-    <p>
-      {`If you have any questions, please email: `}
-      <a style={styles.contactLink} href="mailto:admin@tupaia.org">
-        admin@tupaia.org
-      </a>
-    </p>
-    <BackButton onClick={onBackToProjects}>Back to Projects</BackButton>
-  </>
-);
-
 export const RequestedProjectCountryAccessList = ({
   requestedCountries,
   availableCountries,
@@ -341,22 +333,10 @@ export const RequestedProjectCountryAccessList = ({
   );
 };
 
-SuccessMessage.propTypes = {
-  projectName: PropTypes.string.isRequired,
-  onBackToProjects: PropTypes.func.isRequired,
-};
-
 RequestedProjectCountryAccessList.propTypes = {
   requestedCountries: PropTypes.arrayOf(PropTypes.object).isRequired,
   availableCountries: PropTypes.arrayOf(PropTypes.object).isRequired,
   handleRequest: PropTypes.func.isRequired,
-};
-
-RequestPendingMessage.propTypes = {
-  requestedCountries: PropTypes.arrayOf(PropTypes.object).isRequired,
-  availableCountries: PropTypes.arrayOf(PropTypes.object).isRequired,
-  handleRequest: PropTypes.func.isRequired,
-  onBackToProjects: PropTypes.func.isRequired,
 };
 
 RequestProjectAccessComponent.propTypes = {

--- a/packages/web-frontend/src/containers/UserBar/index.js
+++ b/packages/web-frontend/src/containers/UserBar/index.js
@@ -92,14 +92,16 @@ export class UserBar extends Component {
   }
 
   renderDialog() {
-    const { isDialogVisible, onCloseUserDialog } = this.props;
+    const { isDialogVisible, onCloseUserDialog, dialogPage } = this.props;
     const width = this.getWidth();
+    // Don't let the user close a dialog if it is a password reset form as the one time login token
+    // is used to load the form and so they need to do the password reset now */
     return (
       <Dialog
         open={isDialogVisible}
         style={{ zIndex: 1301 }}
         PaperProps={{ style: { ...styles.dialogBody, width, maxWidth: width } }}
-        onClose={() => onCloseUserDialog()}
+        onClose={dialogPage === DIALOG_PAGE_RESET_PASSWORD ? null : onCloseUserDialog}
         ref={dialog => {
           this.dialog = dialog;
         }}

--- a/packages/web-frontend/src/screens/LandingPage/LandingPage.js
+++ b/packages/web-frontend/src/screens/LandingPage/LandingPage.js
@@ -77,6 +77,7 @@ const Footer = styled.div`
 `;
 
 export const LandingPage = () => {
+  console.log('landing...');
   const { projects, navigateToProject, navigateToRequestProjectAccess } = useProjects();
 
   const { isUserLoggedIn, currentUserUsername, navigateToLogin, navigateToLogout } = useAuth();

--- a/packages/web-frontend/src/screens/LandingPage/LandingPage.js
+++ b/packages/web-frontend/src/screens/LandingPage/LandingPage.js
@@ -9,10 +9,11 @@ import MuiContainer from '@material-ui/core/Container';
 import Box from '@material-ui/core/Box';
 import Typography from '@material-ui/core/Typography';
 import Button from '@material-ui/core/Button';
-import { useAuth } from './useAuth';
 import OverlayDiv from '../../containers/OverlayDiv';
-import { useProjects } from './useProjects';
+import { useAuth } from './useAuth';
+import { useNavigation } from './useNavigation';
 import { renderProjectsWithFilter } from '../../containers/OverlayDiv/components/ProjectPage';
+import { useCustomLandingPages } from './useCustomLandingPages';
 
 const Wrapper = styled.div`
   position: relative;
@@ -47,10 +48,6 @@ const Title = styled(Typography)`
   color: white;
   text-shadow: 1px 1px #333;
   max-width: 480px;
-
-  ${props => props.theme.breakpoints.down('sm')} {
-    line-height: 1.4;
-  }
 `;
 
 const NavBar = styled.div`
@@ -77,10 +74,14 @@ const Footer = styled.div`
 `;
 
 export const LandingPage = () => {
-  console.log('landing...');
-  const { projects, navigateToProject, navigateToRequestProjectAccess } = useProjects();
-
-  const { isUserLoggedIn, currentUserUsername, navigateToLogin, navigateToLogout } = useAuth();
+  const {
+    navigateToProject,
+    navigateToRequestProjectAccess,
+    navigateToLogin,
+    navigateToLogout,
+  } = useNavigation();
+  const { projects } = useCustomLandingPages();
+  const { isUserLoggedIn, currentUserUsername } = useAuth();
 
   const projectsWithAccess = renderProjectsWithFilter(
     projects,
@@ -118,7 +119,7 @@ export const LandingPage = () => {
           <Button onClick={navigateToLogout}>Logout</Button>
         ) : (
           <div>
-            <Button>Register</Button>
+            <Button onClick={navigateToLogin}>Register</Button>
             <Button onClick={navigateToLogin}>Login</Button>
           </div>
         )}

--- a/packages/web-frontend/src/screens/LandingPage/LandingPage.js
+++ b/packages/web-frontend/src/screens/LandingPage/LandingPage.js
@@ -1,6 +1,6 @@
 /*
- * Tupaia
- *  Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ * This is just a place holder Landing Page template. The actual landing page template will be
+ * developed in another ticket. @see waitp-1189
  */
 
 import React from 'react';
@@ -127,6 +127,8 @@ export const LandingPage = () => {
           <Footer />
         </Container>
       </Wrapper>
+      {/* Include the OverlayDiv so that the loging and logout functionality is available on the */}
+      {/* custom landing pages */}
       <OverlayDiv />
     </>
   );

--- a/packages/web-frontend/src/screens/LandingPage/LandingPage.js
+++ b/packages/web-frontend/src/screens/LandingPage/LandingPage.js
@@ -12,7 +12,7 @@ import Button from '@material-ui/core/Button';
 import OverlayDiv from '../../containers/OverlayDiv';
 import { useAuth } from './useAuth';
 import { useNavigation } from './useNavigation';
-import { renderProjectsWithFilter } from '../../containers/OverlayDiv/components/ProjectPage';
+import { ProjectCardList } from '../../containers/OverlayDiv/components/ProjectPage/ProjectCardList';
 import { useCustomLandingPages } from './useCustomLandingPages';
 
 const Wrapper = styled.div`
@@ -83,29 +83,6 @@ export const LandingPage = () => {
   const { projects } = useCustomLandingPages();
   const { isUserLoggedIn, currentUserUsername } = useAuth();
 
-  const projectsWithAccess = renderProjectsWithFilter(
-    projects,
-    true,
-    navigateToProject,
-    'View project',
-  );
-
-  const projectsPendingAccess = renderProjectsWithFilter(
-    projects,
-    'pending',
-    navigateToRequestProjectAccess,
-    'Approval in progress',
-  );
-
-  const noAccessAction = isUserLoggedIn ? navigateToRequestProjectAccess : navigateToLogin;
-  const noAccessText = isUserLoggedIn ? 'Request access' : 'Log in';
-  const projectsWithoutAccess = renderProjectsWithFilter(
-    projects,
-    false,
-    noAccessAction,
-    noAccessText,
-  );
-
   return (
     <>
       <NavBar>
@@ -128,9 +105,24 @@ export const LandingPage = () => {
         <Container maxWidth={false}>
           <Title variant="h1">Select a project below to view.</Title>
           <Projects>
-            {projectsWithAccess}
-            {projectsPendingAccess}
-            {projectsWithoutAccess}
+            <ProjectCardList
+              projects={projects}
+              accessType
+              action={navigateToProject}
+              actionText="View project"
+            />
+            <ProjectCardList
+              projects={projects}
+              accessType="pending"
+              action={navigateToRequestProjectAccess}
+              actionText="Approval in progress"
+            />
+            <ProjectCardList
+              projects={projects}
+              accessType={false}
+              action={isUserLoggedIn ? navigateToRequestProjectAccess : navigateToLogin}
+              actionText={isUserLoggedIn ? 'Request access' : 'Log in'}
+            />
           </Projects>
           <Footer />
         </Container>

--- a/packages/web-frontend/src/screens/LandingPage/LandingPage.js
+++ b/packages/web-frontend/src/screens/LandingPage/LandingPage.js
@@ -127,7 +127,7 @@ export const LandingPage = () => {
           <Footer />
         </Container>
       </Wrapper>
-      {/* Include the OverlayDiv so that the loging and logout functionality is available on the */}
+      {/* Include the OverlayDiv so that the login and logout functionality is available on the */}
       {/* custom landing pages */}
       <OverlayDiv />
     </>

--- a/packages/web-frontend/src/screens/LandingPage/LandingPage.js
+++ b/packages/web-frontend/src/screens/LandingPage/LandingPage.js
@@ -1,0 +1,139 @@
+/*
+ * Tupaia
+ *  Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+
+import React from 'react';
+import styled from 'styled-components';
+import MuiContainer from '@material-ui/core/Container';
+import Box from '@material-ui/core/Box';
+import Typography from '@material-ui/core/Typography';
+import Button from '@material-ui/core/Button';
+import { useAuth } from './useAuth';
+import OverlayDiv from '../../containers/OverlayDiv';
+import { useProjects } from './useProjects';
+import { renderProjectsWithFilter } from '../../containers/OverlayDiv/components/ProjectPage';
+
+const Wrapper = styled.div`
+  position: relative;
+  background-size: cover;
+  background-position: center;
+`;
+
+const Container = styled(MuiContainer)`
+  position: relative;
+  min-height: calc(100vh - 75px);
+  background-color: #bfbfbf;
+  padding-left: 50px;
+  padding-right: 50px;
+  padding-top: 5%;
+`;
+
+const Projects = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  column-gap: 50px;
+  margin: 0 auto;
+  max-width: 1200px;
+  padding-top: 10%;
+`;
+
+const Title = styled(Typography)`
+  font-style: normal;
+  font-weight: 600;
+  font-size: 2rem;
+  line-height: 3rem;
+  margin-bottom: 1.8rem;
+  color: white;
+  text-shadow: 1px 1px #333;
+  max-width: 480px;
+
+  ${props => props.theme.breakpoints.down('sm')} {
+    line-height: 1.4;
+  }
+`;
+
+const NavBar = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  background: #0f3150;
+  color: white;
+  height: 75px;
+  padding: 0 30px;
+
+  button {
+    margin-right: 15px;
+  }
+`;
+
+const Footer = styled.div`
+  position: absolute;
+  bottom: 0;
+  left: 50px;
+  right: 50px;
+  border-top: 1px solid white;
+  height: 75px;
+`;
+
+export const LandingPage = () => {
+  const { projects, navigateToProject, navigateToRequestProjectAccess } = useProjects();
+
+  const { isUserLoggedIn, currentUserUsername, navigateToLogin, navigateToLogout } = useAuth();
+
+  const projectsWithAccess = renderProjectsWithFilter(
+    projects,
+    true,
+    navigateToProject,
+    'View project',
+  );
+
+  const projectsPendingAccess = renderProjectsWithFilter(
+    projects,
+    'pending',
+    navigateToRequestProjectAccess,
+    'Approval in progress',
+  );
+
+  const noAccessAction = isUserLoggedIn ? navigateToRequestProjectAccess : navigateToLogin;
+  const noAccessText = isUserLoggedIn ? 'Request access' : 'Log in';
+  const projectsWithoutAccess = renderProjectsWithFilter(
+    projects,
+    false,
+    noAccessAction,
+    noAccessText,
+  );
+
+  return (
+    <>
+      <NavBar>
+        {currentUserUsername && (
+          <Box mr={3}>
+            {currentUserUsername}
+            <span style={{ marginLeft: 30 }}>|</span>
+          </Box>
+        )}
+        {isUserLoggedIn ? (
+          <Button onClick={navigateToLogout}>Logout</Button>
+        ) : (
+          <div>
+            <Button>Register</Button>
+            <Button onClick={navigateToLogin}>Login</Button>
+          </div>
+        )}
+      </NavBar>
+      <Wrapper>
+        <Container maxWidth={false}>
+          <Title variant="h1">Select a project below to view.</Title>
+          <Projects>
+            {projectsWithAccess}
+            {projectsPendingAccess}
+            {projectsWithoutAccess}
+          </Projects>
+          <Footer />
+        </Container>
+      </Wrapper>
+      <OverlayDiv />
+    </>
+  );
+};

--- a/packages/web-frontend/src/screens/LandingPage/index.js
+++ b/packages/web-frontend/src/screens/LandingPage/index.js
@@ -1,0 +1,6 @@
+/*
+ * Tupaia
+ *  Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+export { LandingPage } from './LandingPage';

--- a/packages/web-frontend/src/screens/LandingPage/useAuth.js
+++ b/packages/web-frontend/src/screens/LandingPage/useAuth.js
@@ -6,7 +6,5 @@
 import { useSelector } from 'react-redux';
 
 export const useAuth = () => {
-  const authentication = useSelector(state => state.authentication);
-
-  return { ...authentication };
+  return useSelector(state => state.authentication);
 };

--- a/packages/web-frontend/src/screens/LandingPage/useAuth.js
+++ b/packages/web-frontend/src/screens/LandingPage/useAuth.js
@@ -1,0 +1,23 @@
+/*
+ * Tupaia
+ *  Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+import { useDispatch, useSelector } from 'react-redux';
+import { attemptUserLogout, setOverlayComponent } from '../../actions';
+import { LANDING } from '../../containers/OverlayDiv/constants';
+
+export const useAuth = () => {
+  const dispatch = useDispatch();
+
+  const authentication = useSelector(state => state.authentication);
+  const navigateToLogin = () => {
+    dispatch(setOverlayComponent(LANDING));
+  };
+
+  const navigateToLogout = () => {
+    dispatch(attemptUserLogout());
+  };
+
+  return { ...authentication, navigateToLogin, navigateToLogout };
+};

--- a/packages/web-frontend/src/screens/LandingPage/useAuth.js
+++ b/packages/web-frontend/src/screens/LandingPage/useAuth.js
@@ -3,21 +3,10 @@
  *  Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
  */
 
-import { useDispatch, useSelector } from 'react-redux';
-import { attemptUserLogout, setOverlayComponent } from '../../actions';
-import { LANDING } from '../../containers/OverlayDiv/constants';
+import { useSelector } from 'react-redux';
 
 export const useAuth = () => {
-  const dispatch = useDispatch();
-
   const authentication = useSelector(state => state.authentication);
-  const navigateToLogin = () => {
-    dispatch(setOverlayComponent(LANDING));
-  };
 
-  const navigateToLogout = () => {
-    dispatch(attemptUserLogout());
-  };
-
-  return { ...authentication, navigateToLogin, navigateToLogout };
+  return { ...authentication };
 };

--- a/packages/web-frontend/src/screens/LandingPage/useCustomLandingPages.js
+++ b/packages/web-frontend/src/screens/LandingPage/useCustomLandingPages.js
@@ -5,6 +5,7 @@
 
 import { useSelector } from 'react-redux';
 
+// This will need to be replace with real data when it's ready. @see waitp-1195
 const customLandingPages = [
   {
     name: 'Fiji',

--- a/packages/web-frontend/src/screens/LandingPage/useCustomLandingPages.js
+++ b/packages/web-frontend/src/screens/LandingPage/useCustomLandingPages.js
@@ -5,7 +5,7 @@
 
 import { useSelector } from 'react-redux';
 
-// This will need to be replace with real data when it's ready. @see waitp-1195
+// This will need to be replaced with real data when it's ready. @see waitp-1195
 const customLandingPages = [
   {
     name: 'Fiji',

--- a/packages/web-frontend/src/screens/LandingPage/useCustomLandingPages.js
+++ b/packages/web-frontend/src/screens/LandingPage/useCustomLandingPages.js
@@ -1,0 +1,36 @@
+/*
+ * Tupaia
+ *  Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+import { useSelector } from 'react-redux';
+
+const customLandingPages = [
+  {
+    name: 'Fiji',
+    urlSegment: 'landing-page-fiji',
+    projects: ['wish', 'fanafana', 'unfpa'],
+  },
+];
+
+function getLandingPage(pathname) {
+  const urlSegment = pathname.substring(1);
+  return customLandingPages.find(page => page.urlSegment === urlSegment);
+}
+
+function getLandingPageProjects(landingPage, projects) {
+  if (!landingPage) {
+    return [];
+  }
+  return projects.filter(project => landingPage.projects.includes(project.code));
+}
+export const useCustomLandingPages = () => {
+  const pathname = useSelector(state => state.routing.pathname);
+  const projectData = useSelector(({ project }) => project?.projects || []);
+  const customLandingPage = getLandingPage(pathname);
+
+  return {
+    isCustomLandingPage: !!customLandingPage,
+    projects: getLandingPageProjects(customLandingPage, projectData),
+  };
+};

--- a/packages/web-frontend/src/screens/LandingPage/useNavigation.js
+++ b/packages/web-frontend/src/screens/LandingPage/useNavigation.js
@@ -1,0 +1,32 @@
+/*
+ * Tupaia
+ *  Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+import { useDispatch } from 'react-redux';
+import { setProject, setRequestingAccess } from '../../projects/actions';
+import { REQUEST_PROJECT_ACCESS, LANDING } from '../../containers/OverlayDiv/constants';
+import { attemptUserLogout, setOverlayComponent } from '../../actions';
+
+export const useNavigation = () => {
+  const dispatch = useDispatch();
+
+  const navigateToLogin = () => {
+    dispatch(setOverlayComponent(LANDING));
+  };
+
+  const navigateToLogout = () => {
+    dispatch(attemptUserLogout());
+  };
+
+  const navigateToRequestProjectAccess = project => {
+    dispatch(setRequestingAccess(project));
+    dispatch(setOverlayComponent(REQUEST_PROJECT_ACCESS));
+  };
+
+  const navigateToProject = project => {
+    dispatch(setProject(project.code));
+  };
+
+  return { navigateToLogin, navigateToLogout, navigateToProject, navigateToRequestProjectAccess };
+};

--- a/packages/web-frontend/src/screens/LandingPage/useProjects.js
+++ b/packages/web-frontend/src/screens/LandingPage/useProjects.js
@@ -1,0 +1,27 @@
+/*
+ * Tupaia
+ *  Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+import { useDispatch, useSelector } from 'react-redux';
+import { setProject, setRequestingAccess } from '../../projects/actions';
+import { setOverlayComponent } from '../../actions';
+import { REQUEST_PROJECT_ACCESS } from '../../containers/OverlayDiv/constants';
+
+const LANDING_PAGES = ['wish', 'fanafana', 'unfpa'];
+export const useProjects = () => {
+  const projectData = useSelector(({ project }) => project?.projects || []);
+  const dispatch = useDispatch();
+
+  const navigateToRequestProjectAccess = project => {
+    dispatch(setRequestingAccess(project));
+    dispatch(setOverlayComponent(REQUEST_PROJECT_ACCESS));
+  };
+
+  const navigateToProject = project => {
+    dispatch(setProject(project.code));
+  };
+
+  const projects = projectData.filter(p => LANDING_PAGES.includes(p.code));
+  return { navigateToProject, navigateToRequestProjectAccess, projects };
+};

--- a/packages/web-frontend/src/screens/desktop/RootScreen/MainPage.js
+++ b/packages/web-frontend/src/screens/desktop/RootScreen/MainPage.js
@@ -13,6 +13,7 @@ import { EnlargedDialog } from '../../../containers/EnlargedDialog';
 import SessionExpiredDialog from '../../../containers/SessionExpiredDialog';
 import OverlayDiv from '../../../containers/OverlayDiv';
 import { DIALOG_Z_INDEX } from '../../../styles';
+import { LandingPage } from '../../LandingPage';
 
 const Container = styled.div`
   position: fixed;
@@ -47,26 +48,32 @@ const MapContainer = styled.div`
   transition: width 0.5s ease;
 `;
 
-const MainPage = ({ enlargedDialogIsVisible, isLoading, sidePanelWidth }) => (
-  <>
-    {/* The order here matters, Map must be added to the DOM body after FlexContainer */}
-    <Container>
-      <EnvBanner />
-      <TopBar />
-      <ContentContainer>
-        <MapDiv />
-        <SidePanel />
-      </ContentContainer>
-      <OverlayDiv />
-      <SessionExpiredDialog />
-      {enlargedDialogIsVisible ? <EnlargedDialog /> : null}
-      <LoadingScreen isLoading={isLoading} />
-    </Container>
-    <MapContainer $rightOffset={sidePanelWidth}>
-      <Map />
-    </MapContainer>
-  </>
-);
+const MainPage = ({ enlargedDialogIsVisible, isLoading, sidePanelWidth, isLandingPage }) => {
+  if (isLandingPage) {
+    return <LandingPage />;
+  }
+
+  return (
+    <>
+      {/* The order here matters, Map must be added to the DOM body after FlexContainer */}
+      <Container>
+        <EnvBanner />
+        <TopBar />
+        <ContentContainer>
+          <MapDiv />
+          <SidePanel />
+        </ContentContainer>
+        <OverlayDiv />
+        <SessionExpiredDialog />
+        {enlargedDialogIsVisible ? <EnlargedDialog /> : null}
+        <LoadingScreen isLoading={isLoading} />
+      </Container>
+      <MapContainer $rightOffset={sidePanelWidth}>
+        <Map />
+      </MapContainer>
+    </>
+  );
+};
 
 MainPage.propTypes = {
   enlargedDialogIsVisible: PropTypes.bool,
@@ -79,11 +86,15 @@ MainPage.defaultProps = {
   isLoading: false,
 };
 
+const LANDING_PAGE_URL = 'landing-page';
+
 const mapStateToProps = state => {
   const { isSidePanelExpanded } = state.global;
   const { contractedWidth, expandedWidth } = state.dashboard;
+  const { pathname } = state.routing;
 
   return {
+    isLandingPage: pathname.substring(1) === LANDING_PAGE_URL,
     enlargedDialogIsVisible: !!selectIsEnlargedDialogVisible(state),
     isLoading: state.global.isLoadingOrganisationUnit,
     sidePanelWidth: isSidePanelExpanded ? expandedWidth : contractedWidth,

--- a/packages/web-frontend/src/screens/desktop/RootScreen/MainPage.js
+++ b/packages/web-frontend/src/screens/desktop/RootScreen/MainPage.js
@@ -14,6 +14,7 @@ import SessionExpiredDialog from '../../../containers/SessionExpiredDialog';
 import OverlayDiv from '../../../containers/OverlayDiv';
 import { DIALOG_Z_INDEX } from '../../../styles';
 import { LandingPage } from '../../LandingPage';
+import { useCustomLandingPages } from '../../LandingPage/useCustomLandingPages';
 
 const Container = styled.div`
   position: fixed;
@@ -48,8 +49,9 @@ const MapContainer = styled.div`
   transition: width 0.5s ease;
 `;
 
-const MainPage = ({ enlargedDialogIsVisible, isLoading, sidePanelWidth, isLandingPage }) => {
-  if (isLandingPage) {
+const MainPage = ({ enlargedDialogIsVisible, isLoading, sidePanelWidth }) => {
+  const { isCustomLandingPage } = useCustomLandingPages();
+  if (isCustomLandingPage) {
     return <LandingPage />;
   }
 
@@ -86,15 +88,11 @@ MainPage.defaultProps = {
   isLoading: false,
 };
 
-const LANDING_PAGE_URL = 'landing-page';
-
 const mapStateToProps = state => {
   const { isSidePanelExpanded } = state.global;
   const { contractedWidth, expandedWidth } = state.dashboard;
-  const { pathname } = state.routing;
 
   return {
-    isLandingPage: pathname.substring(1) === LANDING_PAGE_URL,
     enlargedDialogIsVisible: !!selectIsEnlargedDialogVisible(state),
     isLoading: state.global.isLoadingOrganisationUnit,
     sidePanelWidth: isSidePanelExpanded ? expandedWidth : contractedWidth,

--- a/packages/web-frontend/src/screens/desktop/RootScreen/index.js
+++ b/packages/web-frontend/src/screens/desktop/RootScreen/index.js
@@ -11,7 +11,6 @@
  */
 import React from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import { LandingPage } from '../../LandingPage';
 
 import MainPage from './MainPage';
 import PDFExportPage from './PDFExportPage';
@@ -24,7 +23,6 @@ const RootScreen = () => {
           path=":projectCode/:countryCode/:dashboardCode/:pdfExportType"
           element={<PDFExportPage />}
         />
-        <Route path="landing-page" element={<LandingPage />} />
         <Route path="*" element={<MainPage />} />
       </Routes>
     </BrowserRouter>

--- a/packages/web-frontend/src/screens/desktop/RootScreen/index.js
+++ b/packages/web-frontend/src/screens/desktop/RootScreen/index.js
@@ -11,6 +11,7 @@
  */
 import React from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { LandingPage } from '../../LandingPage';
 
 import MainPage from './MainPage';
 import PDFExportPage from './PDFExportPage';
@@ -23,6 +24,7 @@ const RootScreen = () => {
           path=":projectCode/:countryCode/:dashboardCode/:pdfExportType"
           element={<PDFExportPage />}
         />
+        <Route path="landing-page" element={<LandingPage />} />
         <Route path="*" element={<MainPage />} />
       </Routes>
     </BrowserRouter>


### PR DESCRIPTION
### Issue #: WAITP-1151: landing pages login

### Changes:

- Add mock Landing Page template (most of this doesn't need review) at top level of app
  - Included an additional OverlayDiv in the landing page to re-use login form etc
- Refactored the project card logic into a re-usable ProjectCardList component
- Added utils for navigating to login and logout routes in redux for ease of integration with the existing app
- Hide View Projects from LoginForm and Request Dialogs when it is a custom landing page

I still have to update the login button to stop it re-directing to the explore project. I didn't do that in this PR as it is a bit tricky.

