### PR TITLE
WAITP-1216 Add project permissions to landing page projects in response

### DIFF
--- a/packages/web-config-server/src/apiV1/projects.js
+++ b/packages/web-config-server/src/apiV1/projects.js
@@ -32,7 +32,7 @@ function getHomeEntityCode(project, entitiesWithAccess) {
   return project.entity_code;
 }
 
-async function buildProjectDataForFrontend(project, req) {
+export async function buildProjectDataForFrontend(project, req) {
   const {
     id: projectId,
     name,


### PR DESCRIPTION
### Issue WAITP-1216: Add project permissions to landing pages projects

### Changes:
- Exposed function from `projects` API in `web-config-server` to reuse this in landing pages
- Updated landing page logic to fetch the projects and use the same logic as `projects` API to return the array of projects with the landing page
