### PR TITLE
NOTUP-571: Fix unsafe side effect

### DIFF
--- a/packages/central-server/src/database/models/Question.js
+++ b/packages/central-server/src/database/models/Question.js
@@ -58,7 +58,12 @@ const onChangeUpdateDataElement = async (
   switch (changeType) {
     case 'update': {
       const { code, data_element_id: dataElementId } = newRecord;
-      return models.dataElement.updateById(dataElementId, { code });
+      const { code: oldCode } = oldRecord;
+      // if the code has changed, update the associated data element (if any)
+      if (code !== oldCode && dataElementId) {
+        return models.dataElement.updateById(dataElementId, { code });
+      }
+      return null;
     }
     case 'delete': {
       const { data_element_id: dataElementId } = oldRecord;


### PR DESCRIPTION
### Issue #:

We have code that keeps our data elements in sync with questions, so that data broker can connect to Tupaia internal data even as the questions change. The code in question was not wrapped in any safety checks, so fired in some invalid situations:
- When the code hadn't actually changed, so there was no need to update
- When the question wasn't linked to a data element 

This presumably caused NOTUP-571, though I haven't done any testing - this draft PR is just intended as a starting point.