### PR TITLE
WAITP-1229 Search filter for matrix

### DIFF
--- a/packages/tupaia-web/src/features/Matrix.tsx
+++ b/packages/tupaia-web/src/features/Matrix.tsx
@@ -141,6 +141,13 @@ export const Matrix = ({ viewContent, isEnlarged = false }: MatrixProps) => {
   // Use the first row's data element as a placeholder text if possible
   const placeholderText = rows.length > 0 ? `E.g. ${rows[0].dataElement}` : 'Search Rows';
 
+  const updateSearchFilter = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchFilter(e.target.value);
+  };
+
+  const clearSearchFilter = () => {
+    setSearchFilter('');
+  };
   return (
     <>
       {/** If no datepicker, allow the user to filter the rows */}
@@ -148,11 +155,11 @@ export const Matrix = ({ viewContent, isEnlarged = false }: MatrixProps) => {
         <SearchWrapper>
           <SearchInput
             value={searchFilter}
-            onChange={e => setSearchFilter(e.target.value)}
+            onChange={updateSearchFilter}
             placeholder={placeholderText}
             InputProps={{
               endAdornment: searchFilter ? (
-                <IconButton onClick={() => setSearchFilter('')}>
+                <IconButton onClick={clearSearchFilter}>
                   <Clear />
                 </IconButton>
               ) : (

--- a/packages/tupaia-web/src/features/Matrix.tsx
+++ b/packages/tupaia-web/src/features/Matrix.tsx
@@ -3,17 +3,20 @@
  * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
  */
 
-import React from 'react';
+import React, { useState } from 'react';
+import styled from 'styled-components';
 import {
   MatrixColumnType,
   MatrixRowType,
   getIsUsingDots,
   Matrix as MatrixComponent,
   Alert,
+  TextField,
 } from '@tupaia/ui-components';
-import { MatrixDataColumn, MatrixDataRow, MatrixViewContent } from '../types';
 import { ConditionalPresentationOptions } from '@tupaia/types';
-import styled from 'styled-components';
+import { MatrixDataColumn, MatrixDataRow, MatrixViewContent } from '../types';
+import { Clear, Search } from '@material-ui/icons';
+import { IconButton } from '@material-ui/core';
 
 const NoDataMessage = styled(Alert).attrs({
   severity: 'info',
@@ -23,10 +26,22 @@ const NoDataMessage = styled(Alert).attrs({
   max-width: 24rem;
 `;
 
+const SearchInput = styled(TextField)`
+  .MuiInputBase-root {
+    background-color: transparent;
+  }
+`;
+
+const SearchWrapper = styled.div`
+  width: 100%;
+  max-width: 20rem;
+`;
+
 // This is a recursive function that parses the rows of the matrix into a format that the Matrix component can use.
 const parseRows = (
   rows: MatrixDataRow[],
   categoryId?: MatrixDataRow['categoryId'],
+  searchFilter?: string,
 ): MatrixRowType[] => {
   let topLevelRows = [];
   // if a categoryId is not passed in, then we need to find the top level rows
@@ -41,22 +56,34 @@ const parseRows = (
   }
 
   // loop through the topLevelRows, and parse them into the format that the Matrix component can use
-  return topLevelRows.map(row => {
+  return topLevelRows.reduce((result, row) => {
     const { dataElement = '', category, ...rest } = row;
     // if the row has a category, then it has children, so we need to parse them using this same function
     if (category) {
-      return {
-        title: category,
-        ...rest,
-        children: parseRows(rows, category),
-      };
+      const children = parseRows(rows, category, searchFilter);
+      // if there are no child rows, e.g. because the search filter is hiding them, then we don't need to render this row
+      if (!children.length) return result;
+      return [
+        ...result,
+        {
+          title: category,
+          ...rest,
+          children,
+        },
+      ];
     }
+    // if the row is a regular row, and there is a search filter, then we need to check if the row matches the search filter, and ignore this row if it doesn't. This filter only applies to standard rows, not category rows.
+    if (searchFilter && !dataElement.toLowerCase().includes(searchFilter.toLowerCase()))
+      return result;
     // otherwise, handle as a regular row
-    return {
-      title: dataElement,
-      ...rest,
-    };
-  });
+    return [
+      ...result,
+      {
+        title: dataElement,
+        ...rest,
+      },
+    ];
+  }, [] as MatrixRowType[]);
 };
 
 // This is a recursive function that parses the columns of the matrix into a format that the Matrix component can use.
@@ -98,16 +125,49 @@ interface MatrixProps {
   isEnlarged?: boolean;
 }
 export const Matrix = ({ viewContent, isEnlarged = false }: MatrixProps) => {
+  const [searchFilter, setSearchFilter] = useState('');
   const { columns, rows, ...config } = viewContent;
 
   const placeholderImage = getPlaceholderImage(config);
   // in the dashboard, show a placeholder image
   if (!isEnlarged) return <img src={placeholderImage} alt="Matrix Placeholder" />;
 
-  const parsedRows = parseRows(rows);
+  const parsedRows = parseRows(rows, undefined, searchFilter);
   const parsedColumns = parseColumns(columns);
 
   if (!parsedRows.length) return <NoDataMessage>No data available</NoDataMessage>;
+  const { periodGranularity } = config;
 
-  return <MatrixComponent {...config} rows={parsedRows} columns={parsedColumns} />;
+  // Use the first row's data element as a placeholder text if possible
+  const placeholderText = rows.length > 0 ? `E.g. ${rows[0].dataElement}` : 'Search Rows';
+
+  return (
+    <>
+      {/** If no datepicker, allow the user to filter the rows */}
+      {!periodGranularity && (
+        <SearchWrapper>
+          <SearchInput
+            value={searchFilter}
+            onChange={e => setSearchFilter(e.target.value)}
+            placeholder={placeholderText}
+            InputProps={{
+              endAdornment: searchFilter ? (
+                <IconButton onClick={() => setSearchFilter('')}>
+                  <Clear />
+                </IconButton>
+              ) : (
+                <Search />
+              ),
+            }}
+          />
+        </SearchWrapper>
+      )}
+      <MatrixComponent
+        {...config}
+        rows={parsedRows}
+        columns={parsedColumns}
+        disableExpand={!!searchFilter}
+      />
+    </>
+  );
 };

--- a/packages/ui-components/src/components/Matrix/Matrix.tsx
+++ b/packages/ui-components/src/components/Matrix/Matrix.tsx
@@ -22,10 +22,6 @@ const MatrixTable = styled.table`
   color: ${({ theme }) => theme.palette.text.primary};
   table-layout: fixed; // this is to allow us to set max-widths on the columns
   height: 1px; // this is to make the cell content (eg. buttons) take full height of the cell, and does not actually get applied
-  td,
-  th {
-    border: 1px solid ${({ theme }) => getFullHex(theme.palette.text.primary)}33;
-  }
 `;
 
 // this is a scrollable container
@@ -38,9 +34,10 @@ const Wrapper = styled.div`
 interface MatrixProps extends Omit<MatrixConfig, 'type' | 'name'> {
   columns: MatrixColumnType[];
   rows: MatrixRowType[];
+  disableExpand?: boolean;
 }
 
-export const Matrix = ({ columns = [], rows = [], ...config }: MatrixProps) => {
+export const Matrix = ({ columns = [], rows = [], disableExpand, ...config }: MatrixProps) => {
   const [{ startColumn, expandedRows, maxColumns, enlargedCell }, dispatch] = useReducer(
     matrixReducer,
     {
@@ -81,6 +78,7 @@ export const Matrix = ({ columns = [], rows = [], ...config }: MatrixProps) => {
           maxColumns,
           expandedRows,
           enlargedCell,
+          disableExpand,
         }}
       >
         <MatrixDispatchContext.Provider value={dispatch}>

--- a/packages/ui-components/src/components/Matrix/MatrixContext.ts
+++ b/packages/ui-components/src/components/Matrix/MatrixContext.ts
@@ -16,6 +16,7 @@ const defaultContextValue = {
   maxColumns: 0,
   expandedRows: [],
   enlargedCell: null,
+  disableExpand: false,
 } as Omit<MatrixConfig, 'type' | 'name'> & {
   rows: MatrixRowType[];
   columns: MatrixColumnType[];
@@ -23,6 +24,7 @@ const defaultContextValue = {
   maxColumns: number;
   expandedRows: RowTitle[];
   enlargedCell: Record<string, any> | null;
+  disableExpand?: boolean;
 };
 
 // This is the context for the rows, columns and presentation options of the matrix

--- a/packages/ui-components/src/components/Matrix/MatrixRow.tsx
+++ b/packages/ui-components/src/components/Matrix/MatrixRow.tsx
@@ -65,12 +65,14 @@ const RowHeaderCell = ({
   isExpanded,
   hasChildren,
   children,
+  disableExpandButton,
 }: {
   depth: number;
   isExpanded: boolean;
   rowTitle: string;
   hasChildren: boolean;
   children: React.ReactNode;
+  disableExpandButton?: boolean;
 }) => {
   const dispatch = useContext(MatrixDispatchContext)!;
   const toggleExpandedRows = () => {
@@ -90,6 +92,7 @@ const RowHeaderCell = ({
           aria-label={`${isExpanded ? 'Collapse' : 'Expand'} row`}
           size="small"
           onClick={toggleExpandedRows}
+          disabled={disableExpandButton}
         >
           <ExpandIcon $expanded={isExpanded} />
         </IconButton>
@@ -104,12 +107,14 @@ const RowHeaderCell = ({
  */
 export const MatrixRow = ({ row, parents = [] }: MatrixRowProps) => {
   const { children, title } = row;
-  const { columns, startColumn, maxColumns, expandedRows } = useContext(MatrixContext);
+  const { columns, startColumn, maxColumns, expandedRows, disableExpand = false } = useContext(
+    MatrixContext,
+  );
 
   const displayedColumns = getDisplayedColumns(columns, startColumn, maxColumns);
 
-  const isExpanded = expandedRows.includes(title);
-  const isVisible = parents.every(parent => expandedRows.includes(parent));
+  const isExpanded = expandedRows.includes(title) || disableExpand;
+  const isVisible = parents.every(parent => expandedRows.includes(parent)) || disableExpand;
   const depth = parents.length;
 
   const isCategory = children ? children.length > 0 : false;
@@ -123,6 +128,7 @@ export const MatrixRow = ({ row, parents = [] }: MatrixRowProps) => {
           depth={depth}
           rowTitle={title}
           hasChildren={isCategory}
+          disableExpandButton={disableExpand}
         >
           {title}
         </RowHeaderCell>


### PR DESCRIPTION
### Issue WAITP-1229: Search filter for matrix

### Changes:
- Applied filter to matrix component when no date filter is present on the report
- Added param `disableExpand` to UI Matrix component to allow expand to be forced open, e.g. when a search filter is enabled
---

### Screenshots:

#### No search filter
![Screenshot 2023-07-13 at 4 24 36 pm](https://github.com/beyondessential/tupaia/assets/129009580/d481c9ee-4e00-4744-aab1-cc9428a4fb67)

#### Search filter enabled
![Screenshot 2023-07-13 at 4 25 02 pm](https://github.com/beyondessential/tupaia/assets/129009580/724ad62e-b049-405e-bfcd-fc3377727dc7)
