### PR TITLE
Waitp 1185 landing pages tab

### DIFF
--- a/packages/admin-panel/src/pages/resources/CustomLandingPagesPage.js
+++ b/packages/admin-panel/src/pages/resources/CustomLandingPagesPage.js
@@ -13,260 +13,242 @@ const URL_PREFIX = window.location.origin.replace('admin', 'www');
 
 const DISPLAY_URL_PREFIX = `${URL_PREFIX.replace(new RegExp('(https://)|(http://)'), '')}/`;
 
-// All the fields for create/edit of a custom landing page
-const FIELDS = [
-  {
-    type: SECTION_FIELD_TYPE,
-    fields: [
-      {
-        Header: 'Name',
-        source: 'name',
-        // this is to denote this field as a column in the table
-        column: {
-          // sets what order to put the column in the table
-          sortOrder: 0,
-        },
-      },
-      {
-        Header: 'Add name to header title (optional)',
-        source: 'include_name_in_header',
-        editConfig: {
-          type: 'checkbox',
-          name: 'include_name_in_header',
-          // the value that will be sent to the server if the checkbox is checked
-          optionValue: true,
-          labelTooltip: 'Check this if your logo does not include a name',
-        },
-      },
-      {
-        Header: 'Custom link',
-        source: 'url_segment',
-        isColumn: true,
-        // this is to mark this field as being non-editable (disabled in edit mode)
-        updateDisabled: true,
-        column: {
-          sortOrder: 2,
-        },
-        // format the value to include the URL prefix in the table, and display as a clickable link
-        // eslint-disable-next-line react/prop-types
-        Cell: ({ value }) => (
-          <Link
-            href={`${URL_PREFIX}/${value}`}
-            target="_blank"
-          >{`${DISPLAY_URL_PREFIX}${value}`}</Link>
-        ),
-        editConfig: {
-          // the prefix to display in the field
-          startAdornment: DISPLAY_URL_PREFIX,
-        },
-      },
-    ],
+// All the fields of a custom landing page
+const FIELDS = {
+  NAME: {
+    Header: 'Name',
+    source: 'name',
   },
-  {
+  NAME_HEADER: {
+    Header: 'Add name to header title (optional)',
+    source: 'include_name_in_header',
+    editConfig: {
+      type: 'checkbox',
+      name: 'include_name_in_header',
+      // the value that will be sent to the server if the checkbox is checked
+      optionValue: true,
+      labelTooltip: 'Check this if your logo does not include a name',
+    },
+  },
+  URL_SEGMENT: {
+    Header: 'Custom link',
+    source: 'url_segment',
+    // format the value to include the URL prefix in the table, and display as a clickable link
+    // eslint-disable-next-line react/prop-types
+    Cell: ({ value }) => (
+      <Link href={`${URL_PREFIX}/${value}`} target="_blank">{`${DISPLAY_URL_PREFIX}${value}`}</Link>
+    ),
+    editConfig: {
+      // the prefix to display in the field
+      startAdornment: DISPLAY_URL_PREFIX,
+    },
+  },
+  IMAGE: {
+    Header: 'Main image',
+    source: 'image_url',
+    editConfig: {
+      type: 'image',
+      avatarVariant: 'square',
+      deleteModal: {
+        title: 'Remove landing page image',
+        message: 'Are you sure you want to delete your image?',
+      },
+      maxHeight: 2000,
+      maxWidth: 2000,
+    },
+  },
+  LOGO: {
+    Header: 'Logo image',
+    source: 'logo_url',
+    editConfig: {
+      type: 'image',
+      avatarVariant: 'square',
+      deleteModal: {
+        title: 'Remove logo image',
+        message: 'Are you sure you want to delete your image?',
+      },
+      maxHeight: 800,
+      maxWidth: 800,
+    },
+  },
+  PRIMARY_COLOR: {
+    Header: 'Primary colour hex code',
+    source: 'primary_hexcode',
+    editConfig: {
+      type: 'hexcode',
+    },
+  },
+  SECONDARY_COLOR: {
+    Header: 'Secondary colour',
+    source: 'secondary_hexcode',
+    editConfig: {
+      type: 'radio',
+      name: 'secondary_hexcode',
+      options: [
+        {
+          label: 'White',
+          value: '#FFFFFF',
+        },
+        {
+          label: 'Black',
+          value: '#000000',
+        },
+      ],
+    },
+  },
+  EXTENDED_TITLE: {
+    Header: 'Extended title (max 60 characters)',
+    source: 'extended_title',
+    editConfig: {
+      maxLength: 60,
+      type: 'text',
+      placeholder: 'A short sentence about your project',
+    },
+  },
+  LONG_BIO: {
+    Header: 'Long bio (max 250 characters)',
+    source: 'long_bio',
+    editConfig: {
+      maxLength: 250,
+      type: 'textarea',
+      placeholder: 'A longer bio about your project',
+    },
+  },
+  PHONE_NUMBER: {
+    Header: 'Phone',
+    source: 'phone_number',
+  },
+  WEBSITE_URL: {
+    Header: 'Website',
+    source: 'website_url',
+    editConfig: {
+      placeholder: 'www.example.com',
+    },
+  },
+  EXTERNAL_LINK: {
+    Header: 'URL',
+    source: 'external_link',
+    editConfig: {
+      placeholder: 'www.example.com',
+    },
+  },
+  PROJECTS: {
+    Header: 'Project code/s',
+    source: 'project_codes',
+    Filter: ArrayFilter,
+    Cell: ({ value }) => prettyArray(value),
+    editConfig: {
+      optionsEndpoint: 'projects',
+      optionLabelKey: 'code',
+      optionValueKey: 'code',
+      allowMultipleValues: true,
+    },
+  },
+};
+
+// All the sections
+const SECTIONS = {
+  DETAILS: {
+    type: SECTION_FIELD_TYPE,
+    fields: [FIELDS.NAME, FIELDS.NAME_HEADER, FIELDS.URL_SEGMENT],
+  },
+  MAIN_IMAGE: {
     type: SECTION_FIELD_TYPE,
     title: 'Add main image',
     description: '(2000px x 2000px)',
-    fields: [
-      {
-        Header: 'Main image',
-        source: 'image_url',
-        editConfig: {
-          type: 'image',
-          avatarVariant: 'square',
-          deleteModal: {
-            title: 'Remove landing page image',
-            message: 'Are you sure you want to delete your image?',
-          },
-          maxHeight: 2000,
-          maxWidth: 2000,
-        },
-      },
-    ],
+    fields: [FIELDS.IMAGE],
   },
-  {
+  LOGO: {
     type: SECTION_FIELD_TYPE,
     title: 'Add logo image',
     description: '(800px x 800px)',
-    fields: [
-      {
-        Header: 'Logo image',
-        source: 'logo_url',
-        editConfig: {
-          type: 'image',
-          avatarVariant: 'square',
-          deleteModal: {
-            title: 'Remove logo image',
-            message: 'Are you sure you want to delete your image?',
-          },
-          maxHeight: 800,
-          maxWidth: 800,
-        },
-      },
-    ],
+    fields: [FIELDS.LOGO],
   },
-  {
+  PRIMARY_COLOR: {
     type: SECTION_FIELD_TYPE,
     title: 'Primary colour',
     description:
       'This colour will be used for the header bar and other details. If no colour is specified a default colour will be applied.',
-    fields: [
-      {
-        Header: 'Primary colour hex code',
-        source: 'primary_hexcode',
-        editConfig: {
-          type: 'hexcode',
-        },
-      },
-    ],
+    fields: [FIELDS.PRIMARY_COLOR],
   },
-  {
+  SECONDARY_COLOR: {
     title: 'Secondary colour',
     description:
       'This colour will be used for text and other accents. Please select the option that provides the most contrast to your primary colour. If no colour is specified a default colour will be applied.',
     type: SECTION_FIELD_TYPE,
-    fields: [
-      {
-        Header: 'Secondary colour',
-        source: 'secondary_hexcode',
-        editConfig: {
-          type: 'radio',
-          name: 'secondary_hexcode',
-          options: [
-            {
-              label: 'White',
-              value: '#FFFFFF',
-            },
-            {
-              label: 'Black',
-              value: '#000000',
-            },
-          ],
-        },
-      },
-    ],
+    fields: [FIELDS.SECONDARY_COLOR],
   },
-  {
+  EXTENDED_DETAILS: {
     type: SECTION_FIELD_TYPE,
-    fields: [
-      {
-        Header: 'Extended title (max 60 characters)',
-        source: 'extended_title',
-        editConfig: {
-          maxLength: 60,
-          type: 'text',
-          placeholder: 'A short sentence about your project',
-        },
-      },
-      {
-        Header: 'Long bio (max 250 characters)',
-        source: 'long_bio',
-        editConfig: {
-          maxLength: 250,
-          type: 'textarea',
-          placeholder: 'A longer bio about your project',
-        },
-      },
-    ],
+    fields: [FIELDS.EXTENDED_TITLE, FIELDS.LONG_BIO],
   },
-  {
+  CONTACT_DETAILS: {
     type: SECTION_FIELD_TYPE,
     title: 'Contact information',
     description: 'Add contact information you would like to show on the landing page.',
-    fields: [
-      {
-        Header: 'Phone',
-        source: 'phone_number',
-      },
-      {
-        Header: 'Website',
-        source: 'website_url',
-        editConfig: {
-          placeholder: 'www.example.com',
-        },
-      },
-    ],
+    fields: [FIELDS.PHONE_NUMBER, FIELDS.WEBSITE_URL],
   },
-  {
+  EXTERNAL_LINK: {
     type: SECTION_FIELD_TYPE,
     title: 'External link',
     description: 'Add an external link where users can learn more about your project',
-    fields: [
-      {
-        Header: 'URL',
-        source: 'external_link',
-        editConfig: {
-          placeholder: 'www.example.com',
-        },
-      },
-    ],
+    fields: [FIELDS.EXTERNAL_LINK],
   },
-  {
+  PROJECTS: {
     type: SECTION_FIELD_TYPE,
     title: 'Project',
     description: 'Enter project code below. You may enter multiple codes separated by a comma.',
+    fields: [FIELDS.PROJECTS],
+  },
+};
+
+// Fields for creating a landing page
+const CREATE_FIELDS = [
+  SECTIONS.DETAILS,
+  SECTIONS.MAIN_IMAGE,
+  SECTIONS.LOGO,
+  SECTIONS.PRIMARY_COLOR,
+  SECTIONS.SECONDARY_COLOR,
+  SECTIONS.EXTENDED_DETAILS,
+  SECTIONS.CONTACT_DETAILS,
+  SECTIONS.EXTERNAL_LINK,
+  SECTIONS.PROJECTS,
+];
+
+// Fields for editing a landing page
+const EDIT_FIELDS = [
+  {
+    ...SECTIONS.DETAILS,
     fields: [
+      FIELDS.NAME,
+      FIELDS.NAME_HEADER,
       {
-        Header: 'Project code/s',
-        source: 'project_codes',
-        column: {
-          sortOrder: 1,
-          Header: 'Projects',
-        },
-        Filter: ArrayFilter,
-        Cell: ({ value }) => prettyArray(value),
-        editConfig: {
-          optionsEndpoint: 'projects',
-          optionLabelKey: 'code',
-          optionValueKey: 'code',
-          allowMultipleValues: true,
-        },
+        ...FIELDS.URL_SEGMENT,
+        editable: false,
       },
     ],
   },
+  SECTIONS.MAIN_IMAGE,
+  SECTIONS.LOGO,
+  SECTIONS.PRIMARY_COLOR,
+  SECTIONS.SECONDARY_COLOR,
+  SECTIONS.EXTENDED_DETAILS,
+  SECTIONS.CONTACT_DETAILS,
+  SECTIONS.EXTERNAL_LINK,
+  SECTIONS.PROJECTS,
 ];
 
-const EDIT_FIELDS = FIELDS.reduce((result, item) => {
-  if (item.type === SECTION_FIELD_TYPE) {
-    return [
-      ...result,
-      {
-        ...item,
-        fields: item.fields.map(field => ({
-          ...field,
-          editConfig: {
-            ...(field.editConfig || {}),
-            editable: field.updateDisabled !== true,
-          },
-        })),
-      },
-    ];
-  }
-  return [
-    ...result,
-    {
-      ...item,
-      editConfig: {
-        ...(item.editConfig || {}),
-        editable: item.updateDisabled !== true,
-      },
-    },
-  ];
-}, []);
-
-// Only show fields that are marked as columns, plus the edit and delete buttons
+// Table columns
 const COLUMNS = [
-  ...FIELDS.reduce((result, item) => {
-    const fields = item.fields || [item];
-    return [
-      ...result,
-      ...fields
-        .filter(field => field.column)
-        .map(field => ({
-          ...field,
-          Header: field.column.Header || field.Header,
-        })),
-    ];
-  }, []).sort((a, b) => a.column.sortOrder - b.column.sortOrder),
+  FIELDS.NAME,
+  {
+    ...FIELDS.PROJECTS,
+    Header: 'Projects',
+  },
+  {
+    ...FIELDS.URL_SEGMENT,
+    Header: 'URL',
+  },
   {
     Header: 'Edit',
     type: 'edit',
@@ -291,7 +273,7 @@ const CREATE_CONFIG = {
   actionConfig: {
     title: 'New landing page',
     editEndpoint: LANDING_PAGES_ENDPOINT,
-    fields: FIELDS,
+    fields: CREATE_FIELDS,
   },
 };
 

--- a/packages/admin-panel/src/routes.js
+++ b/packages/admin-panel/src/routes.js
@@ -35,6 +35,7 @@ import {
   DataTablesPage,
   ExternalDatabaseConnectionsPage,
   EntityHierarchyPage,
+  CustomLandingPagesPage,
 } from './pages/resources';
 import { DataElementDataServicesPage } from './pages/resources/DataElementDataServicesPage';
 
@@ -216,6 +217,11 @@ export const ROUTES = [
         label: 'Entity Hierarchy',
         to: '/hierarchy',
         component: EntityHierarchyPage,
+      },
+      {
+        label: 'Landing Pages',
+        to: '/landing-pages',
+        component: CustomLandingPagesPage,
       },
     ],
   },


### PR DESCRIPTION
### Issue WAITP-1185: Add landing page tab to projects section of admin panel

### Changes:
- Added route and tab to landing pages view
- Updated table columns on landing pages view to allow sorting of order, custom headers in columns, and a clickable link to the custom link

### Screenshots:
With fake data:
![Screen Shot 2023-05-02 at 4 03 15 pm](https://user-images.githubusercontent.com/129009580/235576942-f74b507d-84ea-4162-8449-d3be441317a9.png)


