### PR TITLE
RN-917: Fix KoBo sync error when no data is returned

### DIFF
--- a/packages/central-server/src/kobo/startSyncWithKoBo.js
+++ b/packages/central-server/src/kobo/startSyncWithKoBo.js
@@ -123,15 +123,16 @@ export async function syncWithKoBo(models, dataBroker, syncGroupCode) {
     await validateSyncGroup(models, dataServiceSyncGroup);
 
     // Pull data from KoBo
-    const koboData = await dataBroker.pull(
-      {
-        code: syncGroupCode,
-        type: dataBroker.getDataSourceTypes().SYNC_GROUP,
-      },
-      {
-        startSubmissionTime: dataServiceSyncGroup.sync_cursor,
-      },
-    );
+    const koboData =
+      (await dataBroker.pull(
+        {
+          code: syncGroupCode,
+          type: dataBroker.getDataSourceTypes().SYNC_GROUP,
+        },
+        {
+          startSubmissionTime: dataServiceSyncGroup.sync_cursor,
+        },
+      )) || [];
 
     await models.wrapInTransaction(async transactingModels => {
       // Create new survey_responses in Tupaia


### PR DESCRIPTION
### Issue RN-917:

Pretty simple issue in the end. At some point `DataBroker.pull` started returning `undefined` if no data has been found.

No exactly sure why that changed, and arguably it should always return an array, but I don't wanna deal with that now.