### PR TITLE
Fix meditrak api url resolution

### DIFF
--- a/packages/meditrak-app/.env.example
+++ b/packages/meditrak-app/.env.example
@@ -4,6 +4,8 @@ BETA_BRANCH=
 # For Local dev can specify local central server
 # e.g. http://localhost:8090/v2
 # Tip: Android Emulator uses 10.0.2.2 for host -> http://10.0.2.2:8090/v2
+#
+# Use either CENTRAL_API_URL or BETA_BRANCH, not both
 CENTRAL_API_URL=
 
 BUGSNAG_API_KEY=

--- a/packages/meditrak-app/app/api/TupaiaApi.js
+++ b/packages/meditrak-app/app/api/TupaiaApi.js
@@ -22,7 +22,7 @@ const SOCIAL_FEED_ENDPOINT = 'socialFeed';
 const CURRENT_USER_REWARDS_ENDPOINT = 'me/rewards';
 const DEV_BASE_URL = 'https://dev-api.tupaia.org/v2';
 const PRODUCTION_BASE_URL = `https://${isBeta ? `${betaBranch}-` : ''}api.tupaia.org/v2`;
-export const BASE_URL = centralApiUrl ?? (__DEV__ ? DEV_BASE_URL : PRODUCTION_BASE_URL);
+export const BASE_URL = __DEV__ ? centralApiUrl || DEV_BASE_URL : PRODUCTION_BASE_URL;
 
 const TIMEOUT_INTERVAL = 45 * 1000; // 45 seconds in milliseconds
 

--- a/packages/meditrak-app/package.json
+++ b/packages/meditrak-app/package.json
@@ -25,6 +25,7 @@
     "android": "react-native run-android",
     "ios": "react-native run-ios",
     "start": "react-native start",
+    "reset-cache": "echo Run me and exit to reset cache && react-native start --reset-cache",
     "start-dev": "react-native run-android",
     "test": "echo \"No tests specified\" && exit 0"
   },


### PR DESCRIPTION
### Issue #: no issue

This fixes a problem where an empty CENTRAL_API_URL env var was causing the BASE_URL to resolve to '';