### PR TITLE
Waitp 1185 landing pages url

### DIFF
--- a/packages/admin-panel/src/pages/resources/CustomLandingPagesPage.js
+++ b/packages/admin-panel/src/pages/resources/CustomLandingPagesPage.js
@@ -9,9 +9,9 @@ import { prettyArray } from '../../utilities';
 const LANDING_PAGES_ENDPOINT = 'landingPages';
 
 // the URL prefix to display in the url_segment field
-const URL_PREFIX = window.location.origin.replace('admin', 'www');
+const URL_PREFIX = `https://${process.env.NODE_ENV === 'production' ? 'www' : 'dev'}.tupaia.org`;
 
-const DISPLAY_URL_PREFIX = `${URL_PREFIX.replace(new RegExp('(https://)|(http://)'), '')}/`;
+const DISPLAY_URL_PREFIX = `${URL_PREFIX.replace('https://', '')}/`;
 
 // All the fields of a custom landing page
 const FIELDS = {


### PR DESCRIPTION
### Issue WAITP-1185: Admin panel url prefix logic for landing pages

### Changes:
- Update to only direct to dev or prod urls, since that's the reality of where these will be used, so as not to have anything weird happen with release branch urls
