### PR TITLE
WAITP-1269: Fix front end tests config

### DIFF
--- a/packages/utils/jest-setup.js
+++ b/packages/utils/jest-setup.js
@@ -1,0 +1,8 @@
+/*
+ * Tupaia
+ *  Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+module.exports = async () => {
+  process.env.TZ = 'Australia/Melbourne';
+};

--- a/packages/utils/jest.config.js
+++ b/packages/utils/jest.config.js
@@ -3,4 +3,5 @@ const baseConfig = require('../../jest.config-js.json');
 module.exports = async () => ({
   ...baseConfig,
   rootDir: '.',
+  globalSetup: '<rootDir>/jest-setup.js',
 });

--- a/packages/utils/src/__tests__/period/periodGranularities.test.js
+++ b/packages/utils/src/__tests__/period/periodGranularities.test.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
-import moment from 'moment-timezone';
+import moment from 'moment';
 import sinon from 'sinon';
 import { roundStartEndDates, getDefaultDates, getLimits } from '../../period/periodGranularities';
 
@@ -11,15 +11,13 @@ const DEFAULT_NOW_TIMESTAMP = 1549360800000; // 2019-02-05T10:00:00.000Z
 
 const mockNow = (whenIsNow = DEFAULT_NOW_TIMESTAMP) => {
   sinon.useFakeTimers(whenIsNow);
-  moment.tz.setDefault('Australia/Melbourne');
 };
 
 const resetMocks = () => {
   sinon.restore();
-  moment.tz.setDefault();
 };
 
-describe.skip('chartGranularities', () => {
+describe('chartGranularities', () => {
   beforeEach(() => {
     mockNow(1549360800 * 1000); // (2019-02-05 10:00 UTC)
   });

--- a/packages/web-frontend/config/jest/jest-setup.js
+++ b/packages/web-frontend/config/jest/jest-setup.js
@@ -1,0 +1,8 @@
+/*
+ * Tupaia
+ *  Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+module.exports = async () => {
+  process.env.TZ = 'Australia/Melbourne';
+};

--- a/packages/web-frontend/jest.config.js
+++ b/packages/web-frontend/jest.config.js
@@ -3,6 +3,7 @@ const baseConfig = require('../../jest.config-js.json');
 module.exports = {
   ...baseConfig,
   rootDir: '.',
+  globalSetup: '<rootDir>/config/jest/jest-setup.js',
   setupFiles: ['<rootDir>/config/polyfills.js'],
   testMatch: ['<rootDir>/src/**/__tests__/**/*.js?(x)', '<rootDir>/src/**/?(*.)(spec|test).js?(x)'],
   testURL: 'http://localhost',

--- a/packages/web-frontend/package.json
+++ b/packages/web-frontend/package.json
@@ -57,7 +57,6 @@
     "material-ui": "^0.18.3",
     "material-ui-datetimepicker": "^1.0.7",
     "moment": "^2.21.0",
-    "moment-timezone": "^0.5.28",
     "numeral": "^2.0.6",
     "polished": "^3.0.0",
     "prop-types": "^15.6.2",

--- a/packages/web-frontend/src/tests/testutil.js
+++ b/packages/web-frontend/src/tests/testutil.js
@@ -1,14 +1,11 @@
 import sinon from 'sinon';
-import moment from 'moment-timezone';
 
 const DEFAULT_NOW_TIMESTAMP = 1549360800000; // 2019-02-05T10:00:00.000Z
 
 export const mockNow = (whenIsNow = DEFAULT_NOW_TIMESTAMP) => {
   sinon.useFakeTimers(whenIsNow);
-  moment.tz.setDefault('Australia/Melbourne');
 };
 
 export const resetMocks = () => {
   sinon.restore();
-  moment.tz.setDefault();
 };

--- a/packages/web-frontend/src/utils/formatDateForApi.js
+++ b/packages/web-frontend/src/utils/formatDateForApi.js
@@ -5,13 +5,12 @@
  * found in the LICENSE file in the root directory of this source tree.
  */
 
-import moment from 'moment-timezone';
+import moment from 'moment';
 
 const DATE_FORMAT = 'YYYY-MM-DD';
 
-export const formatDateForApi = (date, timezone) => {
+export const formatDateForApi = date => {
   if (!date) return undefined;
   const dateAsMoment = moment(date);
-  if (timezone) dateAsMoment.tz(timezone);
   return dateAsMoment.format(DATE_FORMAT);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -10859,7 +10859,6 @@ __metadata:
     material-ui-datetimepicker: ^1.0.7
     mockdate: ^3.0.5
     moment: ^2.21.0
-    moment-timezone: ^0.5.28
     npm-run-all: ^4.1.5
     numeral: ^2.0.6
     object-assign: 4.1.1


### PR DESCRIPTION
### Issue #: WAITP-1269: Fix front end tests

### Changes:

- Updates to moment-timezone meant that the timezone wasn't getting set correctly at the start of period granularity tests. Fixed by setting the timezone through jest config instead.

