### PR TITLE
WAITP-1298 Add EntityAncestors route

### DIFF
--- a/packages/tupaia-web-server/src/app/createApp.ts
+++ b/packages/tupaia-web-server/src/app/createApp.ts
@@ -18,6 +18,8 @@ import {
   DashboardsRequest,
   EntitiesRoute,
   EntitiesRequest,
+  EntityAncestorsRoute,
+  EntityAncestorsRequest,
   ReportRoute,
   ReportRequest,
   LegacyDashboardReportRoute,
@@ -66,6 +68,10 @@ export function createApp() {
       handleWith(RequestCountryAccessRoute),
     )
     .get<EntitiesRequest>('entities/:hierarchyName/:rootEntityCode', handleWith(EntitiesRoute))
+    .get<EntityAncestorsRequest>(
+      'entityAncestors/:projectCode/:entityCode',
+      handleWith(EntityAncestorsRoute),
+    )
     // TODO: Stop using get for logout, then delete this
     .get<TempLogoutRequest>('logout', handleWith(TempLogoutRoute))
     .build();

--- a/packages/tupaia-web-server/src/routes/EntityAncestorsRoute.ts
+++ b/packages/tupaia-web-server/src/routes/EntityAncestorsRoute.ts
@@ -1,0 +1,36 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+import { Request } from 'express';
+import { Route } from '@tupaia/server-boilerplate';
+import camelcaseKeys from 'camelcase-keys';
+
+export type EntityAncestorsRequest = Request<any, any, any, any>;
+
+const DEFAULT_FIELDS = ['parent_code', 'code', 'name', 'type'];
+
+export class EntityAncestorsRoute extends Route<EntityAncestorsRequest> {
+  public async buildResponse() {
+    const { params, query, ctx } = this.req;
+    const { entityCode, projectCode } = params;
+    const { includeRootEntity = false, ...restOfQuery } = query;
+
+    const project = (
+      await ctx.services.central.fetchResources('projects', {
+        filter: { code: projectCode },
+        columns: ['entity_hierarchy.name'],
+      })
+    )[0];
+
+    const entities = await ctx.services.entity.getAncestorsOfEntity(
+      project['entity_hierarchy.name'],
+      entityCode,
+      { fields: DEFAULT_FIELDS, ...restOfQuery },
+      includeRootEntity,
+    );
+
+    return camelcaseKeys(entities, { deep: true });
+  }
+}

--- a/packages/tupaia-web-server/src/routes/index.ts
+++ b/packages/tupaia-web-server/src/routes/index.ts
@@ -5,9 +5,16 @@
 
 export { DashboardsRequest, DashboardsRoute } from './DashboardsRoute';
 export { EntitiesRequest, EntitiesRoute } from './EntitiesRoute';
+export { EntityAncestorsRequest, EntityAncestorsRoute } from './EntityAncestorsRoute';
 export { ReportRequest, ReportRoute } from './ReportRoute';
-export { LegacyDashboardReportRequest, LegacyDashboardReportRoute } from './LegacyDashboardReportRoute';
-export { LegacyMapOverlayReportRequest, LegacyMapOverlayReportRoute } from './LegacyMapOverlayReportRoute';
+export {
+  LegacyDashboardReportRequest,
+  LegacyDashboardReportRoute,
+} from './LegacyDashboardReportRoute';
+export {
+  LegacyMapOverlayReportRequest,
+  LegacyMapOverlayReportRoute,
+} from './LegacyMapOverlayReportRoute';
 export { MapOverlaysRequest, MapOverlaysRoute } from './MapOverlaysRoute';
 export { UserRequest, UserRoute } from './UserRoute';
 export { ProjectRequest, ProjectRoute } from './ProjectRoute';


### PR DESCRIPTION
### Issue #: WAITP-1298

### Changes:

- Add `entityAncestors` route to `tupaia-web-server`
- Returns an array of entities in ascending hierarchy order `[parent, grandparent, great-grandparent]`
  - This is the default return from `entity-server` so it's mostly just forwarding the request