### PR TITLE
WAITP-1293: Refactor tupaia-web for flat entities data

### DIFF
--- a/packages/tupaia-web/src/api/queries/useEntities.ts
+++ b/packages/tupaia-web/src/api/queries/useEntities.ts
@@ -4,7 +4,7 @@
  */
 import { AxiosRequestConfig } from 'axios';
 import { useQuery, QueryObserverOptions } from 'react-query';
-import { EntityResponse } from '../../types';
+import { Entity } from '../../types';
 import { get } from '../api';
 
 export const useEntities = (
@@ -17,10 +17,23 @@ export const useEntities = (
     queryOptions?.enabled === undefined ? !!projectCode && !!entityCode : queryOptions.enabled;
 
   return useQuery(
-    ['entities', projectCode, entityCode, axiosConfig, queryOptions],
-    async (): Promise<EntityResponse> => {
-      return get(`entities/${projectCode}/${entityCode}`, axiosConfig);
-    },
+    ['entities', projectCode, entityCode, axiosConfig],
+    (): Promise<Entity[]> =>
+      get(`entities/${projectCode}/${entityCode}`, {
+        params: {
+          fields: [
+            'parent_code',
+            'code',
+            'name',
+            'type',
+            'point',
+            'image_url',
+            'attributes',
+            'child_codes',
+          ],
+        },
+        ...axiosConfig,
+      }),
     {
       enabled,
     },
@@ -29,5 +42,19 @@ export const useEntities = (
 
 export const useEntitiesWithLocation = (projectCode?: string, entityCode?: string) =>
   useEntities(projectCode, entityCode, {
-    params: { fields: ['parent_code', 'code', 'name', 'type', 'bounds', 'region'] },
+    params: {
+      fields: [
+        'parent_code',
+        'code',
+        'name',
+        'type',
+        'bounds',
+        'region',
+        'point',
+        'location_type',
+        'image_url',
+        'attributes',
+        'child_codes',
+      ],
+    },
   });

--- a/packages/tupaia-web/src/api/queries/useEntities.ts
+++ b/packages/tupaia-web/src/api/queries/useEntities.ts
@@ -4,7 +4,7 @@
  */
 import { AxiosRequestConfig } from 'axios';
 import { useQuery, QueryObserverOptions } from 'react-query';
-import { Entity } from '../../types';
+import { EntityResponse } from '../../types';
 import { get } from '../api';
 
 export const useEntities = (
@@ -18,9 +18,10 @@ export const useEntities = (
 
   return useQuery(
     ['entities', projectCode, entityCode, axiosConfig],
-    (): Promise<Entity[]> =>
+    (): Promise<EntityResponse[]> =>
       get(`entities/${projectCode}/${entityCode}`, {
         params: {
+          includeRoot: true,
           fields: [
             'parent_code',
             'code',
@@ -43,6 +44,7 @@ export const useEntities = (
 export const useEntitiesWithLocation = (projectCode?: string, entityCode?: string) =>
   useEntities(projectCode, entityCode, {
     params: {
+      includeRoot: true,
       fields: [
         'parent_code',
         'code',

--- a/packages/tupaia-web/src/api/queries/useEntity.ts
+++ b/packages/tupaia-web/src/api/queries/useEntity.ts
@@ -5,7 +5,7 @@
 
 import { useQuery } from 'react-query';
 import { useParams } from 'react-router-dom';
-import { Entity } from '../../types';
+import { EntityResponse } from '../../types';
 import { get } from '../api';
 import { DEFAULT_BOUNDS } from '../../constants';
 
@@ -15,7 +15,7 @@ export const useEntity = (entityCode?: string) => {
 
   return useQuery(
     ['entities', projectCode, entityCode],
-    async (): Promise<Entity> => {
+    async (): Promise<EntityResponse> => {
       const entities = await get(`entities/${projectCode}/${entityCode}`, {
         params: {
           includeRoot: true,

--- a/packages/tupaia-web/src/api/queries/useEntity.ts
+++ b/packages/tupaia-web/src/api/queries/useEntity.ts
@@ -4,34 +4,32 @@
  */
 
 import { useQuery } from 'react-query';
-import { sleep } from '@tupaia/utils';
-
-const response = {
-  type: 'Country',
-  organisationUnitCode: 'TO',
-  countryCode: 'TO',
-  name: 'Tonga',
-  location: {
-    type: 'area',
-    point: null,
-    bounds: [
-      [-24.1625706, 180.604802],
-      [-15.3655722, 186.4704542],
-    ],
-    region: [],
-  },
-  photoUrl:
-    'https://tupaia.s3-ap-southeast-2.amazonaws.com/uploads/images/1499489588784_647646.png',
-  countryHierarchy: [],
-};
+import { useParams } from 'react-router-dom';
+import { Entity } from '../../types';
+import { get } from '../api';
+import { DEFAULT_BOUNDS } from '../../constants';
 
 export const useEntity = (entityCode?: string) => {
+  //  Todo: use entity endpoint when it's done and remove project code
+  const { projectCode } = useParams();
+
   return useQuery(
-    ['entity', entityCode],
-    async () => {
-      await sleep(1000);
-      return response;
+    ['entities', projectCode, entityCode],
+    async (): Promise<Entity> => {
+      const entities = await get(`entities/${projectCode}/${entityCode}`, {
+        params: {
+          includeRoot: true,
+          fields: ['parent_code', 'code', 'name', 'type', 'bounds', 'region', 'image_url'],
+        },
+      });
+      // @ts-ignore
+      const entity = entities.find(e => e.code === entityCode);
+
+      if (entity.code === 'explore') {
+        return { ...entity, bounds: DEFAULT_BOUNDS };
+      }
+
+      return entity;
     },
-    { enabled: !!entityCode },
   );
 };

--- a/packages/tupaia-web/src/features/Dashboard/Dashboard.tsx
+++ b/packages/tupaia-web/src/features/Dashboard/Dashboard.tsx
@@ -13,7 +13,7 @@ import { ExpandButton } from './ExpandButton';
 import { Photo } from './Photo';
 import { Breadcrumbs } from './Breadcrumbs';
 import { StaticMap } from './StaticMap';
-import { useDashboards as useDashboardData, useEntitiesWithLocation } from '../../api/queries';
+import { useDashboards as useDashboardData, useEntity } from '../../api/queries';
 import { DashboardMenu } from './DashboardMenu';
 import { DashboardItem } from '../DashboardItem';
 import { DashboardItemType, DashboardType } from '../../types';
@@ -116,11 +116,11 @@ const useDashboards = () => {
 };
 
 export const Dashboard = () => {
-  const { projectCode, entityCode } = useParams();
+  const { entityCode } = useParams();
   const [isExpanded, setIsExpanded] = useState(false);
   const { dashboards, activeDashboard } = useDashboards();
-  const { data: entityData } = useEntitiesWithLocation(projectCode, entityCode);
-  const bounds = entityData?.bounds;
+  const { data: entity } = useEntity(entityCode);
+  const bounds = entity?.bounds;
 
   const toggleExpanded = () => {
     setIsExpanded(!isExpanded);
@@ -133,13 +133,13 @@ export const Dashboard = () => {
         <Breadcrumbs />
         <DashboardImageContainer>
           {bounds ? (
-            <StaticMap polygonBounds={bounds} />
+            <StaticMap bounds={bounds} />
           ) : (
-            <Photo title={entityData?.name} photoUrl={entityData?.photoUrl} />
+            <Photo title={entity?.name} photoUrl={entity?.photoUrl} />
           )}
         </DashboardImageContainer>
         <TitleBar>
-          <Title variant="h3">{entityData?.name}</Title>
+          <Title variant="h3">{entity?.name}</Title>
           <ExportButton startIcon={<GetAppIcon />}>Export</ExportButton>
         </TitleBar>
         <DashboardMenu activeDashboard={activeDashboard} dashboards={dashboards} />

--- a/packages/tupaia-web/src/features/Dashboard/StaticMap.tsx
+++ b/packages/tupaia-web/src/features/Dashboard/StaticMap.tsx
@@ -64,11 +64,11 @@ const makeStaticMapUrl = (polygonBounds: Position[]) => {
   return `${MAPBOX_BASE_URL}${boundingBoxPath}/${longitude},${latitude},${zoomLevel}/${size}@2x?access_token=${MAPBOX_TOKEN}&attribution=false`;
 };
 
-export const StaticMap = ({ polygonBounds }: { polygonBounds: Position[] }) => {
-  if (!areBoundsValid(polygonBounds)) {
+export const StaticMap = ({ bounds }: { bounds: Position[] }) => {
+  if (!areBoundsValid(bounds)) {
     return null;
   }
 
-  const url = makeStaticMapUrl(polygonBounds);
+  const url = makeStaticMapUrl(bounds);
   return <Media $backgroundImage={url} />;
 };

--- a/packages/tupaia-web/src/features/EntitySearch/EntityMenu.tsx
+++ b/packages/tupaia-web/src/features/EntitySearch/EntityMenu.tsx
@@ -5,8 +5,7 @@
 import React, { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
-import { Entity } from '@tupaia/types';
-import { ProjectCode } from '../../types';
+import { EntityResponse, ProjectCode } from '../../types';
 import { LocalHospital as HospitalIcon, ExpandMore as ExpandIcon } from '@material-ui/icons';
 import { Button, IconButton, List as MuiList, ListItemProps } from '@material-ui/core';
 import { useEntities } from '../../api/queries';
@@ -41,12 +40,10 @@ const MenuLink = styled(Button).attrs({
   }
 `;
 
-type EntityWithChildren = Entity & { children?: Entity[] };
-
 interface EntityMenuProps {
   projectCode: ProjectCode;
-  children: Entity[];
-  grandChildren: Entity[];
+  children: EntityResponse[];
+  grandChildren: EntityResponse[];
   onClose: () => void;
 }
 
@@ -62,7 +59,7 @@ export const EntityMenu = ({ projectCode, children, grandChildren, onClose }: En
         <EntityMenuItem
           key={entity.code}
           projectCode={projectCode}
-          children={grandChildren?.filter(child => child.parentCode === entity.code)}
+          children={grandChildren.filter(child => child.parentCode === entity.code)}
           entity={entity}
           onClose={onClose}
         />
@@ -73,15 +70,14 @@ export const EntityMenu = ({ projectCode, children, grandChildren, onClose }: En
 
 interface EntityMenuItemProps {
   projectCode: ProjectCode;
-  entity: EntityWithChildren;
-  parentIsLoading?: boolean;
+  entity: EntityResponse;
   onClose: () => void;
-  children: Entity[];
+  children?: EntityResponse[];
 }
 const EntityMenuItem = ({ projectCode, entity, children, onClose }: EntityMenuItemProps) => {
   const location = useLocation();
   const [isExpanded, setIsExpanded] = useState(false);
-  const { data } = useEntities(projectCode!, entity.code!, {}, { enabled: isExpanded });
+  const { data = [] } = useEntities(projectCode!, entity.code!, {}, { enabled: isExpanded });
 
   const toggleExpanded = () => {
     setIsExpanded(!isExpanded);
@@ -89,7 +85,7 @@ const EntityMenuItem = ({ projectCode, entity, children, onClose }: EntityMenuIt
 
   const nextChildren =
     data?.filter(childEntity => childEntity.parentCode === entity.code) || children;
-  const grandChildren = data?.filter(childEntity => childEntity.parentCode !== entity.code);
+  const grandChildren = data.filter(childEntity => childEntity.parentCode !== entity.code);
   const link = { ...location, pathname: `/${projectCode}/${entity.code}` };
 
   return (

--- a/packages/tupaia-web/src/features/EntitySearch/EntityMenu.tsx
+++ b/packages/tupaia-web/src/features/EntitySearch/EntityMenu.tsx
@@ -83,9 +83,15 @@ const EntityMenuItem = ({ projectCode, entity, children, onClose }: EntityMenuIt
     setIsExpanded(!isExpanded);
   };
 
+  /*
+   Pre-populate the next layer of the menu with children that came from the previous layer of entity
+   data then replace them with the children from the API response when it arrives
+ */
   const nextChildren =
     data?.filter(childEntity => childEntity.parentCode === entity.code) || children;
+
   const grandChildren = data.filter(childEntity => childEntity.parentCode !== entity.code);
+
   const link = { ...location, pathname: `/${projectCode}/${entity.code}` };
 
   return (

--- a/packages/tupaia-web/src/features/EntitySearch/EntitySearch.tsx
+++ b/packages/tupaia-web/src/features/EntitySearch/EntitySearch.tsx
@@ -56,7 +56,7 @@ const isMobile = () => {
 export const EntitySearch = () => {
   const { projectCode } = useParams();
   const { data: project } = useProject(projectCode!);
-  const { data: entity, isLoading } = useEntities(projectCode!, project?.entityCode);
+  const { data: entities, isLoading } = useEntities(projectCode!, project?.entityCode);
   const [searchValue, setSearchValue] = useState('');
   const [isOpen, setIsOpen] = useState(false);
 
@@ -65,6 +65,9 @@ export const EntitySearch = () => {
       setIsOpen(false);
     }
   };
+
+  const children = entities?.filter(entity => entity.parentCode === project?.entityCode);
+  const grandChildren = entities?.filter(entity => entity.parentCode !== project?.entityCode);
 
   return (
     <ClickAwayListener onClickAway={() => setIsOpen(false)}>
@@ -77,8 +80,8 @@ export const EntitySearch = () => {
             ) : (
               <EntityMenu
                 projectCode={projectCode!}
-                children={entity?.children || []}
-                isLoading={isLoading}
+                children={children}
+                grandChildren={grandChildren}
                 onClose={onClose}
               />
             )}

--- a/packages/tupaia-web/src/features/EntitySearch/EntitySearch.tsx
+++ b/packages/tupaia-web/src/features/EntitySearch/EntitySearch.tsx
@@ -56,7 +56,7 @@ const isMobile = () => {
 export const EntitySearch = () => {
   const { projectCode } = useParams();
   const { data: project } = useProject(projectCode!);
-  const { data: entities, isLoading } = useEntities(projectCode!, project?.entityCode);
+  const { data: entities = [] } = useEntities(projectCode!, project?.entityCode);
   const [searchValue, setSearchValue] = useState('');
   const [isOpen, setIsOpen] = useState(false);
 
@@ -66,8 +66,8 @@ export const EntitySearch = () => {
     }
   };
 
-  const children = entities?.filter(entity => entity.parentCode === project?.entityCode);
-  const grandChildren = entities?.filter(entity => entity.parentCode !== project?.entityCode);
+  const children = entities.filter(entity => entity.parentCode === project?.entityCode);
+  const grandChildren = entities.filter(entity => entity.parentCode !== project?.entityCode);
 
   return (
     <ClickAwayListener onClickAway={() => setIsOpen(false)}>

--- a/packages/tupaia-web/src/features/Map/Map.tsx
+++ b/packages/tupaia-web/src/features/Map/Map.tsx
@@ -64,10 +64,13 @@ const TilePickerWrapper = styled.div`
 
 // This contains the map controls (legend, overlay selector, etc, so that they can fit within the map appropriately)
 const MapControlWrapper = styled.div`
+  position: relative;
   width: 100%;
   height: 100%;
   display: flex;
-  position: relative;
+
+  // This is to prevent the wrapper div from blocking clicks on the map overlays
+  pointer-events: none;
 `;
 
 const MapControlColumn = styled.div`

--- a/packages/tupaia-web/src/features/Map/Map.tsx
+++ b/packages/tupaia-web/src/features/Map/Map.tsx
@@ -12,7 +12,7 @@ import { MapWatermark } from './MapWatermark';
 import { MapLegend } from './MapLegend';
 import { MapOverlays } from '../MapOverlays';
 import { MapOverlaySelector } from './MapOverlaySelector';
-import { useEntitiesWithLocation } from '../../api/queries';
+import { useEntity } from '../../api/queries';
 
 const MapContainer = styled.div`
   height: 100%;
@@ -77,10 +77,10 @@ const MapControlColumn = styled.div`
 `;
 
 export const Map = () => {
-  const { projectCode, entityCode } = useParams();
+  const { entityCode } = useParams();
   const [activeTileSet, setActiveTileSet] = useState(TILE_SETS[0]);
 
-  const { data: entityData } = useEntitiesWithLocation(projectCode, entityCode);
+  const { data: entity } = useEntity(entityCode);
 
   const onTileSetChange = (tileSetKey: string) => {
     setActiveTileSet(TILE_SETS.find(({ key }) => key === tileSetKey) as typeof TILE_SETS[0]);
@@ -88,7 +88,7 @@ export const Map = () => {
 
   return (
     <MapContainer>
-      <StyledMap bounds={entityData?.bounds} shouldSnapToPosition>
+      <StyledMap bounds={entity?.bounds} shouldSnapToPosition>
         <TileLayer tileSetUrl={activeTileSet.url} showAttribution={false} />
         <MapOverlays />
         <ZoomControl position="bottomright" />

--- a/packages/tupaia-web/src/features/Map/MapLegend/DesktopMapLegend.tsx
+++ b/packages/tupaia-web/src/features/Map/MapLegend/DesktopMapLegend.tsx
@@ -9,6 +9,7 @@ import { MOBILE_BREAKPOINT } from '../../../constants';
 
 // Placeholder for legend
 const Wrapper = styled.div`
+  pointer-events: auto;
   display: flex;
   flex-direction: row;
   align-items: flex-end;

--- a/packages/tupaia-web/src/features/Map/MapOverlaySelector/DesktopMapOverlaySelector.tsx
+++ b/packages/tupaia-web/src/features/Map/MapOverlaySelector/DesktopMapOverlaySelector.tsx
@@ -25,6 +25,7 @@ const MaxHeightContainer = styled.div`
 `;
 
 const Wrapper = styled(MaxHeightContainer)`
+  pointer-events: auto;
   max-width: 21.25rem;
   margin: 0.625rem;
   @media screen and (max-width: ${MOBILE_BREAKPOINT}) {

--- a/packages/tupaia-web/src/features/MapOverlays/MapOverlays.tsx
+++ b/packages/tupaia-web/src/features/MapOverlays/MapOverlays.tsx
@@ -10,7 +10,7 @@ import { useEntitiesWithLocation } from '../../api/queries';
 
 export const MapOverlays = () => {
   const { projectCode, entityCode } = useParams();
-  const { data: entityData } = useEntitiesWithLocation(projectCode, entityCode);
+  const { data } = useEntitiesWithLocation(projectCode, entityCode);
 
-  return <PolygonLayer entityData={entityData as EntityResponse} />;
+  return <PolygonLayer entities={data as EntityResponse[]} entityCode={entityCode!} />;
 };

--- a/packages/tupaia-web/src/features/MapOverlays/PolygonLayer.tsx
+++ b/packages/tupaia-web/src/features/MapOverlays/PolygonLayer.tsx
@@ -6,8 +6,7 @@
 import React from 'react';
 import { ActivePolygon } from '@tupaia/ui-map-components';
 import { useParams } from 'react-router-dom';
-import { Entity } from '@tupaia/types';
-import { EntityResponse } from '../../types';
+import { EntityResponse, EntityCode } from '../../types';
 import { InteractivePolygon } from './InteractivePolygon';
 import { useEntitiesWithLocation } from '../../api/queries';
 
@@ -28,8 +27,8 @@ const SiblingEntities = ({
   parentEntityCode,
   activeEntityCode,
 }: {
-  parentEntityCode: Entity['code'];
-  activeEntityCode: Entity['code'];
+  parentEntityCode: EntityCode;
+  activeEntityCode: EntityCode;
 }) => {
   const { projectCode } = useParams();
   const { data: siblingEntities, isLoading } = useEntitiesWithLocation(
@@ -41,13 +40,11 @@ const SiblingEntities = ({
     return null;
   }
 
-  const children = siblingEntities.filter(
-    (entity: EntityResponse) => entity.code !== activeEntityCode,
-  );
+  const children = siblingEntities.filter(entity => entity.code !== activeEntityCode);
 
   return (
     <>
-      {children.map((entity: EntityResponse) => (
+      {children.map(entity => (
         <InteractivePolygon key={entity.code} entity={entity} />
       ))}
     </>
@@ -72,13 +69,12 @@ const ActiveEntity = ({ entity }: { entity: EntityResponse }) => {
   );
 };
 
-export const PolygonLayer = ({
-  entities,
-  entityCode,
-}: {
+interface PolygonLayerProps {
   entities: EntityResponse[];
-  entityCode: string;
-}) => {
+  entityCode: EntityCode;
+}
+
+export const PolygonLayer = ({ entities, entityCode }: PolygonLayerProps) => {
   if (!entities || entities.length === 0) {
     return null;
   }

--- a/packages/tupaia-web/src/types/types.d.ts
+++ b/packages/tupaia-web/src/types/types.d.ts
@@ -80,6 +80,7 @@ export type Entity = KeysToCamelCase<BaseEntity>;
 
 export type EntityResponse = Entity & {
   parentCode: Entity['code'];
+  childCodes: Entity['code'][];
   photoUrl?: string;
   children?: Entity[];
 };


### PR DESCRIPTION
### Issue #: WAITP-1293: Refactor tupaia-web for flat entities data

### Changes:
The context of this refactor is that in [waitp-1293-entity-route-better-filtering](https://github.com/beyondessential/tupaia/tree/waitp-1293-entity-route-better-filtering) the response from the entities api endpoint was refactored to return a flat list of entities and so the front end has to be refactored to match.

- Entity Menu
- Entity Polygons

