### PR TITLE
[no-issue]: Upgrade aws-sdk from v2 -> v3

### DIFF
--- a/packages/central-server/package.json
+++ b/packages/central-server/package.json
@@ -26,6 +26,7 @@
     "create-meditrak-sync-view": "node dist/createMeditrakSyncView.js"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.341.0",
     "@babel/polyfill": "^7.0.0",
     "@tupaia/access-policy": "3.0.0",
     "@tupaia/auth": "1.0.0",
@@ -39,7 +40,6 @@
     "adm-zip": "^0.5.5",
     "api-error-handler": "^1.0.0",
     "async": "^2.6.2",
-    "aws-sdk": "^2.451.0",
     "body-parser": "^1.18.3",
     "case": "^1.6.1",
     "cors": "^2.8.5",

--- a/packages/central-server/src/apiV2/userAccounts/EditUserAccounts.js
+++ b/packages/central-server/src/apiV2/userAccounts/EditUserAccounts.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
-import AWS from 'aws-sdk';
+import { S3 } from '@aws-sdk/client-s3';
 import { hashAndSaltPassword } from '@tupaia/auth';
 import { S3Client } from '@tupaia/utils';
 import { EditHandler } from '../EditHandler';
@@ -47,7 +47,7 @@ export class EditUserAccounts extends EditHandler {
 
     if (profileImage) {
       if (profileImage.data && profileImage.fileId) {
-        const s3Client = new S3Client(new AWS.S3());
+        const s3Client = new S3Client(new S3({}));
         const profileImagePath = await s3Client.uploadImage(profileImage.data, profileImage.fileId);
         updatedFields = {
           ...updatedFields,

--- a/packages/central-server/src/apiV2/utilities/uploadImage.js
+++ b/packages/central-server/src/apiV2/utilities/uploadImage.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
  */
 
-import AWS from 'aws-sdk';
+import { S3 } from '@aws-sdk/client-s3';
 import { S3Client } from '@tupaia/utils';
 import { getStandardisedImageName } from '../../utilities';
 
@@ -28,7 +28,7 @@ export const uploadImage = async (
   // If the image is not a base64 encoded image, then it is an external URL (which we need to accept for backwards compatibility with the older way of uploading things like project images).
   // If the image is null or an empty string, we are not editing it, so return as usual.
   if (encodedImage === null || !encodedImage.includes('data:image')) return encodedImage;
-  const s3Client = new S3Client(new AWS.S3());
+  const s3Client = new S3Client(new S3({}));
 
   // If there is an existing image, remove it before uploading the new one so that we don't end up with extra images for the same field
   if (existingImagePath) await s3Client.deleteFile(existingImagePath);

--- a/packages/central-server/src/dataAccessors/addSurveyImage.js
+++ b/packages/central-server/src/dataAccessors/addSurveyImage.js
@@ -3,14 +3,14 @@
  * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
  */
 
-import AWS from 'aws-sdk';
+import { S3 } from '@aws-sdk/client-s3';
 import winston from 'winston';
 import { S3Client } from '@tupaia/utils';
 
 // Upload a surveyImage to s3
 export const addSurveyImage = async (models, { id, data }) => {
   try {
-    const s3Client = new S3Client(new AWS.S3());
+    const s3Client = new S3Client(new S3({}));
     await s3Client.uploadImage(data, id);
   } catch (error) {
     winston.error(error.message);

--- a/packages/central-server/src/dataAccessors/upsertAnswers.js
+++ b/packages/central-server/src/dataAccessors/upsertAnswers.js
@@ -1,4 +1,9 @@
-import AWS from 'aws-sdk';
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+import { S3 } from '@aws-sdk/client-s3';
 import {
   DatabaseError,
   getS3ImageFilePath,
@@ -26,7 +31,7 @@ export async function upsertAnswers(models, answers, surveyResponseId) {
       } else {
         // included for backwards compatibility passing base64 strings for images
         try {
-          const s3Client = new S3Client(new AWS.S3());
+          const s3Client = new S3Client(new S3({}));
           answerDocument.text = await s3Client.uploadImage(answer.body);
         } catch (error) {
           throw new UploadError(error);

--- a/packages/central-server/src/tests/apiV2/utilities/uploadImage.test.js
+++ b/packages/central-server/src/tests/apiV2/utilities/uploadImage.test.js
@@ -2,7 +2,8 @@
  * Tupaia
  * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
  */
-import AWS from 'aws-sdk';
+
+import { S3 } from '@aws-sdk/client-s3';
 import { S3Client } from '@tupaia/utils';
 import { expect } from 'chai';
 import sinon from 'sinon';
@@ -19,7 +20,7 @@ describe('uploadImage', async () => {
     'data:image/gif;base64,R0lGODdh4AHwANUAAKqqqgAAAO7u7ru7u+Xl5czMzN3d3cPDw7KystTU1H9/fxcXF1VVVXJych0dHRkZGS4uLo+Pjzc3N5SUlMHBwSwsLGpqahUVFSoqKklJScjIyBgYGLm5uTk5OW9vbzAwMKurqxYWFqWlpaOjoxwcHEJCQp+fn3d3d0ZGRhoaGpubm4WFhV1dXVlZWT8/P4qKimFhYTMzM25ubtDQ0ExMTAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACwAAAAA4AHwAAAG/kCAcEgsGo/IpHLJbDqf0Kh0Sq1ar9isdsvter/gsHhMLpvP6LR6zW673/C4fE6v2+/4vH7P7/v/gIGCg4SFhoeIiYqLjI2Oj5CRkpOUlZaXmJmam5ydnp+goaKjpKWmp6ipqqusra6vsLGys7S1tre4ubq7vL2+v8DBwsPExcbHyMnKy8zNzs/Q0dLT1NXW19jZ2tvc3d7f4OHi4+Tl5ufo6err7O3u7/Dx8vP09fb3+Pn6+/z9/v8AAwocSLCgwYMIEypcyLChw4cQI0qcSLGixYsYM2rcyLGjx48gQ4ocSbKkyZMoU6pcybKly5cwY8qcSbOmzZs4c+rcybOn/s+fQIMKHUq0qNGjSJMqXcq0qdOnUKNKnUq1qtWrWLNq3cq1q9evYMOKHUu2rNmzaNOqXcu2rdu3cOPKnUu3rt27ePPq3cu3r9+/gAMLHky4sOHDiBMrXsyYmIIAQyxcCIBBAREFky9YmKIAQ4AADJA8HoI5gObGlhZABmAhgwYBFCBsBjBhAQgBIAJYjoJCxowZNGYXUS2k9u3cu1FHYtDAgZANHBAAQEBhg5ASDQYAGHAChZQEBRAgSGC9CHPnALBr5+5dOSQFDwqs7uBhiIcOQlJIF4IghREXySngQhITkFAEfPLlt990/rn3CAQRALBadQxMwMAHFAgRwIIq/qxGRAIQTEAbBAkk4UFoREAooYYceujgIgxIcMCK04HwQAgBiLCfiwi4OIQIFUxQQYZJQEdEjDOuxqOPLx4ywQNErqbAAhoQUNtsAYg4BJPbvRDACwsawQADCz4ZpYZaatjkIhV85uZntkl3AAjlObDCEBOgZwQMLWSQBHwcENHmm5/Ziaeeax5igACMChAAowGMMMQIBgLAAAtDtIDigTEkYEFyRBgX5qKNPirApZlumugiqwkp4gQlgCCECboBAKgRtWVYQIhGVBCBdkmsRqtlt67KyGoHiIBjCCYAO0BtAcRpRAkR7CdCCUV49iYSqz2rmrTGLiLAEAMQIAABwMAKcYC56B6RwIxCDFAiEaQ2isS46rKbbrj89uvvvwAHLPDABBds8MEIJ6zwwgw37PDDEEcs8cQUV2zxxRhnrPHGHHfs8ccghyzyyCSXbPLJKKes8sost+zyyzDHLPPMNNds880456zzzjz37PPPQAct9NBEF2300UgnrfTSTDft9NNQRy311FRXbfXVWGet9dZcd+3112CHLfbYZJdt9tlop6322my37fbbcMct99x012333XjnrffefPft98pBAAA7';
 
   before(async () => {
-    sinon.createStubInstance(AWS.S3);
+    sinon.createStubInstance(S3);
   });
   beforeEach(() => {
     uploadImageStub = sinon

--- a/packages/meditrak-app-server/package.json
+++ b/packages/meditrak-app-server/package.json
@@ -25,6 +25,7 @@
     "test": "yarn package:test:withdb --runInBand"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.341.0",
     "@tupaia/api-client": "3.1.0",
     "@tupaia/auth": "1.0.0",
     "@tupaia/database": "1.0.0",
@@ -32,7 +33,6 @@
     "@tupaia/tsutils": "1.0.0",
     "@tupaia/types": "1.0.0",
     "@tupaia/utils": "1.0.0",
-    "aws-sdk": "^2.451.0",
     "dotenv": "^8.2.0",
     "express": "^4.16.2",
     "lodash.clonedeep": "^4.5.0",

--- a/packages/meditrak-app-server/src/routes/sync/PushChangesRoute/addSurveyImage.ts
+++ b/packages/meditrak-app-server/src/routes/sync/PushChangesRoute/addSurveyImage.ts
@@ -3,14 +3,14 @@
  * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
  */
 
-import AWS from 'aws-sdk';
+import { S3 } from '@aws-sdk/client-s3';
 import winston from 'winston';
 import { S3Client } from '@tupaia/utils';
 
 // Upload a surveyImage to s3
 export const addSurveyImage = async (id: string, data: string) => {
   try {
-    const s3Client = new S3Client(new AWS.S3());
+    const s3Client = new S3Client(new S3({}));
     await s3Client.uploadImage(data, id);
   } catch (error: any) {
     winston.error(error.message);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,1135 @@ __metadata:
   version: 6
   cacheKey: 8
 
+"@aws-crypto/crc32@npm:3.0.0":
+  version: 3.0.0
+  resolution: "@aws-crypto/crc32@npm:3.0.0"
+  dependencies:
+    "@aws-crypto/util": ^3.0.0
+    "@aws-sdk/types": ^3.222.0
+    tslib: ^1.11.1
+  checksum: 9fdb3e837fc54119b017ea34fd0a6d71d2c88075d99e1e818a5158e0ad30ced67ddbcc423a11ceeef6cc465ab5ffd91830acab516470b48237ca7abd51be9642
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/crc32c@npm:3.0.0":
+  version: 3.0.0
+  resolution: "@aws-crypto/crc32c@npm:3.0.0"
+  dependencies:
+    "@aws-crypto/util": ^3.0.0
+    "@aws-sdk/types": ^3.222.0
+    tslib: ^1.11.1
+  checksum: 0a116b5d1c5b09a3dde65aab04a07b32f543e87b68f2d175081e3f4a1a17502343f223d691dd883ace1ddce65cd40093673e7c7415dcd99062202ba87ffb4038
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/ie11-detection@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@aws-crypto/ie11-detection@npm:3.0.0"
+  dependencies:
+    tslib: ^1.11.1
+  checksum: 299b2ddd46eddac1f2d54d91386ceb37af81aef8a800669281c73d634ed17fd855dcfb8b3157f2879344b93a2666a6d602550eb84b71e4d7868100ad6da8f803
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/sha1-browser@npm:3.0.0":
+  version: 3.0.0
+  resolution: "@aws-crypto/sha1-browser@npm:3.0.0"
+  dependencies:
+    "@aws-crypto/ie11-detection": ^3.0.0
+    "@aws-crypto/supports-web-crypto": ^3.0.0
+    "@aws-crypto/util": ^3.0.0
+    "@aws-sdk/types": ^3.222.0
+    "@aws-sdk/util-locate-window": ^3.0.0
+    "@aws-sdk/util-utf8-browser": ^3.0.0
+    tslib: ^1.11.1
+  checksum: 78c379e105a0c4e7b2ed745dffd8f55054d7dde8b350b61de682bbc3cd081a50e2f87861954fa9cd53c7ea711ebca1ca0137b14cb36483efc971f60f573cf129
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/sha256-browser@npm:3.0.0":
+  version: 3.0.0
+  resolution: "@aws-crypto/sha256-browser@npm:3.0.0"
+  dependencies:
+    "@aws-crypto/ie11-detection": ^3.0.0
+    "@aws-crypto/sha256-js": ^3.0.0
+    "@aws-crypto/supports-web-crypto": ^3.0.0
+    "@aws-crypto/util": ^3.0.0
+    "@aws-sdk/types": ^3.222.0
+    "@aws-sdk/util-locate-window": ^3.0.0
+    "@aws-sdk/util-utf8-browser": ^3.0.0
+    tslib: ^1.11.1
+  checksum: ca89456bf508db2e08060a7f656460db97ac9a15b11e39d6fa7665e2b156508a1758695bff8e82d0a00178d6ac5c36f35eb4bcfac2e48621265224ca14a19bd2
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/sha256-js@npm:3.0.0, @aws-crypto/sha256-js@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@aws-crypto/sha256-js@npm:3.0.0"
+  dependencies:
+    "@aws-crypto/util": ^3.0.0
+    "@aws-sdk/types": ^3.222.0
+    tslib: ^1.11.1
+  checksum: 644ded32ea310237811afae873d3c7320739cb6f6cc39dced9c94801379e68e5ee2cca0c34f0384793fa9e750a7e0a5e2468f95754bd08e6fd72ab833c8fe23c
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/supports-web-crypto@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@aws-crypto/supports-web-crypto@npm:3.0.0"
+  dependencies:
+    tslib: ^1.11.1
+  checksum: 35479a1558db9e9a521df6877a99f95670e972c602f2a0349303477e5d638a5baf569fb037c853710e382086e6fd77e8ed58d3fb9b49f6e1186a9d26ce7be006
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/util@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@aws-crypto/util@npm:3.0.0"
+  dependencies:
+    "@aws-sdk/types": ^3.222.0
+    "@aws-sdk/util-utf8-browser": ^3.0.0
+    tslib: ^1.11.1
+  checksum: d29d5545048721aae3d60b236708535059733019a105f8a64b4e4a8eab7cf8dde1546dc56bff7de20d36140a4d1f0f4693e639c5732a7059273a7b1e56354776
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/abort-controller@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/abort-controller@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/types": 3.341.0
+    tslib: ^2.5.0
+  checksum: b6800f4b7a42b0d07e678b058b9bdad82c9b5b5b5dde7c43485b7bd937da584147ff80aa1ba2f0e93812719634139f900dabf671bec5565389c857ef899266fb
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/chunked-blob-reader@npm:3.310.0":
+  version: 3.310.0
+  resolution: "@aws-sdk/chunked-blob-reader@npm:3.310.0"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: 4969fe05c6cea38d0a8dc3ec8e37cbd82a0a5b6f8c32ad6c7d02f0800bc3641e96356f47981c88b645b4dc2bdcb73d03d7ec67ac38d277dde8337b61688f815b
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/client-s3@npm:^3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/client-s3@npm:3.341.0"
+  dependencies:
+    "@aws-crypto/sha1-browser": 3.0.0
+    "@aws-crypto/sha256-browser": 3.0.0
+    "@aws-crypto/sha256-js": 3.0.0
+    "@aws-sdk/client-sts": 3.341.0
+    "@aws-sdk/config-resolver": 3.341.0
+    "@aws-sdk/credential-provider-node": 3.341.0
+    "@aws-sdk/eventstream-serde-browser": 3.341.0
+    "@aws-sdk/eventstream-serde-config-resolver": 3.341.0
+    "@aws-sdk/eventstream-serde-node": 3.341.0
+    "@aws-sdk/fetch-http-handler": 3.341.0
+    "@aws-sdk/hash-blob-browser": 3.341.0
+    "@aws-sdk/hash-node": 3.341.0
+    "@aws-sdk/hash-stream-node": 3.341.0
+    "@aws-sdk/invalid-dependency": 3.341.0
+    "@aws-sdk/md5-js": 3.341.0
+    "@aws-sdk/middleware-bucket-endpoint": 3.341.0
+    "@aws-sdk/middleware-content-length": 3.341.0
+    "@aws-sdk/middleware-endpoint": 3.341.0
+    "@aws-sdk/middleware-expect-continue": 3.341.0
+    "@aws-sdk/middleware-flexible-checksums": 3.341.0
+    "@aws-sdk/middleware-host-header": 3.341.0
+    "@aws-sdk/middleware-location-constraint": 3.341.0
+    "@aws-sdk/middleware-logger": 3.341.0
+    "@aws-sdk/middleware-recursion-detection": 3.341.0
+    "@aws-sdk/middleware-retry": 3.341.0
+    "@aws-sdk/middleware-sdk-s3": 3.341.0
+    "@aws-sdk/middleware-serde": 3.341.0
+    "@aws-sdk/middleware-signing": 3.341.0
+    "@aws-sdk/middleware-ssec": 3.341.0
+    "@aws-sdk/middleware-stack": 3.341.0
+    "@aws-sdk/middleware-user-agent": 3.341.0
+    "@aws-sdk/node-config-provider": 3.341.0
+    "@aws-sdk/node-http-handler": 3.341.0
+    "@aws-sdk/signature-v4-multi-region": 3.341.0
+    "@aws-sdk/smithy-client": 3.341.0
+    "@aws-sdk/types": 3.341.0
+    "@aws-sdk/url-parser": 3.341.0
+    "@aws-sdk/util-base64": 3.310.0
+    "@aws-sdk/util-body-length-browser": 3.310.0
+    "@aws-sdk/util-body-length-node": 3.310.0
+    "@aws-sdk/util-defaults-mode-browser": 3.341.0
+    "@aws-sdk/util-defaults-mode-node": 3.341.0
+    "@aws-sdk/util-endpoints": 3.341.0
+    "@aws-sdk/util-retry": 3.341.0
+    "@aws-sdk/util-stream-browser": 3.341.0
+    "@aws-sdk/util-stream-node": 3.341.0
+    "@aws-sdk/util-user-agent-browser": 3.341.0
+    "@aws-sdk/util-user-agent-node": 3.341.0
+    "@aws-sdk/util-utf8": 3.310.0
+    "@aws-sdk/util-waiter": 3.341.0
+    "@aws-sdk/xml-builder": 3.310.0
+    "@smithy/protocol-http": ^1.0.1
+    "@smithy/types": ^1.0.0
+    fast-xml-parser: 4.1.2
+    tslib: ^2.5.0
+  checksum: 288acd3215e275458b6e43d6daa6e72d6071fa57e1dca2ca36a04baec1ad3c464a3cfb57012e8ba4b475a0ab25c800d3a88464a076e5ae52cde49f994ae147c8
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/client-sso-oidc@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/client-sso-oidc@npm:3.341.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": 3.0.0
+    "@aws-crypto/sha256-js": 3.0.0
+    "@aws-sdk/config-resolver": 3.341.0
+    "@aws-sdk/fetch-http-handler": 3.341.0
+    "@aws-sdk/hash-node": 3.341.0
+    "@aws-sdk/invalid-dependency": 3.341.0
+    "@aws-sdk/middleware-content-length": 3.341.0
+    "@aws-sdk/middleware-endpoint": 3.341.0
+    "@aws-sdk/middleware-host-header": 3.341.0
+    "@aws-sdk/middleware-logger": 3.341.0
+    "@aws-sdk/middleware-recursion-detection": 3.341.0
+    "@aws-sdk/middleware-retry": 3.341.0
+    "@aws-sdk/middleware-serde": 3.341.0
+    "@aws-sdk/middleware-stack": 3.341.0
+    "@aws-sdk/middleware-user-agent": 3.341.0
+    "@aws-sdk/node-config-provider": 3.341.0
+    "@aws-sdk/node-http-handler": 3.341.0
+    "@aws-sdk/smithy-client": 3.341.0
+    "@aws-sdk/types": 3.341.0
+    "@aws-sdk/url-parser": 3.341.0
+    "@aws-sdk/util-base64": 3.310.0
+    "@aws-sdk/util-body-length-browser": 3.310.0
+    "@aws-sdk/util-body-length-node": 3.310.0
+    "@aws-sdk/util-defaults-mode-browser": 3.341.0
+    "@aws-sdk/util-defaults-mode-node": 3.341.0
+    "@aws-sdk/util-endpoints": 3.341.0
+    "@aws-sdk/util-retry": 3.341.0
+    "@aws-sdk/util-user-agent-browser": 3.341.0
+    "@aws-sdk/util-user-agent-node": 3.341.0
+    "@aws-sdk/util-utf8": 3.310.0
+    "@smithy/protocol-http": ^1.0.1
+    "@smithy/types": ^1.0.0
+    tslib: ^2.5.0
+  checksum: b07494e34febb9e68216b0c9be35514a5e1cb595c428a72fcc310be500c9d53ea14ef9786df438b11d2a8e249462b04cc1dbe577f91737cb0fb359330353ef16
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/client-sso@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/client-sso@npm:3.341.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": 3.0.0
+    "@aws-crypto/sha256-js": 3.0.0
+    "@aws-sdk/config-resolver": 3.341.0
+    "@aws-sdk/fetch-http-handler": 3.341.0
+    "@aws-sdk/hash-node": 3.341.0
+    "@aws-sdk/invalid-dependency": 3.341.0
+    "@aws-sdk/middleware-content-length": 3.341.0
+    "@aws-sdk/middleware-endpoint": 3.341.0
+    "@aws-sdk/middleware-host-header": 3.341.0
+    "@aws-sdk/middleware-logger": 3.341.0
+    "@aws-sdk/middleware-recursion-detection": 3.341.0
+    "@aws-sdk/middleware-retry": 3.341.0
+    "@aws-sdk/middleware-serde": 3.341.0
+    "@aws-sdk/middleware-stack": 3.341.0
+    "@aws-sdk/middleware-user-agent": 3.341.0
+    "@aws-sdk/node-config-provider": 3.341.0
+    "@aws-sdk/node-http-handler": 3.341.0
+    "@aws-sdk/smithy-client": 3.341.0
+    "@aws-sdk/types": 3.341.0
+    "@aws-sdk/url-parser": 3.341.0
+    "@aws-sdk/util-base64": 3.310.0
+    "@aws-sdk/util-body-length-browser": 3.310.0
+    "@aws-sdk/util-body-length-node": 3.310.0
+    "@aws-sdk/util-defaults-mode-browser": 3.341.0
+    "@aws-sdk/util-defaults-mode-node": 3.341.0
+    "@aws-sdk/util-endpoints": 3.341.0
+    "@aws-sdk/util-retry": 3.341.0
+    "@aws-sdk/util-user-agent-browser": 3.341.0
+    "@aws-sdk/util-user-agent-node": 3.341.0
+    "@aws-sdk/util-utf8": 3.310.0
+    "@smithy/protocol-http": ^1.0.1
+    "@smithy/types": ^1.0.0
+    tslib: ^2.5.0
+  checksum: 103a0032b58e7f317fbf58d63033f26876cbeb65c3d78a79d7571a13d7644ba48d0c2de19df647e9e498e6db1966607b8021d0f4a38173574f2d7fb047b3f092
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/client-sts@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/client-sts@npm:3.341.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": 3.0.0
+    "@aws-crypto/sha256-js": 3.0.0
+    "@aws-sdk/config-resolver": 3.341.0
+    "@aws-sdk/credential-provider-node": 3.341.0
+    "@aws-sdk/fetch-http-handler": 3.341.0
+    "@aws-sdk/hash-node": 3.341.0
+    "@aws-sdk/invalid-dependency": 3.341.0
+    "@aws-sdk/middleware-content-length": 3.341.0
+    "@aws-sdk/middleware-endpoint": 3.341.0
+    "@aws-sdk/middleware-host-header": 3.341.0
+    "@aws-sdk/middleware-logger": 3.341.0
+    "@aws-sdk/middleware-recursion-detection": 3.341.0
+    "@aws-sdk/middleware-retry": 3.341.0
+    "@aws-sdk/middleware-sdk-sts": 3.341.0
+    "@aws-sdk/middleware-serde": 3.341.0
+    "@aws-sdk/middleware-signing": 3.341.0
+    "@aws-sdk/middleware-stack": 3.341.0
+    "@aws-sdk/middleware-user-agent": 3.341.0
+    "@aws-sdk/node-config-provider": 3.341.0
+    "@aws-sdk/node-http-handler": 3.341.0
+    "@aws-sdk/smithy-client": 3.341.0
+    "@aws-sdk/types": 3.341.0
+    "@aws-sdk/url-parser": 3.341.0
+    "@aws-sdk/util-base64": 3.310.0
+    "@aws-sdk/util-body-length-browser": 3.310.0
+    "@aws-sdk/util-body-length-node": 3.310.0
+    "@aws-sdk/util-defaults-mode-browser": 3.341.0
+    "@aws-sdk/util-defaults-mode-node": 3.341.0
+    "@aws-sdk/util-endpoints": 3.341.0
+    "@aws-sdk/util-retry": 3.341.0
+    "@aws-sdk/util-user-agent-browser": 3.341.0
+    "@aws-sdk/util-user-agent-node": 3.341.0
+    "@aws-sdk/util-utf8": 3.310.0
+    "@smithy/protocol-http": ^1.0.1
+    "@smithy/types": ^1.0.0
+    fast-xml-parser: 4.1.2
+    tslib: ^2.5.0
+  checksum: 8dcd222099584350ab74830fcc2dac2001624adbe9151879c36d875ae156e35dda4a0db6659039eb374fd7f71b820282998209cc49aeb3c18befcdcfeb8b6c52
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/config-resolver@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/config-resolver@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/types": 3.341.0
+    "@aws-sdk/util-config-provider": 3.310.0
+    "@aws-sdk/util-middleware": 3.341.0
+    tslib: ^2.5.0
+  checksum: bed7d7232c919dc5cb87479d0d0707fe38eaeff729a53c17e59a16b5d9c6611f41cf8ea057d08370b0424fc3b4d0949f981363de1a0b8c8bf4e456fc7f4e4da6
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-env@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/credential-provider-env@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/property-provider": 3.341.0
+    "@aws-sdk/types": 3.341.0
+    tslib: ^2.5.0
+  checksum: e4271170b56036ecfcca78214ada658230d87cace8842ef9da8cb5263181b5fb8f16beedb8bbb088abe455c700b300ec4a2c3ce97a8ea7c8ec599443d148752b
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-imds@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/credential-provider-imds@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/node-config-provider": 3.341.0
+    "@aws-sdk/property-provider": 3.341.0
+    "@aws-sdk/types": 3.341.0
+    "@aws-sdk/url-parser": 3.341.0
+    tslib: ^2.5.0
+  checksum: f14d102e6e4ed770327538d9862d87328c159e3b48417e19e66a7eb631e3dfb7849bf1b136b61587837747335982db136261d9ec56e92d986bd2293682f73670
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-ini@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/credential-provider-ini@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/credential-provider-env": 3.341.0
+    "@aws-sdk/credential-provider-imds": 3.341.0
+    "@aws-sdk/credential-provider-process": 3.341.0
+    "@aws-sdk/credential-provider-sso": 3.341.0
+    "@aws-sdk/credential-provider-web-identity": 3.341.0
+    "@aws-sdk/property-provider": 3.341.0
+    "@aws-sdk/shared-ini-file-loader": 3.341.0
+    "@aws-sdk/types": 3.341.0
+    tslib: ^2.5.0
+  checksum: 080835a060ffc80e4f9a8be5c7c1babf8969e78e87878c28be3b32eed51e47db7867fd6979e2fdcb9abdc1864e21d7d4e02763b5182140bed845723533a06f72
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-node@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/credential-provider-node@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/credential-provider-env": 3.341.0
+    "@aws-sdk/credential-provider-imds": 3.341.0
+    "@aws-sdk/credential-provider-ini": 3.341.0
+    "@aws-sdk/credential-provider-process": 3.341.0
+    "@aws-sdk/credential-provider-sso": 3.341.0
+    "@aws-sdk/credential-provider-web-identity": 3.341.0
+    "@aws-sdk/property-provider": 3.341.0
+    "@aws-sdk/shared-ini-file-loader": 3.341.0
+    "@aws-sdk/types": 3.341.0
+    tslib: ^2.5.0
+  checksum: 6c048a8ce0d7fe1a2f2b967eaa8df8665838e10db220b72f4820a52ac4d13af4cd86312b82a09da8919bcfd7449a2a391147f0f96aee8795dcab4862d76a4237
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-process@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/credential-provider-process@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/property-provider": 3.341.0
+    "@aws-sdk/shared-ini-file-loader": 3.341.0
+    "@aws-sdk/types": 3.341.0
+    tslib: ^2.5.0
+  checksum: 87a370830081a548311f547c393fe0ec809614b7a4101f900ce9ed6b006f88d5ae5c00b5dfd9b011a49cef4ca546dd857ffdedf0df71c6c509788d96002e9ee9
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-sso@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/credential-provider-sso@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/client-sso": 3.341.0
+    "@aws-sdk/property-provider": 3.341.0
+    "@aws-sdk/shared-ini-file-loader": 3.341.0
+    "@aws-sdk/token-providers": 3.341.0
+    "@aws-sdk/types": 3.341.0
+    tslib: ^2.5.0
+  checksum: 44dce1e61e088365857396877b88b5aa4380cab6911ee362298eb3661d03ff3c4b133b2b4b2a2a097cb191450bf3ebfa0cc31bc306c65c634a4385efac2f8706
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-web-identity@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/property-provider": 3.341.0
+    "@aws-sdk/types": 3.341.0
+    tslib: ^2.5.0
+  checksum: 362b394962911912bf8382a20aaeef565a32428a4ad8ef2f947851b71455296743237667529888dc6068582998e9d83b85ad94dae14d4789be2038c0a7bb5f67
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/eventstream-codec@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/eventstream-codec@npm:3.341.0"
+  dependencies:
+    "@aws-crypto/crc32": 3.0.0
+    "@aws-sdk/types": 3.341.0
+    "@aws-sdk/util-hex-encoding": 3.310.0
+    tslib: ^2.5.0
+  checksum: b53433653a9e800c0d3a4db4b464e85b3a8a081de5b879c8730dbd6cd8f7b11d0cdf67b48db1ea558172fceaff2bb896cf58f9f1f45a78b4084485dd9ad2b2f6
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/eventstream-serde-browser@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/eventstream-serde-browser@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/eventstream-serde-universal": 3.341.0
+    "@aws-sdk/types": 3.341.0
+    tslib: ^2.5.0
+  checksum: c07619ed8eb263569000521c19cc2320316db2c8c6c007da36b1cfab55fed94e5a924c674ae36c46d410c49ad83bd19ce8b8953c61e9d4ac908516837836e2fb
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/eventstream-serde-config-resolver@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/eventstream-serde-config-resolver@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/types": 3.341.0
+    tslib: ^2.5.0
+  checksum: 5defc42532bca1d720d49e01decf71884900c7225f326553f20104d95c80c2257bc72bd85c0a5e3c8c42cb9c87f28eb8dd57b24cd324f545b7d02c0fc0374ae1
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/eventstream-serde-node@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/eventstream-serde-node@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/eventstream-serde-universal": 3.341.0
+    "@aws-sdk/types": 3.341.0
+    tslib: ^2.5.0
+  checksum: 9f8c14491b310d7839666c3b1aabb64093b6dc53d86d517ba17ba4f374631184d4ad50590fe49ff7d5369b2c0d16641f2af520a0d9646d18a2c233d9405e1370
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/eventstream-serde-universal@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/eventstream-serde-universal@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/eventstream-codec": 3.341.0
+    "@aws-sdk/types": 3.341.0
+    tslib: ^2.5.0
+  checksum: ac78b4a246b73016a4f23d894e25500330f3534a4b89dd7c53b1a92a24fb61832370d35de8b93faba5624c428adea8664577771f5909a8929932060b099ca626
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/fetch-http-handler@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/fetch-http-handler@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/protocol-http": 3.341.0
+    "@aws-sdk/querystring-builder": 3.341.0
+    "@aws-sdk/types": 3.341.0
+    "@aws-sdk/util-base64": 3.310.0
+    tslib: ^2.5.0
+  checksum: a118cbcbe84615d6caf65e9978626ce7f0a22599ddde4375fc342e166573cc091b6a76921139a997d4a6db2275af662a97e8482cebb05a19f25891d7a6092f6e
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/hash-blob-browser@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/hash-blob-browser@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/chunked-blob-reader": 3.310.0
+    "@aws-sdk/types": 3.341.0
+    tslib: ^2.5.0
+  checksum: bfae5cd785c7013de82a8a1de000f8a3ee2e5b1b1f40aa1baafea1383c2a13b53a2ac580ad810711815655c6938409dff0be8372fef7ee454babec4cc6ffc2ec
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/hash-node@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/hash-node@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/types": 3.341.0
+    "@aws-sdk/util-buffer-from": 3.310.0
+    "@aws-sdk/util-utf8": 3.310.0
+    tslib: ^2.5.0
+  checksum: b723a4d087b33f80a21de62190cf1a53d526a613e5bf5e281d1fa5f473017668256bc16c18d9299dfd7dd6254e4996ede26a1ef103a878ca786e87c3958521ff
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/hash-stream-node@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/hash-stream-node@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/types": 3.341.0
+    "@aws-sdk/util-utf8": 3.310.0
+    tslib: ^2.5.0
+  checksum: 3bb82bec355b342f77553405f3e2867a0ff27f248d8c9f6e0f221b5a6da903259f5bf4689e5c39c503901f574f0e479d03269f74153e648e817d2140d045d6f5
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/invalid-dependency@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/invalid-dependency@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/types": 3.341.0
+    tslib: ^2.5.0
+  checksum: 4b64142f452b890ab2365fb09b1ac315ce2b82101c2f7b0bf328491bbe45e06d39b14db78ff356c0913aaccc3f730fde3f3522f2a33870329a14beaf8df57288
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/is-array-buffer@npm:3.310.0":
+  version: 3.310.0
+  resolution: "@aws-sdk/is-array-buffer@npm:3.310.0"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: ddd1536ad16e29186fb5055bc279cfe9790b7c32552e1ee21e31d4e410e1df297b06c94c6117f854ec368d29e60a231dd8cc77e5b604a6260e7602876fd047f8
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/md5-js@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/md5-js@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/types": 3.341.0
+    "@aws-sdk/util-utf8": 3.310.0
+    tslib: ^2.5.0
+  checksum: 8ba13ce44ba88f2e8c1638b8ca5a1ff9c59b8bd7deab307db3a50933238e7af6ecb6406b515c10f16e123e97f82648f54dc458664f4c6f358aa2cb8c3c67f21c
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-bucket-endpoint@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/middleware-bucket-endpoint@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/protocol-http": 3.341.0
+    "@aws-sdk/types": 3.341.0
+    "@aws-sdk/util-arn-parser": 3.310.0
+    "@aws-sdk/util-config-provider": 3.310.0
+    tslib: ^2.5.0
+  checksum: 6edd29f91d17f0cfbd599577e73876c9413ba1cf8ed26012342ace717eedf4d5ba5981862db9eb2f088ae0eb2e59d01cdc109594817dd45547a4f2ad23c508a6
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-content-length@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/middleware-content-length@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/protocol-http": 3.341.0
+    "@aws-sdk/types": 3.341.0
+    tslib: ^2.5.0
+  checksum: 1eea10eea66b9daf38fefc99d18588f78a0296344c628ab5a6afd02ecc555dd607b58f242969d3f5e7090cfa6895fd1e6fde056f01787583f4f1ebc637a899d2
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-endpoint@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/middleware-endpoint@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/middleware-serde": 3.341.0
+    "@aws-sdk/types": 3.341.0
+    "@aws-sdk/url-parser": 3.341.0
+    "@aws-sdk/util-middleware": 3.341.0
+    tslib: ^2.5.0
+  checksum: bf701a7338e9e9576715d0ce44c9075ee537c66c710db8484b45c54ced261748c51c03e68c8293f162c5b8b46bf966e52099cae47692db4e1fa57ddeb2ffe451
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-expect-continue@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/middleware-expect-continue@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/protocol-http": 3.341.0
+    "@aws-sdk/types": 3.341.0
+    tslib: ^2.5.0
+  checksum: 9071f7e5aa75ed9d934a43a4247e40249dd890ae90ca97df4924d6bb57843f9ac7ccc3638088350e131466bca27d1ee994f73380849b0d6f59e1632d08109526
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-flexible-checksums@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/middleware-flexible-checksums@npm:3.341.0"
+  dependencies:
+    "@aws-crypto/crc32": 3.0.0
+    "@aws-crypto/crc32c": 3.0.0
+    "@aws-sdk/is-array-buffer": 3.310.0
+    "@aws-sdk/protocol-http": 3.341.0
+    "@aws-sdk/types": 3.341.0
+    "@aws-sdk/util-utf8": 3.310.0
+    tslib: ^2.5.0
+  checksum: fa3be7e3c17e8d13e28cb9384f4a3d2414bcbd6db376ecd4e0483b3b5f3b7bf66784d8a12155f226affc7d320f0c3ff06fcf6896df5e1f0a2d81a7d010296b3a
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-host-header@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/middleware-host-header@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/protocol-http": 3.341.0
+    "@aws-sdk/types": 3.341.0
+    tslib: ^2.5.0
+  checksum: d126e260eefb2e54704d3ef2e1b07eca2da1b89cdf1e0c8f431ba806a1ff64e09fc0d6d5437b7ab957a4807283e0b2993add0a93c6d60e2d7da86ffc745326b5
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-location-constraint@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/middleware-location-constraint@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/types": 3.341.0
+    tslib: ^2.5.0
+  checksum: b0c6efd0c7f08b21236797423e6bf8185f050a66ec6b7bf355d732c35ca083c118fc72489e5cc380f04c41fa6961492619964dd287aaff5c477b558cabdb1b41
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-logger@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/middleware-logger@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/types": 3.341.0
+    tslib: ^2.5.0
+  checksum: 258980266e74ca7221732e4c1a64e0b75924e7fd8909ddc6e02c8439232010d4f37d303ac86562240a575a4e2a9dca1e2deab6e2a854e36cd92244ee73e518ff
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-recursion-detection@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/protocol-http": 3.341.0
+    "@aws-sdk/types": 3.341.0
+    tslib: ^2.5.0
+  checksum: eb2fe5cd7bf3198023a743e3a9e4500fedda77712e77ed72b30a3a640388b5c465479d0670afcb103b991cb7fc6026411154df45a1e217346345efbaf1f7f2e0
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-retry@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/middleware-retry@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/protocol-http": 3.341.0
+    "@aws-sdk/service-error-classification": 3.341.0
+    "@aws-sdk/types": 3.341.0
+    "@aws-sdk/util-middleware": 3.341.0
+    "@aws-sdk/util-retry": 3.341.0
+    tslib: ^2.5.0
+    uuid: ^8.3.2
+  checksum: 4a1ca0a86565c9bd54e8c4e06bb13a9132d0e987cc3e605fff438625be506d93b5e918427eba95514191ce99fc539985e9288e78cf03ce0026c1fc3decf99365
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-sdk-s3@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/middleware-sdk-s3@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/protocol-http": 3.341.0
+    "@aws-sdk/types": 3.341.0
+    "@aws-sdk/util-arn-parser": 3.310.0
+    tslib: ^2.5.0
+  checksum: 63500fbed82bf049d5cf6ed6844d947b228b59ed8b2b8125700b5b16f99f3d318a5c1ccdc93112fadadebfe937cf6d65dd267260c702fd044c407835f4e8805c
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-sdk-sts@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/middleware-sdk-sts@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/middleware-signing": 3.341.0
+    "@aws-sdk/types": 3.341.0
+    tslib: ^2.5.0
+  checksum: 29672feac5aac4acee24ba9d1be940f775ca20dc83f71e7e87e0394bd670654a9eeee70c81a86a508a3ffd33f97bfaba9c0dfa1261a612fb207f0f55bf9e3317
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-serde@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/middleware-serde@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/types": 3.341.0
+    tslib: ^2.5.0
+  checksum: 0ca18e506523991ee27072101800d6483a24616ad1581463403fef65139f3f85aecb027f3583c6a2bec878106f32d682e3f5991670b3aacb42989d4772c23f8d
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-signing@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/middleware-signing@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/property-provider": 3.341.0
+    "@aws-sdk/protocol-http": 3.341.0
+    "@aws-sdk/signature-v4": 3.341.0
+    "@aws-sdk/types": 3.341.0
+    "@aws-sdk/util-middleware": 3.341.0
+    tslib: ^2.5.0
+  checksum: 76c0c73de9fd6103171b62fa8086fac26c6eadfbf271c90298546357db7247ad93f970e965f7b9f815602fb642c8a5919e74c1317f13357595fa4e5d6f024e46
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-ssec@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/middleware-ssec@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/types": 3.341.0
+    tslib: ^2.5.0
+  checksum: b2b68c0f18a2a394b87df9f5e0466b0bb5dac592accccd0852740d897bd4ba2c4278836ef8b942fd8c1f0ebe3720202f5ca25db9a7fb25c157d8a9451baeed81
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-stack@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/middleware-stack@npm:3.341.0"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: b333cc73fa19496d9718e07f33c4955ea5c1b16cde1c9d545f396a049837c0c46e2a27c7be0e2fb58795be467613d600f0fd9683aad931cd44962547a706a6df
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-user-agent@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/middleware-user-agent@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/protocol-http": 3.341.0
+    "@aws-sdk/types": 3.341.0
+    "@aws-sdk/util-endpoints": 3.341.0
+    tslib: ^2.5.0
+  checksum: 0ce6398d479dc40f40b6eb5caedd8937f08b41cae8bd6ee9bd07b83da4010b0cee55c4bb9118c3b66725de9ddab1304d3f84c9a8b869fe9672102006b8f3991b
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/node-config-provider@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/node-config-provider@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/property-provider": 3.341.0
+    "@aws-sdk/shared-ini-file-loader": 3.341.0
+    "@aws-sdk/types": 3.341.0
+    tslib: ^2.5.0
+  checksum: f19f73f683018b87b16d948fdcc0a309a150d033123fbd22d4dde86d38622e4da1b1d66aadcec7e42d9c7da7a84246bfc05155f572c680f9da0db251df3299ef
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/node-http-handler@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/node-http-handler@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/abort-controller": 3.341.0
+    "@aws-sdk/protocol-http": 3.341.0
+    "@aws-sdk/querystring-builder": 3.341.0
+    "@aws-sdk/types": 3.341.0
+    tslib: ^2.5.0
+  checksum: 668310a791ea65edcc82d8ba2e4a6a5a2fb136766da92d2585b898b1111a350ff526cc3d8db12fd41fb0255245b659f51f7a769a0a62085f796ee1a5698fde6e
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/property-provider@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/property-provider@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/types": 3.341.0
+    tslib: ^2.5.0
+  checksum: 0a6a6092d34671fd6ead97e10fee8bfd0bd6a40f724897d7daf8eeddecaaee513f122e26a3130326bfaf770907442efef8bb50bbf121ff407323063e23ee12b2
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/protocol-http@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/protocol-http@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/types": 3.341.0
+    tslib: ^2.5.0
+  checksum: f1012909c5b54458713c30a50f0f3efd0c2f56e58a97cd5cc05c6d9c77dff97397a5b2a288dc9cae85c0d19058ceeefa56ccaa31bb7d47e41726d95121ade29b
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/querystring-builder@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/querystring-builder@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/types": 3.341.0
+    "@aws-sdk/util-uri-escape": 3.310.0
+    tslib: ^2.5.0
+  checksum: fbf0d0c4d123d68a08c5ae0b7ed36ddb2eef7168742dc3a534f3d1ec2f17aef243f33c35c0362f1b2fa6e9f39c6bff0897721a0f8f3a522b42bf08d10cf27d39
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/querystring-parser@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/querystring-parser@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/types": 3.341.0
+    tslib: ^2.5.0
+  checksum: c2eccbe98148d8122ea8dbbec380c05c1c22e53623f53defab04f500751cf2b10fabb0f5c0c9897c8e36aa41495b4da09ffa952683eb2b859638e935cb2b4ba4
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/service-error-classification@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/service-error-classification@npm:3.341.0"
+  checksum: cfca32c9ab50583e8cc7a92093f549cece70ba800545aa03f118a965781a96e7c21d08036bc4a70b69cfaf4f0587f21c3eb36f6c3d0c4ad8bdff3fb4cd38ae36
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/shared-ini-file-loader@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/shared-ini-file-loader@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/types": 3.341.0
+    tslib: ^2.5.0
+  checksum: 077e3e6339a38f1e0ada16b87cfbeab42a5190e961c5b1c33426c3440937589920c055495f70310a27fceab4831b46e9ee486d854aa5bb7be254accf088d8266
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/signature-v4-multi-region@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/signature-v4-multi-region@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/protocol-http": 3.341.0
+    "@aws-sdk/signature-v4": 3.341.0
+    "@aws-sdk/types": 3.341.0
+    tslib: ^2.5.0
+  peerDependencies:
+    "@aws-sdk/signature-v4-crt": ^3.118.0
+  peerDependenciesMeta:
+    "@aws-sdk/signature-v4-crt":
+      optional: true
+  checksum: 7d3a6ed78f773a99a010f5cb5feda6b581eb211e0f23cfb3ba52dd50eb294c8cba5b4a3f1dfaa56b3eb4d2dd3c6a88550b213d1ddaf6864a70c63089e9a45687
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/signature-v4@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/signature-v4@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/is-array-buffer": 3.310.0
+    "@aws-sdk/types": 3.341.0
+    "@aws-sdk/util-hex-encoding": 3.310.0
+    "@aws-sdk/util-middleware": 3.341.0
+    "@aws-sdk/util-uri-escape": 3.310.0
+    "@aws-sdk/util-utf8": 3.310.0
+    tslib: ^2.5.0
+  checksum: 241a2345e4305dc3474212f6da3ea26a39bf42a6637e850ee11424d0bf84a825bb08ba6e6f2ea0d24bb8be85a35d741d53d781880f2a4f466b73e63bfbe988da
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/smithy-client@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/smithy-client@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/middleware-stack": 3.341.0
+    "@aws-sdk/types": 3.341.0
+    tslib: ^2.5.0
+  checksum: b2621c32d0f82c21902cfc1ccae35b26af15698d74fd8fe2390304a8021ef84db0e5a3e99e16305c4fcc77cc2f0b3273f2a55aa50df234447034bcbbaa13ee31
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/token-providers@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/token-providers@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/client-sso-oidc": 3.341.0
+    "@aws-sdk/property-provider": 3.341.0
+    "@aws-sdk/shared-ini-file-loader": 3.341.0
+    "@aws-sdk/types": 3.341.0
+    tslib: ^2.5.0
+  checksum: 3844f0f982fd775da403a9abd240b8a52351c661013f10107413b91ba550670a74987f2e3db8fc8f20e84d1b3419c43f26e4d234765b35941337dcd9224623d0
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/types@npm:3.341.0, @aws-sdk/types@npm:^3.222.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/types@npm:3.341.0"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: 5f2cc39729f788daa77e1db542fbf03c8bd71aa1a0a847a93c983e781e2480b1905e34733bdcbb8eb73e454b1ee500133ebb872c09c36483dae726acafe56866
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/url-parser@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/url-parser@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/querystring-parser": 3.341.0
+    "@aws-sdk/types": 3.341.0
+    tslib: ^2.5.0
+  checksum: ae8ce5a82400803c51d5818bd50742758987853ca632359b949839d4a759bc59a7fa3a82f0557790c1e5270d2ae16172d0244ed9845c11514fba13eda7ed0f5a
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-arn-parser@npm:3.310.0":
+  version: 3.310.0
+  resolution: "@aws-sdk/util-arn-parser@npm:3.310.0"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: faac1e10f8bb6c2fe5fee82bcb7ce56c2b37ae9ffdb2b78b0746a7a06005eaa5ea747a0a10eaf490c1c4907ecc327e1c94a600e26a069e023e54b8d63c031e96
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-base64@npm:3.310.0":
+  version: 3.310.0
+  resolution: "@aws-sdk/util-base64@npm:3.310.0"
+  dependencies:
+    "@aws-sdk/util-buffer-from": 3.310.0
+    tslib: ^2.5.0
+  checksum: 3c9f7c818401fe8332d2ce438c0660cc9be7db9a5eef68d7fafa30ddcc44b0af3ba9ea58092f0e2b2537a18ec0942ce3c8f12090d3e3b9568b6a94a0713e9de7
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-body-length-browser@npm:3.310.0":
+  version: 3.310.0
+  resolution: "@aws-sdk/util-body-length-browser@npm:3.310.0"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: c26136521ccbb59ba83ff29d6e52cb0e4b443b68e830c9dab578556539973573e6892093e5dea39101b1517c28b5d53c80ee38b9a01f9fa9fcd75f3aa5689857
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-body-length-node@npm:3.310.0":
+  version: 3.310.0
+  resolution: "@aws-sdk/util-body-length-node@npm:3.310.0"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: 202417ece7078f09f63c4119cb3ab5f321688ea893125f7d97985e8bf7fc61419d8d990f870d9ead3281dc51334975196ef98c50592eca1f9785472bd39b870d
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-buffer-from@npm:3.310.0":
+  version: 3.310.0
+  resolution: "@aws-sdk/util-buffer-from@npm:3.310.0"
+  dependencies:
+    "@aws-sdk/is-array-buffer": 3.310.0
+    tslib: ^2.5.0
+  checksum: 9c3bd9c0664a0cbb5270eb285a662274bb9c46ae0d79e0275a85e74659a4b1f094bab900994780fd70dd0152dc6d2d33a8bc681d87f3911fa48eae9f6c3558d6
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-config-provider@npm:3.310.0":
+  version: 3.310.0
+  resolution: "@aws-sdk/util-config-provider@npm:3.310.0"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: 958efc58ee492111ad746fe6224b25286da415f8aca1197c742bca063672b858d437d2d6b4df5f90ba770e1af9339b3fb1ffa9cc87f2fa993a7177057eb22caf
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-defaults-mode-browser@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/util-defaults-mode-browser@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/property-provider": 3.341.0
+    "@aws-sdk/types": 3.341.0
+    bowser: ^2.11.0
+    tslib: ^2.5.0
+  checksum: bd50110f5fb2246da341afd0733d311d61472b69eab62c61af8efccf7333b4207ded8816b8e4762e9e920b627af11f23920476941f35db26879eced35ea709ac
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-defaults-mode-node@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/util-defaults-mode-node@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/config-resolver": 3.341.0
+    "@aws-sdk/credential-provider-imds": 3.341.0
+    "@aws-sdk/node-config-provider": 3.341.0
+    "@aws-sdk/property-provider": 3.341.0
+    "@aws-sdk/types": 3.341.0
+    tslib: ^2.5.0
+  checksum: 0637de76d43e1c9be767d9943a8ecfe3f4ecaf0de45100ca87860694e70672c1c57fee0f7335861e00249b140ccba9f4620b1e593aef20d913ecfa29dd719828
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-endpoints@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/util-endpoints@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/types": 3.341.0
+    tslib: ^2.5.0
+  checksum: de672e5557d4eb00fee2193dcd8377c8aa3daf8423b934a94f243e99ef6b28860a85cfedd5eef1fa5ab67628168d7dbf401b1c233da8bf78d06ce24989b6de96
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-hex-encoding@npm:3.310.0":
+  version: 3.310.0
+  resolution: "@aws-sdk/util-hex-encoding@npm:3.310.0"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: 97b8d7e0e406189cdbd4fccb0a497dd247a22d54b18caf5a64a63d19d2535b95a64ee79ecf81b13f741bda1d565eb11448d4fd39617e4b86fc8626b05485d98c
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-locate-window@npm:^3.0.0":
+  version: 3.310.0
+  resolution: "@aws-sdk/util-locate-window@npm:3.310.0"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: d552ce5f0f836ecb13d7920ae650552c56706f26a5e8abf894ba471e18775a3791869bda95269153735bac9d211efc3ba78ea01c34428c3fed4318ac693a08bc
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-middleware@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/util-middleware@npm:3.341.0"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: 6c5db3406f57116d69ff53d01f21b86f165bc5740d9b5ff0a6783926a108ed308e77ce085f2202ed98fa592c4f44a1152dd97fced30a2bd8978e78972ce6cc9f
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-retry@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/util-retry@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/service-error-classification": 3.341.0
+    tslib: ^2.5.0
+  checksum: 3d0a5f4562ead57658595dca81bb25db85c5bbf25c508a8a70fb30e0390b417e8bc61748cbae0e0f06d5b64afa4e34538b9e755eb5c3cdd51ac2b7e9fbd12d0d
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-stream-browser@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/util-stream-browser@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/fetch-http-handler": 3.341.0
+    "@aws-sdk/types": 3.341.0
+    "@aws-sdk/util-base64": 3.310.0
+    "@aws-sdk/util-hex-encoding": 3.310.0
+    "@aws-sdk/util-utf8": 3.310.0
+    tslib: ^2.5.0
+  checksum: aa3b0ee816a76539f3056b40e73fe618926bbbcf1a7987cd2576d59b003736f463cd1e6187dde3ef7462e622f94824f87e2fb7e3c31555a661b30fa5a7fe5366
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-stream-node@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/util-stream-node@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/node-http-handler": 3.341.0
+    "@aws-sdk/types": 3.341.0
+    "@aws-sdk/util-buffer-from": 3.310.0
+    tslib: ^2.5.0
+  checksum: 85663a36eab1237b2424d08bce4e150360a6b3bd955299b58e5b140e2784ed6c59ac4f55ed8bcf857b5f00246f662c822292c58e4ccc830515000c3ef5bacb51
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-uri-escape@npm:3.310.0":
+  version: 3.310.0
+  resolution: "@aws-sdk/util-uri-escape@npm:3.310.0"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: 614c0a43b238b7371b6655a5961e21c57b708de3e1ce3138bd56284bedc48888e5c7d2a6965544108c3334fcdc45e9ddba86b2470c8e6901559ad7be8e21d418
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-user-agent-browser@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/util-user-agent-browser@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/types": 3.341.0
+    bowser: ^2.11.0
+    tslib: ^2.5.0
+  checksum: 8ff4044f2bebcfaebf08f47677f0e99cf1ae9c3af20ad3745020e209ca2848fe3d30a6d73331aa0e04ff1f47960521e4179880b270ffd23c20799e7e4c1c5a7d
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-user-agent-node@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/util-user-agent-node@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/node-config-provider": 3.341.0
+    "@aws-sdk/types": 3.341.0
+    tslib: ^2.5.0
+  peerDependencies:
+    aws-crt: ">=1.0.0"
+  peerDependenciesMeta:
+    aws-crt:
+      optional: true
+  checksum: 8bc4a78d21ef07ecf29775a61e06d95aec46f3919cee5968a227bbacd237a1704b1aee052c168cba5e07811aacb1317a88e5820e8cb53bcc84633ffe4ef7e9e8
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-utf8-browser@npm:^3.0.0":
+  version: 3.259.0
+  resolution: "@aws-sdk/util-utf8-browser@npm:3.259.0"
+  dependencies:
+    tslib: ^2.3.1
+  checksum: b6a1e580da1c9b62c749814182a7649a748ca4253edb4063aa521df97d25b76eae3359eb1680b86f71aac668e05cc05c514379bca39ebf4ba998ae4348412da8
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-utf8@npm:3.310.0":
+  version: 3.310.0
+  resolution: "@aws-sdk/util-utf8@npm:3.310.0"
+  dependencies:
+    "@aws-sdk/util-buffer-from": 3.310.0
+    tslib: ^2.5.0
+  checksum: 4045e79b8e3593e12233b359ba77d1b4c162fd9fcb4ab3b58b711c41b725552306dd91402b8d57ce5be080c76309f046a7a0c4ff704d12f9ba71e3b25b810086
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-waiter@npm:3.341.0":
+  version: 3.341.0
+  resolution: "@aws-sdk/util-waiter@npm:3.341.0"
+  dependencies:
+    "@aws-sdk/abort-controller": 3.341.0
+    "@aws-sdk/types": 3.341.0
+    tslib: ^2.5.0
+  checksum: 187248db98da73250a87e679003f1fcad5e35bbc57bb7d712187c149deeb84a7aca7bada84a6f06d5e7fd0a6f580e5a92acec41949b9c09510563e55c5e49808
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/xml-builder@npm:3.310.0":
+  version: 3.310.0
+  resolution: "@aws-sdk/xml-builder@npm:3.310.0"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: fc17fd8f68470702d947948ada46097bdddecafdc68fa57bf584320e92748e8ef0372a51999d3ab7902ba4f62c2dbfbdec2dba1180fca19bb5127bad1ef0e48b
+  languageName: node
+  linkType: hard
+
 "@babel/cli@npm:^7.11.6":
   version: 7.11.6
   resolution: "@babel/cli@npm:7.11.6"
@@ -4108,6 +5237,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/protocol-http@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@smithy/protocol-http@npm:1.0.1"
+  dependencies:
+    "@smithy/types": ^1.0.0
+    tslib: ^2.5.0
+  checksum: ba9ac4880fed48eeea0813663c94c765fe5b900f2fdac4f5de6524306bbc6645829f48bc175d202076b83acaccf008ed77f4b5546a4c180315f253e22fe6c89f
+  languageName: node
+  linkType: hard
+
+"@smithy/types@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@smithy/types@npm:1.0.0"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: ec05163564af050088f3c21cb047640ca842bea645c2a73624475b486d5df8ad9c494bf683a498f4b467b84fab2817cc199893dfb5cee30dce1e0172ab38db00
+  languageName: node
+  linkType: hard
+
 "@sphinxxxx/color-conversion@npm:^2.2.2":
   version: 2.2.2
   resolution: "@sphinxxxx/color-conversion@npm:2.2.2"
@@ -5169,6 +6317,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@tupaia/central-server@workspace:packages/central-server"
   dependencies:
+    "@aws-sdk/client-s3": ^3.341.0
     "@babel/polyfill": ^7.0.0
     "@tupaia/access-policy": 3.0.0
     "@tupaia/auth": 1.0.0
@@ -5182,7 +6331,6 @@ __metadata:
     adm-zip: ^0.5.5
     api-error-handler: ^1.0.0
     async: ^2.6.2
-    aws-sdk: ^2.451.0
     body-parser: ^1.18.3
     case: ^1.6.1
     chai: ^4.1.2
@@ -5501,6 +6649,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@tupaia/meditrak-app-server@workspace:packages/meditrak-app-server"
   dependencies:
+    "@aws-sdk/client-s3": ^3.341.0
     "@tupaia/api-client": 3.1.0
     "@tupaia/auth": 1.0.0
     "@tupaia/database": 1.0.0
@@ -5510,7 +6659,6 @@ __metadata:
     "@tupaia/utils": 1.0.0
     "@types/lodash.clonedeep": ^4.5.0
     "@types/semver-compare": ^1.0.1
-    aws-sdk: ^2.451.0
     dotenv: ^8.2.0
     express: ^4.16.2
     lodash.clonedeep: ^4.5.0
@@ -8834,7 +9982,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aws-sdk@npm:^2.0.4, aws-sdk@npm:^2.451.0":
+"aws-sdk@npm:^2.0.4":
   version: 2.596.0
   resolution: "aws-sdk@npm:2.596.0"
   dependencies:
@@ -9810,6 +10958,13 @@ __metadata:
   version: 1.9.4
   resolution: "bowser@npm:1.9.4"
   checksum: 127584ee1b8f0c27f410f652d409ea8bcb23d185a4269bcbe0229069720be9d83dc80a939e0fa33d8a9055141a0cf2fee5a02b2b5515c38841ddc899d67dec8d
+  languageName: node
+  linkType: hard
+
+"bowser@npm:^2.11.0":
+  version: 2.11.0
+  resolution: "bowser@npm:2.11.0"
+  checksum: 29c3f01f22e703fa6644fc3b684307442df4240b6e10f6cfe1b61c6ca5721073189ca97cdeedb376081148c8518e33b1d818a57f781d70b0b70e1f31fb48814f
   languageName: node
   linkType: hard
 
@@ -15904,6 +17059,17 @@ __metadata:
   version: 2.0.7
   resolution: "fast-safe-stringify@npm:2.0.7"
   checksum: e0055e231d1fe0f97863dcfb45f5f285d59e3d23210e1e8a31348829e4a584e04ffe49f5944a0ba2f21d753b67b0ecb6f0ffc49ecd8c7f6f531cbcd45a5f606b
+  languageName: node
+  linkType: hard
+
+"fast-xml-parser@npm:4.1.2":
+  version: 4.1.2
+  resolution: "fast-xml-parser@npm:4.1.2"
+  dependencies:
+    strnum: ^1.0.5
+  bin:
+    fxparser: src/cli/cli.js
+  checksum: 6a7d1b17057f8470e70603eddfa75f990625735d068d57ece861d0154ad8d27fda63c2831d07e1ecd7e68e993738b2448925cb9277d8c0ed68009623bbcd63c6
   languageName: node
   linkType: hard
 
@@ -33262,6 +34428,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strnum@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "strnum@npm:1.0.5"
+  checksum: 651b2031db5da1bf4a77fdd2f116a8ac8055157c5420f5569f64879133825915ad461513e7202a16d7fec63c54fd822410d0962f8ca12385c4334891b9ae6dd2
+  languageName: node
+  linkType: hard
+
 "style-loader@npm:1.3.0, style-loader@npm:^1.3.0":
   version: 1.3.0
   resolution: "style-loader@npm:1.3.0"
@@ -34410,6 +35583,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tslib@npm:^1.11.1":
+  version: 1.14.1
+  resolution: "tslib@npm:1.14.1"
+  checksum: dbe628ef87f66691d5d2959b3e41b9ca0045c3ee3c7c7b906cc1e328b39f199bb1ad9e671c39025bd56122ac57dfbf7385a94843b1cc07c60a4db74795829acd
+  languageName: node
+  linkType: hard
+
 "tslib@npm:^1.8.1":
   version: 1.10.0
   resolution: "tslib@npm:1.10.0"
@@ -34442,6 +35622,13 @@ __metadata:
   version: 2.3.1
   resolution: "tslib@npm:2.3.1"
   checksum: de17a98d4614481f7fcb5cd53ffc1aaf8654313be0291e1bfaee4b4bb31a20494b7d218ff2e15017883e8ea9626599b3b0e0229c18383ba9dce89da2adf15cb9
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^2.3.1, tslib@npm:^2.5.0":
+  version: 2.5.2
+  resolution: "tslib@npm:2.5.2"
+  checksum: 4d3c1e238b94127ed0e88aa0380db3c2ddae581dc0f4bae5a982345e9f50ee5eda90835b8bfba99b02df10a5734470be197158c36f9129ac49fdc14a6a9da222
   languageName: node
   linkType: hard
 
@@ -35431,7 +36618,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^8.3.0":
+"uuid@npm:^8.3.0, uuid@npm:^8.3.2":
   version: 8.3.2
   resolution: "uuid@npm:8.3.2"
   bin:


### PR DESCRIPTION
Used codemod mentioned in their [docs](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/migrating-to-v3.html) to upgrade usages.

Checked against migration [docs](https://github.com/aws/aws-sdk-js-v3/blob/main/UPGRADING.md) to ensure that our api calls are still valid.