### PR TITLE
Waitp 1191 image upload caching

### DIFF
--- a/packages/admin-panel/src/pages/ProfilePage.js
+++ b/packages/admin-panel/src/pages/ProfilePage.js
@@ -109,7 +109,7 @@ const ProfilePageComponent = React.memo(({ user, onUpdateProfile, getHeaderEl })
           {status === STATUS.SUCCESS && <SuccessMessage>{successMessage}</SuccessMessage>}
           <ImageUploadField
             name="profileImage"
-            encodedImage={profileImage && profileImage.data}
+            imageSrc={profileImage && profileImage.data}
             onChange={handleFileChange}
             onDelete={handleFileDelete}
             avatarInitial={userInitial}

--- a/packages/admin-panel/src/widgets/InputField/registerInputFields.js
+++ b/packages/admin-panel/src/widgets/InputField/registerInputFields.js
@@ -272,7 +272,7 @@ export const registerInputFields = () => {
     <StyledFileInputWrapper>
       <ImageUploadField
         name={props.name}
-        encodedImage={props.value}
+        imageSrc={props.value}
         onDelete={() => props.onChange(props.inputKey, null)}
         onChange={image => props.onChange(props.inputKey, image)}
         label={props.label}

--- a/packages/central-server/src/apiV2/landingPages/CreateLandingPage.js
+++ b/packages/central-server/src/apiV2/landingPages/CreateLandingPage.js
@@ -43,8 +43,14 @@ export class CreateLandingPage extends BESAdminCreateHandler {
         encodedBackgroundImage,
         landingPageUrlSegment,
         'landing_page_image',
+        true,
       ),
-      logo_url: await uploadImage(encodedLogoImage, landingPageUrlSegment, 'landing_page_logo'),
+      logo_url: await uploadImage(
+        encodedLogoImage,
+        landingPageUrlSegment,
+        'landing_page_logo',
+        true,
+      ),
     };
     // The record has already been updated, so update the existing record with the new fields
     return models.landingPage.updateById(landingPageId, updates);

--- a/packages/central-server/src/apiV2/landingPages/EditLandingPage.js
+++ b/packages/central-server/src/apiV2/landingPages/EditLandingPage.js
@@ -6,10 +6,10 @@ import { BESAdminEditHandler } from '../EditHandler';
 import { uploadImage } from '../utilities';
 
 export class EditLandingPage extends BESAdminEditHandler {
-  // Fetch the provided of the landing page
-  async getFields(fields) {
+  // Fetch the url_segment and existing image paths for the landing page
+  async getFields() {
     const landingPage = await this.models.landingPage.findById(this.recordId, {
-      columns: fields,
+      columns: ['url_segment', 'image_url', 'logo_url'],
     });
     return landingPage;
   }
@@ -26,7 +26,7 @@ export class EditLandingPage extends BESAdminEditHandler {
       url_segment: urlSegment,
       image_url: backgroundImageUrl,
       logo_url: logoImageUrl,
-    } = await this.getFields(['url_segment', 'image_url', 'logo_url']);
+    } = await this.getFields();
 
     // check first if field is undefined, as we don't want to upload an image if the field is not being updated, since this might cause the field to be reset
     if (encodedBackgroundImage !== undefined) {

--- a/packages/central-server/src/apiV2/projects/CreateProject.js
+++ b/packages/central-server/src/apiV2/projects/CreateProject.js
@@ -74,8 +74,8 @@ export class CreateProject extends BESAdminCreateHandler {
   async insertImagePaths(models, projectId, projectCode, encodedBackgroundImage, encodedLogoImage) {
     // image_url and logo_url are currently required fields, so the validator will error before this point if either of these is falsey.
     const updates = {
-      image_url: await uploadImage(encodedBackgroundImage, projectCode, 'project_image'),
-      logo_url: await uploadImage(encodedLogoImage, projectCode, 'project_logo'),
+      image_url: await uploadImage(encodedBackgroundImage, projectCode, 'project_image', true),
+      logo_url: await uploadImage(encodedLogoImage, projectCode, 'project_logo', true),
     };
     // The record has already been updated, so update the existing record with the new fields
     return models.project.updateById(projectId, updates);

--- a/packages/central-server/src/apiV2/projects/EditProject.js
+++ b/packages/central-server/src/apiV2/projects/EditProject.js
@@ -6,28 +6,49 @@ import { BESAdminEditHandler } from '../EditHandler';
 import { uploadImage } from '../utilities';
 
 export class EditProject extends BESAdminEditHandler {
-  // Fetch the code of the project, as this is needed as a unique identifier to upload the images to S3. If it is being edited, then the code will be in the updatedFields, otherwise it will need to be fetched from the database
-  async getProjectCode() {
-    const { code } = this.updatedFields;
-    if (code) return code;
+  // Fetch the code of the project, as this is needed as a unique identifier to upload the images to S3.
+  // Also fetch the existing image_url and logo_url, so we can delete the old images from S3.
+  async getFields() {
     const project = await this.models.project.findById(this.recordId, {
-      columns: ['code'],
+      columns: ['code', 'image_url', 'logo_url'],
     });
-    return project.code;
+    return project;
   }
 
   // Before updating the project, if the image_url and logo_url have changed, we need to upload the new images to S3 and update the image_url and logo_url fields with the new urls. This also will handle deleting of the image_url and logo_url fields, as the uploadImage function will return the original value if the encoded image is null or not a base64 encoded image.
   async updateRecord() {
-    const { image_url: encodedBackgroundImage, logo_url: encodedLogoImage } = this.updatedFields;
+    const {
+      image_url: encodedBackgroundImage,
+      logo_url: encodedLogoImage,
+      code: updatedCode,
+    } = this.updatedFields;
     const updatedFields = { ...this.updatedFields };
 
-    const code = await this.getProjectCode();
+    const {
+      image_url: existingBackgroundImage,
+      logo_url: existingLogoImage,
+      code: existingCode,
+    } = await this.getFields();
+
+    const code = updatedCode || existingCode;
     // check first if field is undefined, as we don't want to upload an image if the field is not being updated, since this might cause the field to be reset
     if (encodedBackgroundImage !== undefined) {
-      updatedFields.image_url = await uploadImage(encodedBackgroundImage, code, 'project_image');
+      updatedFields.image_url = await uploadImage(
+        encodedBackgroundImage,
+        code,
+        'project_image',
+        true,
+        existingBackgroundImage,
+      );
     }
     if (encodedLogoImage !== undefined) {
-      updatedFields.logo_url = await uploadImage(encodedLogoImage, code, 'project_logo');
+      updatedFields.logo_url = await uploadImage(
+        encodedLogoImage,
+        code,
+        'project_logo',
+        true,
+        existingLogoImage,
+      );
     }
     await this.models.project.updateById(this.recordId, updatedFields);
   }

--- a/packages/central-server/src/apiV2/utilities/uploadImage.js
+++ b/packages/central-server/src/apiV2/utilities/uploadImage.js
@@ -12,18 +12,31 @@ import { getStandardisedImageName } from '../../utilities';
  * @param {string} encodedImage
  * @param {string} uniqueId
  * @param {string} imageSuffix
+ * @param {boolean} useTimestamp (if true, the image will be uploaded with a timestamp appended to the end of the filename)
+ * @param {string} existingImagePath (if there is an existing image for the same field, this should be passed in so that it can be deleted before uploading the new image)
  * @returns {string} The URL of the uploaded image
  */
-export const uploadImage = async (encodedImage, uniqueId, imageSuffix) => {
-  // If the image is undefined then we are deleting it, so return an empty string
+export const uploadImage = async (
+  encodedImage,
+  uniqueId,
+  imageSuffix,
+  useTimestamp = false,
+  existingImagePath,
+) => {
+  // If the image is undefined then we are removing the value from the field (but not deleting the image), so return an empty string
   if (encodedImage === undefined) return '';
   // If the image is not a base64 encoded image, then it is an external URL (which we need to accept for backwards compatibility with the older way of uploading things like project images).
   // If the image is null or an empty string, we are not editing it, so return as usual.
   if (encodedImage === null || !encodedImage.includes('data:image')) return encodedImage;
   const s3Client = new S3Client(new AWS.S3());
+
+  // If there is an existing image, remove it before uploading the new one so that we don't end up with extra images for the same field
+  if (existingImagePath) await s3Client.deleteFile(existingImagePath);
+
+  // Upload the new image with a standardised name
   const uploadedImageURL = await s3Client.uploadImage(
     encodedImage,
-    getStandardisedImageName(uniqueId, imageSuffix),
+    getStandardisedImageName(uniqueId, imageSuffix, useTimestamp),
     true,
   );
   return uploadedImageURL;

--- a/packages/central-server/src/utilities/getStandardisedImageName.js
+++ b/packages/central-server/src/utilities/getStandardisedImageName.js
@@ -4,4 +4,5 @@
  */
 
 /**  Generates a standardised image name based on the uniqueId and imageSuffix. For example for a project, uniqueId would be the project code and imageSuffix would be either 'project_image' or 'project_logo' */
-export const getStandardisedImageName = (uniqueId, imageSuffix) => `${uniqueId}_${imageSuffix}`;
+export const getStandardisedImageName = (uniqueId, imageSuffix, useTimestamp) =>
+  `${uniqueId}_${imageSuffix}${useTimestamp ? `_${Date.now()}` : ''}`;

--- a/packages/psss/src/views/Tabs/ProfileTabView.js
+++ b/packages/psss/src/views/Tabs/ProfileTabView.js
@@ -105,7 +105,7 @@ const ProfileTabViewComponent = React.memo(({ user, onUpdateProfile }) => {
           {status === STATUS.SUCCESS && <SuccessMessage>{successMessage}</SuccessMessage>}
           <ImageUploadField
             name="profileImage"
-            encodedImage={profileImage && profileImage.data}
+            imageSrc={profileImage && profileImage.data}
             onChange={handleFileChange}
             onDelete={handleFileDelete}
             avatarInitial={userInitial}

--- a/packages/ui-components/src/components/Inputs/ImageUploadField.js
+++ b/packages/ui-components/src/components/Inputs/ImageUploadField.js
@@ -126,6 +126,13 @@ export const ImageUploadField = React.memo(
       if (validated) onChange(image);
     };
 
+    const timestamp = Date.now();
+
+    const decachedImage =
+      encodedImage && !encodedImage.includes('base64')
+        ? `${encodedImage}?t=${timestamp}`
+        : encodedImage;
+
     return (
       <Label as="label" htmlFor={name}>
         <HiddenFileInput
@@ -138,7 +145,12 @@ export const ImageUploadField = React.memo(
           aria-invalid={!isValid}
         />
         <Box position="relative">
-          <StyledAvatar initial={avatarInitial} src={encodedImage} variant={avatarVariant}>
+          <StyledAvatar
+            initial={avatarInitial}
+            src={decachedImage}
+            variant={avatarVariant}
+            alt={`Image for field ${label}`}
+          >
             {avatarInitial}
           </StyledAvatar>
           {encodedImage && (

--- a/packages/ui-components/src/components/Inputs/ImageUploadField.js
+++ b/packages/ui-components/src/components/Inputs/ImageUploadField.js
@@ -79,7 +79,7 @@ const LabelWrapper = styled(Box)`
 export const ImageUploadField = React.memo(
   ({
     name,
-    encodedImage,
+    imageSrc,
     onDelete,
     onChange,
     avatarInitial,
@@ -126,13 +126,6 @@ export const ImageUploadField = React.memo(
       if (validated) onChange(image);
     };
 
-    const timestamp = Date.now();
-
-    const decachedImage =
-      encodedImage && !encodedImage.includes('base64')
-        ? `${encodedImage}?t=${timestamp}`
-        : encodedImage;
-
     return (
       <Label as="label" htmlFor={name}>
         <HiddenFileInput
@@ -147,13 +140,13 @@ export const ImageUploadField = React.memo(
         <Box position="relative">
           <StyledAvatar
             initial={avatarInitial}
-            src={decachedImage}
+            src={imageSrc}
             variant={avatarVariant}
             alt={`Image for field ${label}`}
           >
             {avatarInitial}
           </StyledAvatar>
-          {encodedImage && (
+          {imageSrc && (
             <DeleteButton onClick={() => setConfirmModalIsOpen(true)}>
               <DeleteIcon />
             </DeleteButton>
@@ -191,7 +184,7 @@ export const ImageUploadField = React.memo(
 ImageUploadField.propTypes = {
   name: PropTypes.string.isRequired,
   userInitial: PropTypes.string,
-  encodedImage: PropTypes.string,
+  imageSrc: PropTypes.string,
   onChange: PropTypes.func,
   onDelete: PropTypes.func,
   avatarInitial: PropTypes.string,
@@ -207,7 +200,7 @@ ImageUploadField.propTypes = {
 
 ImageUploadField.defaultProps = {
   userInitial: undefined,
-  encodedImage: null,
+  imageSrc: null,
   onChange: () => {},
   onDelete: () => {},
   avatarInitial: '',

--- a/packages/ui-components/stories/inputs/imageUploadField.stories.js
+++ b/packages/ui-components/stories/inputs/imageUploadField.stories.js
@@ -44,7 +44,7 @@ export const Simple = () => {
     <Container>
       <ImageUploadField
         name="profileImage"
-        encodedImage={profileImage && profileImage.data}
+        imageSrc={profileImage && profileImage.data}
         onChange={handleFileChange}
         onDelete={handleFileDelete}
         avatarInitial="BES"

--- a/packages/utils/src/s3/S3Client.js
+++ b/packages/utils/src/s3/S3Client.js
@@ -98,6 +98,25 @@ export class S3Client {
     return this.uploadPrivateFile(s3FilePath, fileStream);
   }
 
+  async deleteFile(filePath) {
+    const fileName = filePath.split(getS3ImageFilePath())[1];
+    return new Promise((resolve, reject) => {
+      this.s3.deleteObject(
+        {
+          Bucket: S3_BUCKET_NAME,
+          Key: fileName,
+        },
+        (error, data) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve(data);
+          }
+        },
+      );
+    });
+  }
+
   /**
    * @public
    * @param {*} base64EncodedImage

--- a/packages/web-frontend/src/containers/TopBarLogo/index.js
+++ b/packages/web-frontend/src/containers/TopBarLogo/index.js
@@ -68,11 +68,8 @@ export const TopBarLogoComponent = ({ onClickLogo }) => {
     logoUrl: customLandingPageLogo,
   } = customLandingPageSettings;
 
-  const timestamp = Date.now();
   // If is a custom landing page, use the logo from the settings, else use the Tupaia logo
-  const logoSrc = isCustomLandingPage
-    ? `${customLandingPageLogo}?t=${timestamp}`
-    : TUPAIA_LIGHT_LOGO_SRC;
+  const logoSrc = isCustomLandingPage ? customLandingPageLogo : TUPAIA_LIGHT_LOGO_SRC;
   return (
     <LogoWrapper>
       <Logo onClick={onClickLogo} isCustomLandingPage={isCustomLandingPage}>

--- a/packages/web-frontend/src/containers/TopBarLogo/index.js
+++ b/packages/web-frontend/src/containers/TopBarLogo/index.js
@@ -67,8 +67,12 @@ export const TopBarLogoComponent = ({ onClickLogo }) => {
     includeNameInHeader: displayName = false,
     logoUrl: customLandingPageLogo,
   } = customLandingPageSettings;
+
+  const timestamp = Date.now();
   // If is a custom landing page, use the logo from the settings, else use the Tupaia logo
-  const logoSrc = isCustomLandingPage ? customLandingPageLogo : TUPAIA_LIGHT_LOGO_SRC;
+  const logoSrc = isCustomLandingPage
+    ? `${customLandingPageLogo}?t=${timestamp}`
+    : TUPAIA_LIGHT_LOGO_SRC;
   return (
     <LogoWrapper>
       <Logo onClick={onClickLogo} isCustomLandingPage={isCustomLandingPage}>

--- a/packages/web-frontend/src/screens/LandingPage/LandingPage.js
+++ b/packages/web-frontend/src/screens/LandingPage/LandingPage.js
@@ -48,14 +48,11 @@ export const LandingPage = () => {
   const { customLandingPageSettings, projects } = useCustomLandingPages();
   const { imageUrl } = customLandingPageSettings;
 
-  const timestamp = Date.now();
-  const backgroundImage = imageUrl ? `${imageUrl}?t=${timestamp}` : null;
-
   return (
     <>
       <EnvBanner />
       <TopBar />
-      <Wrapper backgroundImage={backgroundImage}>
+      <Wrapper backgroundImage={imageUrl}>
         <Container maxWidth={false}>
           {/* tupaia requires projects to work so we can assume that if there are no projects, it's just */}
           {/* because they haven't loaded yet. We can replace this with more idiomatic loading state */}

--- a/packages/web-frontend/src/screens/LandingPage/LandingPage.js
+++ b/packages/web-frontend/src/screens/LandingPage/LandingPage.js
@@ -46,7 +46,10 @@ const Container = styled(MuiContainer)`
 
 export const LandingPage = () => {
   const { customLandingPageSettings, projects } = useCustomLandingPages();
-  const { imageUrl: backgroundImage } = customLandingPageSettings;
+  const { imageUrl } = customLandingPageSettings;
+
+  const timestamp = Date.now();
+  const backgroundImage = imageUrl ? `${imageUrl}?t=${timestamp}` : null;
 
   return (
     <>


### PR DESCRIPTION
### Issue WAITP-1191

### Changes:
- Added timestamp query string to URL of image in `ImageUpload` component to prevent browser caching incorrectly
- Added timestamp query string to URL of image in landing page background and logo images to prevent browser caching incorrectly
Note: this is in response to an issue identified during testing. There is a slight performance impact by doing this but this should be minor.
