### PR TITLE
Move utcMoment and PERIOD_TYPES to tsutils

### DIFF
--- a/packages/aggregator/package.json
+++ b/packages/aggregator/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@tupaia/data-broker": "1.0.0",
     "@tupaia/server-boilerplate": "1.0.0",
+    "@tupaia/tsutils": "1.0.0",
     "@tupaia/utils": "1.0.0",
     "lodash.groupby": "^4.6.0",
     "winston": "^3.3.3"

--- a/packages/aggregator/src/__tests__/analytics/aggregateAnalytics/aggregations/sumPreviousPerPeriod.test.js
+++ b/packages/aggregator/src/__tests__/analytics/aggregateAnalytics/aggregations/sumPreviousPerPeriod.test.js
@@ -4,7 +4,7 @@
  */
 
 import { arrayToAnalytics } from '@tupaia/data-broker';
-import { PERIOD_TYPES } from '@tupaia/utils';
+import { PERIOD_TYPES } from '@tupaia/tsutils';
 import {
   getDateRangeForSumPreviousPerPeriod,
   sumPreviousPerPeriod,

--- a/packages/aggregator/src/analytics/aggregateAnalytics/aggregateAnalytics.js
+++ b/packages/aggregator/src/analytics/aggregateAnalytics/aggregateAnalytics.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
-import { PERIOD_TYPES } from '@tupaia/utils';
+import { PERIOD_TYPES } from '@tupaia/tsutils';
 import { AGGREGATION_TYPES } from '../../aggregationTypes';
 import {
   countPerOrgGroup,

--- a/packages/aggregator/src/analytics/aggregateAnalytics/aggregations/getFinalValuePerPeriod.js
+++ b/packages/aggregator/src/analytics/aggregateAnalytics/aggregations/getFinalValuePerPeriod.js
@@ -3,7 +3,8 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
-import { PERIOD_TYPES, convertToPeriod, periodToType } from '@tupaia/utils';
+import { PERIOD_TYPES } from '@tupaia/tsutils';
+import { convertToPeriod, periodToType } from '@tupaia/utils';
 import { getPreferredPeriod, getContinuousPeriodsForAnalytics } from './utils';
 
 /**

--- a/packages/aggregator/src/analytics/aggregateAnalytics/aggregations/offsetPeriod.js
+++ b/packages/aggregator/src/analytics/aggregateAnalytics/aggregations/offsetPeriod.js
@@ -3,13 +3,13 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
+import { utcMoment } from '@tupaia/tsutils';
 import {
   momentToDateString,
   momentToPeriod,
   periodToMoment,
   periodToType,
   periodTypeToMomentUnit,
-  utcMoment,
 } from '@tupaia/utils';
 
 class RequiredConfigFieldError extends Error {

--- a/packages/aggregator/src/analytics/aggregateAnalytics/aggregations/sumAcrossPeriods.js
+++ b/packages/aggregator/src/analytics/aggregateAnalytics/aggregations/sumAcrossPeriods.js
@@ -3,7 +3,8 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
-import { convertToPeriod, isFuturePeriod, getCurrentPeriod, PERIOD_TYPES } from '@tupaia/utils';
+import { PERIOD_TYPES } from '@tupaia/tsutils';
+import { convertToPeriod, isFuturePeriod, getCurrentPeriod } from '@tupaia/utils';
 
 /**
  * Add the analytics together across the periods listed in the analytic response, and return an array

--- a/packages/data-api/src/sanitiseFetchDataOptions.ts
+++ b/packages/data-api/src/sanitiseFetchDataOptions.ts
@@ -3,7 +3,8 @@
  * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
  */
 
-import { utcMoment, stripTimezoneFromDate } from '@tupaia/utils';
+import { utcMoment } from '@tupaia/tsutils';
+import { stripTimezoneFromDate } from '@tupaia/utils';
 
 const getAdjustedDates = (startDate?: string, endDate?: string) => {
   const adjustMoment = (moment: any) => stripTimezoneFromDate(moment.toISOString());

--- a/packages/data-api/src/sanitiseFetchDataOptions.ts
+++ b/packages/data-api/src/sanitiseFetchDataOptions.ts
@@ -3,11 +3,13 @@
  * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
  */
 
+import type { Moment } from 'moment';
+
 import { utcMoment } from '@tupaia/tsutils';
 import { stripTimezoneFromDate } from '@tupaia/utils';
 
 const getAdjustedDates = (startDate?: string, endDate?: string) => {
-  const adjustMoment = (moment: any) => stripTimezoneFromDate(moment.toISOString());
+  const adjustMoment = (moment: Moment) => stripTimezoneFromDate(moment.toISOString());
 
   return {
     startDate: startDate ? adjustMoment(utcMoment(startDate).startOf('day')) : undefined,

--- a/packages/data-lake-api/package.json
+++ b/packages/data-lake-api/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@tupaia/database": "1.0.0",
+    "@tupaia/tsutils": "1.0.0",
     "@tupaia/utils": "1.0.0",
     "db-migrate": "^0.11.5",
     "db-migrate-pg": "^1.2.2",

--- a/packages/data-lake-api/src/sanitiseFetchDataOptions.ts
+++ b/packages/data-lake-api/src/sanitiseFetchDataOptions.ts
@@ -3,7 +3,8 @@
  * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
  */
 
-import { utcMoment, stripTimezoneFromDate } from '@tupaia/utils';
+import { utcMoment } from '@tupaia/tsutils';
+import { stripTimezoneFromDate } from '@tupaia/utils';
 
 const getAdjustedDates = (startDate?: string, endDate?: string) => {
   const adjustMoment = (moment: any) => stripTimezoneFromDate(moment.toISOString());

--- a/packages/data-lake-api/src/sanitiseFetchDataOptions.ts
+++ b/packages/data-lake-api/src/sanitiseFetchDataOptions.ts
@@ -3,11 +3,13 @@
  * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
  */
 
+import type { Moment } from 'moment';
+
 import { utcMoment } from '@tupaia/tsutils';
 import { stripTimezoneFromDate } from '@tupaia/utils';
 
 const getAdjustedDates = (startDate?: string, endDate?: string) => {
-  const adjustMoment = (moment: any) => stripTimezoneFromDate(moment.toISOString());
+  const adjustMoment = (moment: Moment) => stripTimezoneFromDate(moment.toISOString());
 
   return {
     startDate: startDate ? adjustMoment(utcMoment(startDate).startOf('day')) : undefined,

--- a/packages/dhis-api/package.json
+++ b/packages/dhis-api/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@tupaia/aggregator": "1.0.0",
+    "@tupaia/tsutils": "1.0.0",
     "@tupaia/utils": "1.0.0",
     "chai-as-promised": "^7.1.1",
     "lodash.groupby": "^4.6.0",

--- a/packages/dhis-api/src/DhisApi.js
+++ b/packages/dhis-api/src/DhisApi.js
@@ -5,7 +5,8 @@
 
 import winston from 'winston';
 import { aggregateAnalytics } from '@tupaia/aggregator';
-import { CustomError, getSortByKey, reduceToDictionary, utcMoment } from '@tupaia/utils';
+import { utcMoment } from '@tupaia/tsutils';
+import { CustomError, getSortByKey, reduceToDictionary } from '@tupaia/utils';
 import { DhisFetcher } from './DhisFetcher';
 import { DHIS2_RESOURCE_TYPES } from './types';
 import {

--- a/packages/dhis-api/src/__tests__/groupResults.test.js
+++ b/packages/dhis-api/src/__tests__/groupResults.test.js
@@ -1,11 +1,11 @@
 /**
- * Tupaia Config Server
- * Copyright (c) 2019 Beyond Essential Systems Pty Ltd
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
  */
 
 /* eslint-disable camelcase */
 
-import { PERIOD_TYPES } from '@tupaia/utils';
+import { PERIOD_TYPES } from '@tupaia/tsutils';
 import { groupAnalyticsByPeriod, groupEventsByOrgUnit, groupEventsByPeriod } from '../groupResults';
 
 const { DAY, WEEK, MONTH, YEAR } = PERIOD_TYPES;

--- a/packages/dhis-api/src/dhisToTupaiaPeriodType.js
+++ b/packages/dhis-api/src/dhisToTupaiaPeriodType.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
-import { PERIOD_TYPES } from '@tupaia/utils';
+import { PERIOD_TYPES } from '@tupaia/tsutils';
 
 const DHIS_TYPE_TO_PERIOD_TYPE = {
   Daily: PERIOD_TYPES.DAY,

--- a/packages/dhis-api/src/groupResults.js
+++ b/packages/dhis-api/src/groupResults.js
@@ -1,6 +1,7 @@
 import groupBy from 'lodash.groupby';
 
-import { utcMoment, momentToPeriod, convertToPeriod } from '@tupaia/utils';
+import { utcMoment } from '@tupaia/tsutils';
+import { momentToPeriod, convertToPeriod } from '@tupaia/utils';
 
 export const groupAnalyticsByPeriod = (analytics = [], periodType) =>
   analytics.reduce((results, analytic) => {

--- a/packages/indicators/package.json
+++ b/packages/indicators/package.json
@@ -24,6 +24,7 @@
     "@tupaia/data-broker": "1.0.0",
     "@tupaia/database": "1.0.0",
     "@tupaia/expression-parser": "1.0.0",
+    "@tupaia/tsutils": "1.0.0",
     "@tupaia/utils": "1.0.0",
     "lodash.groupby": "^4.6.0",
     "lodash.keyby": "^4.6.0"

--- a/packages/indicators/src/Builder/EventCheckConditionsBuilder/EventCheckConditionsBuilder.ts
+++ b/packages/indicators/src/Builder/EventCheckConditionsBuilder/EventCheckConditionsBuilder.ts
@@ -3,7 +3,8 @@
  * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
  */
 
-import { utcMoment, PERIOD_TYPES, momentToPeriod } from '@tupaia/utils';
+import { utcMoment } from '@tupaia/tsutils';
+import { PERIOD_TYPES, momentToPeriod } from '@tupaia/utils';
 
 import { Builder } from '../Builder';
 import { FetchOptions, Event } from '../../types';

--- a/packages/indicators/src/Builder/EventCheckConditionsBuilder/EventCheckConditionsBuilder.ts
+++ b/packages/indicators/src/Builder/EventCheckConditionsBuilder/EventCheckConditionsBuilder.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
  */
 
-import { utcMoment } from '@tupaia/tsutils';
-import { PERIOD_TYPES, momentToPeriod } from '@tupaia/utils';
+import { PERIOD_TYPES, utcMoment } from '@tupaia/tsutils';
+import { momentToPeriod } from '@tupaia/utils';
 
 import { Builder } from '../Builder';
 import { FetchOptions, Event } from '../../types';

--- a/packages/lesmis/package.json
+++ b/packages/lesmis/package.json
@@ -37,7 +37,6 @@
     "@material-ui/styles": "^4.9.10",
     "@tupaia/access-policy": "3.0.0",
     "@tupaia/admin-panel": "1.0.0",
-    "@tupaia/tsutils": "1.0.0",
     "@tupaia/ui-components": "1.0.0",
     "@tupaia/utils": "1.0.0",
     "axios": "^0.21.1",

--- a/packages/lesmis/package.json
+++ b/packages/lesmis/package.json
@@ -37,6 +37,7 @@
     "@material-ui/styles": "^4.9.10",
     "@tupaia/access-policy": "3.0.0",
     "@tupaia/admin-panel": "1.0.0",
+    "@tupaia/tsutils": "1.0.0",
     "@tupaia/ui-components": "1.0.0",
     "@tupaia/utils": "1.0.0",
     "axios": "^0.21.1",

--- a/packages/lesmis/src/api/queries/useVitalsData.js
+++ b/packages/lesmis/src/api/queries/useVitalsData.js
@@ -4,7 +4,7 @@
  *
  */
 import { useQuery } from 'react-query';
-import { utcMoment } from '@tupaia/utils';
+import { utcMoment } from '@tupaia/tsutils';
 import { post } from '../api';
 import { useProjectEntitiesData } from './useEntitiesData';
 import { useEntityData } from './useEntityData';

--- a/packages/lesmis/src/api/queries/useVitalsData.js
+++ b/packages/lesmis/src/api/queries/useVitalsData.js
@@ -4,7 +4,7 @@
  *
  */
 import { useQuery } from 'react-query';
-import { utcMoment } from '@tupaia/tsutils';
+import { utcMoment } from '@tupaia/utils';
 import { post } from '../api';
 import { useProjectEntitiesData } from './useEntitiesData';
 import { useEntityData } from './useEntityData';

--- a/packages/lesmis/src/components/DashboardReportModal.js
+++ b/packages/lesmis/src/components/DashboardReportModal.js
@@ -5,7 +5,7 @@
  */
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
-import { utcMoment } from '@tupaia/utils';
+import { utcMoment } from '@tupaia/tsutils';
 import { useTheme } from '@material-ui/core/styles';
 import {
   Box,

--- a/packages/lesmis/src/components/DashboardReportModal.js
+++ b/packages/lesmis/src/components/DashboardReportModal.js
@@ -5,7 +5,7 @@
  */
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
-import { utcMoment } from '@tupaia/tsutils';
+import { utcMoment } from '@tupaia/utils';
 import { useTheme } from '@material-ui/core/styles';
 import {
   Box,

--- a/packages/report-server/src/__tests__/reportBuilder/transform/fetchData/fetchData.fixtures.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/transform/fetchData/fetchData.fixtures.ts
@@ -3,13 +3,8 @@
  * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
  */
 
-import {
-  EARLIEST_DATA_DATE_STRING,
-  getPeriodsInRange,
-  periodToMoment,
-  utcMoment,
-  yup,
-} from '@tupaia/utils';
+import { utcMoment } from '@tupaia/tsutils';
+import { EARLIEST_DATA_DATE_STRING, getPeriodsInRange, periodToMoment, yup } from '@tupaia/utils';
 
 export const HIERARCHY = 'explore';
 

--- a/packages/tsutils/src/index.ts
+++ b/packages/tsutils/src/index.ts
@@ -1,5 +1,6 @@
 export * from './datetime';
 export * from './downloadPageAsPDF';
 export * from './hashStringToInt';
+export * from './period';
 export * from './typeGuards';
 export * from './validation';

--- a/packages/tsutils/src/period/index.ts
+++ b/packages/tsutils/src/period/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+export * from './period';

--- a/packages/tsutils/src/period/period.ts
+++ b/packages/tsutils/src/period/period.ts
@@ -1,0 +1,21 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+const DAY = 'DAY';
+const WEEK = 'WEEK';
+const MONTH = 'MONTH';
+const YEAR = 'YEAR';
+const QUARTER = 'QUARTER';
+
+/**
+ * Available period formats for aggregation server data
+ */
+export const PERIOD_TYPES = {
+  DAY, // e.g. '20180104'
+  WEEK, // e.g. '2018W01'
+  MONTH, // e.g. '201801'
+  QUARTER, // e.g. '2018Q1'
+  YEAR, // e.g. '2018'
+} as const;

--- a/packages/web-config-server/src/apiV1/dataBuilders/generic/average/averageMonthlyValuesOverCount.js
+++ b/packages/web-config-server/src/apiV1/dataBuilders/generic/average/averageMonthlyValuesOverCount.js
@@ -1,4 +1,5 @@
-import { convertToPeriod, periodToTimestamp, PERIOD_TYPES } from '@tupaia/utils';
+import { PERIOD_TYPES } from '@tupaia/tsutils';
+import { convertToPeriod, periodToTimestamp } from '@tupaia/utils';
 import { aggregateOperationalFacilityValues, getFacilityStatuses } from '/apiV1/utils';
 
 const periodToMonthTimestamp = period =>

--- a/packages/web-config-server/src/apiV1/dataBuilders/generic/comparison/actualMonthlyValuesVsIdeal.js
+++ b/packages/web-config-server/src/apiV1/dataBuilders/generic/comparison/actualMonthlyValuesVsIdeal.js
@@ -1,4 +1,4 @@
-import { utcMoment } from '@tupaia/utils';
+import { utcMoment } from '@tupaia/tsutils';
 import { NO_DATA_AVAILABLE } from '/apiV1/dataBuilders/constants';
 import { regexLabel } from '/apiV1/utils';
 

--- a/packages/web-config-server/src/apiV1/dataBuilders/generic/percentage/percentagesOfValueCountsPerPeriod.js
+++ b/packages/web-config-server/src/apiV1/dataBuilders/generic/percentage/percentagesOfValueCountsPerPeriod.js
@@ -7,7 +7,8 @@ import keyBy from 'lodash.keyby';
 import groupBy from 'lodash.groupby';
 
 import { groupAnalyticsByPeriod } from '@tupaia/dhis-api';
-import { PERIOD_TYPES, parsePeriodType, reduceToDictionary, sortFields } from '@tupaia/utils';
+import { PERIOD_TYPES } from '@tupaia/tsutils';
+import { parsePeriodType, reduceToDictionary, sortFields } from '@tupaia/utils';
 import { DataPerPeriodBuilder } from 'apiV1/dataBuilders/DataPerPeriodBuilder';
 import { PercentagesOfValueCountsBuilder } from '/apiV1/dataBuilders/generic/percentage/percentagesOfValueCounts';
 import { divideValues, mapAnalyticsToCountries } from '/apiV1/dataBuilders/helpers';

--- a/packages/web-config-server/src/apiV1/dataBuilders/generic/percentage/percentagesPerPeriod.js
+++ b/packages/web-config-server/src/apiV1/dataBuilders/generic/percentage/percentagesPerPeriod.js
@@ -3,7 +3,8 @@
  * Copyright (c) 2019 Beyond Essential Systems Pty Ltd
  */
 
-import { PERIOD_TYPES, periodToTimestamp } from '@tupaia/utils';
+import { PERIOD_TYPES } from '@tupaia/tsutils';
+import { periodToTimestamp } from '@tupaia/utils';
 import {
   aggregateOperationalFacilityValues,
   getFacilityStatuses,

--- a/packages/web-config-server/src/apiV1/dataBuilders/generic/sum/sumPerDataGroupPerMonth.js
+++ b/packages/web-config-server/src/apiV1/dataBuilders/generic/sum/sumPerDataGroupPerMonth.js
@@ -2,7 +2,8 @@
  * Tupaia Config Server
  * Copyright (c) 2018 Beyond Essential Systems Pty Ltd
  */
-import { convertToPeriod, periodToDisplayString, PERIOD_TYPES } from '@tupaia/utils';
+import { PERIOD_TYPES } from '@tupaia/tsutils';
+import { convertToPeriod, periodToDisplayString } from '@tupaia/utils';
 
 export const sumPerDataGroupPerMonth = async ({ dataBuilderConfig, query }, aggregator) => {
   const monthlySums = {};

--- a/packages/web-config-server/src/apiV1/dataBuilders/generic/table/tableOfEvents.js
+++ b/packages/web-config-server/src/apiV1/dataBuilders/generic/table/tableOfEvents.js
@@ -7,7 +7,8 @@ import groupBy from 'lodash.groupby';
 import keyBy from 'lodash.keyby';
 import pick from 'lodash.pick';
 
-import { getSortByKey, utcMoment, stripFromString } from '@tupaia/utils';
+import { utcMoment } from '@tupaia/tsutils';
+import { getSortByKey, stripFromString } from '@tupaia/utils';
 import { DataBuilder } from '/apiV1/dataBuilders/DataBuilder';
 import { transformObject } from '/apiV1/dataBuilders/transform';
 import {

--- a/packages/web-config-server/src/apiV1/utils/aggregateOperationalFacilityValues.js
+++ b/packages/web-config-server/src/apiV1/utils/aggregateOperationalFacilityValues.js
@@ -1,4 +1,5 @@
-import { convertToPeriod, PERIOD_TYPES } from '@tupaia/utils';
+import { PERIOD_TYPES } from '@tupaia/tsutils';
+import { convertToPeriod } from '@tupaia/utils';
 
 export const aggregateOperationalFacilityValues = (
   operationalFacilities,

--- a/packages/web-config-server/src/apiV1/utils/timestampToPeriod.js
+++ b/packages/web-config-server/src/apiV1/utils/timestampToPeriod.js
@@ -5,7 +5,7 @@
 
 import winston from 'winston';
 
-import { utcMoment } from '@tupaia/utils';
+import { utcMoment } from '@tupaia/tsutils';
 
 /**
  * transform timestamp to period format

--- a/packages/web-config-server/src/apiV1/utils/timestampToPeriodName.js
+++ b/packages/web-config-server/src/apiV1/utils/timestampToPeriodName.js
@@ -3,7 +3,8 @@
  * Copyright (c) 2018 Beyond Essential Systems Pty Ltd
  */
 
-import { utcMoment, PERIOD_TYPES } from '@tupaia/utils';
+import { utcMoment } from '@tupaia/tsutils';
+import { PERIOD_TYPES } from '@tupaia/utils';
 
 const PERIOD_TYPE_TO_NAME_FORMAT = {
   [PERIOD_TYPES.MONTH]: 'MMM YYYY',

--- a/packages/web-config-server/src/apiV1/utils/timestampToPeriodName.js
+++ b/packages/web-config-server/src/apiV1/utils/timestampToPeriodName.js
@@ -3,8 +3,7 @@
  * Copyright (c) 2018 Beyond Essential Systems Pty Ltd
  */
 
-import { utcMoment } from '@tupaia/tsutils';
-import { PERIOD_TYPES } from '@tupaia/utils';
+import { PERIOD_TYPES, utcMoment } from '@tupaia/tsutils';
 
 const PERIOD_TYPE_TO_NAME_FORMAT = {
   [PERIOD_TYPES.MONTH]: 'MMM YYYY',

--- a/packages/web-config-server/src/utils/getDefaultPeriod.js
+++ b/packages/web-config-server/src/utils/getDefaultPeriod.js
@@ -3,7 +3,8 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
-import { utcMoment, convertDateRangeToPeriods } from '@tupaia/utils';
+import { utcMoment } from '@tupaia/tsutils';
+import { convertDateRangeToPeriods } from '@tupaia/utils';
 
 export const EARLIEST_DATA_DATE = utcMoment('2017-01-01'); // Tupaia started in 2017
 const MAXIMUM_MONTHS_TO_LOOK_BACK = 60; // Last 5 years

--- a/yarn.lock
+++ b/yarn.lock
@@ -5281,6 +5281,7 @@ __metadata:
   resolution: "@tupaia/data-lake-api@workspace:packages/data-lake-api"
   dependencies:
     "@tupaia/database": 1.0.0
+    "@tupaia/tsutils": 1.0.0
     "@tupaia/utils": 1.0.0
     db-migrate: ^0.11.5
     db-migrate-pg: ^1.2.2
@@ -5353,6 +5354,7 @@ __metadata:
   resolution: "@tupaia/dhis-api@workspace:packages/dhis-api"
   dependencies:
     "@tupaia/aggregator": 1.0.0
+    "@tupaia/tsutils": 1.0.0
     "@tupaia/utils": 1.0.0
     chai-as-promised: ^7.1.1
     lodash.groupby: ^4.6.0
@@ -5429,6 +5431,7 @@ __metadata:
     "@tupaia/data-broker": 1.0.0
     "@tupaia/database": 1.0.0
     "@tupaia/expression-parser": 1.0.0
+    "@tupaia/tsutils": 1.0.0
     "@tupaia/utils": 1.0.0
     lodash.groupby: ^4.6.0
     lodash.keyby: ^4.6.0
@@ -5471,6 +5474,7 @@ __metadata:
     "@material-ui/styles": ^4.9.10
     "@tupaia/access-policy": 3.0.0
     "@tupaia/admin-panel": 1.0.0
+    "@tupaia/tsutils": 1.0.0
     "@tupaia/ui-components": 1.0.0
     "@tupaia/utils": 1.0.0
     axios: ^0.21.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -5128,6 +5128,7 @@ __metadata:
   dependencies:
     "@tupaia/data-broker": 1.0.0
     "@tupaia/server-boilerplate": 1.0.0
+    "@tupaia/tsutils": 1.0.0
     "@tupaia/utils": 1.0.0
     lodash.groupby: ^4.6.0
     npm-run-all: ^4.1.5

--- a/yarn.lock
+++ b/yarn.lock
@@ -5474,7 +5474,6 @@ __metadata:
     "@material-ui/styles": ^4.9.10
     "@tupaia/access-policy": 3.0.0
     "@tupaia/admin-panel": 1.0.0
-    "@tupaia/tsutils": 1.0.0
     "@tupaia/ui-components": 1.0.0
     "@tupaia/utils": 1.0.0
     axios: ^0.21.1


### PR DESCRIPTION
1. Change imports of `utcMoment` to`@tupaia/tsutils` instead of `@tupaia/utils`. The util had been copied there in a previous PR
2. Moved `PERIOD_TYPES` to `@tuapia/tsutils` and changed imports to point there

I won't delete their definitions in `@tupaia/utils` yet, since other modules in that package depend on them