### PR TITLE
WAITP-1293 Update filtering on entities route

### DIFF
--- a/packages/tupaia-web-server/src/app/createApp.ts
+++ b/packages/tupaia-web-server/src/app/createApp.ts
@@ -59,7 +59,7 @@ export function createApp() {
       'requestCountryAccess',
       handleWith(RequestCountryAccessRoute),
     )
-    .get<EntitiesRequest>('entities/:hierarchyName/:rootEntityCode', handleWith(EntitiesRoute))
+    .get<EntitiesRequest>('entities/:projectCode/:rootEntityCode', handleWith(EntitiesRoute))
     // TODO: Stop using get for logout, then delete this
     .get<TempLogoutRequest>('logout', handleWith(TempLogoutRoute))
     .build();

--- a/packages/tupaia-web/src/api/queries/useEntities.ts
+++ b/packages/tupaia-web/src/api/queries/useEntities.ts
@@ -17,10 +17,24 @@ export const useEntities = (
     queryOptions?.enabled === undefined ? !!projectCode && !!entityCode : queryOptions.enabled;
 
   return useQuery(
-    ['entities', projectCode, entityCode, axiosConfig, queryOptions],
-    async (): Promise<EntityResponse> => {
-      return get(`entities/${projectCode}/${entityCode}`, axiosConfig);
-    },
+    ['entities', projectCode, entityCode, axiosConfig],
+    (): Promise<EntityResponse[]> =>
+      get(`entities/${projectCode}/${entityCode}`, {
+        params: {
+          includeRoot: true,
+          fields: [
+            'parent_code',
+            'code',
+            'name',
+            'type',
+            'point',
+            'image_url',
+            'attributes',
+            'child_codes',
+          ],
+        },
+        ...axiosConfig,
+      }),
     {
       enabled,
     },
@@ -29,5 +43,20 @@ export const useEntities = (
 
 export const useEntitiesWithLocation = (projectCode?: string, entityCode?: string) =>
   useEntities(projectCode, entityCode, {
-    params: { fields: ['parent_code', 'code', 'name', 'type', 'bounds', 'region'] },
+    params: {
+      includeRoot: true,
+      fields: [
+        'parent_code',
+        'code',
+        'name',
+        'type',
+        'bounds',
+        'region',
+        'point',
+        'location_type',
+        'image_url',
+        'attributes',
+        'child_codes',
+      ],
+    },
   });

--- a/packages/tupaia-web/src/features/Dashboard/Dashboard.tsx
+++ b/packages/tupaia-web/src/features/Dashboard/Dashboard.tsx
@@ -13,7 +13,7 @@ import { ExpandButton } from './ExpandButton';
 import { Photo } from './Photo';
 import { Breadcrumbs } from './Breadcrumbs';
 import { StaticMap } from './StaticMap';
-import { useDashboards as useDashboardData, useEntitiesWithLocation } from '../../api/queries';
+import { useDashboards as useDashboardData, useEntity } from '../../api/queries';
 import { DashboardMenu } from './DashboardMenu';
 import { DashboardItem } from '../DashboardItem';
 import { DashboardItemType, DashboardType } from '../../types';
@@ -116,11 +116,11 @@ const useDashboards = () => {
 };
 
 export const Dashboard = () => {
-  const { projectCode, entityCode } = useParams();
+  const { entityCode } = useParams();
   const [isExpanded, setIsExpanded] = useState(false);
   const { dashboards, activeDashboard } = useDashboards();
-  const { data: entityData } = useEntitiesWithLocation(projectCode, entityCode);
-  const bounds = entityData?.bounds;
+  const { data: entity } = useEntity(entityCode);
+  const bounds = entity?.bounds;
 
   const toggleExpanded = () => {
     setIsExpanded(!isExpanded);
@@ -133,13 +133,13 @@ export const Dashboard = () => {
         <Breadcrumbs />
         <DashboardImageContainer>
           {bounds ? (
-            <StaticMap polygonBounds={bounds} />
+            <StaticMap bounds={bounds} />
           ) : (
-            <Photo title={entityData?.name} photoUrl={entityData?.photoUrl} />
+            <Photo title={entity?.name} photoUrl={entity?.photoUrl} />
           )}
         </DashboardImageContainer>
         <TitleBar>
-          <Title variant="h3">{entityData?.name}</Title>
+          <Title variant="h3">{entity?.name}</Title>
           <ExportButton startIcon={<GetAppIcon />}>Export</ExportButton>
         </TitleBar>
         <DashboardMenu activeDashboard={activeDashboard} dashboards={dashboards} />

--- a/packages/tupaia-web/src/features/Dashboard/StaticMap.tsx
+++ b/packages/tupaia-web/src/features/Dashboard/StaticMap.tsx
@@ -64,11 +64,11 @@ const makeStaticMapUrl = (polygonBounds: Position[]) => {
   return `${MAPBOX_BASE_URL}${boundingBoxPath}/${longitude},${latitude},${zoomLevel}/${size}@2x?access_token=${MAPBOX_TOKEN}&attribution=false`;
 };
 
-export const StaticMap = ({ polygonBounds }: { polygonBounds: Position[] }) => {
-  if (!areBoundsValid(polygonBounds)) {
+export const StaticMap = ({ bounds }: { bounds: Position[] }) => {
+  if (!areBoundsValid(bounds)) {
     return null;
   }
 
-  const url = makeStaticMapUrl(polygonBounds);
+  const url = makeStaticMapUrl(bounds);
   return <Media $backgroundImage={url} />;
 };

--- a/packages/tupaia-web/src/features/EntitySearch/EntityMenu.tsx
+++ b/packages/tupaia-web/src/features/EntitySearch/EntityMenu.tsx
@@ -5,8 +5,7 @@
 import React, { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
-import { Entity } from '@tupaia/types';
-import { ProjectCode } from '../../types';
+import { EntityResponse, ProjectCode } from '../../types';
 import { LocalHospital as HospitalIcon, ExpandMore as ExpandIcon } from '@material-ui/icons';
 import { Button, IconButton, List as MuiList, ListItemProps } from '@material-ui/core';
 import { useEntities } from '../../api/queries';
@@ -41,12 +40,10 @@ const MenuLink = styled(Button).attrs({
   }
 `;
 
-type EntityWithChildren = Entity & { children?: Entity[] };
-
 interface EntityMenuProps {
   projectCode: ProjectCode;
-  children: EntityWithChildren[];
-  isLoading: boolean;
+  children: EntityResponse[];
+  grandChildren: EntityResponse[];
   onClose: () => void;
 }
 
@@ -54,16 +51,16 @@ interface EntityMenuProps {
  * ExpandedList is a recursive component that renders a list of entities and their children to
  * display an expandable entity menu.
  */
-export const EntityMenu = ({ projectCode, children, isLoading, onClose }: EntityMenuProps) => {
-  const entityList = children.sort((a, b) => a.name.localeCompare(b.name));
+export const EntityMenu = ({ projectCode, children, grandChildren, onClose }: EntityMenuProps) => {
+  const sortedChildren = children.sort((a, b) => a.name.localeCompare(b.name));
   return (
     <List aria-expanded>
-      {entityList.map(entity => (
+      {sortedChildren.map(entity => (
         <EntityMenuItem
           key={entity.code}
           projectCode={projectCode}
+          children={grandChildren.filter(child => child.parentCode === entity.code)}
           entity={entity}
-          parentIsLoading={isLoading}
           onClose={onClose}
         />
       ))}
@@ -73,29 +70,27 @@ export const EntityMenu = ({ projectCode, children, isLoading, onClose }: Entity
 
 interface EntityMenuItemProps {
   projectCode: ProjectCode;
-  entity: EntityWithChildren;
-  parentIsLoading?: boolean;
+  entity: EntityResponse;
   onClose: () => void;
+  children?: EntityResponse[];
 }
-const EntityMenuItem = ({
-  projectCode,
-  entity,
-  parentIsLoading = false,
-  onClose,
-}: EntityMenuItemProps) => {
+const EntityMenuItem = ({ projectCode, entity, children, onClose }: EntityMenuItemProps) => {
   const location = useLocation();
   const [isExpanded, setIsExpanded] = useState(false);
-  const { data, isLoading } = useEntities(projectCode!, entity.code!, {}, { enabled: isExpanded });
+  const { data = [] } = useEntities(projectCode!, entity.code!, {}, { enabled: isExpanded });
 
   const toggleExpanded = () => {
     setIsExpanded(!isExpanded);
   };
 
   /*
-    Pre-populate the next layer of the menu with children that came from the previous layer of entity
-    data then replace them with the children from the API response when it arrives
-  */
-  const nextChildren = data?.children || entity.children;
+   Pre-populate the next layer of the menu with children that came from the previous layer of entity
+   data then replace them with the children from the API response when it arrives
+ */
+  const nextChildren =
+    data?.filter(childEntity => childEntity.parentCode === entity.code) || children;
+
+  const grandChildren = data.filter(childEntity => childEntity.parentCode !== entity.code);
 
   const link = { ...location, pathname: `/${projectCode}/${entity.code}` };
 
@@ -107,7 +102,7 @@ const EntityMenuItem = ({
         </MenuLink>
         <IconButton
           onClick={toggleExpanded}
-          disabled={parentIsLoading || !nextChildren}
+          disabled={!entity.childCodes}
           aria-label="toggle menu for this entity"
         >
           <ExpandIcon />
@@ -116,9 +111,9 @@ const EntityMenuItem = ({
       {isExpanded && (
         <EntityMenu
           children={nextChildren!}
+          grandChildren={grandChildren}
           projectCode={projectCode}
           onClose={onClose}
-          isLoading={isLoading}
         />
       )}
     </div>

--- a/packages/tupaia-web/src/features/EntitySearch/EntitySearch.tsx
+++ b/packages/tupaia-web/src/features/EntitySearch/EntitySearch.tsx
@@ -56,7 +56,7 @@ const isMobile = () => {
 export const EntitySearch = () => {
   const { projectCode } = useParams();
   const { data: project } = useProject(projectCode!);
-  const { data: entity, isLoading } = useEntities(projectCode!, project?.entityCode);
+  const { data: entities = [] } = useEntities(projectCode!, project?.entityCode);
   const [searchValue, setSearchValue] = useState('');
   const [isOpen, setIsOpen] = useState(false);
 
@@ -65,6 +65,9 @@ export const EntitySearch = () => {
       setIsOpen(false);
     }
   };
+
+  const children = entities.filter(entity => entity.parentCode === project?.entityCode);
+  const grandChildren = entities.filter(entity => entity.parentCode !== project?.entityCode);
 
   return (
     <ClickAwayListener onClickAway={() => setIsOpen(false)}>
@@ -77,8 +80,8 @@ export const EntitySearch = () => {
             ) : (
               <EntityMenu
                 projectCode={projectCode!}
-                children={entity?.children || []}
-                isLoading={isLoading}
+                children={children}
+                grandChildren={grandChildren}
                 onClose={onClose}
               />
             )}

--- a/packages/tupaia-web/src/features/Map/Map.tsx
+++ b/packages/tupaia-web/src/features/Map/Map.tsx
@@ -12,7 +12,7 @@ import { MapWatermark } from './MapWatermark';
 import { MapLegend } from './MapLegend';
 import { MapOverlays } from '../MapOverlays';
 import { MapOverlaySelector } from './MapOverlaySelector';
-import { useEntitiesWithLocation } from '../../api/queries';
+import { useEntity } from '../../api/queries';
 
 const MapContainer = styled.div`
   height: 100%;
@@ -64,10 +64,13 @@ const TilePickerWrapper = styled.div`
 
 // This contains the map controls (legend, overlay selector, etc, so that they can fit within the map appropriately)
 const MapControlWrapper = styled.div`
+  position: relative;
   width: 100%;
   height: 100%;
   display: flex;
-  position: relative;
+
+  // This is to prevent the wrapper div from blocking clicks on the map overlays
+  pointer-events: none;
 `;
 
 const MapControlColumn = styled.div`
@@ -77,10 +80,10 @@ const MapControlColumn = styled.div`
 `;
 
 export const Map = () => {
-  const { projectCode, entityCode } = useParams();
+  const { entityCode } = useParams();
   const [activeTileSet, setActiveTileSet] = useState(TILE_SETS[0]);
 
-  const { data: entityData } = useEntitiesWithLocation(projectCode, entityCode);
+  const { data: entity } = useEntity(entityCode);
 
   const onTileSetChange = (tileSetKey: string) => {
     setActiveTileSet(TILE_SETS.find(({ key }) => key === tileSetKey) as typeof TILE_SETS[0]);
@@ -88,7 +91,7 @@ export const Map = () => {
 
   return (
     <MapContainer>
-      <StyledMap bounds={entityData?.bounds} shouldSnapToPosition>
+      <StyledMap bounds={entity?.bounds} shouldSnapToPosition>
         <TileLayer tileSetUrl={activeTileSet.url} showAttribution={false} />
         <MapOverlays />
         <ZoomControl position="bottomright" />

--- a/packages/tupaia-web/src/features/Map/MapLegend/DesktopMapLegend.tsx
+++ b/packages/tupaia-web/src/features/Map/MapLegend/DesktopMapLegend.tsx
@@ -9,6 +9,7 @@ import { MOBILE_BREAKPOINT } from '../../../constants';
 
 // Placeholder for legend
 const Wrapper = styled.div`
+  pointer-events: auto;
   display: flex;
   flex-direction: row;
   align-items: flex-end;

--- a/packages/tupaia-web/src/features/Map/MapOverlaySelector/DesktopMapOverlaySelector.tsx
+++ b/packages/tupaia-web/src/features/Map/MapOverlaySelector/DesktopMapOverlaySelector.tsx
@@ -25,6 +25,7 @@ const MaxHeightContainer = styled.div`
 `;
 
 const Wrapper = styled(MaxHeightContainer)`
+  pointer-events: auto;
   max-width: 21.25rem;
   margin: 0.625rem;
   @media screen and (max-width: ${MOBILE_BREAKPOINT}) {

--- a/packages/tupaia-web/src/features/MapOverlays/MapOverlays.tsx
+++ b/packages/tupaia-web/src/features/MapOverlays/MapOverlays.tsx
@@ -10,7 +10,7 @@ import { useEntitiesWithLocation } from '../../api/queries';
 
 export const MapOverlays = () => {
   const { projectCode, entityCode } = useParams();
-  const { data: entityData } = useEntitiesWithLocation(projectCode, entityCode);
+  const { data } = useEntitiesWithLocation(projectCode, entityCode);
 
-  return <PolygonLayer entityData={entityData as EntityResponse} />;
+  return <PolygonLayer entities={data as EntityResponse[]} entityCode={entityCode!} />;
 };

--- a/packages/tupaia-web/src/types/types.d.ts
+++ b/packages/tupaia-web/src/types/types.d.ts
@@ -80,6 +80,7 @@ export type Entity = KeysToCamelCase<BaseEntity>;
 
 export type EntityResponse = Entity & {
   parentCode: Entity['code'];
+  childCodes: Entity['code'][];
   photoUrl?: string;
   children?: Entity[];
 };


### PR DESCRIPTION
### Issue #: WAITP-1293

### Changes:

- `EntitiesRoute` now takes `projectCode` and does a lookup for `hierarchyName`
- Allow overwriting the default `generational_distance` filter easier