### PR TITLE
Fix chart tests

### DIFF
--- a/packages/ui-chart-components/src/__tests__/parseChartConfig.test.ts
+++ b/packages/ui-chart-components/src/__tests__/parseChartConfig.test.ts
@@ -4,27 +4,35 @@
  *
  */
 
-import { parseChartConfig } from '../utils';
+import { ADD_TO_ALL_KEY, parseChartConfig } from '../utils';
+import { ChartType } from '../types';
 import { CHART_COLOR_PALETTE, EXPANDED_CHART_COLOR_PALETTE } from '../constants';
 
 const testViewJson = {
-  chartType: 'bar',
+  chartType: ChartType.Bar,
+  name: 'test',
   data: [
-    { name: '1', timestamp: 1230000, metric1: 3, metric2: 5 },
-    { name: '2', timestamp: 1240000, metric1: 4, metric2: 4 },
-    { name: '3', timestamp: 1250000, metric1: 5, metric2: 3 },
-    { name: '4', timestamp: 1260000, metric1: 6, metric2: 2 },
-    { name: '5', timestamp: 1270000, metric1: 7, metric2: 1 },
+    { name: '1', timestamp: '1230000', metric1: 3, metric2: 5, value: 10 },
+    { name: '2', timestamp: '1240000', metric1: 4, metric2: 4, value: 20 },
+    { name: '3', timestamp: '1250000', metric1: 5, metric2: 3, value: 30 },
+    { name: '4', timestamp: '1260000', metric1: 6, metric2: 2, value: 40 },
+    { name: '5', timestamp: '1270000', metric1: 7, metric2: 1, value: 50 },
   ],
-};
-const testConfig = {
-  metric1: { stackId: 1 },
-  metric2: { stackId: 2 },
 };
 
 describe('parseChartConfig', () => {
   it('should add correct colors based on default color palette', () => {
-    expect(parseChartConfig({ ...testViewJson, chartConfig: testConfig })).toEqual({
+    const chartConfig = {
+      metric1: { stackId: 1 },
+      metric2: { stackId: 2 },
+      name: 'Test',
+    };
+    expect(
+      parseChartConfig({
+        ...testViewJson,
+        chartConfig,
+      }),
+    ).toEqual({
       metric1: { stackId: 1, color: CHART_COLOR_PALETTE.blue },
       metric2: { stackId: 2, color: CHART_COLOR_PALETTE.red },
     });
@@ -32,39 +40,40 @@ describe('parseChartConfig', () => {
 
   it('should add any config in the dynamic key', () => {
     const chartConfig = {
-      $all: { test: 'hi' },
+      name: 'Test',
+      [ADD_TO_ALL_KEY]: { test: 'hi' },
       metric1: { stackId: 1 },
       metric2: { stackId: 2 },
     };
-    const expected = {
+    expect(parseChartConfig({ ...testViewJson, chartConfig })).toEqual({
       metric1: { stackId: 1, color: CHART_COLOR_PALETTE.blue, test: 'hi' },
       metric2: { stackId: 2, color: CHART_COLOR_PALETTE.red, test: 'hi' },
-    };
-    expect(parseChartConfig({ ...testViewJson, chartConfig })).toEqual(expected);
+      value: {
+        color: CHART_COLOR_PALETTE.purple,
+        test: 'hi',
+      },
+    });
   });
 
   // Bad practice to rely on object ordering: https://stackoverflow.com/questions/9179680/is-it-acceptable-style-for-node-js-libraries-to-rely-on-object-key-order
   // As such this test only checks for color assignment
   it('should sort by legend order to assign colors (actual sort not tested)', () => {
     const chartConfig = {
+      name: 'Test',
       metric1: { stackId: 1, legendOrder: 5 },
       metric2: { stackId: 2, legendOrder: -2 },
     };
-    const expected = {
+    expect(parseChartConfig({ ...testViewJson, chartConfig })).toEqual({
       metric1: { stackId: 1, legendOrder: 5, color: CHART_COLOR_PALETTE.red },
       metric2: { stackId: 2, legendOrder: -2, color: CHART_COLOR_PALETTE.blue },
-    };
-    expect(parseChartConfig({ ...testViewJson, chartConfig })).toEqual(expected);
+    });
   });
 
   it('should use a specified palette', () => {
     const chartConfig = {
+      name: 'Test',
       metric1: { stackId: 1 },
       metric2: { stackId: 2 },
-    };
-    const expected = {
-      metric1: { stackId: 1, color: EXPANDED_CHART_COLOR_PALETTE.maroon },
-      metric2: { stackId: 2, color: EXPANDED_CHART_COLOR_PALETTE.red },
     };
     expect(
       parseChartConfig({
@@ -72,6 +81,9 @@ describe('parseChartConfig', () => {
         chartConfig,
         colorPalette: 'EXPANDED_CHART_COLOR_PALETTE',
       }),
-    ).toEqual(expected);
+    ).toEqual({
+      metric1: { stackId: 1, color: EXPANDED_CHART_COLOR_PALETTE.maroon },
+      metric2: { stackId: 2, color: EXPANDED_CHART_COLOR_PALETTE.red },
+    });
   });
 });

--- a/packages/ui-chart-components/src/utils/parseChartConfig.ts
+++ b/packages/ui-chart-components/src/utils/parseChartConfig.ts
@@ -8,7 +8,7 @@ import { COLOR_PALETTES } from '../constants';
 import { ChartType, DataProps, LooseObject, ViewContent } from '../types';
 import { isDataKey } from './utils';
 
-const ADD_TO_ALL_KEY = '$all';
+export const ADD_TO_ALL_KEY = '$all';
 
 export const getLayeredOpacity = (
   numberOfLayers: number,
@@ -25,11 +25,11 @@ type ColorPalette = keyof typeof COLOR_PALETTES;
 export const parseChartConfig = (viewContent: ViewContent<ChartConfig>) => {
   const {
     chartType,
-    chartConfig = { [ADD_TO_ALL_KEY]: {} },
+    chartConfig = { [ADD_TO_ALL_KEY]: {}, name: '' },
     data,
     colorPalette: paletteName,
   } = viewContent;
-  const { [ADD_TO_ALL_KEY]: configForAllKeys, ...restOfConfig } = chartConfig;
+  const { [ADD_TO_ALL_KEY]: configForAllKeys, name, ...restOfConfig } = chartConfig;
 
   const baseConfig = configForAllKeys
     ? createDynamicConfig(restOfConfig as BaseChartConfig, configForAllKeys, data)


### PR DESCRIPTION
### Issue No ticket: Fix chart tests

### Changes:
- Updated tests to be correct types in `ui-chart-components`
- Updated `$all` to be optional in `parseChartConfig`, because the method itself handles when this is unset
- Updated `parseChartConfig` to not try and spread `name` string 