### PR TITLE
WAITP-1142 connect file upload to landing pages

### DIFF
--- a/packages/admin-panel/src/pages/resources/CustomLandingPagesPage.js
+++ b/packages/admin-panel/src/pages/resources/CustomLandingPagesPage.js
@@ -285,6 +285,13 @@ export const CustomLandingPagesPage = ({ getHeaderEl }) => {
       columns={COLUMNS}
       getHeaderEl={getHeaderEl}
       createConfig={CREATE_CONFIG}
+      onProcessDataForSave={(editedFields, recordData) => {
+        // If the landing page is being edited, and the url_segment field is not being edited, then include the existing url_segment in the edited fields so that it can be used for generating landing page image names.
+        if (recordData.url_segment && !editedFields.url_segment) {
+          return { ...editedFields, url_segment: recordData.url_segment };
+        }
+        return editedFields;
+      }}
     />
   );
 };

--- a/packages/admin-panel/src/routes.js
+++ b/packages/admin-panel/src/routes.js
@@ -37,7 +37,6 @@ import {
   DataTablesPage,
   ExternalDatabaseConnectionsPage,
   EntityHierarchyPage,
-  CustomLandingPagesPage,
 } from './pages/resources';
 import { DataElementDataServicesPage } from './pages/resources/DataElementDataServicesPage';
 

--- a/packages/central-server/src/apiV2/index.js
+++ b/packages/central-server/src/apiV2/index.js
@@ -123,6 +123,8 @@ import {
   GETExternalDatabaseConnections,
   TestExternalDatabaseConnection,
 } from './externalDatabaseConnections';
+import { CreateLandingPage, EditLandingPage } from './landingPages';
+
 // quick and dirty permission wrapper for open endpoints
 const allowAnyone = routeHandler => (req, res, next) => {
   req.assertPermissions(allowNoPermissions);
@@ -281,7 +283,7 @@ apiV2.post('/dataServiceSyncGroups', useRouteHandler(CreateSyncGroups));
 apiV2.post('/dataServiceSyncGroups/:recordId/sync', useRouteHandler(ManuallySyncSyncGroup));
 apiV2.post('/dataElementDataServices', useRouteHandler(BESAdminCreateHandler));
 apiV2.post('/externalDatabaseConnections', useRouteHandler(BESAdminCreateHandler));
-apiV2.post('/landingPages', useRouteHandler(BESAdminCreateHandler));
+apiV2.post('/landingPages', useRouteHandler(CreateLandingPage));
 
 /**
  * PUT routes
@@ -319,7 +321,7 @@ apiV2.put('/dataServiceSyncGroups/:recordId', useRouteHandler(EditSyncGroups));
 apiV2.put('/dataElementDataServices/:recordId', useRouteHandler(BESAdminEditHandler));
 apiV2.put('/externalDatabaseConnections/:recordId', useRouteHandler(BESAdminEditHandler));
 apiV2.put('/entityHierarchy/:recordId', useRouteHandler(BESAdminEditHandler));
-apiV2.put('/landingPages/:recordId', useRouteHandler(BESAdminEditHandler));
+apiV2.put('/landingPages/:recordId', useRouteHandler(EditLandingPage));
 
 /**
  * DELETE routes

--- a/packages/central-server/src/apiV2/landingPages/CreateLandingPage.js
+++ b/packages/central-server/src/apiV2/landingPages/CreateLandingPage.js
@@ -1,0 +1,55 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+/* eslint-disable camelcase */
+import AWS from 'aws-sdk';
+import { S3Client } from '@tupaia/utils';
+import { BESAdminCreateHandler } from '../CreateHandler';
+import { getStandardisedImageName } from '../../utilities';
+
+export class CreateLandingPage extends BESAdminCreateHandler {
+  async uploadImage(encodedImage, landingPageUrlSegment, type) {
+    const s3Client = new S3Client(new AWS.S3());
+    // Upload the image with a standardised file name and upload to s3.
+    const imagePath = await s3Client.uploadImage(
+      encodedImage,
+      getStandardisedImageName(landingPageUrlSegment, type),
+      true,
+    );
+    return imagePath;
+  }
+
+  async createRecord() {
+    const { url_segment, image_url, logo_url } = this.newRecordData;
+
+    await this.models.wrapInTransaction(async transactingModels => {
+      // Add the project, and then upload the images afterward, so that if an error is caught when creating the record, the images aren't uploaded unnecessarily
+      const newLandingPage = await transactingModels.landingPage.create({
+        ...this.newRecordData,
+        image_url: '',
+        logo_url: '',
+      });
+      await this.insertImagePaths(
+        transactingModels,
+        newLandingPage.id,
+        url_segment,
+        image_url,
+        logo_url,
+      );
+
+      return newLandingPage;
+    });
+  }
+
+  async insertImagePaths(models, landingPageId, landingPageUrlSegment, imageUrl, logoUrl) {
+    // image_url and logo_url are currently required fields, so the validator will error before this point if either of these is falsey.
+    const updates = {
+      image_url: await this.uploadImage(imageUrl, landingPageUrlSegment, 'landing_page_image'),
+      logo_url: await this.uploadImage(logoUrl, landingPageUrlSegment, 'landing_page_logo'),
+    };
+    // The record has already been updated, so update the existing record with the new fields
+    return models.landingPage.updateById(landingPageId, updates);
+  }
+}

--- a/packages/central-server/src/apiV2/landingPages/EditLandingPage.js
+++ b/packages/central-server/src/apiV2/landingPages/EditLandingPage.js
@@ -1,0 +1,38 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+import AWS from 'aws-sdk';
+import { S3Client } from '@tupaia/utils';
+import { BESAdminEditHandler } from '../EditHandler';
+import { getStandardisedImageName } from '../../utilities';
+
+export class EditLandingPage extends BESAdminEditHandler {
+  async uploadImage(encodedImage = '', landingPageUrlSegment, type) {
+    // If the image is not a base64 encoded image, then it is already a url to an image in S3, so we can just return that url as it is. This is on the off chance that the image is being uploaded as a url instead of an encoded image, or it is not being updated at all.
+    if (!encodedImage || !encodedImage.includes('data:image')) return encodedImage;
+    const s3Client = new S3Client(new AWS.S3());
+    // Upload the image with a standardised file name and upload to s3
+    const imagePath = await s3Client.uploadImage(
+      encodedImage,
+      getStandardisedImageName(landingPageUrlSegment, type),
+      true,
+    );
+    return imagePath;
+  }
+
+  // Before updating the landingPage, if the image_url and logo_url have changed, we need to upload the new images to S3 and update the image_url and logo_url fields with the new urls. This also will handle deleting of the image_url and logo_url fields, as the uploadImage function will return the original value if the encoded image is null or not a base64 encoded image.
+  async updateRecord() {
+    const { image_url: imageUrl, logo_url: logoUrl, url_segment: urlSegment } = this.updatedFields;
+    const updatedFields = { ...this.updatedFields };
+
+    // check first if field is undefined, as we don't want to upload an image if the field is not being updated, since this might cause the field to be reset
+    if (imageUrl !== undefined) {
+      updatedFields.image_url = await this.uploadImage(imageUrl, urlSegment, 'landing_page_image');
+    }
+    if (logoUrl !== undefined) {
+      updatedFields.logo_url = await this.uploadImage(logoUrl, urlSegment, 'landing_page_logo');
+    }
+    await this.models.landingPage.updateById(this.recordId, updatedFields);
+  }
+}

--- a/packages/central-server/src/apiV2/landingPages/index.js
+++ b/packages/central-server/src/apiV2/landingPages/index.js
@@ -1,0 +1,7 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+export { CreateLandingPage } from './CreateLandingPage';
+export { EditLandingPage } from './EditLandingPage';

--- a/packages/central-server/src/apiV2/projects/CreateProject.js
+++ b/packages/central-server/src/apiV2/projects/CreateProject.js
@@ -7,19 +7,19 @@ import AWS from 'aws-sdk';
 import { snake } from 'case';
 import { S3Client } from '@tupaia/utils';
 import { BESAdminCreateHandler } from '../CreateHandler';
-import { getProjectImageUploadName } from './getProjectImageUploadName';
+import { getStandardisedImageName } from '../../utilities';
 /**
  * Handles POST endpoints:
  * - /projects
  */
 
 export class CreateProject extends BESAdminCreateHandler {
-  async uploadImage(encodedImage, projectCode, type) { 
+  async uploadImage(encodedImage, projectCode, type) {
     const s3Client = new S3Client(new AWS.S3());
     // Upload the image with a standardised file name and upload to s3.
     const imagePath = await s3Client.uploadImage(
       encodedImage,
-      getProjectImageUploadName(projectCode, type),
+      getStandardisedImageName(projectCode, type),
       true,
     );
     return imagePath;

--- a/packages/central-server/src/apiV2/projects/EditProject.js
+++ b/packages/central-server/src/apiV2/projects/EditProject.js
@@ -5,7 +5,7 @@
 import AWS from 'aws-sdk';
 import { S3Client } from '@tupaia/utils';
 import { BESAdminEditHandler } from '../EditHandler';
-import { getProjectImageUploadName } from './getProjectImageUploadName';
+import { getStandardisedImageName } from '../../utilities';
 
 export class EditProject extends BESAdminEditHandler {
   async uploadImage(encodedImage = '', projectCode, type) {
@@ -15,7 +15,7 @@ export class EditProject extends BESAdminEditHandler {
     // Upload the image with a standardised file name and upload to s3
     const imagePath = await s3Client.uploadImage(
       encodedImage,
-      getProjectImageUploadName(projectCode, type),
+      getStandardisedImageName(projectCode, type),
       true,
     );
     return imagePath;

--- a/packages/central-server/src/apiV2/projects/getProjectImageUploadName.js
+++ b/packages/central-server/src/apiV2/projects/getProjectImageUploadName.js
@@ -1,1 +1,0 @@
-export const getProjectImageUploadName = (projectCode, type) => `${projectCode}_${type}`;

--- a/packages/central-server/src/tests/apiV2/landingPages/CreateLandingPage.test.js
+++ b/packages/central-server/src/tests/apiV2/landingPages/CreateLandingPage.test.js
@@ -1,0 +1,115 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+import AWS from 'aws-sdk';
+import { S3Client } from '@tupaia/utils';
+import { findOrCreateDummyRecord } from '@tupaia/database';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { BES_ADMIN_PERMISSION_GROUP } from '../../../permissions';
+import { TestableApp } from '../../testUtilities';
+
+describe('Creating a landing page', async () => {
+  let s3ClientStub;
+  const BES_ADMIN_POLICY = {
+    DL: [BES_ADMIN_PERMISSION_GROUP],
+  };
+
+  const EXAMPLE_UPLOADED_IMAGE_URL = 'https://example.com/image.jpg';
+  const TEST_PROJECT_CODE = 'explore';
+
+  const ENCODED_IMAGE =
+    'data:image/gif;base64,R0lGODdh4AHwANUAAKqqqgAAAO7u7ru7u+Xl5czMzN3d3cPDw7KystTU1H9/fxcXF1VVVXJych0dHRkZGS4uLo+Pjzc3N5SUlMHBwSwsLGpqahUVFSoqKklJScjIyBgYGLm5uTk5OW9vbzAwMKurqxYWFqWlpaOjoxwcHEJCQp+fn3d3d0ZGRhoaGpubm4WFhV1dXVlZWT8/P4qKimFhYTMzM25ubtDQ0ExMTAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACwAAAAA4AHwAAAG/kCAcEgsGo/IpHLJbDqf0Kh0Sq1ar9isdsvter/gsHhMLpvP6LR6zW673/C4fE6v2+/4vH7P7/v/gIGCg4SFhoeIiYqLjI2Oj5CRkpOUlZaXmJmam5ydnp+goaKjpKWmp6ipqqusra6vsLGys7S1tre4ubq7vL2+v8DBwsPExcbHyMnKy8zNzs/Q0dLT1NXW19jZ2tvc3d7f4OHi4+Tl5ufo6err7O3u7/Dx8vP09fb3+Pn6+/z9/v8AAwocSLCgwYMIEypcyLChw4cQI0qcSLGixYsYM2rcyLGjx48gQ4ocSbKkyZMoU6pcybKly5cwY8qcSbOmzZs4c+rcybOn/s+fQIMKHUq0qNGjSJMqXcq0qdOnUKNKnUq1qtWrWLNq3cq1q9evYMOKHUu2rNmzaNOqXcu2rdu3cOPKnUu3rt27ePPq3cu3r9+/gAMLHky4sOHDiBMrXsyYmIIAQyxcCIBBAREFky9YmKIAQ4AADJA8HoI5gObGlhZABmAhgwYBFCBsBjBhAQgBIAJYjoJCxowZNGYXUS2k9u3cu1FHYtDAgZANHBAAQEBhg5ASDQYAGHAChZQEBRAgSGC9CHPnALBr5+5dOSQFDwqs7uBhiIcOQlJIF4IghREXySngQhITkFAEfPLlt990/rn3CAQRALBadQxMwMAHFAgRwIIq/qxGRAIQTEAbBAkk4UFoREAooYYceujgIgxIcMCK04HwQAgBiLCfiwi4OIQIFUxQQYZJQEdEjDOuxqOPLx4ywQNErqbAAhoQUNtsAYg4BJPbvRDACwsawQADCz4ZpYZaatjkIhV85uZntkl3AAjlObDCEBOgZwQMLWSQBHwcENHmm5/Ziaeeax5igACMChAAowGMMMQIBgLAAAtDtIDigTEkYEFyRBgX5qKNPirApZlumugiqwkp4gQlgCCECboBAKgRtWVYQIhGVBCBdkmsRqtlt67KyGoHiIBjCCYAO0BtAcRpRAkR7CdCCUV49iYSqz2rmrTGLiLAEAMQIAABwMAKcYC56B6RwIxCDFAiEaQ2isS46rKbbrj89uvvvwAHLPDABBds8MEIJ6zwwgw37PDDEEcs8cQUV2zxxRhnrPHGHHfs8ccghyzyyCSXbPLJKKes8sost+zyyzDHLPPMNNds880456zzzjz37PPPQAct9NBEF2300UgnrfTSTDft9NNQRy311FRXbfXVWGet9dZcd+3112CHLfbYZJdt9tlop6322my37fbbcMct99x012333XjnrffefPft98pBAAA7';
+
+  const TEST_LANDING_PAGE_INPUT = {
+    name: 'test_name',
+    project_codes: [TEST_PROJECT_CODE],
+    url_segment: 'test_url_segment',
+    image_url: EXAMPLE_UPLOADED_IMAGE_URL,
+    logo_url: EXAMPLE_UPLOADED_IMAGE_URL,
+    primary_hexcode: '#000000',
+    secondary_hexcode: '#ffffff',
+    extended_title: 'test_extended_title',
+    long_bio: 'test_long_bio',
+    external_link: 'www.example.com',
+    website_url: 'www.example.com',
+    phone_numer: '12345678',
+    include_name_in_header: false,
+  };
+
+  const app = new TestableApp();
+  const { models } = app;
+
+  before(async () => {
+    sinon.createStubInstance(AWS.S3);
+  });
+  beforeEach(async () => {
+    s3ClientStub = sinon
+      .stub(S3Client.prototype, 'uploadImage')
+      .returns(Promise.resolve(EXAMPLE_UPLOADED_IMAGE_URL));
+    await findOrCreateDummyRecord(models.project, { code: TEST_PROJECT_CODE });
+  });
+
+  afterEach(async () => {
+    await models.landingPage.delete({ url_segment: TEST_LANDING_PAGE_INPUT.url_segment });
+    await models.project.delete({ code: TEST_PROJECT_CODE });
+    app.revokeAccess();
+    s3ClientStub.restore();
+  });
+
+  describe('POST /landingPages', async () => {
+    describe('Record creation', async () => {
+      it('creates a valid landing page record', async () => {
+        await app.grantAccess(BES_ADMIN_POLICY);
+
+        await app.post('landingPages', {
+          body: {
+            ...TEST_LANDING_PAGE_INPUT,
+          },
+        });
+
+        const result = await models.landingPage.find({
+          url_segment: TEST_LANDING_PAGE_INPUT.url_segment,
+        });
+        expect(result.length).to.equal(1);
+        expect(result[0].url_segment).to.equal(TEST_LANDING_PAGE_INPUT.url_segment);
+      });
+
+      it('uploads the value of image_url if is a base64 encoded image', async () => {
+        await app.grantAccess(BES_ADMIN_POLICY);
+
+        await app.post('landingPages', {
+          body: {
+            ...TEST_LANDING_PAGE_INPUT,
+            image_url: ENCODED_IMAGE,
+          },
+        });
+
+        const result = await models.landingPage.find({
+          url_segment: TEST_LANDING_PAGE_INPUT.url_segment,
+        });
+        expect(result.length).to.equal(1);
+        expect(result[0].image_url).to.equal(EXAMPLE_UPLOADED_IMAGE_URL);
+      });
+
+      it('uploads the value of logo_url if is a base64 encoded image', async () => {
+        await app.grantAccess(BES_ADMIN_POLICY);
+
+        await app.post('landingPages', {
+          body: {
+            ...TEST_LANDING_PAGE_INPUT,
+            logo_url: ENCODED_IMAGE,
+          },
+        });
+
+        const result = await models.landingPage.find({
+          url_segment: TEST_LANDING_PAGE_INPUT.url_segment,
+        });
+        expect(result.length).to.equal(1);
+        expect(result[0].logo_url).to.equal(EXAMPLE_UPLOADED_IMAGE_URL);
+      });
+    });
+  });
+});

--- a/packages/central-server/src/tests/apiV2/landingPages/EditLandingPage.test.js
+++ b/packages/central-server/src/tests/apiV2/landingPages/EditLandingPage.test.js
@@ -1,0 +1,143 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
+ */
+
+import { generateId, findOrCreateDummyRecord } from '@tupaia/database';
+import AWS from 'aws-sdk';
+import { S3Client } from '@tupaia/utils';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { BES_ADMIN_PERMISSION_GROUP } from '../../../permissions';
+import { TestableApp } from '../../testUtilities';
+
+describe('Editing a landing page', async () => {
+  let s3ClientStub;
+  const BES_ADMIN_POLICY = {
+    DL: [BES_ADMIN_PERMISSION_GROUP],
+  };
+
+  const EXAMPLE_UPLOADED_IMAGE_URL = 'https://example.com/image.jpg';
+
+  const TEST_LANDING_PAGE_INPUT = {
+    id: generateId(),
+    image_url: 'www.image.com',
+    logo_url: 'www.image.com',
+    extended_title: 'old extended title',
+  };
+  const ENCODED_IMAGE =
+    'data:image/gif;base64,R0lGODdh4AHwANUAAKqqqgAAAO7u7ru7u+Xl5czMzN3d3cPDw7KystTU1H9/fxcXF1VVVXJych0dHRkZGS4uLo+Pjzc3N5SUlMHBwSwsLGpqahUVFSoqKklJScjIyBgYGLm5uTk5OW9vbzAwMKurqxYWFqWlpaOjoxwcHEJCQp+fn3d3d0ZGRhoaGpubm4WFhV1dXVlZWT8/P4qKimFhYTMzM25ubtDQ0ExMTAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACwAAAAA4AHwAAAG/kCAcEgsGo/IpHLJbDqf0Kh0Sq1ar9isdsvter/gsHhMLpvP6LR6zW673/C4fE6v2+/4vH7P7/v/gIGCg4SFhoeIiYqLjI2Oj5CRkpOUlZaXmJmam5ydnp+goaKjpKWmp6ipqqusra6vsLGys7S1tre4ubq7vL2+v8DBwsPExcbHyMnKy8zNzs/Q0dLT1NXW19jZ2tvc3d7f4OHi4+Tl5ufo6err7O3u7/Dx8vP09fb3+Pn6+/z9/v8AAwocSLCgwYMIEypcyLChw4cQI0qcSLGixYsYM2rcyLGjx48gQ4ocSbKkyZMoU6pcybKly5cwY8qcSbOmzZs4c+rcybOn/s+fQIMKHUq0qNGjSJMqXcq0qdOnUKNKnUq1qtWrWLNq3cq1q9evYMOKHUu2rNmzaNOqXcu2rdu3cOPKnUu3rt27ePPq3cu3r9+/gAMLHky4sOHDiBMrXsyYmIIAQyxcCIBBAREFky9YmKIAQ4AADJA8HoI5gObGlhZABmAhgwYBFCBsBjBhAQgBIAJYjoJCxowZNGYXUS2k9u3cu1FHYtDAgZANHBAAQEBhg5ASDQYAGHAChZQEBRAgSGC9CHPnALBr5+5dOSQFDwqs7uBhiIcOQlJIF4IghREXySngQhITkFAEfPLlt990/rn3CAQRALBadQxMwMAHFAgRwIIq/qxGRAIQTEAbBAkk4UFoREAooYYceujgIgxIcMCK04HwQAgBiLCfiwi4OIQIFUxQQYZJQEdEjDOuxqOPLx4ywQNErqbAAhoQUNtsAYg4BJPbvRDACwsawQADCz4ZpYZaatjkIhV85uZntkl3AAjlObDCEBOgZwQMLWSQBHwcENHmm5/Ziaeeax5igACMChAAowGMMMQIBgLAAAtDtIDigTEkYEFyRBgX5qKNPirApZlumugiqwkp4gQlgCCECboBAKgRtWVYQIhGVBCBdkmsRqtlt67KyGoHiIBjCCYAO0BtAcRpRAkR7CdCCUV49iYSqz2rmrTGLiLAEAMQIAABwMAKcYC56B6RwIxCDFAiEaQ2isS46rKbbrj89uvvvwAHLPDABBds8MEIJ6zwwgw37PDDEEcs8cQUV2zxxRhnrPHGHHfs8ccghyzyyCSXbPLJKKes8sost+zyyzDHLPPMNNds880456zzzjz37PPPQAct9NBEF2300UgnrfTSTDft9NNQRy311FRXbfXVWGet9dZcd+3112CHLfbYZJdt9tlop6322my37fbbcMct99x012333XjnrffefPft98pBAAA7';
+
+  const app = new TestableApp();
+  const { models } = app;
+
+  before(async () => {
+    await findOrCreateDummyRecord(models.landingPage, TEST_LANDING_PAGE_INPUT);
+    sinon.createStubInstance(AWS.S3);
+  });
+  beforeEach(() => {
+    s3ClientStub = sinon
+      .stub(S3Client.prototype, 'uploadImage')
+      .returns(Promise.resolve(EXAMPLE_UPLOADED_IMAGE_URL));
+  });
+
+  afterEach(async () => {
+    app.revokeAccess();
+    s3ClientStub.restore();
+  });
+
+  after(async () => {
+    await models.landingPage.delete({ id: TEST_LANDING_PAGE_INPUT.id });
+  });
+
+  describe('PUT /landingPages', async () => {
+    it('updates a landingPage record', async () => {
+      await app.grantAccess(BES_ADMIN_POLICY);
+
+      await app.put(`landingPages/${TEST_LANDING_PAGE_INPUT.id}`, {
+        body: {
+          ...TEST_LANDING_PAGE_INPUT,
+          extended_title: 'the updated extended title',
+        },
+      });
+
+      const result = await models.landingPage.find({
+        id: TEST_LANDING_PAGE_INPUT.id,
+      });
+      expect(result.length).to.equal(1);
+      expect(result[0].extended_title).to.equal('the updated extended title');
+    });
+
+    it('uploads the value of image_url if is a base64 encoded image', async () => {
+      await app.grantAccess(BES_ADMIN_POLICY);
+
+      await app.put(`landingPages/${TEST_LANDING_PAGE_INPUT.id}`, {
+        body: {
+          ...TEST_LANDING_PAGE_INPUT,
+          image_url: ENCODED_IMAGE,
+        },
+      });
+
+      const result = await models.landingPage.find({
+        id: TEST_LANDING_PAGE_INPUT.id,
+      });
+
+      expect(result.length).to.equal(1);
+      expect(result[0].image_url).to.equal(EXAMPLE_UPLOADED_IMAGE_URL);
+    });
+
+    it('uploads the value of logo_url if is a base64 encoded image', async () => {
+      await app.grantAccess(BES_ADMIN_POLICY);
+
+      await app.put(`landingPages/${TEST_LANDING_PAGE_INPUT.id}`, {
+        body: {
+          ...TEST_LANDING_PAGE_INPUT,
+          logo_url: ENCODED_IMAGE,
+        },
+      });
+
+      const result = await models.landingPage.find({
+        id: TEST_LANDING_PAGE_INPUT.id,
+      });
+
+      expect(result.length).to.equal(1);
+      expect(result[0].logo_url).to.equal(EXAMPLE_UPLOADED_IMAGE_URL);
+    });
+
+    it('does not upload a new image_url or logo_url if is not a base64 encoded image', async () => {
+      await app.grantAccess(BES_ADMIN_POLICY);
+
+      await app.put(`landingPages/${TEST_LANDING_PAGE_INPUT.id}`, {
+        body: TEST_LANDING_PAGE_INPUT,
+      });
+
+      const result = await models.landingPage.find({
+        id: TEST_LANDING_PAGE_INPUT.id,
+      });
+
+      expect(result.length).to.equal(1);
+      expect(result[0].image_url).to.equal(TEST_LANDING_PAGE_INPUT.image_url);
+      expect(result[0].logo_url).to.equal(TEST_LANDING_PAGE_INPUT.logo_url);
+    });
+
+    it('does not upload a new image_url or logo_url if these are null', async () => {
+      await app.grantAccess(BES_ADMIN_POLICY);
+
+      await app.put(`landingPages/${TEST_LANDING_PAGE_INPUT.id}`, {
+        body: {
+          ...TEST_LANDING_PAGE_INPUT,
+          image_url: null,
+          logo_url: null,
+        },
+      });
+
+      const result = await models.landingPage.find({
+        id: TEST_LANDING_PAGE_INPUT.id,
+      });
+
+      expect(result.length).to.equal(1);
+      expect(result[0].image_url).to.equal(null);
+      expect(result[0].logo_url).to.equal(null);
+    });
+  });
+});

--- a/packages/central-server/src/tests/utilities/getStandardisedImageName.test.js
+++ b/packages/central-server/src/tests/utilities/getStandardisedImageName.test.js
@@ -1,0 +1,12 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+import { expect } from 'chai';
+import { getStandardisedImageName } from '../../utilities/getStandardisedImageName';
+
+describe('getStandardisedImageName()', () => {
+  it('should return the correct image name', () => {
+    expect(getStandardisedImageName('test', 'logo')).to.equal('test_logo');
+  });
+});

--- a/packages/central-server/src/utilities/getStandardisedImageName.js
+++ b/packages/central-server/src/utilities/getStandardisedImageName.js
@@ -1,0 +1,7 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+/**  Generates a standardised image name based on the uniqueId and imageSuffix. For example for a project, uniqueId would be the project code and imageSuffix would be either 'project_image' or 'project_logo' */
+export const getStandardisedImageName = (uniqueId, imageSuffix) => `${uniqueId}_${imageSuffix}`;

--- a/packages/central-server/src/utilities/index.js
+++ b/packages/central-server/src/utilities/index.js
@@ -7,3 +7,4 @@ export { getApiUrl } from './getApiUrl';
 export { getTempDirectory } from './getTempDirectory';
 export { resourceToRecordType } from './resourceToRecordType';
 export { sendEmail } from './sendEmail';
+export { getStandardisedImageName } from './getStandardisedImageName';

--- a/packages/utils/src/validation/validatorFunctions.js
+++ b/packages/utils/src/validation/validatorFunctions.js
@@ -99,7 +99,7 @@ export const isHexColor = value => {
 };
 
 export const isUrl = value => {
-  if (!validator.isUrl(value.toString())) {
+  if (!validator.isURL(value.toString())) {
     // Coerce to string before checking with validator
     throw new ValidationError('Not a valid url');
   }


### PR DESCRIPTION
### Issue WAITP-1142: image file upload

### Changes:
- Created handlers for creating and editing landing pages to allow for image upload handling
- Updated S3Client util to handle different image types because the previous way would not correctly upload svg images. 
- Added validation S3Client util to throw an error if the file is not an image type
- Fixed casing error in validator util: `isUrl` became `isURL`

