### PR TITLE
[no-issue]: Fix missing android:exported="true" in AndroidManifest.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ dockercfg
 packages/.vscode/settings.json
 **/testRequests/*.http
 *:Zone.Identifier
+.gradle
 
 # yarn
 .yarn/*

--- a/packages/meditrak-app/android/app/src/main/AndroidManifest.xml
+++ b/packages/meditrak-app/android/app/src/main/AndroidManifest.xml
@@ -27,6 +27,7 @@
       android:largeHeap="true">
       <activity
         android:name=".MainActivity"
+        android:exported="true"
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
         android:launchMode="singleTask"


### PR DESCRIPTION
https://stackoverflow.com/questions/70333565/targeting-s-version-31-and-above-requires-that-an-explicit-value-for-android