### PR TITLE
WAITP-1255: Tupaia web server report and dashboard routes

### DIFF
--- a/packages/api-client/src/MockTupaiaApiClient.ts
+++ b/packages/api-client/src/MockTupaiaApiClient.ts
@@ -9,6 +9,7 @@ import {
   DataTableApiInterface,
   EntityApiInterface,
   ReportApiInterface,
+  WebConfigApiInterface,
 } from './connections';
 
 import {
@@ -17,6 +18,7 @@ import {
   MockDataTableApi,
   MockEntityApi,
   MockReportApi,
+  MockWebConfigApi,
 } from './connections/mocks';
 
 export class MockTupaiaApiClient {
@@ -25,6 +27,7 @@ export class MockTupaiaApiClient {
   public readonly dataTable: DataTableApiInterface;
   public readonly entity: EntityApiInterface;
   public readonly report: ReportApiInterface;
+  public readonly webConfig: WebConfigApiInterface;
 
   public constructor({
     auth = new MockAuthApi(),
@@ -32,11 +35,13 @@ export class MockTupaiaApiClient {
     dataTable = new MockDataTableApi(),
     entity = new MockEntityApi(),
     report = new MockReportApi(),
+    webConfig = new MockWebConfigApi(),
   } = {}) {
     this.auth = auth;
     this.central = central;
     this.dataTable = dataTable;
     this.entity = entity;
     this.report = report;
+    this.webConfig = webConfig
   }
 }

--- a/packages/api-client/src/TupaiaApiClient.ts
+++ b/packages/api-client/src/TupaiaApiClient.ts
@@ -12,11 +12,13 @@ import {
   DataTableApi,
   EntityApi,
   ReportApi,
+  WebConfigApi,
   AuthApiInterface,
   CentralApiInterface,
   DataTableApiInterface,
   EntityApiInterface,
   ReportApiInterface,
+  WebConfigApiInterface,
 } from './connections';
 import { PRODUCTION_BASE_URLS, ServiceBaseUrlSet } from './constants';
 
@@ -26,6 +28,7 @@ export class TupaiaApiClient {
   public readonly dataTable: DataTableApiInterface;
   public readonly auth: AuthApiInterface;
   public readonly report: ReportApiInterface;
+  public readonly webConfig: WebConfigApiInterface;
 
   public constructor(authHandler: AuthHandler, baseUrls: ServiceBaseUrlSet = PRODUCTION_BASE_URLS) {
     this.auth = new AuthApi(new ApiConnection(authHandler, baseUrls.auth));
@@ -33,5 +36,6 @@ export class TupaiaApiClient {
     this.central = new CentralApi(new ApiConnection(authHandler, baseUrls.central));
     this.report = new ReportApi(new ApiConnection(authHandler, baseUrls.report));
     this.dataTable = new DataTableApi(new ApiConnection(authHandler, baseUrls.dataTable));
+    this.webConfig = new WebConfigApi(new ApiConnection(authHandler, baseUrls.webConfig));
   }
 }

--- a/packages/api-client/src/auth/SessionSwitchingAuthHandler.ts
+++ b/packages/api-client/src/auth/SessionSwitchingAuthHandler.ts
@@ -3,14 +3,8 @@
  * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
  */
 
-import { createBasicHeader } from '@tupaia/utils';
+import { createBasicHeader, getEnvVarOrDefault } from '@tupaia/utils';
 import { AuthHandler, SessionType } from '../types';
-
-const { API_CLIENT_NAME = '', API_CLIENT_PASSWORD = '' } = process.env;
-const DEFAULT_AUTH_HEADER = createBasicHeader(
-  API_CLIENT_NAME,
-  API_CLIENT_PASSWORD,
-);
 
 // Handles switching between microservice client and user login sessions
 export class SessionSwitchingAuthHandler implements AuthHandler {
@@ -29,6 +23,9 @@ export class SessionSwitchingAuthHandler implements AuthHandler {
       return this.session.getAuthHeader();
     }
 
-    return DEFAULT_AUTH_HEADER;
+    return createBasicHeader(
+      getEnvVarOrDefault('API_CLIENT_NAME', ''),
+      getEnvVarOrDefault('API_CLIENT_PASSWORD', ''),
+    );
   }
 }

--- a/packages/api-client/src/connections/ReportApi.ts
+++ b/packages/api-client/src/connections/ReportApi.ts
@@ -16,6 +16,10 @@ export class ReportApi extends BaseApi {
   public async fetchTransformSchemas() {
     return this.connection.get('fetchTransformSchemas');
   }
+
+  public async fetchReport(reportCode: string, query?: QueryParameters | null) {
+    return this.connection.get(`fetchReport/${reportCode}`, query);
+  }
 }
 
 export interface ReportApiInterface extends PublicInterface<ReportApi> {}

--- a/packages/api-client/src/connections/WebConfigApi.ts
+++ b/packages/api-client/src/connections/WebConfigApi.ts
@@ -1,0 +1,16 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+import { QueryParameters } from '../types';
+import { BaseApi } from './BaseApi';
+import { PublicInterface } from './types';
+
+export class WebConfigApi extends BaseApi {
+  public async fetchReport(reportCode: string, query?: QueryParameters | null) {
+    return this.connection.get(`report/${reportCode}`, query);
+  }
+}
+
+export interface WebConfigApiInterface extends PublicInterface<WebConfigApi> {};

--- a/packages/api-client/src/connections/index.ts
+++ b/packages/api-client/src/connections/index.ts
@@ -10,3 +10,4 @@ export { DataTableApi, DataTableApiInterface } from './DataTableApi';
 export { EntityApi, EntityApiInterface } from './EntityApi';
 export { CentralApi, CentralApiInterface } from './CentralApi';
 export { ReportApi, ReportApiInterface } from './ReportApi';
+export { WebConfigApi, WebConfigApiInterface } from './WebConfigApi';

--- a/packages/api-client/src/connections/mocks/MockReportApi.ts
+++ b/packages/api-client/src/connections/mocks/MockReportApi.ts
@@ -18,4 +18,7 @@ export class MockReportApi implements ReportApiInterface {
   public fetchTransformSchemas(): Promise<any> {
     throw new Error('Method not implemented.');
   }
+  public fetchReport(): Promise<any> {
+    throw new Error('Method not implemented.');
+  }
 }

--- a/packages/api-client/src/connections/mocks/MockWebConfigApi.ts
+++ b/packages/api-client/src/connections/mocks/MockWebConfigApi.ts
@@ -1,0 +1,12 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+import { WebConfigApiInterface } from '..';
+
+export class MockWebConfigApi implements WebConfigApiInterface {
+  public fetchReport(): Promise<any> {
+    throw new Error('Method not implemented.');
+  }
+}

--- a/packages/api-client/src/connections/mocks/index.ts
+++ b/packages/api-client/src/connections/mocks/index.ts
@@ -8,3 +8,4 @@ export { MockCentralApi } from './MockCentralApi';
 export { MockDataTableApi } from './MockDataTableApi';
 export { MockEntityApi } from './MockEntityApi';
 export { MockReportApi } from './MockReportApi';
+export { MockWebConfigApi } from './MockWebConfigApi';

--- a/packages/api-client/src/constants.ts
+++ b/packages/api-client/src/constants.ts
@@ -5,7 +5,7 @@
 
 export const DATA_TIME_FORMAT = 'YYYY-MM-DD HH:mm:ss';
 
-type ServiceName = 'auth' | 'entity' | 'central' | 'report' | 'dataTable';
+type ServiceName = 'auth' | 'entity' | 'central' | 'report' | 'dataTable' | 'webConfig';
 export type ServiceBaseUrlSet = Record<ServiceName, string>;
 
 const productionSubdomains = [
@@ -52,6 +52,11 @@ const SERVICES = {
     version: 'v1',
     localPort: '8010',
   },
+  webConfig: {
+    subdomain: 'config',
+    version: 'v1',
+    localPort: '8000',
+  },
 };
 
 const getLocalUrl = (service: ServiceName): string =>
@@ -62,6 +67,7 @@ export const LOCALHOST_BASE_URLS: ServiceBaseUrlSet = {
   central: getLocalUrl('central'),
   report: getLocalUrl('report'),
   dataTable: getLocalUrl('dataTable'),
+  webConfig: getLocalUrl('webConfig'),
 };
 
 const getServiceUrl = (service: ServiceName, subdomainPrefix?: string): string => {
@@ -76,6 +82,7 @@ export const DEV_BASE_URLS: ServiceBaseUrlSet = {
   central: getServiceUrl('central', 'dev'),
   report: getServiceUrl('report', 'dev'),
   dataTable: getServiceUrl('dataTable', 'dev'),
+  webConfig: getServiceUrl('webConfig', 'dev'),
 };
 
 export const PRODUCTION_BASE_URLS: ServiceBaseUrlSet = {
@@ -84,6 +91,7 @@ export const PRODUCTION_BASE_URLS: ServiceBaseUrlSet = {
   central: getServiceUrl('central'),
   report: getServiceUrl('report'),
   dataTable: getServiceUrl('dataTable'),
+  webConfig: getServiceUrl('webConfig'),
 };
 
 const getServiceUrlForSubdomain = (service: ServiceName, originalSubdomain: string): string => {
@@ -122,16 +130,18 @@ const getDefaultBaseUrls = (hostname: string): ServiceBaseUrlSet => {
     central: getServiceUrlForSubdomain('central', subdomain),
     report: getServiceUrlForSubdomain('report', subdomain),
     dataTable: getServiceUrlForSubdomain('dataTable', subdomain),
+    webConfig: getServiceUrlForSubdomain('webConfig', subdomain),
   };
 };
 
 export const getBaseUrlsForHost = (hostname: string): ServiceBaseUrlSet => {
-  const { auth, entity, central, report, dataTable } = getDefaultBaseUrls(hostname);
+  const { auth, entity, central, report, dataTable, webConfig } = getDefaultBaseUrls(hostname);
   return {
     auth: process.env.AUTH_API_URL || auth,
     entity: process.env.ENTITY_API_URL || entity,
     central: process.env.CENTRAL_API_URL || central,
     report: process.env.REPORT_API_URL || report,
     dataTable: process.env.DATA_TABLE_API_URL || dataTable,
+    webConfig: process.env.WEB_CONFIG_API_URL || webConfig,
   };
 };

--- a/packages/server-boilerplate/src/index.ts
+++ b/packages/server-boilerplate/src/index.ts
@@ -17,6 +17,7 @@ export {
   SessionType,
   SessionCookie,
   attachSession,
+  attachSessionIfAvailable,
 } from './orchestrator';
 export * from './types';
 export * from './models';

--- a/packages/server-boilerplate/src/orchestrator/index.ts
+++ b/packages/server-boilerplate/src/orchestrator/index.ts
@@ -6,4 +6,4 @@
 export { ApiBuilder } from './api';
 export { SessionModel, SessionType } from './models';
 export { SessionCookie } from './types';
-export { attachSession } from './session';
+export { attachSession, attachSessionIfAvailable } from './session';

--- a/packages/server-boilerplate/src/orchestrator/session/attachSession.ts
+++ b/packages/server-boilerplate/src/orchestrator/session/attachSession.ts
@@ -29,10 +29,15 @@ export const attachSession = async (req: Request, res: Response, next: NextFunct
 };
 
 export const attachSessionIfAvailable = async (req: Request, res: Response, next: NextFunction) => {
-  // Discard errors from attach session so function succeeds even if session doesn't exist
+  // Discard authorization errors from attach session so function succeeds even if session doesn't exist
+  const UNAUTHORIZED_STATUS_CODE = 401;
   try {
-    attachSession(req, res, () => { next() });
-  } catch(error) {
-    next();
+    attachSession(req, res, next);
+  } catch(error: any) {
+    if (error.statusCode === UNAUTHORIZED_STATUS_CODE) {
+      next();
+    } else {
+      next(error);
+    }
   }
 };

--- a/packages/server-boilerplate/src/orchestrator/session/attachSession.ts
+++ b/packages/server-boilerplate/src/orchestrator/session/attachSession.ts
@@ -27,3 +27,12 @@ export const attachSession = async (req: Request, res: Response, next: NextFunct
     next(error);
   }
 };
+
+export const attachSessionIfAvailable = async (req: Request, res: Response, next: NextFunction) => {
+  // Discard errors from attach session so function succeeds even if session doesn't exist
+  try {
+    attachSession(req, res, () => { next() });
+  } catch(error) {
+    next();
+  }
+};

--- a/packages/server-boilerplate/src/orchestrator/session/attachSession.ts
+++ b/packages/server-boilerplate/src/orchestrator/session/attachSession.ts
@@ -30,14 +30,13 @@ export const attachSession = async (req: Request, res: Response, next: NextFunct
 
 export const attachSessionIfAvailable = async (req: Request, res: Response, next: NextFunction) => {
   // Discard authorization errors from attach session so function succeeds even if session doesn't exist
-  const UNAUTHORIZED_STATUS_CODE = 401;
   try {
-    attachSession(req, res, next);
+    attachSession(req, res, () => { next() });
   } catch(error: any) {
-    if (error.statusCode === UNAUTHORIZED_STATUS_CODE) {
+    if (error instanceof UnauthenticatedError) {
       next();
     } else {
-      next(error);
+      throw error;
     }
   }
 };

--- a/packages/server-boilerplate/src/orchestrator/session/index.ts
+++ b/packages/server-boilerplate/src/orchestrator/session/index.ts
@@ -3,4 +3,4 @@
  * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
  */
 
-export { attachSession } from './attachSession';
+export { attachSession, attachSessionIfAvailable } from './attachSession';

--- a/packages/tupaia-web-server/src/@types/express/index.d.ts
+++ b/packages/tupaia-web-server/src/@types/express/index.d.ts
@@ -6,12 +6,20 @@
 import { AccessPolicy } from '@tupaia/access-policy';
 import { TupaiaApiClient } from '@tupaia/api-client';
 
-import { TupaiaWebSessionType } from '../../models';
+import { TupaiaWebSessionType, TupaiaWebSessionModel } from '../../models';
+
+interface SessionCookie {
+  id: string;
+  email: string;
+  reset?: () => void;
+}
 
 declare global {
   namespace Express {
     export interface Request {
       accessPolicy: AccessPolicy;
+      sessionModel: TupaiaWebSessionModel;
+      sessionCookie?: SessionCookie;
       session: TupaiaWebSessionType;
       ctx: {
         services: TupaiaApiClient;

--- a/packages/tupaia-web-server/src/@types/express/index.d.ts
+++ b/packages/tupaia-web-server/src/@types/express/index.d.ts
@@ -5,14 +5,9 @@
 
 import { AccessPolicy } from '@tupaia/access-policy';
 import { TupaiaApiClient } from '@tupaia/api-client';
+import { SessionCookie } from '@tupaia/server-boilerplate';
 
 import { TupaiaWebSessionType, TupaiaWebSessionModel } from '../../models';
-
-interface SessionCookie {
-  id: string;
-  email: string;
-  reset?: () => void;
-}
 
 declare global {
   namespace Express {

--- a/packages/tupaia-web-server/src/app/createApp.ts
+++ b/packages/tupaia-web-server/src/app/createApp.ts
@@ -9,6 +9,7 @@ import {
   OrchestratorApiBuilder,
   handleWith,
   useForwardUnhandledRequests,
+  attachSessionIfAvailable,
 } from '@tupaia/server-boilerplate';
 import { SessionSwitchingAuthHandler } from '@tupaia/api-client';
 import { TupaiaWebSessionModel } from '../models';
@@ -26,8 +27,9 @@ const { WEB_CONFIG_API_URL = 'http://localhost:8000/api/v1' } = process.env;
 
 export function createApp() {
   const app = new OrchestratorApiBuilder(new TupaiaDatabase(), 'tupaia-web')
-    .attachApiClientToContext(req => new SessionSwitchingAuthHandler(req.session))
     .useSessionModel(TupaiaWebSessionModel)
+    .useAttachSession(attachSessionIfAvailable)
+    .attachApiClientToContext(req => new SessionSwitchingAuthHandler(req.session))
     .get<ReportRequest>('report/:reportCode', handleWith(ReportRoute))
     .get<UserRequest>('getUser', handleWith(UserRoute))
     // TODO: Stop using get for logout, then delete this

--- a/packages/tupaia-web-server/src/app/createApp.ts
+++ b/packages/tupaia-web-server/src/app/createApp.ts
@@ -3,7 +3,6 @@
  * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
  */
 
-import { Request } from 'express';
 import { TupaiaDatabase } from '@tupaia/database';
 import {
   OrchestratorApiBuilder,

--- a/packages/tupaia-web-server/src/app/createApp.ts
+++ b/packages/tupaia-web-server/src/app/createApp.ts
@@ -15,9 +15,11 @@ import { TupaiaWebSessionModel } from '../models';
 import {
   ReportRoute,
   UserRoute,
+  TempLogoutRoute,
 
   ReportRequest,
   UserRequest,
+  TempLogoutRequest,
 } from '../routes';
 
 const { WEB_CONFIG_API_URL = 'http://localhost:8000/api/v1' } = process.env;
@@ -28,6 +30,8 @@ export function createApp() {
     .useSessionModel(TupaiaWebSessionModel)
     .get<ReportRequest>('report/:reportCode', handleWith(ReportRoute))
     .get<UserRequest>('getUser', handleWith(UserRoute))
+    // TODO: Stop using get for logout, then delete this
+    .get<TempLogoutRequest>('logout', handleWith(TempLogoutRoute))
     .build();
 
   useForwardUnhandledRequests(app, WEB_CONFIG_API_URL);

--- a/packages/tupaia-web-server/src/app/createApp.ts
+++ b/packages/tupaia-web-server/src/app/createApp.ts
@@ -14,10 +14,12 @@ import {
 import { SessionSwitchingAuthHandler } from '@tupaia/api-client';
 import { TupaiaWebSessionModel } from '../models';
 import {
+  DashboardsRoute,
   ReportRoute,
   UserRoute,
   TempLogoutRoute,
 
+  DashboardsRequest,
   ReportRequest,
   UserRequest,
   TempLogoutRequest,
@@ -32,6 +34,7 @@ export function createApp() {
     .attachApiClientToContext(req => new SessionSwitchingAuthHandler(req.session))
     .get<ReportRequest>('report/:reportCode', handleWith(ReportRoute))
     .get<UserRequest>('getUser', handleWith(UserRoute))
+    .get<DashboardsRequest>('dashboards', handleWith(DashboardsRoute))
     // TODO: Stop using get for logout, then delete this
     .get<TempLogoutRequest>('logout', handleWith(TempLogoutRoute))
     .build();

--- a/packages/tupaia-web-server/src/app/createApp.ts
+++ b/packages/tupaia-web-server/src/app/createApp.ts
@@ -2,6 +2,8 @@
  * Tupaia
  * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
  */
+
+import { Request } from 'express';
 import { TupaiaDatabase } from '@tupaia/database';
 import {
   OrchestratorApiBuilder,
@@ -10,6 +12,13 @@ import {
 } from '@tupaia/server-boilerplate';
 import { SessionSwitchingAuthHandler } from '@tupaia/api-client';
 import { TupaiaWebSessionModel } from '../models';
+import {
+  ReportRoute,
+  UserRoute,
+
+  ReportRequest,
+  UserRequest,
+} from '../routes';
 
 const { WEB_CONFIG_API_URL = 'http://localhost:8000/api/v1' } = process.env;
 
@@ -17,6 +26,8 @@ export function createApp() {
   const app = new OrchestratorApiBuilder(new TupaiaDatabase(), 'tupaia-web')
     .attachApiClientToContext(req => new SessionSwitchingAuthHandler(req.session))
     .useSessionModel(TupaiaWebSessionModel)
+    .get<ReportRequest>('report/:reportCode', handleWith(ReportRoute))
+    .get<UserRequest>('getUser', handleWith(UserRoute))
     .build();
 
   useForwardUnhandledRequests(app, WEB_CONFIG_API_URL);

--- a/packages/tupaia-web-server/src/routes/DashboardsRoute.ts
+++ b/packages/tupaia-web-server/src/routes/DashboardsRoute.ts
@@ -1,0 +1,31 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+import { Request } from 'express';
+import { Route } from '@tupaia/server-boilerplate';
+
+export type DashboardsRequest = Request<
+  any,
+  any,
+  any,
+  any
+>;
+
+export class DashboardsRoute extends Route<DashboardsRequest> {
+  public async buildResponse() {
+    const { query, ctx } = this.req;
+    const { organisationUnitCode, projectCode } = query;
+
+    const project = (await ctx.services.central.fetchResources('projects', { filter: { code: projectCode }, columns: JSON.stringify(['entity_id', 'entity_hierarchy.name']) }))[0];
+    const baseEntity = await ctx.services.entity.getEntity(project['entity_hierarchy.name'], organisationUnitCode);
+    // TODO: Add a better getAncestors function to the EntityApi
+    const entities = await ctx.services.entity.getRelationshipsOfEntity(project['entity_hierarchy.name'], project.entity_id, 'descendant', {}, {} , { filter: { type: baseEntity.type } });
+    const dashboards = await ctx.services.central.fetchResources('dashboards', { filter: { root_entity_code: entities.ancestors }});
+    return Promise.all(dashboards.map(async (dash: any) => ({
+      ...dash,
+      items: await ctx.services.central.fetchResources(`dashbaords/${dash.id}/dashboardRelations`)
+    })));
+  }
+}

--- a/packages/tupaia-web-server/src/routes/DashboardsRoute.ts
+++ b/packages/tupaia-web-server/src/routes/DashboardsRoute.ts
@@ -25,7 +25,7 @@ export class DashboardsRoute extends Route<DashboardsRequest> {
     const dashboards = await ctx.services.central.fetchResources('dashboards', { filter: { root_entity_code: entities.ancestors }});
     return Promise.all(dashboards.map(async (dash: any) => ({
       ...dash,
-      items: await ctx.services.central.fetchResources(`dashbaords/${dash.id}/dashboardRelations`)
+      items: await ctx.services.central.fetchResources(`dashboards/${dash.id}/dashboardRelations`)
     })));
   }
 }

--- a/packages/tupaia-web-server/src/routes/ReportRoute.ts
+++ b/packages/tupaia-web-server/src/routes/ReportRoute.ts
@@ -1,0 +1,30 @@
+/*
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ *
+ */
+
+import { Request } from 'express';
+import { Route } from '@tupaia/server-boilerplate';
+
+export type ReportRequest = Request<
+  { reportCode: string },
+  any,
+  any,
+  any
+>;
+
+export class ReportRoute extends Route<ReportRequest> {
+  public async buildResponse() {
+    const { query, ctx } = this.req;
+    const { reportCode } = this.req.params;
+    const { legacy } = query;
+
+    // Legacy data builders are handled through the web config server still
+    if (legacy === 'true') {
+      return ctx.services.webConfig.fetchReport(reportCode, query);
+    }
+
+    return ctx.services.report.fetchReport(reportCode, query);
+  }
+}

--- a/packages/tupaia-web-server/src/routes/TempLogoutRoute.ts
+++ b/packages/tupaia-web-server/src/routes/TempLogoutRoute.ts
@@ -1,0 +1,28 @@
+// TODO: Stop using get for logout, then delete this whole file
+
+import { Request } from 'express';
+import { Route } from '@tupaia/server-boilerplate';
+
+export type TempLogoutRequest = Request<
+  any,
+  { loggedOut: boolean },
+  any,
+  any
+>;
+
+export class TempLogoutRoute extends Route<TempLogoutRequest> {
+  public async buildResponse() {
+    const { sessionCookie } = this.req;
+    const sessionId = sessionCookie?.id;
+
+    if (sessionId && this.req.sessionModel) {
+      await this.req.sessionModel.deleteById(sessionId);
+    }
+
+    if (sessionCookie !== undefined) {
+      sessionCookie.reset?.();
+    }
+
+    return { loggedOut: true };
+  }
+}

--- a/packages/tupaia-web-server/src/routes/UserRoute.ts
+++ b/packages/tupaia-web-server/src/routes/UserRoute.ts
@@ -1,0 +1,22 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+import { Request } from 'express';
+import { Route } from '@tupaia/server-boilerplate';
+
+export type UserRequest = Request;
+
+export class UserRoute extends Route<UserRequest> {
+  public async buildResponse() {
+    const { ctx, session } = this.req;
+
+    // Avoid sending a 'me' request as the api user
+    if (!session) {
+      return {};
+    }
+
+    return ctx.services.central.getUser();
+  }
+}

--- a/packages/tupaia-web-server/src/routes/UserRoute.ts
+++ b/packages/tupaia-web-server/src/routes/UserRoute.ts
@@ -14,7 +14,8 @@ export class UserRoute extends Route<UserRequest> {
 
     // Avoid sending a 'me' request as the api user
     if (!session) {
-      return {};
+      // Triggers frontend login
+      return { name: 'public' };
     }
 
     return ctx.services.central.getUser();

--- a/packages/tupaia-web-server/src/routes/index.ts
+++ b/packages/tupaia-web-server/src/routes/index.ts
@@ -3,6 +3,7 @@
  * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
  */
 
+export { DashboardsRequest, DashboardsRoute } from './DashboardsRoute';
 export { ReportRequest, ReportRoute } from './ReportRoute';
 export { UserRequest, UserRoute } from './UserRoute';
 

--- a/packages/tupaia-web-server/src/routes/index.ts
+++ b/packages/tupaia-web-server/src/routes/index.ts
@@ -5,3 +5,6 @@
 
 export { ReportRequest, ReportRoute } from './ReportRoute';
 export { UserRequest, UserRoute } from './UserRoute';
+
+// TODO: Stop using get for logout, then delete this
+export { TempLogoutRequest, TempLogoutRoute } from './TempLogoutRoute';

--- a/packages/tupaia-web-server/src/routes/index.ts
+++ b/packages/tupaia-web-server/src/routes/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+export { ReportRequest, ReportRoute } from './ReportRoute';
+export { UserRequest, UserRoute } from './UserRoute';


### PR DESCRIPTION
### Issue #: WAITP-1255 WAITP-1256

### Changes:

- Adding `reports` route to `tupaia-web-server`
  - Basic forwarder route
- Adding `dashboards` route
  - Fetch dashboards and items based on the entity hierarchy of the project
- Adding `TempLogout` route
  - Currently the frontend uses a `GET` for logout which doesn't play nice with the `server-boilerplate` logout functionality