### PR TITLE
Waitp 1216 projects default dashboard response

### DIFF
--- a/packages/database/src/modelClasses/Project.js
+++ b/packages/database/src/modelClasses/Project.js
@@ -33,7 +33,7 @@ export class ProjectModel extends DatabaseModel {
             p.sort_order, p.permission_groups,
             p.entity_id, p.image_url,
             p.logo_url, p.dashboard_group_name,
-            p.default_measure, p.config
+            p.default_measure, p.config, p.entity_hierarchy_id
       from project p
         left join entity e
           on p.entity_id = e.id


### PR DESCRIPTION
### Issue WAITP-1216b: Add default dashboard code to project response

### Changes:
- return `entity_hierarchy_id` with `getAllProjectDetails` response
- return default dashboard code with projects response in `web-config-server` (uses `dashboardGroupName` to find default dashboard if possible, otherwise returns the first dashboard code. If no dashboards can be found it returns 'General' - this is because this is what web-frontend does I believe, so I kept the same logic)
