### PR TITLE
Split DataBroker.pull API per data source

### DIFF
--- a/packages/aggregator/src/Aggregator.js
+++ b/packages/aggregator/src/Aggregator.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
+import { toArray } from '@tupaia/utils';
 import {
   adjustOptionsToAggregationList,
   aggregateAnalytics,
@@ -59,8 +60,6 @@ export class Aggregator {
     }, analytics);
 
   async fetchAnalytics(codeInput, fetchOptions, aggregationOptions = {}) {
-    const code = Array.isArray(codeInput) ? codeInput : [codeInput];
-    const dataSourceSpec = { code, type: this.dataSourceTypes.DATA_ELEMENT };
     const [adjustedFetchOptions, adjustedAggregationOptions] = await adjustOptionsToAggregationList(
       this.context,
       fetchOptions,
@@ -79,7 +78,8 @@ export class Aggregator {
       };
     }
 
-    const { results, metadata } = await this.dataBroker.pull(dataSourceSpec, adjustedFetchOptions);
+    const codes = toArray(codeInput);
+    const { results, metadata } = await this.dataBroker.pullAnalytics(codes, adjustedFetchOptions);
     const rawAnalytics = results.reduce((array, { analytics }) => array.concat(analytics), []);
 
     return {
@@ -108,7 +108,6 @@ export class Aggregator {
    * @returns
    */
   async fetchEvents(code, fetchOptions, aggregationOptions = {}) {
-    const dataSourceSpec = { code, type: this.dataSourceTypes.DATA_GROUP };
     const [adjustedFetchOptions, adjustedAggregationOptions] = await adjustOptionsToAggregationList(
       this.context,
       fetchOptions,
@@ -120,7 +119,7 @@ export class Aggregator {
       return [];
     }
 
-    const events = await this.dataBroker.pull(dataSourceSpec, adjustedFetchOptions);
+    const events = await this.dataBroker.pullEvents([code], adjustedFetchOptions);
 
     return this.processEvents(events, adjustedAggregationOptions);
   }

--- a/packages/central-server/src/kobo/startSyncWithKoBo.js
+++ b/packages/central-server/src/kobo/startSyncWithKoBo.js
@@ -124,15 +124,9 @@ export async function syncWithKoBo(models, dataBroker, syncGroupCode) {
 
     // Pull data from KoBo
     const koboData =
-      (await dataBroker.pull(
-        {
-          code: syncGroupCode,
-          type: dataBroker.getDataSourceTypes().SYNC_GROUP,
-        },
-        {
-          startSubmissionTime: dataServiceSyncGroup.sync_cursor,
-        },
-      )) || [];
+      (await dataBroker.pullSyncGroupResults(syncGroupCode, {
+        startSubmissionTime: dataServiceSyncGroup.sync_cursor,
+      })) || [];
 
     await models.wrapInTransaction(async transactingModels => {
       // Create new survey_responses in Tupaia

--- a/packages/data-broker/src/DataBroker/DataBroker.ts
+++ b/packages/data-broker/src/DataBroker/DataBroker.ts
@@ -349,7 +349,7 @@ export class DataBroker {
     return (nestedResults as EventResults[]).flat();
   }
 
-  public async pullSyncGroupsResults(
+  public async pullSyncGroupResults(
     syncGroupCodes: string[],
     options: PullOptions,
   ): Promise<SyncGroupResults> {

--- a/packages/data-broker/src/DataBroker/DataBroker.ts
+++ b/packages/data-broker/src/DataBroker/DataBroker.ts
@@ -57,6 +57,11 @@ type PermissionChecker = (
   organisationUnitCodes?: string[],
 ) => Promise<string[] | undefined>;
 
+interface PullOptions {
+  organisationUnitCode?: string;
+  organisationUnitCodes?: string[];
+}
+
 type ValidatedOptions = { organisationUnitCodes?: string[] } & Record<string, unknown>;
 
 let modelRegistry: DataBrokerModelRegistry;
@@ -77,12 +82,7 @@ const getPermissionListWithWildcard = (accessPolicy?: AccessPolicy, countryCodes
   return ['*', ...userPermissionGroups];
 };
 
-const setOrganisationUnitCodes = (
-  options: Record<string, unknown> & {
-    organisationUnitCode?: string;
-    organisationUnitCodes?: string[];
-  },
-) => {
+const setOrganisationUnitCodes = (options: PullOptions) => {
   const { organisationUnitCode, organisationUnitCodes, ...restOfOptions } = options;
   const orgUnitCodes =
     organisationUnitCodes || (organisationUnitCode ? [organisationUnitCode] : undefined);
@@ -313,7 +313,7 @@ export class DataBroker {
 
   public async pullAnalytics(
     dataElementCodes: string[],
-    options: Record<string, unknown>,
+    options: PullOptions,
   ): Promise<AnalyticResults> {
     const dataElements = await fetchDataElements(this.models, dataElementCodes);
     const validatedOptions = setOrganisationUnitCodes(options);
@@ -338,10 +338,7 @@ export class DataBroker {
     );
   }
 
-  public async pullEvents(
-    dataGroupCodes: string[],
-    options: Record<string, unknown>,
-  ): Promise<EventResults> {
+  public async pullEvents(dataGroupCodes: string[], options: PullOptions): Promise<EventResults> {
     const dataGroups = await fetchDataGroups(this.models, dataGroupCodes);
     const validatedOptions = setOrganisationUnitCodes(options);
 
@@ -364,7 +361,7 @@ export class DataBroker {
 
   public async pullSyncGroupsResults(
     syncGroupCodes: string[],
-    options: Record<string, unknown>,
+    options: PullOptions,
   ): Promise<SyncGroupResults> {
     const syncGroups = await fetchSyncGroups(this.models, syncGroupCodes);
     const validatedOptions = setOrganisationUnitCodes(options);

--- a/packages/data-broker/src/DataBroker/fetchDataSources.ts
+++ b/packages/data-broker/src/DataBroker/fetchDataSources.ts
@@ -4,7 +4,6 @@
  */
 
 import { DataBrokerModelRegistry } from '../types';
-import { DATA_SOURCE_TYPES } from '../utils';
 
 const checkRequestedVsFound = (requested: string[], found: string[], description: string) => {
   if (found.length === 0) {

--- a/packages/data-broker/src/DataBroker/fetchDataSources.ts
+++ b/packages/data-broker/src/DataBroker/fetchDataSources.ts
@@ -1,0 +1,48 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+import { DataBrokerModelRegistry } from '../types';
+import { DATA_SOURCE_TYPES } from '../utils';
+
+const checkRequestedVsFound = (requested: string[], found: string[], description: string) => {
+  if (found.length === 0) {
+    throw new Error(`None of the following ${description} exist: ${requested}`);
+  }
+  const notFound = requested.filter(c => !found.includes(c));
+  if (notFound.length > 0) {
+    // eslint-disable-next-line no-console
+    console.warn(`Could not find the following ${description}: ${notFound}`);
+  }
+};
+
+export const fetchDataElements = async (models: DataBrokerModelRegistry, codes: string[]) => {
+  if (codes.length === 0) {
+    throw new Error('Please provide at least one existing data element code');
+  }
+  const dataElements = await models.dataElement.find({ code: codes });
+  const foundCodes = dataElements.map(({ code }) => code);
+  checkRequestedVsFound(codes, foundCodes, 'data elements');
+  return dataElements;
+};
+
+export const fetchDataGroups = async (models: DataBrokerModelRegistry, codes: string[]) => {
+  if (codes.length === 0) {
+    throw new Error('Please provide at least one existing data group code');
+  }
+  const dataGroups = await models.dataGroup.find({ code: codes });
+  const foundCodes = dataGroups.map(({ code }) => code);
+  checkRequestedVsFound(codes, foundCodes, 'data groups');
+  return dataGroups;
+};
+
+export const fetchSyncGroups = async (models: DataBrokerModelRegistry, codes: string[]) => {
+  if (codes.length === 0) {
+    throw new Error('Please provide at least one existing sync group code');
+  }
+  const syncGroups = await models.dataServiceSyncGroup.find({ code: codes });
+  const foundCodes = syncGroups.map(({ code }) => code);
+  checkRequestedVsFound(codes, foundCodes, 'sync groups');
+  return syncGroups;
+};

--- a/packages/data-broker/src/DataBroker/index.ts
+++ b/packages/data-broker/src/DataBroker/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+export { DataBroker } from './DataBroker';

--- a/packages/data-broker/src/DataBroker/mergeAnalytics.ts
+++ b/packages/data-broker/src/DataBroker/mergeAnalytics.ts
@@ -1,0 +1,59 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+import { Analytic, AnalyticResults as RawAnalyticResults } from '../types';
+
+export interface AnalyticResults {
+  results: {
+    analytics: Analytic[];
+    numAggregationsProcessed: number;
+  }[];
+  metadata: {
+    dataElementCodeToName: Record<string, string>;
+  };
+}
+
+export const mergeAnalytics = (
+  target: AnalyticResults,
+  source: RawAnalyticResults,
+): AnalyticResults => {
+  const sourceNumAggregationsProcessed = source.numAggregationsProcessed || 0;
+  const targetResults = target.results;
+
+  // Result analytics can be combined if they've processed aggregations to the same level
+  const matchingResultIndex = targetResults.findIndex(
+    ({ numAggregationsProcessed }) => numAggregationsProcessed === sourceNumAggregationsProcessed,
+  );
+
+  let newResults;
+  if (matchingResultIndex >= 0) {
+    // Found a matching result, combine the matching result analytics and the new analytics
+    const matchingResult = targetResults[matchingResultIndex];
+    newResults = targetResults
+      .slice(0, matchingResultIndex)
+      .concat([
+        {
+          ...matchingResult,
+          analytics: matchingResult.analytics.concat(source.results),
+        },
+      ])
+      .concat(targetResults.slice(matchingResultIndex + 1, targetResults.length - 1));
+  } else {
+    // No matching result, just append this result to previous results
+    newResults = targetResults.concat([
+      { analytics: source.results, numAggregationsProcessed: sourceNumAggregationsProcessed },
+    ]);
+  }
+
+  return {
+    results: newResults,
+    metadata: {
+      dataElementCodeToName: {
+        ...target.metadata.dataElementCodeToName,
+        ...source.metadata.dataElementCodeToName,
+      },
+    },
+  };
+};

--- a/packages/data-broker/src/__tests__/DataBroker/DataBroker.fixtures.ts
+++ b/packages/data-broker/src/__tests__/DataBroker/DataBroker.fixtures.ts
@@ -4,7 +4,12 @@
  */
 
 import { Analytic, DataElementDataService, DataElementMetadata, Event } from '../../types';
-import { dataElementTypes, dataGroupTypes, entities } from '../testUtils';
+import {
+  dataElementTypes,
+  dataGroupTypes,
+  dataServiceSyncGroupTypes,
+  entities,
+} from '../testUtils';
 
 // Data elements and groups share the same codes on purpose, to assert that
 // `DataBroker` can still distinguish them using their type
@@ -24,6 +29,11 @@ export const DATA_GROUPS = dataGroupTypes({
   DHIS_PROGRAM_01: { code: 'DHIS_PROGRAM_01', service_type: 'dhis' },
   DHIS_PROGRAM_02: { code: 'DHIS_PROGRAM_02', service_type: 'dhis' },
   TUPAIA_PROGRAM_01: { code: 'TUPAIA_PROGRAM_01', service_type: 'tupaia' },
+});
+
+export const SYNC_GROUPS = dataServiceSyncGroupTypes({
+  SYNC_GROUP_01: { code: 'SYNC_GROUP_01', data_group_code: 'SYNC_GROUP_01', service_type: 'dhis' },
+  SYNC_GROUP_02: { code: 'SYNC_GROUP_02', data_group_code: 'SYNC_GROUP_02', service_type: 'dhis' },
 });
 
 export interface MockServiceData {

--- a/packages/data-broker/src/__tests__/DataBroker/DataBroker.fixtures.ts
+++ b/packages/data-broker/src/__tests__/DataBroker/DataBroker.fixtures.ts
@@ -32,8 +32,21 @@ export const DATA_GROUPS = dataGroupTypes({
 });
 
 export const SYNC_GROUPS = dataServiceSyncGroupTypes({
-  SYNC_GROUP_01: { code: 'SYNC_GROUP_01', data_group_code: 'SYNC_GROUP_01', service_type: 'dhis' },
-  SYNC_GROUP_02: { code: 'SYNC_GROUP_02', data_group_code: 'SYNC_GROUP_02', service_type: 'dhis' },
+  DHIS_SYNC_GROUP_01: {
+    code: 'DHIS_SYNC_GROUP_01',
+    data_group_code: 'DHIS_SYNC_GROUP_01',
+    service_type: 'dhis',
+  },
+  DHIS_SYNC_GROUP_02: {
+    code: 'DHIS_SYNC_GROUP_02',
+    data_group_code: 'DHIS_SYNC_GROUP_02',
+    service_type: 'dhis',
+  },
+  TUPAIA_SYNC_GROUP_01: {
+    code: 'TUPAIA_SYNC_GROUP_01',
+    data_group_code: 'TUPAIA_SYNC_GROUP_01',
+    service_type: 'tupaia',
+  },
 });
 
 export interface MockServiceData {
@@ -51,7 +64,7 @@ export const DATA_BY_SERVICE = {
     eventsByProgram: {
       DHIS_PROGRAM_01: [
         {
-          event: 'eventId',
+          event: 'dhisEventId1',
           eventDate: '2020-02-06T10:18:00.000',
           orgUnit: 'TO',
           orgUnitName: 'Tonga',
@@ -60,11 +73,29 @@ export const DATA_BY_SERVICE = {
       ],
       DHIS_PROGRAM_02: [
         {
-          event: 'eventId',
+          event: 'dhisEventId2',
           eventDate: '2020-02-06T10:18:00.000',
           orgUnit: 'TO',
           orgUnitName: 'Tonga',
           dataValues: { DHIS_02: 20 },
+        },
+      ],
+      DHIS_SYNC_GROUP_01: [
+        {
+          event: 'dhisEventId3',
+          eventDate: '2021-02-06T10:18:00.000',
+          orgUnit: 'TO',
+          orgUnitName: 'Tonga',
+          dataValues: { DHIS_01: 30 },
+        },
+      ],
+      DHIS_SYNC_GROUP_02: [
+        {
+          event: 'dhisEventId4',
+          eventDate: '2021-01-06T10:18:00.000',
+          orgUnit: 'TO',
+          orgUnitName: 'Tonga',
+          dataValues: { DHIS_02: 40 },
         },
       ],
     },
@@ -82,11 +113,20 @@ export const DATA_BY_SERVICE = {
     eventsByProgram: {
       TUPAIA_PROGRAM_01: [
         {
-          event: 'eventId',
+          event: 'tupaiaEventId1',
           eventDate: '2020-02-06T10:18:00.000',
           orgUnit: 'TO',
           orgUnitName: 'Tonga',
-          dataValues: { TUPAIA_01: 30 },
+          dataValues: { TUPAIA_01: 50 },
+        },
+      ],
+      TUPAIA_SYNC_GROUP_01: [
+        {
+          event: 'tupaiaEventId2',
+          eventDate: '2020-02-06T10:18:00.000',
+          orgUnit: 'TO',
+          orgUnitName: 'Tonga',
+          dataValues: { TUPAIA_01: 60 },
         },
       ],
     },

--- a/packages/data-broker/src/__tests__/DataBroker/DataBroker.stubs.ts
+++ b/packages/data-broker/src/__tests__/DataBroker/DataBroker.stubs.ts
@@ -13,6 +13,7 @@ import {
   DATA_GROUPS,
   ENTITIES,
   MockServiceData,
+  SYNC_GROUPS,
 } from './DataBroker.fixtures';
 import { DataBrokerModelRegistry, DataSource, DataSourceType } from '../../types';
 
@@ -110,6 +111,9 @@ export const createModelsStub = () => {
       extraMethods: {
         getDataElementsInDataGroup: () => [],
       },
+    },
+    dataServiceSyncGroup: {
+      records: Object.values(SYNC_GROUPS),
     },
     entity: {
       records: Object.values(ENTITIES),

--- a/packages/data-broker/src/__tests__/DataBroker/DataBroker.stubs.ts
+++ b/packages/data-broker/src/__tests__/DataBroker/DataBroker.stubs.ts
@@ -16,6 +16,7 @@ import {
   SYNC_GROUPS,
 } from './DataBroker.fixtures';
 import { DataBrokerModelRegistry, DataSource, DataSourceType } from '../../types';
+import pickBy from 'lodash.pickby';
 
 export const stubCreateService = (services: Record<string, Service>) =>
   jest.spyOn(CreateService, 'createService').mockImplementation((_, type) => {
@@ -80,6 +81,11 @@ export class MockService extends Service {
             return Object.entries(eventsByProgram)
               .filter(([program]) => dataSourceCodes.includes(program))
               .flatMap(([, events]) => events);
+          }
+          case 'syncGroup': {
+            return pickBy(eventsByProgram, (_, programCode) =>
+              dataSourceCodes.includes(programCode),
+            );
           }
           default:
             throw new Error(`Invalid data source type: ${type}`);

--- a/packages/data-broker/src/__tests__/DataBroker/DataBroker.test.ts
+++ b/packages/data-broker/src/__tests__/DataBroker/DataBroker.test.ts
@@ -382,32 +382,7 @@ describe('DataBroker', () => {
   });
 
   describe('pullAnalytics', () => {
-    it('single code', async () => {
-      const dataBroker = new DataBroker();
-      const data = await dataBroker.pullAnalytics(['DHIS_01'], options);
-
-      expect(createServiceMock).toHaveBeenCalledOnceWith(mockModels, 'dhis', dataBroker);
-      expect(SERVICES.dhis.pull).toHaveBeenCalledOnceWith(
-        [DATA_ELEMENTS.DHIS_01],
-        'dataElement',
-        expect.objectContaining(options),
-      );
-      expect(data).toStrictEqual({
-        results: [
-          {
-            analytics: [
-              { dataElement: 'DHIS_01', organisationUnit: 'TO', period: '20210101', value: 1 },
-            ],
-            numAggregationsProcessed: 0,
-          },
-        ],
-        metadata: {
-          dataElementCodeToName: { DHIS_01: 'DHIS element 1' },
-        },
-      });
-    });
-
-    it('multiple codes', async () => {
+    it('same service', async () => {
       const dataBroker = new DataBroker();
       const data = await dataBroker.pullAnalytics(['DHIS_01', 'DHIS_02'], options);
 
@@ -473,20 +448,7 @@ describe('DataBroker', () => {
   });
 
   describe('pullEvents', () => {
-    it('single code', async () => {
-      const dataBroker = new DataBroker();
-      const data = await dataBroker.pullEvents(['DHIS_PROGRAM_01'], options);
-
-      expect(createServiceMock).toHaveBeenCalledOnceWith(mockModels, 'dhis', dataBroker);
-      expect(SERVICES.dhis.pull).toHaveBeenCalledOnceWith(
-        [DATA_GROUPS.DHIS_PROGRAM_01],
-        'dataGroup',
-        expect.objectContaining(options),
-      );
-      expect(data).toStrictEqual(DATA_BY_SERVICE.dhis.eventsByProgram.DHIS_PROGRAM_01);
-    });
-
-    it('multiple codes', async () => {
+    it('same service', async () => {
       const dataBroker = new DataBroker();
       const data = await dataBroker.pullEvents(['DHIS_PROGRAM_01', 'DHIS_PROGRAM_02'], options);
 

--- a/packages/data-broker/src/__tests__/DataBroker/DataBroker.test.ts
+++ b/packages/data-broker/src/__tests__/DataBroker/DataBroker.test.ts
@@ -4,11 +4,11 @@
  */
 
 import { AccessPolicy } from '@tupaia/access-policy';
-import { DataBroker } from '../../DataBroker';
+import { DataBroker } from '../../DataBroker/DataBroker';
 import { Service } from '../../services/Service';
-import { DataElement, ServiceType } from '../../types';
+import { DataBrokerModelRegistry, DataElement, ServiceType } from '../../types';
 import { DATA_SOURCE_TYPES } from '../../utils';
-import { DATA_BY_SERVICE, DATA_ELEMENTS, DATA_GROUPS } from './DataBroker.fixtures';
+import { DATA_BY_SERVICE, DATA_ELEMENTS, DATA_GROUPS, SYNC_GROUPS } from './DataBroker.fixtures';
 import { stubCreateService, createModelsStub, MockService } from './DataBroker.stubs';
 import { DataServiceMapping } from '../../services/DataServiceMapping';
 
@@ -28,6 +28,15 @@ jest.mock('@tupaia/server-boilerplate', () => ({
   ApiConnection: jest.fn().mockImplementation(() => {}),
 }));
 
+jest.mock('../../DataBroker/fetchDataSources', () => ({
+  fetchDataElements: async (models: DataBrokerModelRegistry, codes: string[]) =>
+    Object.values(DATA_ELEMENTS).filter(({ code }) => codes.includes(code)),
+  fetchDataGroups: async (models: DataBrokerModelRegistry, codes: string[]) =>
+    Object.values(DATA_GROUPS).filter(({ code }) => codes.includes(code)),
+  fetchSyncGroups: async (models: DataBrokerModelRegistry, codes: string[]) =>
+    Object.values(SYNC_GROUPS).filter(({ code }) => codes.includes(code)),
+}));
+
 describe('DataBroker', () => {
   const SERVICES = {
     dhis: new MockService(mockModels).setMockData(DATA_BY_SERVICE.dhis),
@@ -41,7 +50,7 @@ describe('DataBroker', () => {
   });
 
   describe('Data service resolution', () => {
-    type MethodUnderTest = 'push' | 'pull' | 'delete' | 'pullMetadata';
+    type MethodUnderTest = 'push' | 'pullAnalytics' | 'pullEvents' | 'delete' | 'pullMetadata';
 
     const TO_OPTIONS = { organisationUnitCode: 'TO_FACILITY_01' };
     const FJ_OPTIONS = { organisationUnitCode: 'FJ_FACILITY_01' };
@@ -59,8 +68,8 @@ describe('DataBroker', () => {
         ],
         ['delete', 1, [{ code: 'DHIS_01', type: 'dataElement' }, TO_OPTIONS], 'dhis'],
         ['delete', 2, [{ code: 'DHIS_PROGRAM_01', type: 'dataGroup' }, TO_OPTIONS], 'dhis'],
-        ['pull', 1, [{ code: 'DHIS_01', type: 'dataElement' }, TO_OPTIONS], 'dhis'],
-        ['pull', 2, [{ code: 'DHIS_PROGRAM_01', type: 'dataGroup' }, TO_OPTIONS], 'dhis'],
+        ['pullAnalytics', 1, ['DHIS_01', TO_OPTIONS], 'dhis'],
+        ['pullEvents', 2, ['DHIS_PROGRAM_01', TO_OPTIONS], 'dhis'],
         ['pullMetadata', 1, [{ code: 'DHIS_01', type: 'dataElement' }, TO_OPTIONS], 'dhis'],
         ['pullMetadata', 2, [{ code: 'DHIS_PROGRAM_01', type: 'dataGroup' }, TO_OPTIONS], 'dhis'],
       ];
@@ -94,8 +103,8 @@ describe('DataBroker', () => {
         ],
         ['delete', 1, [{ code: 'DHIS_01', type: 'dataElement' }, NO_OU_OPT], 'dhis'],
         ['delete', 2, [{ code: 'DHIS_PROGRAM_01', type: 'dataGroup' }, NO_OU_OPT], 'dhis'],
-        ['pull', 1, [{ code: 'DHIS_01', type: 'dataElement' }, NO_OU_OPT], 'dhis'],
-        ['pull', 2, [{ code: 'DHIS_PROGRAM_01', type: 'dataGroup' }, NO_OU_OPT], 'dhis'],
+        ['pullAnalytics', 1, ['DHIS_01', NO_OU_OPT], 'dhis'],
+        ['pullEvents', 2, ['DHIS_PROGRAM_01', NO_OU_OPT], 'dhis'],
         ['pullMetadata', 1, [{ code: 'DHIS_01', type: 'dataElement' }, NO_OU_OPT], 'dhis'],
         ['pullMetadata', 2, [{ code: 'DHIS_PROGRAM_01', type: 'dataGroup' }, NO_OU_OPT], 'dhis'],
       ];
@@ -127,7 +136,7 @@ describe('DataBroker', () => {
           [{ code: 'MAPPED_01', type: 'dataElement' }, { value: 2 }, FJ_OPTIONS],
           'tupaia',
         ],
-        ['pull', [{ code: 'MAPPED_01', type: 'dataElement' }, FJ_OPTIONS], 'tupaia'],
+        ['pullAnalytics', ['MAPPED_01', FJ_OPTIONS], 'tupaia'],
         ['pullMetadata', [{ code: 'MAPPED_01', type: 'dataElement' }, FJ_OPTIONS], 'tupaia'],
       ];
 
@@ -153,14 +162,18 @@ describe('DataBroker', () => {
       const testData: [MethodUnderTest, any[], DataServiceMapping][] = [
         ['push', [{ code: 'DHIS_01', type: 'dataElement' }, [{ value: 2 }], TO_OPTIONS], mapping],
         ['delete', [{ code: 'DHIS_01', type: 'dataElement' }, { value: 2 }, TO_OPTIONS], mapping],
-        ['pull', [{ code: 'DHIS_01', type: 'dataElement' }, TO_OPTIONS], mapping],
+        ['pullAnalytics', ['DHIS_01', TO_OPTIONS], mapping],
         ['pullMetadata', [{ code: 'DHIS_01', type: 'dataElement' }, TO_OPTIONS], mapping],
       ];
 
       testData.forEach(([methodUnderTest, inputArgs, expectedMapping]) =>
         it(`passes mapping to service: ${methodUnderTest}`, async () => {
           await dataBroker[methodUnderTest](inputArgs[0], inputArgs[1], inputArgs[2]);
-          expect(SERVICES.dhis[methodUnderTest]).toHaveBeenCalledOnceWith(
+          const serviceMethod =
+            methodUnderTest === 'pullAnalytics' || methodUnderTest === 'pullEvents'
+              ? 'pull'
+              : methodUnderTest;
+          expect(SERVICES.dhis[serviceMethod]).toHaveBeenCalledOnceWith(
             expect.anything(),
             expect.anything(),
             expect.objectContaining({ dataServiceMapping: expectedMapping }),
@@ -199,10 +212,9 @@ describe('DataBroker', () => {
       it('pulls from different data services for the same data element', async () => {
         const dataBroker = new DataBroker();
         const multipleCountryFacilities = ['FJ_FACILITY_01', 'TO_FACILITY_01'];
-        await dataBroker.pull(
-          { code: ['MAPPED_01', 'MAPPED_02'], type: 'dataElement' },
-          { organisationUnitCodes: multipleCountryFacilities },
-        );
+        await dataBroker.pullAnalytics(['MAPPED_01', 'MAPPED_02'], {
+          organisationUnitCodes: multipleCountryFacilities,
+        });
 
         expect(createServiceMock).toHaveBeenCalledTimes(2);
         expect(createServiceMock).toHaveBeenCalledWith(
@@ -282,62 +294,11 @@ describe('DataBroker', () => {
   });
 
   describe('pull()', () => {
-    describe('input validation', () => {
-      const testData: [string, Record<string, unknown>, string][] = [
-        ['empty object', {}, 'Please provide at least one existing data source code'],
-        [
-          'no `code` field',
-          { type: 'dataElement' },
-          'Please provide at least one existing data source code',
-        ],
-        [
-          'code is empty string',
-          { code: '' },
-          'Please provide at least one existing data source code',
-        ],
-        [
-          'code is empty array',
-          { code: [] },
-          'Please provide at least one existing data source code',
-        ],
-        [
-          "data element doesn't exist",
-          { code: 'NON_EXISTING', type: 'dataElement' },
-          'None of the following data elements exist: NON_EXISTING',
-        ],
-        [
-          "data group doesn't exist",
-          { code: 'NON_EXISTING', type: 'dataGroup' },
-          'None of the following data groups exist: NON_EXISTING',
-        ],
-        [
-          'multiple codes, none exists',
-          { code: ['NON_EXISTING1', 'NON_EXISTING2'], type: 'dataElement' },
-          'None of the following data elements exist: NON_EXISTING1,NON_EXISTING2',
-        ],
-      ];
-
-      it.each(testData)('%s', async (_, dataSourceSpec, expectedError) =>
-        expect(new DataBroker().pull(dataSourceSpec as any, {})).toBeRejectedWith(expectedError),
-      );
-
-      it('does not throw if options omitted', async () =>
-        expect(new DataBroker().pull({ code: ['DHIS_01'], type: 'dataElement' }, {})).toResolve());
-
-      it('does not throw if at least one code exists', async () =>
-        expect(
-          new DataBroker().pull({ code: ['DHIS_01', 'NON_EXISTING'], type: 'dataElement' }, {}),
-        ).toResolve());
-    });
-
     describe('permissions', () => {
       it("throws an error if fetching for a data element the user doesn't have required permissions for", async () => {
         await expect(
-          new DataBroker({ accessPolicy: new AccessPolicy({ DL: ['Public'] }) }).pull(
-            {
-              code: ['RESTRICTED_01'],
-              type: 'dataElement',
-            },
+          new DataBroker({ accessPolicy: new AccessPolicy({ DL: ['Public'] }) }).pullAnalytics(
+            ['RESTRICTED_01'],
             {},
           ),
         ).toBeRejectedWith('Missing permissions to the following data elements: RESTRICTED_01');
@@ -345,11 +306,8 @@ describe('DataBroker', () => {
 
       it("throws an error if fetching for a data element in an entity the user doesn't have required permissions for", async () => {
         await expect(
-          new DataBroker({ accessPolicy: new AccessPolicy({ DL: ['Admin'] }) }).pull(
-            {
-              code: ['RESTRICTED_01'],
-              type: 'dataElement',
-            },
+          new DataBroker({ accessPolicy: new AccessPolicy({ DL: ['Admin'] }) }).pullAnalytics(
+            ['RESTRICTED_01'],
             { organisationUnitCodes: ['TO'] },
           ),
         ).toBeRejectedWith('Missing permissions to the following data elements:\nRESTRICTED_01');
@@ -357,11 +315,8 @@ describe('DataBroker', () => {
 
       it("throws an error if any of data elements in fetch the user doesn't have required permissions for", async () => {
         await expect(
-          new DataBroker({ accessPolicy: new AccessPolicy({ TO: ['Public'] }) }).pull(
-            {
-              code: ['TUPAIA_01', 'RESTRICTED_01'],
-              type: 'dataElement',
-            },
+          new DataBroker({ accessPolicy: new AccessPolicy({ TO: ['Public'] }) }).pullAnalytics(
+            ['TUPAIA_01', 'RESTRICTED_01'],
             { organisationUnitCodes: ['TO'] },
           ),
         ).toBeRejectedWith(`Missing permissions to the following data elements:\nRESTRICTED_01`);
@@ -369,11 +324,8 @@ describe('DataBroker', () => {
 
       it("doesn't throw if the user has BES Admin access", async () => {
         await expect(
-          new DataBroker({ accessPolicy: new AccessPolicy({ DL: ['BES Admin'] }) }).pull(
-            {
-              code: ['RESTRICTED_01'],
-              type: 'dataElement',
-            },
+          new DataBroker({ accessPolicy: new AccessPolicy({ DL: ['BES Admin'] }) }).pullAnalytics(
+            ['RESTRICTED_01'],
             { organisationUnitCodes: ['TO'] },
           ),
         ).toResolve();
@@ -382,13 +334,7 @@ describe('DataBroker', () => {
       it("doesn't throw if the user has access to the data element in the requested entity", async () => {
         const results = await new DataBroker({
           accessPolicy: new AccessPolicy({ TO: ['Admin'] }),
-        }).pull(
-          {
-            code: ['RESTRICTED_01'],
-            type: 'dataElement',
-          },
-          { organisationUnitCodes: ['TO'] },
-        );
+        }).pullAnalytics(['RESTRICTED_01'], { organisationUnitCodes: ['TO'] });
         expect(results).toEqual({
           results: [
             {
@@ -412,13 +358,7 @@ describe('DataBroker', () => {
       it('just returns data for entities that the user have appropriate access to', async () => {
         const results = await new DataBroker({
           accessPolicy: new AccessPolicy({ FJ: ['Admin'] }),
-        }).pull(
-          {
-            code: ['RESTRICTED_01'],
-            type: 'dataElement',
-          },
-          { organisationUnitCodes: ['TO', 'FJ'] },
-        );
+        }).pullAnalytics(['RESTRICTED_01'], { organisationUnitCodes: ['TO', 'FJ'] });
         expect(results).toEqual({
           results: [
             {
@@ -439,163 +379,154 @@ describe('DataBroker', () => {
         });
       });
     });
+  });
 
-    describe('analytics', () => {
-      it('single code', async () => {
-        const dataBroker = new DataBroker();
-        const data = await dataBroker.pull({ code: 'DHIS_01', type: 'dataElement' }, options);
+  describe('pullAnalytics', () => {
+    it('single code', async () => {
+      const dataBroker = new DataBroker();
+      const data = await dataBroker.pullAnalytics(['DHIS_01'], options);
 
-        expect(createServiceMock).toHaveBeenCalledOnceWith(mockModels, 'dhis', dataBroker);
-        expect(SERVICES.dhis.pull).toHaveBeenCalledOnceWith(
-          [DATA_ELEMENTS.DHIS_01],
-          'dataElement',
-          expect.objectContaining(options),
-        );
-        expect(data).toStrictEqual({
-          results: [
-            {
-              analytics: [
-                { dataElement: 'DHIS_01', organisationUnit: 'TO', period: '20210101', value: 1 },
-              ],
-              numAggregationsProcessed: 0,
-            },
-          ],
-          metadata: {
-            dataElementCodeToName: { DHIS_01: 'DHIS element 1' },
+      expect(createServiceMock).toHaveBeenCalledOnceWith(mockModels, 'dhis', dataBroker);
+      expect(SERVICES.dhis.pull).toHaveBeenCalledOnceWith(
+        [DATA_ELEMENTS.DHIS_01],
+        'dataElement',
+        expect.objectContaining(options),
+      );
+      expect(data).toStrictEqual({
+        results: [
+          {
+            analytics: [
+              { dataElement: 'DHIS_01', organisationUnit: 'TO', period: '20210101', value: 1 },
+            ],
+            numAggregationsProcessed: 0,
           },
-        });
-      });
-
-      it('multiple codes', async () => {
-        const dataBroker = new DataBroker();
-        const data = await dataBroker.pull(
-          { code: ['DHIS_01', 'DHIS_02'], type: 'dataElement' },
-          options,
-        );
-
-        expect(createServiceMock).toHaveBeenCalledOnceWith(mockModels, 'dhis', dataBroker);
-        expect(SERVICES.dhis.pull).toHaveBeenCalledOnceWith(
-          [DATA_ELEMENTS.DHIS_01, DATA_ELEMENTS.DHIS_02],
-          'dataElement',
-          expect.objectContaining(options),
-        );
-        expect(data).toStrictEqual({
-          results: [
-            {
-              analytics: [
-                { dataElement: 'DHIS_01', organisationUnit: 'TO', period: '20210101', value: 1 },
-                { dataElement: 'DHIS_02', organisationUnit: 'TO', period: '20210101', value: 2 },
-              ],
-              numAggregationsProcessed: 0,
-            },
-          ],
-          metadata: {
-            dataElementCodeToName: { DHIS_01: 'DHIS element 1', DHIS_02: 'DHIS element 2' },
-          },
-        });
-      });
-
-      it('multiple services', async () => {
-        const dataBroker = new DataBroker();
-        const data = await dataBroker.pull(
-          { code: ['DHIS_01', 'TUPAIA_01', 'DHIS_02'], type: 'dataElement' },
-          options,
-        );
-
-        expect(createServiceMock).toHaveBeenCalledTimes(2);
-        expect(createServiceMock).toHaveBeenCalledWith(mockModels, 'dhis', dataBroker);
-        expect(createServiceMock).toHaveBeenCalledWith(mockModels, 'tupaia', dataBroker);
-        expect(SERVICES.dhis.pull).toHaveBeenCalledOnceWith(
-          [DATA_ELEMENTS.DHIS_01, DATA_ELEMENTS.DHIS_02],
-          'dataElement',
-          expect.objectContaining(options),
-        );
-        expect(SERVICES.tupaia.pull).toHaveBeenCalledOnceWith(
-          [DATA_ELEMENTS.TUPAIA_01],
-          'dataElement',
-          expect.objectContaining(options),
-        );
-        expect(data).toStrictEqual({
-          results: [
-            {
-              analytics: [
-                { dataElement: 'DHIS_01', organisationUnit: 'TO', period: '20210101', value: 1 },
-                { dataElement: 'DHIS_02', organisationUnit: 'TO', period: '20210101', value: 2 },
-                { dataElement: 'TUPAIA_01', organisationUnit: 'TO', period: '20210101', value: 3 },
-              ],
-              numAggregationsProcessed: 0,
-            },
-          ],
-          metadata: {
-            dataElementCodeToName: {
-              DHIS_01: 'DHIS element 1',
-              DHIS_02: 'DHIS element 2',
-              TUPAIA_01: 'Tupaia element 1',
-            },
-          },
-        });
+        ],
+        metadata: {
+          dataElementCodeToName: { DHIS_01: 'DHIS element 1' },
+        },
       });
     });
 
-    describe('dataGroups', () => {
-      it('single code', async () => {
-        const dataBroker = new DataBroker();
-        const data = await dataBroker.pull({ code: 'DHIS_PROGRAM_01', type: 'dataGroup' }, options);
+    it('multiple codes', async () => {
+      const dataBroker = new DataBroker();
+      const data = await dataBroker.pullAnalytics(['DHIS_01', 'DHIS_02'], options);
 
-        expect(createServiceMock).toHaveBeenCalledOnceWith(mockModels, 'dhis', dataBroker);
-        expect(SERVICES.dhis.pull).toHaveBeenCalledOnceWith(
-          [DATA_GROUPS.DHIS_PROGRAM_01],
-          'dataGroup',
-          expect.objectContaining(options),
-        );
-        expect(data).toStrictEqual(DATA_BY_SERVICE.dhis.eventsByProgram.DHIS_PROGRAM_01);
+      expect(createServiceMock).toHaveBeenCalledOnceWith(mockModels, 'dhis', dataBroker);
+      expect(SERVICES.dhis.pull).toHaveBeenCalledOnceWith(
+        [DATA_ELEMENTS.DHIS_01, DATA_ELEMENTS.DHIS_02],
+        'dataElement',
+        expect.objectContaining(options),
+      );
+      expect(data).toStrictEqual({
+        results: [
+          {
+            analytics: [
+              { dataElement: 'DHIS_01', organisationUnit: 'TO', period: '20210101', value: 1 },
+              { dataElement: 'DHIS_02', organisationUnit: 'TO', period: '20210101', value: 2 },
+            ],
+            numAggregationsProcessed: 0,
+          },
+        ],
+        metadata: {
+          dataElementCodeToName: { DHIS_01: 'DHIS element 1', DHIS_02: 'DHIS element 2' },
+        },
       });
+    });
 
-      it('multiple codes', async () => {
-        const dataBroker = new DataBroker();
-        const data = await dataBroker.pull(
-          { code: ['DHIS_PROGRAM_01', 'DHIS_PROGRAM_02'], type: 'dataGroup' },
-          options,
-        );
+    it('multiple services', async () => {
+      const dataBroker = new DataBroker();
+      const data = await dataBroker.pullAnalytics(['DHIS_01', 'TUPAIA_01', 'DHIS_02'], options);
 
-        expect(createServiceMock).toHaveBeenCalledOnceWith(mockModels, 'dhis', dataBroker);
-        expect(SERVICES.dhis.pull).toHaveBeenCalledOnceWith(
-          [DATA_GROUPS.DHIS_PROGRAM_01, DATA_GROUPS.DHIS_PROGRAM_02],
-          'dataGroup',
-          expect.objectContaining(options),
-        );
-        expect(data).toStrictEqual([
-          ...DATA_BY_SERVICE.dhis.eventsByProgram.DHIS_PROGRAM_01,
-          ...DATA_BY_SERVICE.dhis.eventsByProgram.DHIS_PROGRAM_02,
-        ]);
+      expect(createServiceMock).toHaveBeenCalledTimes(2);
+      expect(createServiceMock).toHaveBeenCalledWith(mockModels, 'dhis', dataBroker);
+      expect(createServiceMock).toHaveBeenCalledWith(mockModels, 'tupaia', dataBroker);
+      expect(SERVICES.dhis.pull).toHaveBeenCalledOnceWith(
+        [DATA_ELEMENTS.DHIS_01, DATA_ELEMENTS.DHIS_02],
+        'dataElement',
+        expect.objectContaining(options),
+      );
+      expect(SERVICES.tupaia.pull).toHaveBeenCalledOnceWith(
+        [DATA_ELEMENTS.TUPAIA_01],
+        'dataElement',
+        expect.objectContaining(options),
+      );
+      expect(data).toStrictEqual({
+        results: [
+          {
+            analytics: [
+              { dataElement: 'DHIS_01', organisationUnit: 'TO', period: '20210101', value: 1 },
+              { dataElement: 'DHIS_02', organisationUnit: 'TO', period: '20210101', value: 2 },
+              { dataElement: 'TUPAIA_01', organisationUnit: 'TO', period: '20210101', value: 3 },
+            ],
+            numAggregationsProcessed: 0,
+          },
+        ],
+        metadata: {
+          dataElementCodeToName: {
+            DHIS_01: 'DHIS element 1',
+            DHIS_02: 'DHIS element 2',
+            TUPAIA_01: 'Tupaia element 1',
+          },
+        },
       });
+    });
+  });
 
-      it('multiple services', async () => {
-        const dataBroker = new DataBroker();
-        const data = await dataBroker.pull(
-          { code: ['DHIS_PROGRAM_01', 'TUPAIA_PROGRAM_01', 'DHIS_PROGRAM_02'], type: 'dataGroup' },
-          options,
-        );
+  describe('pullEvents', () => {
+    it('single code', async () => {
+      const dataBroker = new DataBroker();
+      const data = await dataBroker.pullEvents(['DHIS_PROGRAM_01'], options);
 
-        expect(createServiceMock).toHaveBeenCalledTimes(2);
-        expect(createServiceMock).toHaveBeenCalledWith(mockModels, 'dhis', dataBroker);
-        expect(createServiceMock).toHaveBeenCalledWith(mockModels, 'tupaia', dataBroker);
-        expect(SERVICES.dhis.pull).toHaveBeenCalledOnceWith(
-          [DATA_GROUPS.DHIS_PROGRAM_01, DATA_GROUPS.DHIS_PROGRAM_02],
-          'dataGroup',
-          expect.objectContaining(options),
-        );
-        expect(SERVICES.tupaia.pull).toHaveBeenCalledOnceWith(
-          [DATA_GROUPS.TUPAIA_PROGRAM_01],
-          'dataGroup',
-          expect.objectContaining(options),
-        );
-        expect(data).toStrictEqual([
-          ...DATA_BY_SERVICE.dhis.eventsByProgram.DHIS_PROGRAM_01,
-          ...DATA_BY_SERVICE.dhis.eventsByProgram.DHIS_PROGRAM_02,
-          ...DATA_BY_SERVICE.tupaia.eventsByProgram.TUPAIA_PROGRAM_01,
-        ]);
-      });
+      expect(createServiceMock).toHaveBeenCalledOnceWith(mockModels, 'dhis', dataBroker);
+      expect(SERVICES.dhis.pull).toHaveBeenCalledOnceWith(
+        [DATA_GROUPS.DHIS_PROGRAM_01],
+        'dataGroup',
+        expect.objectContaining(options),
+      );
+      expect(data).toStrictEqual(DATA_BY_SERVICE.dhis.eventsByProgram.DHIS_PROGRAM_01);
+    });
+
+    it('multiple codes', async () => {
+      const dataBroker = new DataBroker();
+      const data = await dataBroker.pullEvents(['DHIS_PROGRAM_01', 'DHIS_PROGRAM_02'], options);
+
+      expect(createServiceMock).toHaveBeenCalledOnceWith(mockModels, 'dhis', dataBroker);
+      expect(SERVICES.dhis.pull).toHaveBeenCalledOnceWith(
+        [DATA_GROUPS.DHIS_PROGRAM_01, DATA_GROUPS.DHIS_PROGRAM_02],
+        'dataGroup',
+        expect.objectContaining(options),
+      );
+      expect(data).toStrictEqual([
+        ...DATA_BY_SERVICE.dhis.eventsByProgram.DHIS_PROGRAM_01,
+        ...DATA_BY_SERVICE.dhis.eventsByProgram.DHIS_PROGRAM_02,
+      ]);
+    });
+
+    it('multiple services', async () => {
+      const dataBroker = new DataBroker();
+      const data = await dataBroker.pullEvents(
+        ['DHIS_PROGRAM_01', 'TUPAIA_PROGRAM_01', 'DHIS_PROGRAM_02'],
+        options,
+      );
+
+      expect(createServiceMock).toHaveBeenCalledTimes(2);
+      expect(createServiceMock).toHaveBeenCalledWith(mockModels, 'dhis', dataBroker);
+      expect(createServiceMock).toHaveBeenCalledWith(mockModels, 'tupaia', dataBroker);
+      expect(SERVICES.dhis.pull).toHaveBeenCalledOnceWith(
+        [DATA_GROUPS.DHIS_PROGRAM_01, DATA_GROUPS.DHIS_PROGRAM_02],
+        'dataGroup',
+        expect.objectContaining(options),
+      );
+      expect(SERVICES.tupaia.pull).toHaveBeenCalledOnceWith(
+        [DATA_GROUPS.TUPAIA_PROGRAM_01],
+        'dataGroup',
+        expect.objectContaining(options),
+      );
+      expect(data).toStrictEqual([
+        ...DATA_BY_SERVICE.dhis.eventsByProgram.DHIS_PROGRAM_01,
+        ...DATA_BY_SERVICE.dhis.eventsByProgram.DHIS_PROGRAM_02,
+        ...DATA_BY_SERVICE.tupaia.eventsByProgram.TUPAIA_PROGRAM_01,
+      ]);
     });
   });
 

--- a/packages/data-broker/src/__tests__/DataBroker/fetchDataSources.test.ts
+++ b/packages/data-broker/src/__tests__/DataBroker/fetchDataSources.test.ts
@@ -70,10 +70,10 @@ describe('fetchSyncGroups', () => {
 
   it('returns all found sync groups', async () => {
     const results = await fetchSyncGroups(models, [
-      'SYNC_GROUP_01',
-      'SYNC_GROUP_02',
+      'DHIS_SYNC_GROUP_01',
+      'DHIS_SYNC_GROUP_02',
       'NON_EXISTING',
     ]);
-    expect(results).toStrictEqual([SYNC_GROUPS.SYNC_GROUP_01, SYNC_GROUPS.SYNC_GROUP_02]);
+    expect(results).toStrictEqual([SYNC_GROUPS.DHIS_SYNC_GROUP_01, SYNC_GROUPS.DHIS_SYNC_GROUP_02]);
   });
 });

--- a/packages/data-broker/src/__tests__/DataBroker/fetchDataSources.test.ts
+++ b/packages/data-broker/src/__tests__/DataBroker/fetchDataSources.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+import {
+  fetchDataElements,
+  fetchDataGroups,
+  fetchSyncGroups,
+} from '../../DataBroker/fetchDataSources';
+import { DATA_ELEMENTS, DATA_GROUPS, SYNC_GROUPS } from './DataBroker.fixtures';
+import { createModelsStub } from './DataBroker.stubs';
+
+const models = createModelsStub();
+
+describe('fetchDataElements', () => {
+  it('empty input', async () => {
+    await expect(fetchDataElements(models, [])).toBeRejectedWith(
+      'Please provide at least one existing data element code',
+    );
+  });
+
+  it('no data element found', async () => {
+    await expect(fetchDataElements(models, ['NON_EXISTING1', 'NON_EXISTING2'])).toBeRejectedWith(
+      'None of the following data elements exist: NON_EXISTING1,NON_EXISTING2',
+    );
+  });
+
+  it('returns all found data elements', async () => {
+    const results = await fetchDataElements(models, ['DHIS_01', 'DHIS_02', 'NON_EXISTING']);
+    expect(results).toStrictEqual([DATA_ELEMENTS.DHIS_01, DATA_ELEMENTS.DHIS_02]);
+  });
+});
+
+describe('fetchDataGroups', () => {
+  it('empty input', async () => {
+    await expect(fetchDataGroups(models, [])).toBeRejectedWith(
+      'Please provide at least one existing data group code',
+    );
+  });
+
+  it('no data group found', async () => {
+    await expect(fetchDataGroups(models, ['NON_EXISTING1', 'NON_EXISTING2'])).toBeRejectedWith(
+      'None of the following data groups exist: NON_EXISTING1,NON_EXISTING2',
+    );
+  });
+
+  it('returns all found data groups', async () => {
+    const results = await fetchDataGroups(models, [
+      'DHIS_PROGRAM_01',
+      'DHIS_PROGRAM_02',
+      'NON_EXISTING',
+    ]);
+    expect(results).toStrictEqual([DATA_GROUPS.DHIS_PROGRAM_01, DATA_GROUPS.DHIS_PROGRAM_02]);
+  });
+});
+
+describe('fetchSyncGroups', () => {
+  it('empty input', async () => {
+    await expect(fetchSyncGroups(models, [])).toBeRejectedWith(
+      'Please provide at least one existing sync group code',
+    );
+  });
+
+  it('no sync group found', async () => {
+    await expect(fetchSyncGroups(models, ['NON_EXISTING1', 'NON_EXISTING2'])).toBeRejectedWith(
+      'None of the following sync groups exist: NON_EXISTING1,NON_EXISTING2',
+    );
+  });
+
+  it('returns all found sync groups', async () => {
+    const results = await fetchSyncGroups(models, [
+      'SYNC_GROUP_01',
+      'SYNC_GROUP_02',
+      'NON_EXISTING',
+    ]);
+    expect(results).toStrictEqual([SYNC_GROUPS.SYNC_GROUP_01, SYNC_GROUPS.SYNC_GROUP_02]);
+  });
+});

--- a/packages/data-broker/src/__tests__/services/dhis/DhisService.test.ts
+++ b/packages/data-broker/src/__tests__/services/dhis/DhisService.test.ts
@@ -14,7 +14,6 @@ import {
 } from './DhisService.fixtures';
 import { DhisService } from '../../../services/dhis';
 import { createMockDhisApi, createModelsStub, stubGetDhisApi } from './DhisService.stubs';
-import { DataServiceMapping } from '../../../services/DataServiceMapping';
 
 const mockPullAnalytics = jest.fn();
 const mockPullEvents = jest.fn();

--- a/packages/data-broker/src/__tests__/testUtils/createInstances.ts
+++ b/packages/data-broker/src/__tests__/testUtils/createInstances.ts
@@ -75,9 +75,17 @@ export const dataServiceSyncGroup = (fields: DataServiceSyncGroupFields): DataSe
   } = fields;
   return { code, data_group_code, service_type, config, sync_cursor, sync_status };
 };
+export const dataServiceSyncGroupType = (fields: DataServiceSyncGroupFields) =>
+  ({
+    ...dataServiceSyncGroup(fields),
+    databaseType: TYPES.DATA_SERVICE_SYNC_GROUP,
+  } as DataServiceSyncGroup);
 export const dataServiceSyncGroups = <K extends string>(
   fieldsByKey: Record<K, DataServiceSyncGroupFields>,
 ) => createInstances(fieldsByKey, dataServiceSyncGroup);
+export const dataServiceSyncGroupTypes = <K extends string>(
+  fieldsByKey: Record<K, DataServiceSyncGroupFields>,
+) => createInstances(fieldsByKey, dataServiceSyncGroupType);
 
 type EntityFields = {
   code: string;


### PR DESCRIPTION
## Motivation

I've wanted to make this change for some time now... We're talking about years :smile: 

When we were writing `data-broker`, @edmofro had warned me that we shouldn't use the same API for different data sources (e.g. `pull()` for both analytics and events). Unfortunately, I didn't heed his warning back then - we were moving fast and all that. It is time to set things right!

This PR splits `DataBroker.pull()` in one API per pulled data source type:

* `pullAnalytics()`
* `pullEvents()`
* `pullSyncGroupResults`

Benefits:
* Fix an over-abstraction. Get rid of `this.mergers`, `this.fetchers` etc
* More sensible types
* Easier to see what's happening at the function level
* Can still reuse functionality when needed, as an implementation detail

## Testing

The package has good coverage and most parts of the refactoring are mechanical, however it may be wise to do a smoke test with a few vizes using various data source types, even if post-merge.

A change like this is probably not a top priority, so it's only worth the hassle if it's relatively easy to review and test.

## Next steps

Next steps could be:
* Split `DataBroker.push()`, `DataBroker.delete()`, `DataBroker.pullMetadata()` APIs
* Split Service-level implementations of those APIs (`DhisService.pull()` etc)

Good news is that those changes can happen gradually, in small and safe PRs :slightly_smiling_face: 

