### PR TITLE
WAITP-1243 Bar charts

### DIFF
--- a/packages/tupaia-web-server/examples.http
+++ b/packages/tupaia-web-server/examples.http
@@ -38,3 +38,11 @@ content-type: {{contentType}}
 ### Fetch country access list
 GET {{host}}/countryAccessList
 content-type: {{contentType}}
+
+### Fetch legacy report
+GET {{host}}/report/28?dashboardCode=explore_General&itemCode=28&legacy=true&organisationUnitCode=explore&projectCode=explore&timeZone=Pacific%2FAuckland
+content-type: {{contentType}}
+
+### Fetch report
+GET {{host}}/report/tupaia_metrics_n_visuals_by_country?dashboardCode=explore_tupaia_metrics&endDate=2023-06-26&itemCode=tupaia_metrics_n_visuals_by_country&legacy=false&organisationUnitCode=explore&projectCode=explore&startDate=2015-01-01&timeZone=Pacific%2FAuckland
+content-type: {{contentType}}

--- a/packages/tupaia-web-server/src/routes/ReportRoute.ts
+++ b/packages/tupaia-web-server/src/routes/ReportRoute.ts
@@ -13,13 +13,29 @@ export class ReportRoute extends Route<ReportRequest> {
   public async buildResponse() {
     const { query, ctx } = this.req;
     const { reportCode } = this.req.params;
-    const { legacy } = query;
+    const { legacy, organisationUnitCode, projectCode, startDate, endDate } = query;
 
     // Legacy data builders are handled through the web config server still
     if (legacy === 'true') {
       return ctx.services.webConfig.fetchReport(reportCode, query);
     }
+    // the params for the non-legacy reports are different
+    const params = {
+      organisationUnitCodes: organisationUnitCode,
+      hierarchyName: projectCode,
+      startDate,
+      endDate,
+    };
 
-    return ctx.services.report.fetchReport(reportCode, query);
+    const { results } = await ctx.services.report.fetchReport(reportCode, params);
+
+    // format to be the same as the legacy report results, so that the FE can handle accordingly
+    const reportData = Array.isArray(results) ? { data: results } : { ...results };
+
+    return {
+      ...reportData,
+      startDate,
+      endDate,
+    };
   }
 }

--- a/packages/tupaia-web/src/api/queries/useDashboards.ts
+++ b/packages/tupaia-web/src/api/queries/useDashboards.ts
@@ -6,7 +6,7 @@ import { useQuery } from 'react-query';
 import { DashboardType } from '../../types';
 // import { get } from '../api';
 
-const testData = [
+const exploreData = [
   {
     id: 'test',
     code: 'explore_General',
@@ -46,11 +46,49 @@ const testData = [
     ],
   },
 ];
+const unfpaData = [
+  {
+    name: 'UNFPA',
+    id: 'test2',
+    code: 'FJ_UNFPA',
+    rootEntityCode: 'unfpa',
+    sortOrder: null,
+    items: [
+      {
+        code: 'rh_n_stock_card_use_at_facilities',
+        legacy: false,
+        reportCode: 'rh_n_stock_card_use_at_facilities',
+        name: 'Stock Card Use at Facilities (Yearly survey data)',
+        type: 'chart',
+        chartType: 'bar',
+        labelType: 'fractionAndPercentage',
+        valueType: 'percentage',
+        chartConfig: {
+          'Stock card available': {
+            color: 'green',
+          },
+          'Stock card up to date': {
+            color: 'orange',
+          },
+        },
+        description:
+          'Facilities that have at least 1 stock card available for managed RH commodities. Of the stock cards available, facilities where at least 1 stock card is up to date.',
+        periodGranularity: 'year',
+        isFavourite: false,
+      },
+    ],
+  },
+];
 
 export const useDashboards = (projectCode?: string, entityCode?: string) => {
   return useQuery(
     ['dashboards', projectCode, entityCode],
     () => {
+      // @ts-ignore - just for testData
+      let testData = [];
+      if (projectCode === 'explore') testData = exploreData;
+      else if (projectCode === 'unfpa') testData = unfpaData;
+      // @ts-ignore - just for testData
       return Promise.resolve(() => testData as DashboardType[]); // TODO: replace this with actual data fetching
     },
     // get('dashboards', {

--- a/packages/tupaia-web/src/api/queries/useDashboards.ts
+++ b/packages/tupaia-web/src/api/queries/useDashboards.ts
@@ -46,34 +46,203 @@ const exploreData = [
     ],
   },
 ];
-const unfpaData = [
+
+const fanafanaOla = [
   {
-    name: 'UNFPA',
-    id: 'test2',
-    code: 'FJ_UNFPA',
-    rootEntityCode: 'unfpa',
-    sortOrder: null,
+    name: 'Reproductive Health Indicators',
+    id: 'test3',
+    code: 'to_reproductive_health_indicators',
+    rootEntityCode: 'TO',
     items: [
       {
-        code: 'rh_n_stock_card_use_at_facilities',
+        code: 'rh_to_bar_adolescent_birth_rate_per_1000_women_ages_15_19_years',
         legacy: false,
-        reportCode: 'rh_n_stock_card_use_at_facilities',
-        name: 'Stock Card Use at Facilities (Yearly survey data)',
+        reportCode: 'rh_to_bar_adolescent_birth_rate_per_1000_women_ages_15_19_years',
+        name: 'Adolescent birth rate (per 1000 women ages 15-19 years)',
         type: 'chart',
-        chartType: 'bar',
-        labelType: 'fractionAndPercentage',
-        valueType: 'percentage',
+        yName: 'Adolescent Birth Rate',
+        chartType: 'line',
+        reference: {
+          link:
+            'https://www.who.int/data/gho/data/indicators/indicator-details/GHO/adolescent-birth-rate-(per-1000-women-aged-15-19-years)',
+          name: 'WHO',
+        },
         chartConfig: {
-          'Stock card available': {
-            color: 'green',
-          },
-          'Stock card up to date': {
-            color: 'orange',
+          value: {
+            color: '#47A2DA',
+            label: 'Adolescent Birth Rate',
           },
         },
-        description:
-          'Facilities that have at least 1 stock card available for managed RH commodities. Of the stock cards available, facilities where at least 1 stock card is up to date.',
+        defaultTimePeriod: {
+          start: {
+            unit: 'year',
+            offset: -3,
+          },
+        },
         periodGranularity: 'year',
+        isFavourite: false,
+      },
+      {
+        code: 'rh_to_line_antenatal_care_coverage',
+        legacy: false,
+        reportCode: 'rh_to_line_antenatal_care_coverage',
+        name: 'Antenatal Care Coverage',
+        type: 'chart',
+        chartType: 'line',
+        reference: {
+          link: 'https://www.who.int/data/gho/indicator-metadata-registry/imr-details/80',
+          name: 'WHO',
+        },
+        valueType: 'percentage',
+        periodGranularity: 'month',
+        presentationOptions: {
+          hideAverage: true,
+        },
+        isFavourite: false,
+      },
+      {
+        code: 'rh_to_line_births_attended_skilled_health_personnel',
+        legacy: false,
+        reportCode: 'rh_to_line_births_attended_skilled_health_personnel',
+        name: 'Births attended by skilled health personnel',
+        type: 'chart',
+        chartType: 'line',
+        reference: {
+          link:
+            'https://www.who.int/data/gho/data/indicators/indicator-details/GHO/births-attended-by-skilled-health-personnel-(-)',
+          name: 'WHO',
+        },
+        valueType: 'percentage',
+        description:
+          'Note the following are considered skilled health personnel: Doctor, Midwife or Nurse',
+        periodGranularity: 'month',
+        isFavourite: false,
+      },
+      {
+        code: 'rh_to_n_comp_births_delivered_by_cesarean_delivery',
+        legacy: false,
+        reportCode: 'rh_to_n_comp_births_delivered_by_cesarean_delivery',
+        name: 'Births delivered by cesarean delivery',
+        type: 'chart',
+        chartType: 'composed',
+        reference: {
+          link:
+            'https://www.measureevaluation.org/rbf/indicator-collections/health-outcome-impact-indicators/cesarean-sections-as-a-percent-of-all-births.html',
+          name: 'WHO',
+        },
+        chartConfig: {
+          'Number of Cesarean Deliveries': {
+            color: '#B744B8',
+            label: 'Number of Cesarean Deliveries',
+            yName: 'Number of Cesarean Deliveries',
+            stackId: '1',
+            chartType: 'bar',
+            legendOrder: '1',
+          },
+          '% of Births Delivered by Cesarean Delivery': {
+            color: '#47A2DA',
+            yName: '% of Births Delivered by Cesarean Delivery',
+            chartType: 'line',
+            valueType: 'percentage',
+            legendOrder: '2',
+            yAxisOrientation: 'right',
+          },
+        },
+        periodGranularity: 'month',
+        isFavourite: false,
+      },
+      {
+        code: 'rh_to_n_bar_maternal_mortality_number',
+        legacy: false,
+        reportCode: 'rh_to_n_bar_maternal_mortality_number',
+        name: 'Maternal Mortality Number',
+        type: 'chart',
+        chartType: 'bar',
+        chartConfig: {
+          value: {
+            color: '#B744B8',
+            label: 'Total maternal deaths',
+          },
+        },
+        description: 'Total maternal deaths',
+        periodGranularity: 'year',
+        presentationOptions: {
+          hideAverage: true,
+        },
+        isFavourite: false,
+      },
+      {
+        code: 'rh_to_composed_number_and_prevalence_of_anaemic_pregnancies ',
+        legacy: false,
+        reportCode: 'rh_to_composed_number_and_prevalence_of_anaemic_pregnancies ',
+        name: 'Number and Prevalence of Anaemic Pregnancies ',
+        type: 'chart',
+        chartType: 'composed',
+        chartConfig: {
+          aneamic: {
+            color: '#FFB400',
+            label: 'Anaemic Pregnancies',
+            yName: 'Total Deliveries',
+            stackId: '1',
+            chartType: 'bar',
+            legendOrder: '1',
+          },
+          nonaneamic: {
+            color: '#B744B8',
+            label: 'Non Anaemic Pregnancies',
+            yName: 'Total Deliveries',
+            stackId: '1',
+            chartType: 'bar',
+            legendOrder: '1',
+          },
+          anaemic_pregnancy_prevalence_rate: {
+            color: '#47A2DA',
+            label: 'Anaemic Pregnancy Prevalence rate',
+            yName: 'Anaemic Pregnancy Prevalence rate',
+            chartType: 'line',
+            valueType: 'percentage',
+            legendOrder: '3',
+            yAxisOrientation: 'right',
+          },
+        },
+        periodGranularity: 'month',
+        isFavourite: false,
+      },
+      {
+        code: 'rh_to_number_of_still_births',
+        legacy: false,
+        reportCode: 'rh_to_number_of_still_births',
+        name: 'Number of still births',
+        type: 'chart',
+        xName: 'Year',
+        yName: 'Number of Still Birth',
+        chartType: 'bar',
+        valueType: 'number',
+        chartConfig: {
+          value: {
+            color: '#B744B8',
+            label: 'Still Birth',
+          },
+        },
+        periodGranularity: 'year',
+        presentationOptions: {
+          hideAverage: true,
+        },
+        isFavourite: false,
+      },
+      {
+        code: 'rh_to_line_low_birth_weight_among_newborns',
+        legacy: false,
+        reportCode: 'rh_to_line_low_birth_weight_among_newborns',
+        name: 'Low Birth Weight Among Newborns',
+        type: 'chart',
+        chartType: 'line',
+        valueType: 'percentage',
+        description: '% of live births weighing less than 2500g',
+        periodGranularity: 'month',
+        presentationOptions: {
+          hideAverage: true,
+        },
         isFavourite: false,
       },
     ],
@@ -87,7 +256,7 @@ export const useDashboards = (projectCode?: string, entityCode?: string) => {
       // @ts-ignore - just for testData
       let testData = [];
       if (projectCode === 'explore') testData = exploreData;
-      else if (projectCode === 'unfpa') testData = unfpaData;
+      else if (projectCode === 'fanafana') testData = fanafanaOla;
       // @ts-ignore - just for testData
       return Promise.resolve(() => testData as DashboardType[]); // TODO: replace this with actual data fetching
     },

--- a/packages/tupaia-web/src/api/queries/useReport.ts
+++ b/packages/tupaia-web/src/api/queries/useReport.ts
@@ -7,7 +7,7 @@
 import { useQuery } from 'react-query';
 import { get } from '../api';
 import { DashboardType, DashboardItemType, EntityCode, ProjectCode } from '../../types';
-import { getBrowserTimeZone } from '@tupaia/utils';
+import { formatDateForApi, getBrowserTimeZone } from '@tupaia/utils';
 
 export const useReport = (
   projectCode?: ProjectCode,
@@ -16,24 +16,36 @@ export const useReport = (
   reportCode?: DashboardItemType['reportCode'],
   itemCode?: DashboardItemType['code'],
   legacy?: DashboardItemType['legacy'],
+  startDate?: string | null,
+  endDate?: string | null,
 ) => {
   const timeZone = getBrowserTimeZone();
+  const formattedStartDate = formatDateForApi(startDate, null);
+  const formattedEndDate = formatDateForApi(endDate, null);
   return useQuery(
-    ['report', reportCode, dashboardCode, projectCode, entityCode, itemCode],
+    [
+      'report',
+      reportCode,
+      dashboardCode,
+      projectCode,
+      entityCode,
+      itemCode,
+      formattedStartDate,
+      formattedEndDate,
+    ],
     () =>
-      get(
-        `report/${reportCode}`,
-        {
-          params: {
-            dashboardCode,
-            legacy,
-            itemCode,
-            projectCode,
-            organisationUnitCode: entityCode,
-            timeZone
-          }
+      get(`report/${reportCode}`, {
+        params: {
+          dashboardCode,
+          legacy,
+          itemCode,
+          projectCode,
+          organisationUnitCode: entityCode,
+          timeZone,
+          startDate: formattedStartDate,
+          endDate: formattedEndDate,
         },
-      ),
+      }),
     {
       enabled: !!reportCode && !!dashboardCode && !!projectCode && !!entityCode,
     },

--- a/packages/tupaia-web/src/api/queries/useReport.ts
+++ b/packages/tupaia-web/src/api/queries/useReport.ts
@@ -9,16 +9,18 @@ import { get } from '../api';
 import { DashboardType, DashboardItemType, EntityCode, ProjectCode } from '../../types';
 import { formatDateForApi, getBrowserTimeZone } from '@tupaia/utils';
 
-export const useReport = (
-  projectCode?: ProjectCode,
-  entityCode?: EntityCode,
-  dashboardCode?: DashboardType['code'],
-  reportCode?: DashboardItemType['reportCode'],
-  itemCode?: DashboardItemType['code'],
-  legacy?: DashboardItemType['legacy'],
-  startDate?: string | null,
-  endDate?: string | null,
-) => {
+type QueryParams = {
+  projectCode?: ProjectCode;
+  entityCode?: EntityCode;
+  dashboardCode?: DashboardType['code'];
+  itemCode?: DashboardItemType['code'];
+  legacy?: DashboardItemType['legacy'];
+  startDate?: string | null;
+  endDate?: string | null;
+};
+
+export const useReport = (reportCode?: DashboardItemType['reportCode'], params: QueryParams) => {
+  const { dashboardCode, projectCode, entityCode, itemCode, startDate, endDate } = params;
   const timeZone = getBrowserTimeZone();
   const formattedStartDate = formatDateForApi(startDate, null);
   const formattedEndDate = formatDateForApi(endDate, null);

--- a/packages/tupaia-web/src/features/Chart.tsx
+++ b/packages/tupaia-web/src/features/Chart.tsx
@@ -18,7 +18,7 @@ const Wrapper = styled.div<{
   align-items: stretch;
   height: ${({ $isEnlarged, $hasData }) => {
     if (!$hasData) return 'auto';
-    return $isEnlarged ? '22.5rem' : '12rem';
+    return $isEnlarged ? '22.5rem' : '14rem';
   }};
   flex-direction: column;
   .recharts-responsive-container {

--- a/packages/tupaia-web/src/features/Chart.tsx
+++ b/packages/tupaia-web/src/features/Chart.tsx
@@ -9,20 +9,24 @@ import { Chart as ChartComponent, ViewContent } from '@tupaia/ui-chart-component
 
 const Wrapper = styled.div<{
   $isEnlarged: boolean;
+  $hasData: boolean;
 }>`
   display: flex;
   position: relative;
   align-content: stretch;
   -webkit-box-align: stretch;
   align-items: stretch;
-  height: ${({ $isEnlarged }) => ($isEnlarged ? '22.5rem' : '12rem')};
+  height: ${({ $isEnlarged, $hasData }) => {
+    if (!$hasData) return 'auto';
+    return $isEnlarged ? '22.5rem' : '12rem';
+  }};
   flex-direction: column;
   .recharts-responsive-container {
     min-width: 0px;
   }
   // Make the charts conform to the parent container's size
   .recharts-wrapper,
-  svg {
+  .recharts-wrapper svg {
     height: 100% !important;
     width: 100%;
   }
@@ -37,8 +41,9 @@ interface ChartProps {
 }
 
 export const Chart = ({ viewContent, isEnlarged = false }: ChartProps) => {
+  const hasData = viewContent.data && viewContent.data.length > 0 ? true : false;
   return (
-    <Wrapper $isEnlarged={isEnlarged}>
+    <Wrapper $isEnlarged={isEnlarged} $hasData={hasData}>
       <ChartComponent viewContent={viewContent} isEnlarged={isEnlarged} isExporting={false} />
     </Wrapper>
   );

--- a/packages/tupaia-web/src/features/Dashboard/Dashboard.tsx
+++ b/packages/tupaia-web/src/features/Dashboard/Dashboard.tsx
@@ -31,6 +31,9 @@ const Panel = styled.div<{
   width: 100%;
   overflow: visible;
   min-height: 100%;
+  .recharts-wrapper {
+    font-size: 1rem !important;
+  }
   @media screen and (min-width: ${MOBILE_BREAKPOINT}) {
     width: ${({ $isExpanded }) =>
       $isExpanded
@@ -40,6 +43,12 @@ const Panel = styled.div<{
     min-width: ${MIN_SIDEBAR_WIDTH}px;
     max-width: ${({ $isExpanded }) =>
       $isExpanded ? MAX_SIDEBAR_EXPANDED_WIDTH : MAX_SIDEBAR_COLLAPSED_WIDTH}px;
+    .recharts-wrapper {
+      font-size: ${({ $isExpanded }) =>
+        $isExpanded
+          ? '1rem'
+          : '1.2rem'} !important; // this is to set the font size of the chart overall, including the axis labels, because the library uses ems, so shrinks the text relative to the font size of the parent
+    }
   }
 `;
 

--- a/packages/tupaia-web/src/features/DashboardItem/DashboardItem.tsx
+++ b/packages/tupaia-web/src/features/DashboardItem/DashboardItem.tsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { useParams } from 'react-router';
+import { getDefaultDates } from '@tupaia/utils';
 import { DashboardCode, DashboardItemType } from '../../types';
 import { useReport } from '../../api/queries';
 import { EnlargedDashboardItem } from './EnlargedDashboardItem';
@@ -42,6 +43,12 @@ interface DashboardItemProps {
 export const DashboardItem = ({ dashboardItem, dashboardCode }: DashboardItemProps) => {
   const { projectCode, entityCode } = useParams();
   const { legacy, code, reportCode, viewType, type } = dashboardItem;
+
+  // get dates from the dashboard config, where applicable
+  const { startDate, endDate } = getDefaultDates(dashboardItem) as {
+    startDate?: string | null;
+    endDate?: string | null;
+  };
   // query for the report data
   const { data: reportData, isLoading, error, isError, refetch } = useReport(
     projectCode,
@@ -50,6 +57,8 @@ export const DashboardItem = ({ dashboardItem, dashboardCode }: DashboardItemPro
     reportCode,
     code,
     legacy,
+    startDate,
+    endDate,
   );
 
   const viewContent = {

--- a/packages/tupaia-web/src/features/DashboardItem/DashboardItem.tsx
+++ b/packages/tupaia-web/src/features/DashboardItem/DashboardItem.tsx
@@ -50,16 +50,15 @@ export const DashboardItem = ({ dashboardItem, dashboardCode }: DashboardItemPro
     endDate?: string | null;
   };
   // query for the report data
-  const { data: reportData, isLoading, error, isError, refetch } = useReport(
+  const { data: reportData, isLoading, error, isError, refetch } = useReport(reportCode, {
     projectCode,
     entityCode,
     dashboardCode,
-    reportCode,
-    code,
+    itemCode: code,
     legacy,
     startDate,
     endDate,
-  );
+  });
 
   const viewContent = {
     ...dashboardItem,

--- a/packages/ui-chart-components/src/components/Axes/YAxes.tsx
+++ b/packages/ui-chart-components/src/components/Axes/YAxes.tsx
@@ -83,6 +83,7 @@ const renderYAxisLabel = (
       style: { textAnchor: 'middle', fontSize: isEnlarged ? '1em' : '0.8em' },
       position: orientation === 'right' ? 'insideRight' : 'insideLeft',
     };
+
   return undefined;
 };
 

--- a/packages/ui-chart-components/src/components/CartesianChart.tsx
+++ b/packages/ui-chart-components/src/components/CartesianChart.tsx
@@ -219,7 +219,6 @@ export const CartesianChart = ({
   const hasLegend = hasDataSeries || renderLegendForOneItem;
   const aspect = !isEnlarged && !isMobileSize && !isExporting ? 1.6 : undefined;
   const height = getHeight(isExporting, isEnlarged, hasLegend, isMobileSize);
-  console.log(height);
 
   const { verticalAlign, align, layout } = getLegendAlignment(legendPosition, isExporting);
 


### PR DESCRIPTION
### Issue WAITP-1243: Bar charts for `tupaia-web`

### Changes:
- Minor styling change for no data display with charts
- Updated `ReportRoute` to return non-legacy reports in the correct format
- Added examples to `tupaia-web-server` for report fetching
- Updated `useReport` to be able to accept `startDate` and `endDate`

---

### Screenshots:
![Screenshot 2023-06-26 at 3 29 37 pm](https://github.com/beyondessential/tupaia/assets/129009580/75b88d0d-3531-4a07-a7a0-c43309fcf2e5)
