### PR TITLE
RN-950: Configure cypress babel-preprocessor to parse node_modules

### DIFF
--- a/packages/e2e/cypress/plugins/index.js
+++ b/packages/e2e/cypress/plugins/index.js
@@ -4,6 +4,7 @@
  */
 
 const cypressDotenv = require('cypress-dotenv');
+const webpackPreprocessor = require('@cypress/webpack-preprocessor');
 const fs = require('fs');
 
 module.exports = (on, config) => {
@@ -19,6 +20,14 @@ module.exports = (on, config) => {
       return fs.existsSync(filename) ? fs.readFileSync(filename, 'utf8') : null;
     },
   });
+
+  const options = webpackPreprocessor.defaultOptions;
+  options.webpackOptions.module.rules[0].options.presets.push(
+    '@babel/preset-env',
+    '@babel/preset-react',
+  );
+
+  on('file:preprocessor', webpackPreprocessor(options));
 
   return cypressDotenv(config);
 };

--- a/packages/e2e/cypress/plugins/index.js
+++ b/packages/e2e/cypress/plugins/index.js
@@ -24,6 +24,7 @@ module.exports = (on, config) => {
 
   const options = webpackPreprocessor.defaultOptions;
 
+  // Stub out unsupported transitive dependencies
   options.webpackOptions.resolve = {
     alias: {
       fs: path.resolve(__dirname, 'moduleMock.js'),
@@ -32,6 +33,7 @@ module.exports = (on, config) => {
     },
   };
 
+  // Run latest @babel/preset-env preset to transpile modern js
   options.webpackOptions.module.rules.push({
     test: /\.(js|jsx)$/,
     loader: require.resolve('babel-loader'),

--- a/packages/e2e/cypress/plugins/index.js
+++ b/packages/e2e/cypress/plugins/index.js
@@ -5,6 +5,7 @@
 
 const cypressDotenv = require('cypress-dotenv');
 const webpackPreprocessor = require('@cypress/webpack-preprocessor');
+const path = require('path');
 const fs = require('fs');
 
 module.exports = (on, config) => {
@@ -22,10 +23,22 @@ module.exports = (on, config) => {
   });
 
   const options = webpackPreprocessor.defaultOptions;
-  options.webpackOptions.module.rules[0].options.presets.push(
-    '@babel/preset-env',
-    '@babel/preset-react',
-  );
+
+  options.webpackOptions.resolve = {
+    alias: {
+      fs: path.resolve(__dirname, 'moduleMock.js'),
+      yargs: path.resolve(__dirname, 'moduleMock.js'),
+      child_process: path.resolve(__dirname, 'moduleMock.js'),
+    },
+  };
+
+  options.webpackOptions.module.rules.push({
+    test: /\.(js|jsx)$/,
+    loader: require.resolve('babel-loader'),
+    options: {
+      presets: ['@babel/preset-env'],
+    },
+  });
 
   on('file:preprocessor', webpackPreprocessor(options));
 

--- a/packages/e2e/cypress/plugins/moduleMock.js
+++ b/packages/e2e/cypress/plugins/moduleMock.js
@@ -1,0 +1,4 @@
+// mock implementation of a module to stub out dependencies, because certain modules in `@tupaia/utils` break cypress
+module.exports = {
+  strict: () => {},
+};

--- a/packages/e2e/cypress/support/actions.js
+++ b/packages/e2e/cypress/support/actions.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
-import { requireCyEnv } from '@tupaia/utils';
+import { requireCyEnv } from './utils';
 
 export const submitLoginForm = () => {
   // eslint-disable-next-line cypress/no-force

--- a/packages/e2e/cypress/support/actions.js
+++ b/packages/e2e/cypress/support/actions.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
-import { requireCyEnv } from './utils';
+import { requireCyEnv } from '@tupaia/utils';
 
 export const submitLoginForm = () => {
   // eslint-disable-next-line cypress/no-force

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -22,6 +22,7 @@
     "@babel/node": "^7.10.5",
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.14.5",
     "@cypress/snapshot": "^2.1.7",
+    "@cypress/webpack-preprocessor": "^5.17.1",
     "@testing-library/cypress": "^7.0.0",
     "@tupaia/database": "1.0.0",
     "@tupaia/utils": "1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3707,6 +3707,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@cypress/webpack-preprocessor@npm:^5.17.1":
+  version: 5.17.1
+  resolution: "@cypress/webpack-preprocessor@npm:5.17.1"
+  dependencies:
+    bluebird: 3.7.1
+    debug: ^4.3.4
+    lodash: ^4.17.20
+  peerDependencies:
+    "@babel/core": ^7.0.1
+    "@babel/preset-env": ^7.0.0
+    babel-loader: ^8.0.2 || ^9
+    webpack: ^4 || ^5
+  checksum: 4dc2babc77df5fad7eb16629ca716f73df930739563be6bff4e336f9a8f08cf80915a7eed2ea582294ed67336313b62cc30d04ebe3fc2a9b1e48e1445be3c297
+  languageName: node
+  linkType: hard
+
 "@cypress/xvfb@npm:^1.2.4":
   version: 1.2.4
   resolution: "@cypress/xvfb@npm:1.2.4"
@@ -6706,6 +6722,7 @@ __metadata:
     "@babel/node": ^7.10.5
     "@babel/plugin-proposal-nullish-coalescing-operator": ^7.14.5
     "@cypress/snapshot": ^2.1.7
+    "@cypress/webpack-preprocessor": ^5.17.1
     "@testing-library/cypress": ^7.0.0
     "@tupaia/database": 1.0.0
     "@tupaia/utils": 1.0.0
@@ -11112,6 +11129,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bluebird@npm:3.7.1":
+  version: 3.7.1
+  resolution: "bluebird@npm:3.7.1"
+  checksum: 58c295399e109925149977ebcb40e42fd109d3e458899e71441bc7e5e0867bbd796fdd20278b425fa29f13377fe335fbfc2a6e68e5ca1da03b1c3afdc439d097
+  languageName: node
+  linkType: hard
+
 "bluebird@npm:^3.1.1, bluebird@npm:^3.3.5, bluebird@npm:^3.5.0, bluebird@npm:^3.5.1, bluebird@npm:^3.5.5, bluebird@npm:^3.7.2":
   version: 3.7.2
   resolution: "bluebird@npm:3.7.2"
@@ -14448,7 +14472,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4.3.4, debug@npm:^4.3.3":
+"debug@npm:4.3.4, debug@npm:^4.3.3, debug@npm:^4.3.4":
   version: 4.3.4
   resolution: "debug@npm:4.3.4"
   dependencies:


### PR DESCRIPTION
### Issue RN-950:

The issue here is that the [default cypress webpack preprocessor](https://github.com/cypress-io/cypress/tree/develop/npm/webpack-preprocessor) config only supports ES2015 and doesn't parse files under `/node_modules/`.

This meant that dependencies which used modern js (eg. optional chaining) caused webpack build errors. 

Extended the config here to parse depedencies and to stub out unsupported peer depedencies.