### PR TITLE
Tupaia web server fixup attach session

### DIFF
--- a/packages/server-boilerplate/src/orchestrator/session/attachSession.ts
+++ b/packages/server-boilerplate/src/orchestrator/session/attachSession.ts
@@ -29,14 +29,13 @@ export const attachSession = async (req: Request, res: Response, next: NextFunct
 };
 
 export const attachSessionIfAvailable = async (req: Request, res: Response, next: NextFunction) => {
-  // Discard authorization errors from attach session so function succeeds even if session doesn't exist
-  try {
-    attachSession(req, res, () => { next() });
-  } catch(error: any) {
-    if (error instanceof UnauthenticatedError) {
-      next();
-    } else {
-      throw error;
+  // Same as above but don't throw errors on failure
+  const sessionId = req.sessionCookie?.id;
+  if (sessionId) {
+    const session: SessionType = await req.sessionModel.findById(sessionId);
+    if (session) {
+      req.session = session;
     }
   }
+  next();
 };

--- a/packages/tupaia-web-server/src/routes/UserRoute.ts
+++ b/packages/tupaia-web-server/src/routes/UserRoute.ts
@@ -15,7 +15,7 @@ export class UserRoute extends Route<UserRequest> {
     // Avoid sending a 'me' request as the api user
     if (!session) {
       // Triggers frontend login
-      return { name: 'public' };
+      return {};
     }
 
     return ctx.services.central.getUser();


### PR DESCRIPTION
### Issue #: No issue

### Changes:

- `server-boilerplate` already wraps middleware in a try/catch so the original method wasn't working as expected
- Rather than wrap the existing `attachSession` function and discarding the error, just write it a little WET but without the throws