### PR TITLE
Waitp 1189b single project landing page - desktop

### DIFF
--- a/packages/web-frontend/src/containers/TopBar/index.js
+++ b/packages/web-frontend/src/containers/TopBar/index.js
@@ -19,6 +19,7 @@ const TopBarWrapper = styled.div`
   background-color: ${props => props.primaryColor};
   min-height: ${TOP_BAR_HEIGHT}px;
   height: ${TOP_BAR_HEIGHT}px;
+  box-sizing: border-box;
   display: flex;
   z-index: 1000;
   position: relative;

--- a/packages/web-frontend/src/containers/UserMenu/index.js
+++ b/packages/web-frontend/src/containers/UserMenu/index.js
@@ -60,10 +60,12 @@ const StyledMenuIcon = styled(MenuIcon)`
   height: 28px;
 `;
 
-const UsernameContainer = styled.div`
+const UsernameContainer = styled.p`
   padding-right: 5px;
-  font-weight: 400;
+  font-weight: ${({ theme, isCustomLandingPage }) =>
+    isCustomLandingPage ? theme.typography.fontWeightMedium : theme.typography.fontWeightRegular};
   font-size: 0.875rem;
+  text-transform: ${({ isCustomLandingPage }) => (isCustomLandingPage ? 'uppercase' : 'none')};
 `;
 
 const MenuItemButton = styled(Button)`
@@ -214,7 +216,9 @@ const UserMenu = ({
   return (
     <UserMenuContainer secondaryColor={secondaryColor}>
       {isUserLoggedIn ? (
-        <UsernameContainer>{currentUserUsername}</UsernameContainer>
+        <UsernameContainer isCustomLandingPage={isCustomLandingPage}>
+          {currentUserUsername}
+        </UsernameContainer>
       ) : (
         <>
           {showRegisterButton && (

--- a/packages/web-frontend/src/screens/LandingPage/LandingPage.js
+++ b/packages/web-frontend/src/screens/LandingPage/LandingPage.js
@@ -6,12 +6,17 @@
 import React from 'react';
 import styled from 'styled-components';
 import MuiContainer from '@material-ui/core/Container';
+import { Link, Typography } from '@material-ui/core';
 import { EnvBanner } from '@tupaia/ui-components';
 import OverlayDiv from '../../containers/OverlayDiv';
 import { useCustomLandingPages } from './useCustomLandingPages';
 import { SingleProjectLandingPage } from './SingleProjectLandingPage';
 import { MultiProjectLandingPage } from './MultiProjectLandingPage';
 import TopBar from '../../containers/TopBar';
+import { TOP_BAR_HEIGHT } from '../../styles';
+import { List } from 'material-ui';
+import { ListItem } from 'material-ui/List';
+import { LandingPageFooter } from './LandingPageFooter';
 
 const Wrapper = styled.div`
   position: relative;
@@ -20,36 +25,42 @@ const Wrapper = styled.div`
   background-color: #000000;
   background-image: ${({ backgroundImage }) =>
     backgroundImage ? `url(${backgroundImage})` : 'none'};
+  display: flex;
+  flex-direction: column;
 `;
 
 const Container = styled(MuiContainer)`
-  position: relative;
-  min-height: calc(100vh - 75px);
-  background: linear-gradient(rgba(0, 0, 0, 0.1) 35%, rgba(0, 0, 0, 0.7) 100%);
+  background: linear-gradient(rgba(0, 0, 0, 0.1) 0%, rgba(0, 0, 0, 0.7) 100%);
   padding: 3.5rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: calc(100vh - ${TOP_BAR_HEIGHT}px);
+  overflow-y: auto;
 `;
 
-const Footer = styled.div`
-  position: absolute;
-  bottom: 0;
-  left: 50px;
-  right: 50px;
-  border-top: 1px solid white;
-  height: 75px;
+const ContentWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  height: 80%;
 `;
 
 export const LandingPage = () => {
-  const { projects, customLandingPageSettings } = useCustomLandingPages();
-  const { image_url: backgroundImage } = customLandingPageSettings;
+  const {
+    projects,
+    customLandingPageSettings: { image_url: backgroundImage },
+  } = useCustomLandingPages();
 
   return (
     <>
-      <EnvBanner />
-      <TopBar />
       <Wrapper backgroundImage={backgroundImage}>
+        <EnvBanner />
+        <TopBar />
         <Container maxWidth={false}>
-          {projects.length > 1 ? <MultiProjectLandingPage /> : <SingleProjectLandingPage />}
-          <Footer />
+          <ContentWrapper>
+            {projects.length > 1 ? <MultiProjectLandingPage /> : <SingleProjectLandingPage />}
+          </ContentWrapper>
+          <LandingPageFooter />
         </Container>
       </Wrapper>
       {/* Include the OverlayDiv so that the login and logout functionality is available on the */}

--- a/packages/web-frontend/src/screens/LandingPage/LandingPageDesktop.js
+++ b/packages/web-frontend/src/screens/LandingPage/LandingPageDesktop.js
@@ -6,7 +6,6 @@
 import React from 'react';
 import styled from 'styled-components';
 import MuiContainer from '@material-ui/core/Container';
-import { Link, Typography } from '@material-ui/core';
 import { EnvBanner } from '@tupaia/ui-components';
 import OverlayDiv from '../../containers/OverlayDiv';
 import { useCustomLandingPages } from './useCustomLandingPages';
@@ -14,8 +13,6 @@ import { SingleProjectLandingPage } from './SingleProjectLandingPage';
 import { MultiProjectLandingPage } from './MultiProjectLandingPage';
 import TopBar from '../../containers/TopBar';
 import { TOP_BAR_HEIGHT } from '../../styles';
-import { List } from 'material-ui';
-import { ListItem } from 'material-ui/List';
 import { LandingPageFooter } from './LandingPageFooter';
 
 const Wrapper = styled.div`
@@ -45,7 +42,7 @@ const ContentWrapper = styled.div`
   height: 80%;
 `;
 
-export const LandingPage = () => {
+export const LandingPageDesktop = () => {
   const {
     projects,
     customLandingPageSettings: { image_url: backgroundImage },

--- a/packages/web-frontend/src/screens/LandingPage/LandingPageDesktop.js
+++ b/packages/web-frontend/src/screens/LandingPage/LandingPageDesktop.js
@@ -15,6 +15,10 @@ import TopBar from '../../containers/TopBar';
 import { TOP_BAR_HEIGHT } from '../../styles';
 import { LandingPageFooter } from './LandingPageFooter';
 
+/**
+ * This is the template for landing pages when the user is not on a mobile device
+ */
+
 const Wrapper = styled.div`
   position: relative;
   background-size: cover;

--- a/packages/web-frontend/src/screens/LandingPage/LandingPageFooter.js
+++ b/packages/web-frontend/src/screens/LandingPage/LandingPageFooter.js
@@ -1,0 +1,89 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Link, Typography } from '@material-ui/core';
+import { List } from 'material-ui';
+import { useCustomLandingPages } from './useCustomLandingPages';
+
+const FooterHeader = styled(Typography)`
+  font-size: 1.2em;
+  font-weight: ${props => props.theme.typography.fontWeightBold};
+`;
+const Footer = styled.div`
+  color: ${props => props.theme.palette.common.white};
+  display: flex;
+`;
+const FooterBodyText = styled.p`
+  margin-bottom: 0;
+`;
+
+const FooterLink = styled(Link)`
+  color: ${props => props.theme.palette.common.white};
+  text-decoration: underline;
+`;
+
+const FooterContentWrapper = styled.div`
+  & + & {
+    margin-left: 4em;
+  }
+  @media screen and (min-width: ${props => props.theme.breakpoints.values.md}px) {
+    width: 30%;
+  }
+`;
+
+const FooterContactList = styled(List)`
+  list-style: none;
+`;
+
+const FooterContactListItem = styled.li`
+  & + & {
+    margin-top: 0.5em;
+  }
+`;
+
+export const LandingPageFooter = () => {
+  const { customLandingPageSettings } = useCustomLandingPages();
+  const {
+    long_bio: longBio,
+    name,
+    include_name_in_header: includeNameInHeader,
+    external_link: externalLink,
+    phone_number: phoneNumber,
+    website_url: websiteUrl,
+  } = customLandingPageSettings;
+  return (
+    <Footer>
+      <FooterContentWrapper>
+        <FooterHeader variant={includeNameInHeader ? 'h3' : 'h2'}>About {name}</FooterHeader>
+        <FooterBodyText>
+          {longBio}
+          {externalLink && (
+            <>
+              &nbsp;
+              <FooterLink href={externalLink} target="_blank">
+                Learn more
+              </FooterLink>
+            </>
+          )}
+        </FooterBodyText>
+      </FooterContentWrapper>
+      <FooterContentWrapper>
+        <FooterHeader variant={includeNameInHeader ? 'h3' : 'h2'}>Contact us</FooterHeader>
+        <FooterContactList>
+          {phoneNumber && (
+            <FooterContactListItem>
+              Ph: &nbsp;<FooterLink href={`tel:${phoneNumber}`}>{phoneNumber}</FooterLink>
+            </FooterContactListItem>
+          )}
+          {websiteUrl && (
+            <FooterContactListItem>
+              Website: &nbsp;
+              <FooterLink href={websiteUrl} target="_blank">
+                {websiteUrl}
+              </FooterLink>
+            </FooterContactListItem>
+          )}
+        </FooterContactList>
+      </FooterContentWrapper>
+    </Footer>
+  );
+};

--- a/packages/web-frontend/src/screens/LandingPage/LandingPageFooter.js
+++ b/packages/web-frontend/src/screens/LandingPage/LandingPageFooter.js
@@ -50,10 +50,12 @@ export const LandingPageFooter = () => {
     phone_number: phoneNumber,
     website_url: websiteUrl,
   } = customLandingPageSettings;
+  // use h3 for footer item headers if there is already an h2 in the page (i.e. the name is h1, and the extended title is h2, else h2)
+  const footerHeaderVariant = includeNameInHeader ? 'h3' : 'h2';
   return (
     <Footer>
       <FooterContentWrapper>
-        <FooterHeader variant={includeNameInHeader ? 'h3' : 'h2'}>About {name}</FooterHeader>
+        <FooterHeader variant={footerHeaderVariant}>About {name}</FooterHeader>
         <FooterBodyText>
           {longBio}
           {externalLink && (
@@ -67,7 +69,7 @@ export const LandingPageFooter = () => {
         </FooterBodyText>
       </FooterContentWrapper>
       <FooterContentWrapper>
-        <FooterHeader variant={includeNameInHeader ? 'h3' : 'h2'}>Contact us</FooterHeader>
+        <FooterHeader variant={footerHeaderVariant}>Contact us</FooterHeader>
         <FooterContactList>
           {phoneNumber && (
             <FooterContactListItem>

--- a/packages/web-frontend/src/screens/LandingPage/SingleProjectLandingPage.js
+++ b/packages/web-frontend/src/screens/LandingPage/SingleProjectLandingPage.js
@@ -1,5 +1,78 @@
 import React from 'react';
+import styled from 'styled-components';
+import { Button, Typography } from '@material-ui/core';
+import { useCustomLandingPages } from './useCustomLandingPages';
+import { useAuth } from './useAuth';
+import { getProjectAccessType } from '../../utils';
+import { PROJECT_ACCESS_TYPES } from '../../constants';
+import { useNavigation } from './useNavigation';
+
+const Wrapper = styled.div`
+  max-width: 30em;
+`;
+
+const ExtendedTitle = styled(Typography)`
+  color: ${props => props.theme.palette.common.white};
+  font-weight: ${props => props.theme.typography.fontWeightBold};
+  font-size: 2em;
+`;
+
+const ActionButton = styled(Button)`
+  width: 75%;
+  background-color: ${props => props.theme.palette.common.white};
+  color: ${props => props.theme.palette.common.black};
+  text-transform: none;
+  font-size: 1em;
+  line-height: 1.5;
+  padding: 1em;
+  border-radius: 0.6em;
+  ${ExtendedTitle} + & {
+    margin-top: 2em;
+  }
+`;
 
 export function SingleProjectLandingPage() {
-  return <div> </div>;
+  const {
+    customLandingPageSettings: {
+      extended_title: extendedTitle,
+      include_name_in_header: includeNameInHeader,
+    },
+    projects,
+  } = useCustomLandingPages();
+  const { isUserLoggedIn } = useAuth();
+  const { navigateToLogin, navigateToProject, navigateToRequestProjectAccess } = useNavigation();
+  const actionTexts = {
+    [PROJECT_ACCESS_TYPES.PENDING]: 'Approval in progress',
+    [PROJECT_ACCESS_TYPES.ALLOWED]: 'View data',
+    [PROJECT_ACCESS_TYPES.DENIED]: isUserLoggedIn ? 'Request access' : 'Log in to view data',
+  };
+  const accessType = getProjectAccessType(projects[0]);
+  const actions = {
+    [PROJECT_ACCESS_TYPES.ALLOWED]: navigateToProject,
+    [PROJECT_ACCESS_TYPES.DENIED]: isUserLoggedIn
+      ? navigateToRequestProjectAccess
+      : navigateToLogin,
+  };
+
+  const onClickActionButton = () => {
+    const action = actions[accessType];
+    if (!action) return;
+    action(projects[0]);
+  };
+  return (
+    <Wrapper>
+      {extendedTitle && (
+        <ExtendedTitle variant={includeNameInHeader ? 'h2' : 'h1'}>{extendedTitle}</ExtendedTitle>
+      )}
+      {accessType && (
+        <ActionButton
+          variant="contained"
+          disabled={accessType === PROJECT_ACCESS_TYPES.PENDING}
+          onClick={onClickActionButton}
+        >
+          {actionTexts[accessType]}
+        </ActionButton>
+      )}
+    </Wrapper>
+  );
 }

--- a/packages/web-frontend/src/screens/LandingPage/SingleProjectLandingPage.js
+++ b/packages/web-frontend/src/screens/LandingPage/SingleProjectLandingPage.js
@@ -1,3 +1,8 @@
+/*
+ * Tupaia
+ *  Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
 import React from 'react';
 import styled from 'styled-components';
 import { Button, Typography } from '@material-ui/core';
@@ -6,6 +11,10 @@ import { useAuth } from './useAuth';
 import { getProjectAccessType } from '../../utils';
 import { PROJECT_ACCESS_TYPES } from '../../constants';
 import { useNavigation } from './useNavigation';
+
+/**
+ * This is the template for the content of a landing page if there is only one project
+ */
 
 const Wrapper = styled.div`
   max-width: 30em;
@@ -39,14 +48,20 @@ export function SingleProjectLandingPage() {
     },
     projects,
   } = useCustomLandingPages();
+
   const { isUserLoggedIn } = useAuth();
   const { navigateToLogin, navigateToProject, navigateToRequestProjectAccess } = useNavigation();
+
   const actionTexts = {
     [PROJECT_ACCESS_TYPES.PENDING]: 'Approval in progress',
     [PROJECT_ACCESS_TYPES.ALLOWED]: 'View data',
     [PROJECT_ACCESS_TYPES.DENIED]: isUserLoggedIn ? 'Request access' : 'Log in to view data',
   };
-  const accessType = getProjectAccessType(projects[0]);
+
+  const [project] = projects;
+
+  const accessType = getProjectAccessType(project);
+
   const actions = {
     [PROJECT_ACCESS_TYPES.ALLOWED]: navigateToProject,
     [PROJECT_ACCESS_TYPES.DENIED]: isUserLoggedIn
@@ -57,13 +72,14 @@ export function SingleProjectLandingPage() {
   const onClickActionButton = () => {
     const action = actions[accessType];
     if (!action) return;
-    action(projects[0]);
+    action(project);
   };
   return (
     <Wrapper>
       {extendedTitle && (
         <ExtendedTitle variant={includeNameInHeader ? 'h2' : 'h1'}>{extendedTitle}</ExtendedTitle>
       )}
+      {/* Only display a button if access type is set */}
       {accessType && (
         <ActionButton
           variant="contained"

--- a/packages/web-frontend/src/screens/LandingPage/SingleProjectLandingPage.js
+++ b/packages/web-frontend/src/screens/LandingPage/SingleProjectLandingPage.js
@@ -79,7 +79,7 @@ export function SingleProjectLandingPage() {
       {extendedTitle && (
         <ExtendedTitle variant={includeNameInHeader ? 'h2' : 'h1'}>{extendedTitle}</ExtendedTitle>
       )}
-      {/* Only display a button if access type is set */}
+      {/* Only display a button if access type is set, and button is disabled if access has not yet been granted */}
       {accessType && (
         <ActionButton
           variant="contained"

--- a/packages/web-frontend/src/screens/LandingPage/index.js
+++ b/packages/web-frontend/src/screens/LandingPage/index.js
@@ -3,4 +3,4 @@
  *  Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
  */
 
-export { LandingPage } from './LandingPage';
+export { LandingPageDesktop } from './LandingPageDesktop';

--- a/packages/web-frontend/src/screens/LandingPage/useCustomLandingPages.js
+++ b/packages/web-frontend/src/screens/LandingPage/useCustomLandingPages.js
@@ -10,11 +10,17 @@ const customLandingPages = [
   {
     name: 'Fiji',
     urlSegment: 'landing-page-fiji',
-    projects: ['wish'],
+    projects: ['fanafana'],
     image_url: 'https://loremflickr.com/2000/2000',
     logo_url: 'https://loremflickr.com/800/800',
     include_name_in_header: true,
     primary_hexcode: 'pink',
+    extended_title: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+    long_bio:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
+    external_link: 'https://www.bes.au',
+    phone_number: '+123 456 789',
+    website_url: 'https://www.bes.au',
   },
 ];
 

--- a/packages/web-frontend/src/screens/desktop/RootScreen/MainPage.js
+++ b/packages/web-frontend/src/screens/desktop/RootScreen/MainPage.js
@@ -13,8 +13,8 @@ import { EnlargedDialog } from '../../../containers/EnlargedDialog';
 import SessionExpiredDialog from '../../../containers/SessionExpiredDialog';
 import OverlayDiv from '../../../containers/OverlayDiv';
 import { DIALOG_Z_INDEX } from '../../../styles';
-import { LandingPage } from '../../LandingPage';
 import { useCustomLandingPages } from '../../LandingPage/useCustomLandingPages';
+import { LandingPageDesktop } from '../../LandingPage';
 
 const Container = styled.div`
   position: fixed;
@@ -51,7 +51,7 @@ const MapContainer = styled.div`
 
 const MainPage = ({ enlargedDialogIsVisible, isLoading, sidePanelWidth }) => {
   const { isCustomLandingPage } = useCustomLandingPages();
-  if (isCustomLandingPage) return <LandingPage />;
+  if (isCustomLandingPage) return <LandingPageDesktop />;
 
   return (
     <>

--- a/packages/web-frontend/src/utils/getProjectAccessType.js
+++ b/packages/web-frontend/src/utils/getProjectAccessType.js
@@ -1,0 +1,13 @@
+import { PROJECT_ACCESS_TYPES } from '../constants';
+
+export const getProjectAccessType = project => {
+  if (!project) return null;
+  const { hasAccess, hasPendingAccess } = project;
+  if (hasPendingAccess) {
+    return PROJECT_ACCESS_TYPES.PENDING;
+  }
+  if (hasAccess) {
+    return PROJECT_ACCESS_TYPES.ALLOWED;
+  }
+  return PROJECT_ACCESS_TYPES.DENIED;
+};

--- a/packages/web-frontend/src/utils/index.js
+++ b/packages/web-frontend/src/utils/index.js
@@ -36,3 +36,4 @@ export {
 } from './getUniqueViewId';
 export { sleep } from './sleep';
 export { getLayeredOpacity } from './opacity';
+export { getProjectAccessType } from './getProjectAccessType';


### PR DESCRIPTION
### Issue WAITP-1189: UI for single project landing page, desktop

### Changes:
- Update landing page file to be named for desktop
- Create footer for landing page
- Create single project page
- Update access type button components to have text already in them

### Screenshots:

Example with fake data

![Screenshot 2023-05-04 at 3 52 37 pm](https://user-images.githubusercontent.com/129009580/236109205-09f3c6db-8a40-4776-b5c6-ca0a8f54b4d1.png)

