### PR TITLE
Update central server map overlays filter to account for empty string

### DIFF
--- a/packages/central-server/src/apiV2/mapOverlays/assertMapOverlaysPermissions.js
+++ b/packages/central-server/src/apiV2/mapOverlays/assertMapOverlaysPermissions.js
@@ -122,9 +122,13 @@ export const createMapOverlayDBFilter = (accessPolicy, criteria) => {
   dbConditions[RAW] = {
     sql: `
     (
+      -- Special case for no permission
+      (
+        "map_overlay"."permission_group" = ''
+      )
       -- Look up the country codes list from the map overlay and check that the user has
       -- access to at least one of the countries for the appropriate permissions group
-      (
+      OR (
         "map_overlay"."country_codes"
         &&
         ARRAY(

--- a/packages/tupaia-web-server/src/routes/MapOverlaysRoute.ts
+++ b/packages/tupaia-web-server/src/routes/MapOverlaysRoute.ts
@@ -16,6 +16,7 @@ export type MapOverlaysRequest = Request<any, any, any, any>;
 // TODO: Can these be moved into types?
 const ROOT_MAP_OVERLAY_CODE = 'Root';
 const MAP_OVERLAY_CHILD_TYPE = 'mapOverlay';
+const PAGE_SIZE = 200;
 
 // We return a simplified version of data to the frontend
 interface TranslatedMapOverlay {
@@ -57,6 +58,7 @@ export class MapOverlaysRoute extends Route<MapOverlaysRequest> {
           comparisonValue: [projectCode],
         },
       },
+      pageSize: PAGE_SIZE,
     });
 
     if (mapOverlays.length === 0) {
@@ -72,6 +74,7 @@ export class MapOverlaysRoute extends Route<MapOverlaysRequest> {
           child_type: 'mapOverlay',
           child_id: mapOverlays.map((overlay: MapOverlay) => overlay.id),
         },
+        pageSize: PAGE_SIZE,
       },
     );
     let parentMapOverlayRelations = await ctx.services.central.fetchResources(
@@ -83,6 +86,7 @@ export class MapOverlaysRoute extends Route<MapOverlaysRequest> {
             (relation: MapOverlayGroupRelation) => relation.map_overlay_group_id,
           ),
         },
+        pageSize: PAGE_SIZE,
       },
     );
     while (parentMapOverlayRelations.length) {
@@ -97,6 +101,7 @@ export class MapOverlaysRoute extends Route<MapOverlaysRequest> {
               (relation: MapOverlayGroupRelation) => relation.map_overlay_group_id,
             ),
           },
+          pageSize: PAGE_SIZE,
         },
       );
     }


### PR DESCRIPTION
### Issue #: WAITP-1286

### Changes:

- Special case filter for when we have no permission groups on a map overlay
- Increase the limits on the fetch from `tupaia-web-server -> central`, with full permissions it's possible to have >100 map overlays return at once