### PR TITLE
Hotfix: Update usage of react-query in PSSS after version bump

### DIFF
--- a/packages/psss/package.json
+++ b/packages/psss/package.json
@@ -57,7 +57,6 @@
     "react-hook-form": "^6.0.0",
     "react-password-strength-bar": "^0.3.3",
     "react-query": "^3.19.0",
-    "react-query-devtools": "^2.6.0",
     "react-redux": "^7.1.0",
     "react-router-dom": "^5.1.2",
     "redux": "^4.0.2",

--- a/packages/psss/src/AppProviders.js
+++ b/packages/psss/src/AppProviders.js
@@ -5,11 +5,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Provider } from 'react-redux';
+import { QueryClient, QueryClientProvider } from 'react-query';
 import { MuiThemeProvider, StylesProvider } from '@material-ui/core/styles';
 import { ThemeProvider } from 'styled-components';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import { PersistGateProvider } from './utils/PersistGateProvider';
 import { theme } from './theme';
+
+const queryClient = new QueryClient();
 
 export const AppProviders = ({ children, store }) => {
   return (
@@ -18,8 +21,10 @@ export const AppProviders = ({ children, store }) => {
         <StylesProvider injectFirst>
           <MuiThemeProvider theme={theme}>
             <ThemeProvider theme={theme}>
-              <CssBaseline />
-              {children}
+              <QueryClientProvider client={queryClient}>
+                <CssBaseline />
+                {children}
+              </QueryClientProvider>
             </ThemeProvider>
           </MuiThemeProvider>
         </StylesProvider>

--- a/packages/psss/src/api/mutations.js
+++ b/packages/psss/src/api/mutations.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
-import { queryCache, useMutation } from 'react-query';
+import { useQueryClient, useMutation } from 'react-query';
 import { remove, put, post } from './api';
 
 export const useConfirmWeeklyReport = (countryCode, period) =>
@@ -15,15 +15,15 @@ export const useConfirmWeeklyReport = (countryCode, period) =>
     {
       onSuccess: response => {
         // Same as useSaveWeeklyReport, we need to invalidate all weekly data
-        queryCache.invalidateQueries(`confirmedWeeklyReport/${countryCode}`);
+        useQueryClient().invalidateQueries(`confirmedWeeklyReport/${countryCode}`);
         // regional (multi-country) level
-        queryCache.invalidateQueries('confirmedWeeklyReport', { exact: true });
+        useQueryClient().invalidateQueries('confirmedWeeklyReport', { exact: true });
 
         if (response?.alertData?.createdAlerts?.length > 0) {
-          queryCache.invalidateQueries(`alerts/active`);
+          useQueryClient().invalidateQueries(`alerts/active`);
         }
         if (response?.alertData?.alertsArchived) {
-          queryCache.invalidateQueries(`alerts/archive`);
+          useQueryClient().invalidateQueries(`alerts/archive`);
         }
       },
     },
@@ -38,10 +38,10 @@ export const useSaveWeeklyReport = ({ countryCode, siteCode = '', week }) =>
       }),
     {
       onSuccess: () => {
-        queryCache.invalidateQueries(`weeklyReport/${countryCode}/sites`);
+        useQueryClient().invalidateQueries(`weeklyReport/${countryCode}/sites`);
         // Even though we only changed one week of data, we need to re-fetch the complete list because
         // the data for a specific week is dependant on previous weeks, even across pages.
-        queryCache.invalidateQueries(`weeklyReport/${countryCode}`);
+        useQueryClient().invalidateQueries(`weeklyReport/${countryCode}`);
       },
     },
   );
@@ -55,7 +55,7 @@ export const useDeleteWeeklyReport = ({ countryCode, week }) =>
     {
       onSuccess: () => {
         // Same as useSaveWeeklyReport, we need to invalidate all weekly data
-        queryCache.invalidateQueries(`weeklyReport/${countryCode}`);
+        useQueryClient().invalidateQueries(`weeklyReport/${countryCode}`);
       },
     },
   );

--- a/packages/psss/src/api/queries/helpers/query.js
+++ b/packages/psss/src/api/queries/helpers/query.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
  */
 
-import { usePaginatedQuery, useQuery } from 'react-query';
+import { useQuery } from 'react-query';
 import { get } from '../../api';
 
 const COMMON_QUERY_OPTIONS = {
@@ -44,11 +44,12 @@ export const useReport = (endpoint, apiOptions = {}, queryOptions = {}) => {
  * @param queryOptions react-query options
  */
 export const usePaginatedReport = (endpoint, apiOptions = {}, queryOptions = {}) => {
-  const query = usePaginatedQuery([endpoint, apiOptions.params], () => get(endpoint, apiOptions), {
+  const query = useQuery([endpoint, apiOptions.params], () => get(endpoint, apiOptions), {
     ...COMMON_QUERY_OPTIONS,
     ...queryOptions,
+    keepPreviousData: true,
   });
-  const data = query?.resolvedData?.data?.results ?? [];
+  const data = query?.data?.results ?? [];
 
   return { ...query, data };
 };

--- a/packages/psss/src/api/queries/useAlerts.js
+++ b/packages/psss/src/api/queries/useAlerts.js
@@ -4,7 +4,7 @@
  */
 
 import orderBy from 'lodash.orderby';
-import { queryCache, useMutation } from 'react-query';
+import { useQueryClient, useMutation } from 'react-query';
 import { MIN_DATE, SYNDROMES } from '../../constants';
 import { getPeriodByDate } from '../../utils';
 import { useData } from './helpers';
@@ -37,8 +37,8 @@ export const useAlerts = (period, orgUnitCodes, alertCategory) => {
 export const useArchiveAlert = alertId =>
   useMutation(() => put(`alerts/${alertId}/archive`), {
     onSuccess: () => {
-      queryCache.invalidateQueries(`alerts/active`);
-      queryCache.invalidateQueries(`alerts/archive`);
+      useQueryClient().invalidateQueries(`alerts/active`);
+      useQueryClient().invalidateQueries(`alerts/archive`);
     },
     throwOnError: true,
   });
@@ -46,8 +46,8 @@ export const useArchiveAlert = alertId =>
 export const useRestoreArchivedAlert = alertId =>
   useMutation(() => put(`alerts/${alertId}/unarchive`), {
     onSuccess: () => {
-      queryCache.invalidateQueries(`alerts/active`);
-      queryCache.invalidateQueries(`alerts/archive`);
+      useQueryClient().invalidateQueries(`alerts/active`);
+      useQueryClient().invalidateQueries(`alerts/archive`);
     },
     throwOnError: true,
   });
@@ -55,7 +55,7 @@ export const useRestoreArchivedAlert = alertId =>
 export const useDeleteAlert = alertId =>
   useMutation(() => remove(`alerts/${alertId}`), {
     onSuccess: () => {
-      queryCache.invalidateQueries(`alerts/archive`);
+      useQueryClient().invalidateQueries(`alerts/archive`);
     },
     throwOnError: true,
   });

--- a/packages/psss/src/api/queries/useSingleWeeklyReport.js
+++ b/packages/psss/src/api/queries/useSingleWeeklyReport.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
-import { queryCache } from 'react-query';
+import { useQueryClient } from 'react-query';
 import { calculateWeekStatus } from '../../utils';
 import { REPORT_STATUSES } from '../../constants';
 import { EMPTY_SYNDROME_DATA, getSyndromeData, useReport } from './helpers';
@@ -32,7 +32,7 @@ const useCachedQuery = (endpoint, period, queryKey) => {
       initialData: () => {
         // If we have a page of data, and we open a detail for a specific week, we don't want
         // to re-fetch the data for that week, so we get the specific week data from the cache
-        const cachedQuery = queryCache.getQueryData([endpoint, queryKey]);
+        const cachedQuery = useQueryClient().getQueryData([endpoint, queryKey]);
         const results = cachedQuery?.data?.results;
 
         if (!results) {

--- a/packages/psss/src/containers/Modals/ArchiveAlertModal.js
+++ b/packages/psss/src/containers/Modals/ArchiveAlertModal.js
@@ -44,7 +44,7 @@ const STATUS = {
 export const ArchiveAlertModal = ({ isOpen, onClose, alertId }) => {
   const [status, setStatus] = useState(STATUS.INITIAL);
   const { setIsOpen } = useContext(AlertsPanelContext);
-  const [archiveAlert, { error }] = useArchiveAlert(alertId);
+  const { mutate: archiveAlert, error } = useArchiveAlert(alertId);
 
   const handleArchive = useCallback(async () => {
     setStatus(STATUS.LOADING);

--- a/packages/psss/src/containers/Modals/DeleteAlertModal.js
+++ b/packages/psss/src/containers/Modals/DeleteAlertModal.js
@@ -20,7 +20,7 @@ const STATUS = {
 
 export const DeleteAlertModal = ({ isOpen, onClose, alertId }) => {
   const [status, setStatus] = useState(STATUS.INITIAL);
-  const [deleteAlert, { error }] = useDeleteAlert(alertId);
+  const { mutate: deleteAlert, error } = useDeleteAlert(alertId);
 
   const handleDelete = useCallback(async () => {
     setStatus(STATUS.LOADING);

--- a/packages/psss/src/containers/Modals/RestoreArchivedAlertModal.js
+++ b/packages/psss/src/containers/Modals/RestoreArchivedAlertModal.js
@@ -20,7 +20,7 @@ const STATUS = {
 
 export const RestoreArchivedAlertModal = ({ isOpen, onClose, alertId }) => {
   const [status, setStatus] = useState(STATUS.INITIAL);
-  const [restoreArchivedAlert, { error }] = useRestoreArchivedAlert(alertId);
+  const { mutate: restoreArchivedAlert, error } = useRestoreArchivedAlert(alertId);
 
   const handleArchive = useCallback(async () => {
     setStatus(STATUS.LOADING);

--- a/packages/psss/src/containers/Panels/WeeklyReportsPanel.js
+++ b/packages/psss/src/containers/Panels/WeeklyReportsPanel.js
@@ -124,7 +124,7 @@ export const WeeklyReportsPanelComponent = React.memo(
       pageQueryKey,
     );
 
-    const [confirmReport, { isLoading: isConfirming, reset, error }] = useConfirmWeeklyReport(
+    const { mutate: confirmReport, isLoading: isConfirming, reset, error } = useConfirmWeeklyReport(
       countryCode,
       activeWeek,
     );

--- a/packages/psss/src/containers/Tables/WeeklyReportTable/WeeklyReportTable.js
+++ b/packages/psss/src/containers/Tables/WeeklyReportTable/WeeklyReportTable.js
@@ -99,12 +99,12 @@ export const WeeklyReportTable = React.memo(
     const { tableStatus, setTableStatus } = useContext(EditableTableContext);
     const { countryCode } = useParams();
     const { handleSubmit, ...methods } = useForm();
-    const [saveReport, saveResults] = useSaveWeeklyReport({
+    const { mutate: saveReport, ...saveResults } = useSaveWeeklyReport({
       countryCode,
       siteCode,
       week: weekNumber,
     });
-    const [deleteReport, deleteResults] = useDeleteWeeklyReport({
+    const { mutate: deleteReport, ...deleteResults } = useDeleteWeeklyReport({
       countryCode,
       week: weekNumber,
     });

--- a/packages/psss/src/index.js
+++ b/packages/psss/src/index.js
@@ -4,7 +4,7 @@
  */
 import React from 'react';
 import { render as renderReactApp } from 'react-dom';
-import { ReactQueryDevtools } from 'react-query-devtools';
+import { ReactQueryDevtools } from 'react-query/devtools';
 import { EnvBanner } from '@tupaia/ui-components';
 import App from './App';
 import { AppProviders } from './AppProviders';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2116,7 +2116,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.10.3, @babel/runtime@npm:^7.10.5, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.14.0, @babel/runtime@npm:^7.14.6, @babel/runtime@npm:^7.14.8, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.4.2, @babel/runtime@npm:^7.4.4, @babel/runtime@npm:^7.5.0, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.0, @babel/runtime@npm:^7.6.2, @babel/runtime@npm:^7.6.3, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.3, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.10.3, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.14.0, @babel/runtime@npm:^7.14.6, @babel/runtime@npm:^7.14.8, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.4.2, @babel/runtime@npm:^7.4.4, @babel/runtime@npm:^7.5.0, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.0, @babel/runtime@npm:^7.6.2, @babel/runtime@npm:^7.6.3, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.3, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
   version: 7.15.4
   resolution: "@babel/runtime@npm:7.15.4"
   dependencies:
@@ -5637,7 +5637,6 @@ __metadata:
     react-hook-form: ^6.0.0
     react-password-strength-bar: ^0.3.3
     react-query: ^3.19.0
-    react-query-devtools: ^2.6.0
     react-redux: ^7.1.0
     react-router-dom: ^5.1.2
     redux: ^4.0.2
@@ -23278,16 +23277,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"match-sorter@npm:^4.1.0":
-  version: 4.2.1
-  resolution: "match-sorter@npm:4.2.1"
-  dependencies:
-    "@babel/runtime": ^7.10.5
-    remove-accents: 0.4.2
-  checksum: 7f3cd8f84cdb4567b7a81f66a095e418044f318f41b6c8a1640730c99e370af9e5054f5a1ed2dfa1287a23101d75a105da63e4d95e8ac2f7061a8f8b32367c7d
-  languageName: node
-  linkType: hard
-
 "match-sorter@npm:^6.0.2":
   version: 6.1.0
   resolution: "match-sorter@npm:6.1.0"
@@ -29740,18 +29729,6 @@ __metadata:
     "@popperjs/core": ^2.0.0
     react: ^16.8.0 || ^17
   checksum: 915fcf08e1da4fd48a200074fcdd936f601ee2173f1e730cfed8a54fd47716aa8bf9cce2392463e3bcbe64a096d0baf463809ed2874b94d3a9d430ae6d817b5d
-  languageName: node
-  linkType: hard
-
-"react-query-devtools@npm:^2.6.0":
-  version: 2.6.3
-  resolution: "react-query-devtools@npm:2.6.3"
-  dependencies:
-    match-sorter: ^4.1.0
-  peerDependencies:
-    react: ^16.6.3 || ^17.0.0
-    react-query: ^2.0.0
-  checksum: 55cd257c32af83ac33ddff32a7234922fc53dd212c8a92dbee2a5c494c08763a94f60c8f455416ee4dde8ee7d908c7762b90f11d25d86e87efff9b729a8c2cfc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
As part of RN-736, the version of `react-query` used by PSSS was bumped from `2.25.2` to `3.19.0`.

There are a number of breaking changes between these versions that need to be addressed: https://tanstack.com/query/v4/docs/react/guides/migrating-to-react-query-3