### PR TITLE
[no-issue]: Add generational_distance filter in entity-server

### DIFF
--- a/packages/api-client/src/connections/CentralApi.ts
+++ b/packages/api-client/src/connections/CentralApi.ts
@@ -9,10 +9,20 @@ import { RequestBody } from './ApiConnection';
 import { BaseApi } from './BaseApi';
 import { PublicInterface } from './types';
 
-const stringifyParams = (queryParameters?: Record<string, unknown>) => {
-  const translatedParams = queryParameters?.filter
-    ? { ...queryParameters, filter: JSON.stringify(queryParameters?.filter) }
-    : queryParameters;
+const stringifyParams = (queryParameters: Record<string, unknown> = {}) => {
+  const { filter, columns, sort, ...restOfParameters } = queryParameters;
+
+  const translatedParams = restOfParameters;
+  if (filter) {
+    translatedParams.filter = JSON.stringify(filter);
+  }
+  if (columns) {
+    translatedParams.columns = JSON.stringify(columns);
+  }
+  if (sort) {
+    translatedParams.sort = JSON.stringify(sort);
+  }
+
   return translatedParams as QueryParameters;
 };
 

--- a/packages/api-client/src/connections/EntityApi.ts
+++ b/packages/api-client/src/connections/EntityApi.ts
@@ -15,7 +15,11 @@ const MULTIPLE_VALUES_DELIMITER = ',';
 const comparatorToOperator = {
   '=': '==' as const, // Exact match
   '!=': '!=' as const, // Does not match
-  ilike: '=@' as const, // Contains sub string
+  ilike: '=@' as const, // Contains sub string,
+  '<': '<' as const, // Less than
+  '<=': '<=' as const, // Less than or equal
+  '>': '>' as const, // Greater than
+  '>=': '>=' as const, // Greater than or equal
 };
 
 type ValueOf<T> = T extends Record<string, any> ? T[keyof T] : never;

--- a/packages/entity-server/src/__tests__/__integration__/fieldsAndFilters.test.ts
+++ b/packages/entity-server/src/__tests__/__integration__/fieldsAndFilters.test.ts
@@ -239,6 +239,50 @@ describe('fieldsAndFilters', () => {
       expect(entities).toIncludeSameMembers(['PKMN_MANSION', 'PKMN_TOWER']);
     });
 
+    it('it can filter using <', async () => {
+      const { body: entities } = await app.get('hierarchy/redblue/redblue/descendants', {
+        query: { field: 'code', filter: 'generational_distance<2' },
+      });
+
+      expect(entities).toIncludeSameMembers(['KANTO']);
+    });
+
+    it('it can filter using <=', async () => {
+      const { body: entities } = await app.get('hierarchy/redblue/redblue/descendants', {
+        query: { field: 'code', filter: 'generational_distance<=2' },
+      });
+
+      expect(entities).toIncludeSameMembers([
+        'CELADON',
+        'CERULEAN',
+        'CINNABAR',
+        'FUCHSIA',
+        'KANTO',
+        'LAVENDER',
+        'PALLET',
+        'PEWTER',
+        'SAFFRON',
+        'VERMILLION',
+        'VIRIDIAN',
+      ]);
+    });
+
+    it('it can filter using >', async () => {
+      const { body: entities } = await app.get('hierarchy/redblue/redblue/descendants', {
+        query: { field: 'code', filter: 'name>Saffron City' },
+      });
+
+      expect(entities).toIncludeSameMembers(['BLUE', 'SILPH', 'VERMILLION', 'VIRIDIAN']);
+    });
+
+    it('it can filter using >=', async () => {
+      const { body: entities } = await app.get('hierarchy/redblue/redblue/descendants', {
+        query: { field: 'code', filter: 'name>=Saffron City' },
+      });
+
+      expect(entities).toIncludeSameMembers(['BLUE', 'SAFFRON', 'SILPH', 'VERMILLION', 'VIRIDIAN']);
+    });
+
     it('it can filter on deep properties of object properties', async () => {
       const { body: entities } = await app.get('hierarchy/redblue/redblue/descendants', {
         query: { field: 'code', filter: 'attributes_type==gym' },

--- a/packages/entity-server/src/models/Entity.ts
+++ b/packages/entity-server/src/models/Entity.ts
@@ -21,7 +21,11 @@ export type EntityFields = Readonly<{
   };
 }>;
 
-export type EntityFilter = DbFilter<EntityFields>;
+export type EntityQueryFields = EntityFields & {
+  generational_distance: number;
+};
+
+export type EntityFilter = DbFilter<EntityQueryFields>;
 
 export interface EntityType extends EntityFields, Omit<BaseEntityType, 'id'> {
   getChildren: (hierarchyId: string, criteria?: EntityFilter) => Promise<EntityType[]>;

--- a/packages/entity-server/src/models/index.ts
+++ b/packages/entity-server/src/models/index.ts
@@ -7,6 +7,6 @@ export {
   AncestorDescendantRelationModel,
   AncestorDescendantRelationType,
 } from './AncestorDescendantRelation';
-export { EntityModel, EntityType, EntityFields, EntityFilter } from './Entity';
+export { EntityModel, EntityType, EntityFields, EntityFilter, EntityQueryFields } from './Entity';
 export { EntityHierarchyModel } from './EntityHierarchy';
 export { ProjectModel } from './Project';

--- a/packages/entity-server/src/routes/hierarchy/middleware/filter.ts
+++ b/packages/entity-server/src/routes/hierarchy/middleware/filter.ts
@@ -5,8 +5,9 @@
 
 import { QueryConjunctions } from '@tupaia/server-boilerplate';
 import { ObjectLikeKeys, Flatten } from '@tupaia/types';
-import { Writable } from '../../../types';
-import { EntityFilter, EntityFields } from '../../../models';
+import { getSortByKey } from '@tupaia/utils';
+import { Writable, NumericKeys } from '../../../types';
+import { EntityFilter, EntityQueryFields } from '../../../models';
 
 const CLAUSE_DELIMITER = ';';
 const NESTED_FIELD_DELIMITER = '_';
@@ -14,17 +15,21 @@ const JSONB_FIELD_DELIMITER = '->>';
 const MULTIPLE_VALUES_DELIMITER = ',';
 
 type NestedFilterQueryFields = Flatten<
-  Pick<EntityFields, ObjectLikeKeys<EntityFields>>,
+  Pick<EntityQueryFields, ObjectLikeKeys<EntityQueryFields>>,
   typeof NESTED_FIELD_DELIMITER
 >;
 
+type NumericFilterQueryFields = Pick<EntityQueryFields, NumericKeys<EntityQueryFields>>;
+
 type EntityFilterQuery = Partial<
-  Omit<EntityFields, ObjectLikeKeys<EntityFields>> & NestedFilterQueryFields
+  Omit<EntityQueryFields, ObjectLikeKeys<EntityQueryFields>> & NestedFilterQueryFields
 >;
 type NotNull<T> = T extends Array<infer U> ? Array<Exclude<U, null>> : Exclude<T, null>;
 type NotNullValues<T> = {
   [field in keyof T]: NotNull<T[field]>;
 };
+
+type ExtractArrays<T> = T extends unknown[] ? T : never;
 
 const filterableFields: (keyof EntityFilterQuery)[] = [
   'id',
@@ -34,6 +39,7 @@ const filterableFields: (keyof EntityFilterQuery)[] = [
   'image_url',
   'type',
   'attributes_type',
+  'generational_distance',
 ];
 const isFilterableField = (field: string): field is keyof EntityFilterQuery =>
   (filterableFields as string[]).includes(field);
@@ -41,6 +47,10 @@ const isFilterableField = (field: string): field is keyof EntityFilterQuery =>
 const nestedFields: (keyof NestedFilterQueryFields)[] = ['attributes_type'];
 const isNestedField = (field: keyof EntityFilterQuery): field is keyof NestedFilterQueryFields =>
   (nestedFields as (keyof EntityFilterQuery)[]).includes(field);
+
+const numericFields: (keyof NumericFilterQueryFields)[] = ['generational_distance'];
+const isNumericField = (field: keyof EntityFilterQuery): field is keyof NumericFilterQueryFields =>
+  (numericFields as (keyof EntityFilterQuery)[]).includes(field);
 
 type JsonBKey<
   T extends keyof NestedFilterQueryFields
@@ -58,12 +68,18 @@ const operatorToSqlComparator = {
   '==': '=' as const, // Exact match
   '!=': '!=' as const, // Does not match
   '=@': 'ilike' as const, // Contains sub string
+  '<': '<' as const, // Less than
+  '<=': '<=' as const, // Less than or equal
+  '>': '>' as const, // Greater than
+  '>=': '>=' as const, // Greater than or equal
 };
 type Operator = keyof typeof operatorToSqlComparator;
 
 const filterOperators = Object.keys(operatorToSqlComparator) as Operator[];
 
-const formatComparisonValue = (value: string | string[], operator: Operator) => {
+type Value = string | string[] | number | number[];
+
+const formatComparisonValue = (value: Value, operator: Operator) => {
   if (operator === '=@' && typeof value === 'string') {
     return `%${value}%`;
   }
@@ -71,22 +87,37 @@ const formatComparisonValue = (value: string | string[], operator: Operator) => 
   return value;
 };
 
-const convertValueToAdvancedCriteria = (operator: Operator, value: string | string[]) => {
+const formatValue = <T extends keyof EntityFilterQuery>(field: T, value: string) =>
+  isNumericField(field) ? parseFloat(value) : value;
+
+const convertValueToAdvancedCriteria = (
+  field: keyof EntityFilterQuery,
+  operator: Operator,
+  value: string,
+) => {
+  const formattedValue = value.includes(MULTIPLE_VALUES_DELIMITER)
+    ? (value
+        .split(MULTIPLE_VALUES_DELIMITER)
+        .map(val => formatValue(field, val)) as ExtractArrays<Value>)
+    : formatValue(field, value);
+
   // For equal operator, we do not need to specify comparison object.
   if (operator === '==') {
-    return value;
+    return formattedValue;
   }
 
   const comparator = operatorToSqlComparator[operator];
 
   return {
     comparator,
-    comparisonValue: formatComparisonValue(value, operator),
+    comparisonValue: formatComparisonValue(formattedValue, operator),
   };
 };
 
 const toFilterClause = (queryClause: string) => {
-  const operator = filterOperators.find(o => queryClause.includes(o));
+  const [operator] = filterOperators
+    .filter(o => queryClause.includes(o))
+    .sort(getSortByKey('length', { ascending: false }));
 
   if (!operator) {
     throw new Error(
@@ -106,13 +137,7 @@ const toFilterClause = (queryClause: string) => {
     throw new Error(`Unknown filter key: ${field}, must be one of: ${filterableFields}`);
   }
 
-  const formattedField = isNestedField(field) ? toJsonBKey(field) : field;
-
-  return [formattedField, operator, value] as [
-    typeof formattedField,
-    typeof operator,
-    typeof value,
-  ];
+  return [field, operator, value] as [typeof field, typeof operator, typeof value];
 };
 
 export const extractFilterFromQuery = (
@@ -129,14 +154,11 @@ export const extractFilterFromQuery = (
   }
 
   const filterClauses = queryFilter.split(CLAUSE_DELIMITER).map(toFilterClause);
-  const filter: Writable<NotNullValues<EntityFilter>> = {};
+  const filter: Writable<NotNullValues<Record<string, unknown>>> = {};
 
   filterClauses.forEach(([field, operator, value]) => {
-    const parsedValue = value.includes(MULTIPLE_VALUES_DELIMITER)
-      ? value.split(MULTIPLE_VALUES_DELIMITER)
-      : value;
-
-    filter[field] = convertValueToAdvancedCriteria(operator, parsedValue);
+    const formattedField = isNestedField(field) ? toJsonBKey(field) : field;
+    filter[formattedField] = convertValueToAdvancedCriteria(field, operator, value);
   });
 
   // To always force returning only entities in allowed countries, even if there is country_code filter in the query params.

--- a/packages/entity-server/src/routes/hierarchy/middleware/filter.ts
+++ b/packages/entity-server/src/routes/hierarchy/middleware/filter.ts
@@ -4,9 +4,9 @@
  */
 
 import { QueryConjunctions } from '@tupaia/server-boilerplate';
-import { ObjectLikeKeys, Flatten } from '@tupaia/types';
+import { NumericKeys, ObjectLikeKeys, Flatten } from '@tupaia/types';
 import { getSortByKey } from '@tupaia/utils';
-import { Writable, NumericKeys } from '../../../types';
+import { Writable } from '../../../types';
 import { EntityFilter, EntityQueryFields } from '../../../models';
 
 const CLAUSE_DELIMITER = ';';
@@ -117,6 +117,7 @@ const convertValueToAdvancedCriteria = (
 const toFilterClause = (queryClause: string) => {
   const [operator] = filterOperators
     .filter(o => queryClause.includes(o))
+    // Keep the longest matching operator, e.g. >= instead of >
     .sort(getSortByKey('length', { ascending: false }));
 
   if (!operator) {

--- a/packages/entity-server/src/types.ts
+++ b/packages/entity-server/src/types.ts
@@ -18,6 +18,16 @@ export interface EntityServerModelRegistry extends ModelRegistry {
   readonly project: ProjectModel;
 }
 
+// Extracts keys that have object-like values from type T
+export type ObjectLikeKeys<T> = {
+  [K in keyof T]: T[K] extends Record<string, unknown> ? K : never;
+}[keyof T];
+
+// Extracts keys that have numeric values from type T
+export type NumericKeys<T> = {
+  [K in keyof T]: T[K] extends number ? K : never;
+}[keyof T];
+
 export type Writable<T> = { -readonly [field in keyof T]?: T[field] };
 
 type SimpleKeys<T> = {

--- a/packages/entity-server/src/types.ts
+++ b/packages/entity-server/src/types.ts
@@ -18,16 +18,6 @@ export interface EntityServerModelRegistry extends ModelRegistry {
   readonly project: ProjectModel;
 }
 
-// Extracts keys that have object-like values from type T
-export type ObjectLikeKeys<T> = {
-  [K in keyof T]: T[K] extends Record<string, unknown> ? K : never;
-}[keyof T];
-
-// Extracts keys that have numeric values from type T
-export type NumericKeys<T> = {
-  [K in keyof T]: T[K] extends number ? K : never;
-}[keyof T];
-
 export type Writable<T> = { -readonly [field in keyof T]?: T[field] };
 
 type SimpleKeys<T> = {

--- a/packages/types/src/utils/utils.ts
+++ b/packages/types/src/utils/utils.ts
@@ -34,6 +34,13 @@ export type RecursivePartial<T> = {
 };
 
 /**
+ * Extracts keys that have numeric values from type T
+ */
+export type NumericKeys<T> = {
+  [K in keyof T]: T[K] extends number ? K : never;
+}[keyof T];
+
+/**
  * Extracts keys that have object-like values from type T
  */
 export type ObjectLikeKeys<T> = {

--- a/packages/utils/src/object.js
+++ b/packages/utils/src/object.js
@@ -33,7 +33,7 @@ export const getKeysSortedByValues = (object, options = {}) => {
  *
  * @param {string} key
  * @param {{ ascending: boolean }} [options]
- * @returns { (a: Object<string, any>, b: Object<string, any> ) => number }
+ * @returns { (a: any, b: any ) => number }
  */
 export function getSortByKey(key, options) {
   return getSortByExtractedValue(o => o[key], options);


### PR DESCRIPTION
### Issue #:

This is required for OSC-17. It's used in https://github.com/beyondessential/tupaia/pull/4353, but I'm looking to get this merged separately to avoid further conflicts.

This PR is almost the same as the already approved https://github.com/beyondessential/tupaia/pull/4352 (reviewed by @edmofro).  Changes are:

* Removed any functionality that is implemented in `dev` now (`central-server: GetEntityRelations`)
* Removed `admin-panel-server: FetchEntityHierarchyTreeRoute` as it won't be needed
* Conflicts with `dev` resolved

After that there should be one more PR and OSC-17 should be ready for testing!

---

**Testing notes:** this PR does touch filtering in `entity-server`, so it may need to be QAed. At the same time, `entity-serfver` has great test coverage. I'll leave the testing strategy to you - happy to help with QA if there are specific things I could test locally @rohan-bes 