### PR TITLE
WAITP-1268: Update map overlay route

### DIFF
--- a/packages/api-client/src/connections/WebConfigApi.ts
+++ b/packages/api-client/src/connections/WebConfigApi.ts
@@ -11,8 +11,8 @@ export class WebConfigApi extends BaseApi {
   public async fetchReport(reportCode: string, query?: QueryParameters | null) {
     return this.connection.get(`report/${reportCode}`, query);
   }
-  public async fetchMeasureData(reportCode: string, query?: QueryParameters | null) {
-    return this.connection.get(`measureData/${reportCode}`, query);
+  public async fetchMeasureData(mapOverlayCode: string, query?: QueryParameters | null) {
+    return this.connection.get('measureData', { ...query, mapOverlayCode });
   }
   public async fetchProjects() {
     return this.connection.get('projects');

--- a/packages/tupaia-web-server/src/app/createApp.ts
+++ b/packages/tupaia-web-server/src/app/createApp.ts
@@ -47,7 +47,7 @@ export function createApp() {
     .attachApiClientToContext(authHandlerProvider)
     .get<ReportRequest>('report/:reportCode', handleWith(ReportRoute))
     .get<LegacyMapOverlayReportRequest>(
-      'legacyMapOverlayReport/:reportCode',
+      'legacyMapOverlayReport/:mapOverlayCode',
       handleWith(LegacyMapOverlayReportRoute),
     )
     .get<MapOverlaysRequest>('mapOverlays/:projectCode/:entityCode', handleWith(MapOverlaysRoute))

--- a/packages/tupaia-web-server/src/routes/LegacyMapOverlayReportRoute.ts
+++ b/packages/tupaia-web-server/src/routes/LegacyMapOverlayReportRoute.ts
@@ -6,13 +6,13 @@
 import { Request } from 'express';
 import { Route } from '@tupaia/server-boilerplate';
 
-export type LegacyMapOverlayReportRequest = Request<{ reportCode: string }, any, any, any>;
+export type LegacyMapOverlayReportRequest = Request<{ mapOverlayCode: string }, any, any, any>;
 
 export class LegacyMapOverlayReportRoute extends Route<LegacyMapOverlayReportRequest> {
   public async buildResponse() {
     const { query, ctx } = this.req;
-    const { reportCode } = this.req.params;
+    const { mapOverlayCode } = this.req.params;
 
-    return ctx.services.webConfig.fetchMeasureData(reportCode, query);
+    return ctx.services.webConfig.fetchMeasureData(mapOverlayCode, query);
   }
 }

--- a/packages/tupaia-web-server/src/routes/MapOverlaysRoute.ts
+++ b/packages/tupaia-web-server/src/routes/MapOverlaysRoute.ts
@@ -59,6 +59,10 @@ export class MapOverlaysRoute extends Route<MapOverlaysRequest> {
       },
     });
 
+    if (mapOverlays.length === 0) {
+      return [];
+    }
+
     // Map overlay groups can be nested so we need to keep
     // searching until we find the root groups
     let mapOverlayRelations = await ctx.services.central.fetchResources(

--- a/packages/tupaia-web/src/api/queries/useMapOverlayData.ts
+++ b/packages/tupaia-web/src/api/queries/useMapOverlayData.ts
@@ -13,11 +13,10 @@ export const useMapOverlayData = (
   mapOverlayCode?: SingleMapOverlayItem['code'],
 ) => {
   return useQuery(
-    ['mapOverlayData', projectCode, entityCode, mapOverlayCode],
+    ['legacyMapOverlayReport', projectCode, entityCode, mapOverlayCode],
     async () => {
-      return get('measureData', {
+      return get(`legacyMapOverlayReport/${mapOverlayCode}`, {
         params: {
-          mapOverlayCode,
           organisationUnitCode: entityCode,
           projectCode,
           shouldShowAllParentCountryResults: projectCode !== entityCode, // TODO: figure out the logic here for shouldShowAllParentCountryResults


### PR DESCRIPTION
### Issue #: WAITP-1268: Update map overlay route

### Changes:
- Pass mapOverlay param to query string params instead of report report route param in legacy map overlay report route 
- Handle when there are no map overlays for a project and entity on the map overlays route