### PR TITLE
Waitp 1188 multi project landing page styling

### DIFF
--- a/packages/web-frontend/src/screens/LandingPage/LandingPage.js
+++ b/packages/web-frontend/src/screens/LandingPage/LandingPage.js
@@ -34,11 +34,12 @@ const Container = styled(MuiContainer)`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  height: calc(100vh - ${TOP_BAR_HEIGHT_MOBILE}px);
+  min-height: calc(100vh - ${TOP_BAR_HEIGHT_MOBILE}px);
   overflow-y: auto;
-  @media screen and (min-width: ${({ theme }) => theme.breakpoints.values.sm}px) {
+  @media screen and (min-width: ${({ theme }) =>
+      theme.breakpoints.values.sm}px) and (min-height: 600px) {
     padding: 2em 3.5em;
-    height: calc(100vh - ${TOP_BAR_HEIGHT}px);
+    min-height: calc(100vh - ${TOP_BAR_HEIGHT}px);
   }
 `;
 

--- a/packages/web-frontend/src/screens/LandingPage/LandingPageFooter.js
+++ b/packages/web-frontend/src/screens/LandingPage/LandingPageFooter.js
@@ -31,7 +31,8 @@ const FooterHeader = styled(Typography)`
 const FooterBodyText = styled.p`
   margin: 0;
   font-size: 0.875em;
-  @media screen and (min-width: ${props => props.theme.breakpoints.values.sm}px) {
+  @media screen and (min-width: ${({ theme }) =>
+      theme.breakpoints.values.sm}px) and (min-height: 600px) {
     font-size: 1em;
   }
 `;
@@ -64,7 +65,8 @@ const FooterContactListItem = styled.li`
   & + & {
     margin-top: 0.5em;
   }
-  @media screen and (min-width: ${props => props.theme.breakpoints.values.sm}px) {
+  @media screen and (min-width: ${({ theme }) =>
+      theme.breakpoints.values.sm}px) and (min-height: 600px) {
     font-size: 1em;
   }
 `;
@@ -75,7 +77,8 @@ const FooterPoweredByWrapper = styled.div`
   display: flex;
   justify-content: flex-end;
   padding-top: 1em;
-  @media screen and (min-width: ${props => props.theme.breakpoints.values.sm}px) {
+  @media screen and (min-width: ${({ theme }) =>
+      theme.breakpoints.values.sm}px) and (min-height: 600px) {
     padding-top: 2em;
     margin-top: -3px;
   }

--- a/packages/web-frontend/src/screens/LandingPage/MultiProjectLandingPage.js
+++ b/packages/web-frontend/src/screens/LandingPage/MultiProjectLandingPage.js
@@ -43,7 +43,8 @@ const Title = styled(Typography)`
   color: ${({ theme }) => theme.palette.common.white};
   text-shadow: 1px 1px ${TRANS_BLACK};
   max-width: 30em;
-  @media (min-width: ${({ theme }) => theme.breakpoints.values.md}px) {
+  @media screen and (min-width: ${({ theme }) =>
+      theme.breakpoints.values.sm}px) and (min-height: 600px) {
     font-size: 2em;
     margin-bottom: 1.8em;
   }
@@ -64,17 +65,16 @@ export function MultiProjectLandingPage() {
   const { navigateToProject, navigateToRequestProjectAccess, navigateToLogin } = useNavigation();
   const {
     projects,
-    customLandingPageSettings: {
-      include_name_in_header: includeNameInHeader,
-      primary_hexcode: primaryColor,
-    },
+    customLandingPageSettings: { includeNameInHeader, primaryHexcode },
   } = useCustomLandingPages();
+
   const { isUserLoggedIn } = useAuth();
+
   return (
     <Wrapper>
       <Title variant={includeNameInHeader ? 'h2' : 'h1'}>Select a project below to view.</Title>
       <ProjectsWrapper>
-        <ProjectsContainer primaryColor={primaryColor}>
+        <ProjectsContainer primaryColor={primaryHexcode}>
           <ProjectCardList
             projects={projects}
             actions={{

--- a/packages/web-frontend/src/screens/LandingPage/SingleProjectLandingPage.js
+++ b/packages/web-frontend/src/screens/LandingPage/SingleProjectLandingPage.js
@@ -22,13 +22,15 @@ const Wrapper = styled.div`
   flex-direction: column;
   justify-content: center;
   height: 100%;
+  min-height: 55vh;
 `;
 
 const ExtendedTitle = styled(Typography)`
   color: ${props => props.theme.palette.common.white};
   font-weight: ${props => props.theme.typography.fontWeightBold};
   font-size: 1.5em;
-  @media screen and (min-width: ${({ theme }) => theme.breakpoints.values.sm}px) {
+  @media screen and (min-width: ${({ theme }) =>
+      theme.breakpoints.values.sm}px) and (min-height: 600px) {
     font-size: 2em;
   }
 `;
@@ -46,7 +48,8 @@ const ActionButton = styled(Button)`
   ${ExtendedTitle} + & {
     margin-top: 2em;
   }
-  @media screen and (min-width: ${({ theme }) => theme.breakpoints.values.sm}px) {
+  @media screen and (min-width: ${({ theme }) =>
+      theme.breakpoints.values.sm}px) and (min-height: 600px) {
     font-size: 1em;
   }
 `;


### PR DESCRIPTION
### Issue WAITP-1188: Update styling for multi project landing page

### Changes:
- Restricted the height setting of the wrapper to single project view so that multi projects on mobile didn't overlap the footer
- Updated media queries to handle landscape mobile
- Updated names of fields to reflect casing of API return value
