### PR TITLE
Waitp 1191 admin panel config elements

### DIFF
--- a/packages/admin-panel/src/pages/resources/CustomLandingPagesPage.js
+++ b/packages/admin-panel/src/pages/resources/CustomLandingPagesPage.js
@@ -1,0 +1,290 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { SECTION_FIELD_TYPE } from '../../editor/constants';
+import { ResourcePage } from './ResourcePage';
+import { ArrayFilter } from '../../table/columnTypes/columnFilters';
+import { prettyArray } from '../../utilities';
+
+const LANDING_PAGES_ENDPOINT = 'landingPages';
+
+// the URL prefix to display in the url_segment field
+const URL_PREFIX = `${window.location.origin
+  .replace('admin', 'www')
+  .replace(new RegExp('(https://)|(http://)'), '')}/`;
+
+// All the fields for create/edit of a custom landing page
+const FIELDS = [
+  {
+    type: SECTION_FIELD_TYPE,
+    fields: [
+      {
+        Header: 'Name',
+        source: 'name',
+        // this is to denote this field as a column in the table
+        isColumn: true,
+      },
+      {
+        Header: 'Add name to header title (optional)',
+        source: 'include_name_in_header',
+        editConfig: {
+          type: 'checkbox',
+          name: 'include_name_in_header',
+          // the value that will be sent to the server if the checkbox is checked
+          optionValue: true,
+          labelTooltip: 'Check this if your logo does not include a name',
+        },
+      },
+      {
+        Header: 'Custom link',
+        source: 'url_segment',
+        isColumn: true,
+        // this is to mark this field as being non-editable (disabled in edit mode)
+        updateDisabled: true,
+        // format the value to include the URL prefix in the table
+        Cell: ({ value }) => `${URL_PREFIX}${value}`,
+        editConfig: {
+          // the prefix to display in the field
+          startAdornment: URL_PREFIX,
+        },
+      },
+    ],
+  },
+  {
+    type: SECTION_FIELD_TYPE,
+    title: 'Add main image',
+    description: '(2000px x 2000px)',
+    fields: [
+      {
+        Header: 'Main image',
+        source: 'image_url',
+        editConfig: {
+          type: 'image',
+          avatarVariant: 'square',
+          deleteModal: {
+            title: 'Remove landing page image',
+            message: 'Are you sure you want to delete your image?',
+          },
+          maxHeight: 2000,
+          maxWidth: 2000,
+        },
+      },
+    ],
+  },
+  {
+    type: SECTION_FIELD_TYPE,
+    title: 'Add logo image',
+    description: '(800px x 800px)',
+    fields: [
+      {
+        Header: 'Logo image',
+        source: 'logo_url',
+        editConfig: {
+          type: 'image',
+          avatarVariant: 'square',
+          deleteModal: {
+            title: 'Remove logo image',
+            message: 'Are you sure you want to delete your image?',
+          },
+          maxHeight: 800,
+          maxWidth: 800,
+        },
+      },
+    ],
+  },
+  {
+    type: SECTION_FIELD_TYPE,
+    title: 'Primary colour',
+    description:
+      'This colour will be used for the header bar and other details. If no colour is specified a default colour will be applied.',
+    fields: [
+      {
+        Header: 'Primary colour hex code',
+        source: 'primary_hexcode',
+        editConfig: {
+          type: 'hexcode',
+        },
+      },
+    ],
+  },
+  {
+    title: 'Secondary colour',
+    description:
+      'This colour will be used for text and other accents. Please select the option that provides the most contrast to your primary colour. If no colour is specified a default colour will be applied.',
+    type: SECTION_FIELD_TYPE,
+    fields: [
+      {
+        Header: 'Secondary colour',
+        source: 'secondary_hexcode',
+        editConfig: {
+          type: 'radio',
+          name: 'secondary_hexcode',
+          options: [
+            {
+              label: 'White',
+              value: '#FFFFFF',
+            },
+            {
+              label: 'Black',
+              value: '#000000',
+            },
+          ],
+        },
+      },
+    ],
+  },
+  {
+    type: SECTION_FIELD_TYPE,
+    fields: [
+      {
+        Header: 'Extended title (max 60 characters)',
+        source: 'extended_title',
+        editConfig: {
+          maxLength: 60,
+          type: 'text',
+          placeholder: 'A short sentence about your project',
+        },
+      },
+      {
+        Header: 'Long bio (max 250 characters)',
+        source: 'long_bio',
+        editConfig: {
+          maxLength: 250,
+          type: 'textarea',
+          placeholder: 'A longer bio about your project',
+        },
+      },
+    ],
+  },
+  {
+    type: SECTION_FIELD_TYPE,
+    title: 'Contact information',
+    description: 'Add contact information you would like to show on the landing page.',
+    fields: [
+      {
+        Header: 'Phone',
+        source: 'phone_number',
+      },
+      {
+        Header: 'Website',
+        source: 'website_url',
+        editConfig: {
+          placeholder: 'www.example.com',
+        },
+      },
+    ],
+  },
+  {
+    type: SECTION_FIELD_TYPE,
+    title: 'External link',
+    description: 'Add an external link where users can learn more about your project',
+    fields: [
+      {
+        Header: 'URL',
+        source: 'external_link',
+        editConfig: {
+          placeholder: 'www.example.com',
+        },
+      },
+    ],
+  },
+  {
+    type: SECTION_FIELD_TYPE,
+    title: 'Project',
+    description: 'Enter project code below. You may enter multiple codes separated by a comma.',
+    fields: [
+      {
+        Header: 'Project code/s',
+        source: 'project_codes',
+        isColumn: true,
+        Filter: ArrayFilter,
+        Cell: ({ value }) => prettyArray(value),
+        editConfig: {
+          optionsEndpoint: 'projects',
+          optionLabelKey: 'code',
+          optionValueKey: 'code',
+          allowMultipleValues: true,
+        },
+      },
+    ],
+  },
+];
+
+const EDIT_FIELDS = FIELDS.reduce((result, item) => {
+  if (item.type === SECTION_FIELD_TYPE) {
+    return [
+      ...result,
+      {
+        ...item,
+        fields: item.fields.map(field => ({
+          ...field,
+          editConfig: {
+            ...(field.editConfig || {}),
+            editable: field.updateDisabled !== true,
+          },
+        })),
+      },
+    ];
+  }
+  return [
+    ...result,
+    {
+      ...item,
+      editConfig: {
+        ...(item.editConfig || {}),
+        editable: item.updateDisabled !== true,
+      },
+    },
+  ];
+}, []);
+
+// Only show fields that are marked as columns, plus the edit and delete buttons
+const COLUMNS = [
+  ...FIELDS.reduce((result, item) => {
+    if (item.type === SECTION_FIELD_TYPE) {
+      return [...result, ...item.fields.filter(field => field.isColumn)];
+    }
+    return item.isColumn ? [...result, item] : result;
+  }, []),
+  {
+    Header: 'Edit',
+    type: 'edit',
+    source: 'id',
+    actionConfig: {
+      title: 'Edit Landing page',
+      editEndpoint: LANDING_PAGES_ENDPOINT,
+      fields: EDIT_FIELDS,
+    },
+  },
+  {
+    Header: 'Delete',
+    source: 'id',
+    type: 'delete',
+    actionConfig: {
+      endpoint: LANDING_PAGES_ENDPOINT,
+    },
+  },
+];
+
+const CREATE_CONFIG = {
+  actionConfig: {
+    title: 'New landing page',
+    editEndpoint: LANDING_PAGES_ENDPOINT,
+    fields: FIELDS,
+  },
+};
+
+export const CustomLandingPagesPage = ({ getHeaderEl }) => {
+  return (
+    <ResourcePage
+      title="Landing Pages"
+      endpoint={LANDING_PAGES_ENDPOINT}
+      columns={COLUMNS}
+      getHeaderEl={getHeaderEl}
+      createConfig={CREATE_CONFIG}
+    />
+  );
+};
+
+CustomLandingPagesPage.propTypes = {
+  getHeaderEl: PropTypes.func.isRequired,
+};

--- a/packages/admin-panel/src/pages/resources/index.js
+++ b/packages/admin-panel/src/pages/resources/index.js
@@ -35,3 +35,4 @@ export { ProjectsPage } from './ProjectsPage';
 export { SyncGroupsPage } from './SyncGroupsPage';
 export { ExternalDatabaseConnectionsPage } from './ExternalDatabaseConnectionsPage';
 export { EntityHierarchyPage } from './EntityHierarchyPage';
+export { CustomLandingPagesPage } from './CustomLandingPagesPage';

--- a/packages/admin-panel/src/widgets/InputField/InputField.js
+++ b/packages/admin-panel/src/widgets/InputField/InputField.js
@@ -13,7 +13,7 @@ export const registerInputField = (type, Component) => {
 };
 
 const getInputType = ({ options, optionsEndpoint, type }) => {
-  if (options) {
+  if (options && type !== 'radio') {
     return 'enum';
   }
   if (optionsEndpoint) {

--- a/packages/admin-panel/src/widgets/InputField/registerInputFields.js
+++ b/packages/admin-panel/src/widgets/InputField/registerInputFields.js
@@ -6,6 +6,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import moment from 'moment';
+import { InputAdornment } from '@material-ui/core';
 import styled from 'styled-components';
 import {
   Button,
@@ -16,6 +17,7 @@ import {
   Select,
   ImageUploadField,
   HexcodeField,
+  Checkbox,
 } from '@tupaia/ui-components';
 import { stripTimezoneFromDate } from '@tupaia/utils';
 import { registerInputField } from './InputField';
@@ -42,6 +44,20 @@ const StyledLink = styled(Link)`
 
 const StyledFileInputWrapper = styled.div`
   margin-bottom: 1.2rem;
+`;
+
+// Handle styling of the checkbox for just the admin-panel so as not to overwrite styles of the checkbox used elsewhere
+export const StyledCheckboxWrapper = styled.div`
+  .MuiFormControlLabel-label {
+    font-size: 0.975rem;
+    color: ${props => props.theme.palette.text.secondary};
+  }
+  .MuiButtonBase-root:not(.MuiIconButton-colorPrimary) {
+    color: ${props => props.theme.palette.text.secondary};
+  }
+  .MuiSvgIcon-root {
+    font-size: 1.2rem;
+  }
 `;
 
 export const registerInputFields = () => {
@@ -212,6 +228,9 @@ export const registerInputFields = () => {
       type="textarea"
       rows="4"
       tooltip={props.labelTooltip}
+      placeholder={props.placeholder}
+      minLength={props.minLength}
+      maxLength={props.maxLength}
     />
   ));
   registerInputField('text', props => (
@@ -224,6 +243,14 @@ export const registerInputFields = () => {
       helperText={props.secondaryLabel}
       type={props.type}
       tooltip={props.labelTooltip}
+      placeholder={props.placeholder}
+      minLength={props.minLength}
+      maxLength={props.maxLength}
+      InputProps={{
+        startAdornment: props.startAdornment ? (
+          <InputAdornment position="start">{props.startAdornment}</InputAdornment>
+        ) : null,
+      }}
     />
   ));
   registerInputField('password', props => (
@@ -265,6 +292,34 @@ export const registerInputFields = () => {
       disabled={props.disabled}
       helperText={props.secondaryLabel}
       tooltip={props.labelTooltip}
+    />
+  ));
+  registerInputField('checkbox', props => (
+    <StyledCheckboxWrapper>
+      <Checkbox
+        id={props.id}
+        label={props.label}
+        checked={props.value || false}
+        value={props.optionValue}
+        onChange={e => props.onChange(props.inputKey, e.target.checked ? props.optionValue : null)}
+        disabled={props.disabled}
+        helperText={props.secondaryLabel}
+        tooltip={props.labelTooltip}
+        color="secondary"
+      />
+    </StyledCheckboxWrapper>
+  ));
+  registerInputField('radio', props => (
+    <RadioGroup
+      id={props.id}
+      label={props.label}
+      onChange={event => props.onChange(props.inputKey, event.target.value)} // convert to boolean value
+      options={props.options}
+      value={props.value}
+      disabled={props.disabled}
+      helperText={props.secondaryLabel}
+      tooltip={props.labelTooltip}
+      name={props.name}
     />
   ));
 };

--- a/packages/ui-components/src/components/Inputs/RadioGroup.js
+++ b/packages/ui-components/src/components/Inputs/RadioGroup.js
@@ -9,7 +9,7 @@ import MuiRadio from '@material-ui/core/Radio';
 import MuiRadioGroup from '@material-ui/core/RadioGroup';
 import MuiFormControlLabel from '@material-ui/core/FormControlLabel';
 import MuiFormControl from '@material-ui/core/FormControl';
-import MuiFormLabel from '@material-ui/core/FormLabel';
+import FormHelperText from '@material-ui/core/FormHelperText';
 import { InputLabel } from './InputLabel';
 
 const FormControl = styled(MuiFormControl)`
@@ -17,13 +17,13 @@ const FormControl = styled(MuiFormControl)`
   margin-bottom: 1.2rem;
 `;
 
-const FormLabel = styled(MuiFormLabel)`
+const Legend = styled.legend`
   position: relative;
   font-size: 0.9375rem;
   line-height: 1.125rem;
   margin-bottom: 0.25rem;
   color: ${props => props.theme.palette.text.secondary};
-
+  padding-inline-start: 0;
   &.Mui-focused {
     color: ${props => props.theme.palette.text.secondary};
   }
@@ -78,13 +78,21 @@ export const RadioGroup = ({
   valueKey,
   tooltipKey,
   tooltip,
+  helperText,
 }) => (
   <FormControl component="fieldset" className={className} color="primary">
-    <InputLabel as={FormLabel} label={label} tooltip={tooltip} />
-    <StyledRadioGroup aria-label={name} name={name} value={value} onChange={onChange}>
+    <InputLabel as={Legend} label={label} tooltip={tooltip} />
+    {helperText && <FormHelperText id={`${name}-helperText`}>{helperText}</FormHelperText>}
+    <StyledRadioGroup name={name} value={value} onChange={onChange}>
       {options.map(option => (
         <FormControlLabel
-          control={<Radio />}
+          control={
+            <Radio
+              InputProps={{
+                'aria-describedby': helperText ? `${name}-helperText` : null,
+              }}
+            />
+          }
           key={option[valueKey].toString()}
           value={option[valueKey]}
           label={<InputLabel label={option[labelKey]} tooltip={option[tooltipKey]} />}
@@ -105,6 +113,7 @@ RadioGroup.propTypes = {
   valueKey: PropTypes.string,
   tooltipKey: PropTypes.string,
   tooltip: PropTypes.string,
+  helperText: PropTypes.string,
 };
 
 RadioGroup.defaultProps = {
@@ -114,4 +123,5 @@ RadioGroup.defaultProps = {
   valueKey: 'value',
   tooltipKey: 'tooltip',
   tooltip: '',
+  helperText: '',
 };

--- a/packages/ui-components/src/components/Inputs/TextField.js
+++ b/packages/ui-components/src/components/Inputs/TextField.js
@@ -8,6 +8,7 @@ import MuiTextField from '@material-ui/core/TextField';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { InputLabel } from './InputLabel';
+import { InputAdornment } from '@material-ui/core';
 
 const FOCUS_COLOUR = '#99d6ff';
 const ADORNMENT_COLOUR = '#c4c4c7';
@@ -98,6 +99,9 @@ const StyledTextField = styled(MuiTextField)`
 
   .MuiInputAdornment-positionStart {
     margin-right: 0;
+    .MuiTypography-body1 {
+      padding-left: 0.5rem;
+    }
   }
 
   .MuiInputBase-inputAdornedStart,


### PR DESCRIPTION
### Issue WAITP-1191: Create admin panel config elements

### Changes:
- Amend the `RadioGroup` component to handle `helperText` prop
- Update styling of `startAdornment` text in `TextField`
- Add `radio` and `checkbox` field types to `registerInputFields` for use in admin panel
- Add other props for validation and `placeholder` to `text` and `textarea` input types
- Create and configure the page for Custom landing pages 
- 
### Notes
- The tab has not been added to `Projects` as yet, because there is another ticket for this
- The endpoint has not yet been created and the schema is not finalised, so some details may change, however these will be easy to update in `CustomLandingPagesPage.js`

### Screenshots:
![Screen Shot 2023-05-02 at 2 57 32 pm](https://user-images.githubusercontent.com/129009580/235570286-51728696-5af7-4eb0-93f8-d042b029883f.png)
