### PR TITLE
WAITP-1286 Web config forward auth header to report server

### DIFF
--- a/packages/web-config-server/src/connections/ReportConnection.js
+++ b/packages/web-config-server/src/connections/ReportConnection.js
@@ -27,6 +27,12 @@ export class ReportConnection extends ApiConnection {
     const userName = req?.userJson?.userName;
 
     const getAuthHeader = async () => {
+      // If we're authorized using a header already, forward that header
+      const authHeader = req?.headers?.authorization || req?.headers?.Authorization;
+      if (authHeader) {
+        return authHeader;
+      }
+
       if (userName === PUBLIC_USER_NAME) {
         return PUBLIC_USER_AUTH_HEADER;
       }


### PR DESCRIPTION
### Issue #: WAITP-1286

### Changes:

- Skip the token refresh if we're already using an auth header
- There's a separate handler for forwarding to central server that's still going to be an issue