### PR TITLE
WAITP-1269: Fix frontend package vulnerabilities

### DIFF
--- a/packages/admin-panel/package.json
+++ b/packages/admin-panel/package.json
@@ -56,7 +56,7 @@
     "lodash.keyby": "^4.6.0",
     "lodash.throttle": "^4.1.1",
     "moment": "^2.22.2",
-    "parse-link-header": "^1.0.1",
+    "parse-link-header": "^2.0.0",
     "prop-types": "^15.6.0",
     "query-string": "^5.1.1",
     "react": "^16.13.1",

--- a/packages/central-server/package.json
+++ b/packages/central-server/package.json
@@ -55,7 +55,7 @@
     "lodash.keyby": "^4.6.0",
     "lodash.pick": "^4.4.0",
     "moment": "^2.24.0",
-    "moment-timezone": "^0.5.27",
+    "moment-timezone": "^0.5.28",
     "morgan": "^1.9.0",
     "multer": "^1.4.3",
     "nodemailer": "^4.7.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -32,7 +32,7 @@
     "lodash.get": "^4.4.2",
     "lodash.pickby": "^4.6.0",
     "moment": "^2.24.0",
-    "moment-timezone": "^0.5.27",
+    "moment-timezone": "^0.5.28",
     "node-fetch": "^1.7.3",
     "numeral": "^2.0.6",
     "prop-types": "^15.6.2",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -36,7 +36,7 @@
     "node-fetch": "^1.7.3",
     "numeral": "^2.0.6",
     "prop-types": "^15.6.2",
-    "validator": "^8.2.0",
+    "validator": "^13.7.0",
     "winston": "^3.3.3",
     "xlsx": "^0.10.9",
     "yup": "^0.32.9"

--- a/packages/web-frontend/package.json
+++ b/packages/web-frontend/package.json
@@ -57,7 +57,7 @@
     "material-ui": "^0.18.3",
     "material-ui-datetimepicker": "^1.0.7",
     "moment": "^2.21.0",
-    "moment-timezone": "^0.5.27",
+    "moment-timezone": "^0.5.28",
     "numeral": "^2.0.6",
     "polished": "^3.0.0",
     "prop-types": "^15.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10247,7 +10247,7 @@ __metadata:
     npm-run-all: ^4.1.5
     numeral: ^2.0.6
     prop-types: ^15.6.2
-    validator: ^8.2.0
+    validator: ^13.7.0
     winston: ^3.3.3
     xlsx: ^0.10.9
     yup: ^0.32.9
@@ -42826,10 +42826,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"validator@npm:^8.2.0":
-  version: 8.2.0
-  resolution: "validator@npm:8.2.0"
-  checksum: a249ffd5a565704d19ed213da3e5003509f3fb4181577892e1d4520d24e49ea1f0c260708df07c8532089d0937431c5ece8af347a65b1310a3fa4e3945928e62
+"validator@npm:^13.7.0":
+  version: 13.9.0
+  resolution: "validator@npm:13.9.0"
+  checksum: e2c936f041f61faa42bafd17c6faddf939498666cd82e88d733621c286893730b008959f4cb12ab3e236148a4f3805c30b85e3dcf5e0efd8b0cbcd36c02bfc0c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9407,7 +9407,7 @@ __metadata:
     lodash.throttle: ^4.1.1
     moment: ^2.22.2
     npm-run-all: ^4.1.5
-    parse-link-header: ^1.0.1
+    parse-link-header: ^2.0.0
     prop-types: ^15.6.0
     query-string: ^5.1.1
     react: ^16.13.1
@@ -33083,12 +33083,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parse-link-header@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "parse-link-header@npm:1.0.1"
+"parse-link-header@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "parse-link-header@npm:2.0.0"
   dependencies:
     xtend: ~4.0.1
-  checksum: daccaf9168b4117dcbf9488360a4d855348062b537431aac01e5fa158038b958130186dd711d331b2d7690c3baae4ddc2bc0b1bd45685413cc2ed3cf4dca5f0c
+  checksum: 0e96c6af9910e8f92084b49b8dc6a10dd58db470847d1499f562576180c1ac5e49d18007697f0d538e5f3efdc8ce1d8777641f3ae225302b74af0dd0578b628e
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9516,7 +9516,7 @@ __metadata:
     lodash.pick: ^4.4.0
     mocha: ^8.1.3
     moment: ^2.24.0
-    moment-timezone: ^0.5.27
+    moment-timezone: ^0.5.28
     morgan: ^1.9.0
     multer: ^1.4.3
     nodemailer: ^4.7.0
@@ -10242,7 +10242,7 @@ __metadata:
     lodash.get: ^4.4.2
     lodash.pickby: ^4.6.0
     moment: ^2.24.0
-    moment-timezone: ^0.5.27
+    moment-timezone: ^0.5.28
     node-fetch: ^1.7.3
     npm-run-all: ^4.1.5
     numeral: ^2.0.6
@@ -10353,7 +10353,7 @@ __metadata:
     material-ui-datetimepicker: ^1.0.7
     mockdate: ^3.0.5
     moment: ^2.21.0
-    moment-timezone: ^0.5.27
+    moment-timezone: ^0.5.28
     npm-run-all: ^4.1.5
     numeral: ^2.0.6
     object-assign: 4.1.1
@@ -31060,6 +31060,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"moment-timezone@npm:^0.5.28":
+  version: 0.5.43
+  resolution: "moment-timezone@npm:0.5.43"
+  dependencies:
+    moment: ^2.29.4
+  checksum: 8075c897ed8a044f992ef26fe8cdbcad80caf974251db424cae157473cca03be2830de8c74d99341b76edae59f148c9d9d19c1c1d9363259085688ec1cf508d0
+  languageName: node
+  linkType: hard
+
 "moment@npm:2.x.x, moment@npm:>= 2.9.0, moment@npm:^2.18.1, moment@npm:^2.21.0, moment@npm:^2.22.2, moment@npm:^2.24.0":
   version: 2.24.0
   resolution: "moment@npm:2.24.0"
@@ -31067,7 +31076,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"moment@npm:>=2.14.0":
+"moment@npm:>=2.14.0, moment@npm:^2.29.4":
   version: 2.29.4
   resolution: "moment@npm:2.29.4"
   checksum: 0ec3f9c2bcba38dc2451b1daed5daded747f17610b92427bebe1d08d48d8b7bdd8d9197500b072d14e326dd0ccf3e326b9e3d07c5895d3d49e39b6803b76e80e


### PR DESCRIPTION
### Issue #: WAITP-1269: Fix frontend package vulnerabilities

### Changes:

Bump versions of moment-timezone, parse-link-header and validator to the recommended versions.

I tested building all the packages and smoke tested the front end apps and everything seems fine.
