### PR TITLE
Move search bar

### DIFF
--- a/packages/tupaia-web/src/features/DashboardItem/DashboardItemContent.tsx
+++ b/packages/tupaia-web/src/features/DashboardItem/DashboardItemContent.tsx
@@ -89,7 +89,7 @@ const getHasNoData = (report: DashboardItemReport, type: DashboardItemConfig['ty
  * DashboardItemContent handles displaying of the content within a dashboard item, e.g. charts. It also handles error messages and loading states
  */
 export const DashboardItemContent = ({
-  config,
+  config = {},
   report,
   isEnlarged,
   isLoading,
@@ -100,6 +100,8 @@ export const DashboardItemContent = ({
   const { name, reportCode, type, viewType } = config;
 
   const DisplayComponent = DisplayComponents[type as keyof typeof DisplayComponents] || null;
+
+  if (!DisplayComponent) return null;
 
   if (isLoading)
     return (

--- a/packages/tupaia-web/src/features/Matrix.tsx
+++ b/packages/tupaia-web/src/features/Matrix.tsx
@@ -27,14 +27,10 @@ const NoDataMessage = styled(Alert).attrs({
 `;
 
 const SearchInput = styled(TextField)`
+  margin-bottom: 0;
   .MuiInputBase-root {
     background-color: transparent;
   }
-`;
-
-const SearchWrapper = styled.div`
-  width: 100%;
-  max-width: 20rem;
 `;
 
 // This is a recursive function that parses the rows of the matrix into a format that the Matrix component can use.
@@ -135,12 +131,8 @@ export const Matrix = ({ config, report, isEnlarged = false }: MatrixProps) => {
 
   const parsedRows = parseRows(rows, undefined, searchFilter);
   const parsedColumns = parseColumns(columns);
-
   if (!parsedRows.length) return <NoDataMessage>No data available</NoDataMessage>;
   const { periodGranularity } = config;
-
-  // Use the first row's data element as a placeholder text if possible
-  const placeholderText = rows.length > 0 ? `E.g. ${rows[0].dataElement}` : 'Search Rows';
 
   const updateSearchFilter = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchFilter(e.target.value);
@@ -150,14 +142,17 @@ export const Matrix = ({ config, report, isEnlarged = false }: MatrixProps) => {
     setSearchFilter('');
   };
   return (
-    <>
-      {/** If no datepicker, allow the user to filter the rows */}
-      {!periodGranularity && (
-        <SearchWrapper>
+    <MatrixComponent
+      {...config}
+      rows={parsedRows}
+      columns={parsedColumns}
+      disableExpand={!!searchFilter}
+      rowHeaderColumnTitle={
+        periodGranularity ? null : (
           <SearchInput
             value={searchFilter}
             onChange={updateSearchFilter}
-            placeholder={placeholderText}
+            placeholder="Search..."
             InputProps={{
               endAdornment: searchFilter ? (
                 <IconButton onClick={clearSearchFilter}>
@@ -168,14 +163,8 @@ export const Matrix = ({ config, report, isEnlarged = false }: MatrixProps) => {
               ),
             }}
           />
-        </SearchWrapper>
-      )}
-      <MatrixComponent
-        {...config}
-        rows={parsedRows}
-        columns={parsedColumns}
-        disableExpand={!!searchFilter}
-      />
-    </>
+        )
+      }
+    />
   );
 };

--- a/packages/ui-components/src/components/Matrix/MatrixContext.ts
+++ b/packages/ui-components/src/components/Matrix/MatrixContext.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
  */
 
-import { Dispatch, createContext } from 'react';
+import { Dispatch, ReactNode, createContext } from 'react';
 import { MatrixConfig, PresentationOptions } from '@tupaia/types';
 import { MatrixColumnType, MatrixRowType } from '../../types';
 
@@ -25,6 +25,7 @@ const defaultContextValue = {
   expandedRows: RowTitle[];
   enlargedCell: Record<string, any> | null;
   disableExpand?: boolean;
+  rowHeaderColumnTitle?: ReactNode;
 };
 
 // This is the context for the rows, columns and presentation options of the matrix

--- a/packages/ui-components/src/components/Matrix/MatrixHeader.tsx
+++ b/packages/ui-components/src/components/Matrix/MatrixHeader.tsx
@@ -26,7 +26,13 @@ const ColGroup = styled.colgroup`
  * This is a component that renders the header rows in the matrix. It renders the column groups and columns.
  */
 export const MatrixHeader = () => {
-  const { columns, startColumn, maxColumns, hideColumnTitles = false } = useContext(MatrixContext);
+  const {
+    columns,
+    startColumn,
+    maxColumns,
+    hideColumnTitles = false,
+    rowHeaderColumnTitle,
+  } = useContext(MatrixContext);
   const displayedColumns = getDisplayedColumns(columns, startColumn, maxColumns);
   // If a column is not displayed, then it should not be rendered in the header. This means that if a column group has no displayed children, then it should not be rendered either.
   const displayedColumnGroups = columns.reduce(
@@ -43,6 +49,9 @@ export const MatrixHeader = () => {
   // If there are parents, then there should be two rows: 1 for the column group headings, and one for the column headings
   const hasParents = displayedColumnGroups.length > 0;
 
+  const RowHeaderColumn = () => (
+    <HeaderCell rowSpan={hasParents ? 2 : 1}>{rowHeaderColumnTitle}</HeaderCell>
+  );
   return (
     /** If there are no parents, then there are only column groups to style for the row header column and the rest of the table. Otherwise, there are column groups for each displayed column group, plus one for the row header column.*/
     <>
@@ -59,7 +68,7 @@ export const MatrixHeader = () => {
       <TableHead>
         {hasParents && (
           <TableRow>
-            <HeaderCell rowSpan={2} />
+            <RowHeaderColumn />
             {displayedColumnGroups.map(({ title, children = [] }) => (
               <HeaderCell key={title} colSpan={children.length}>
                 {title}
@@ -69,7 +78,7 @@ export const MatrixHeader = () => {
         )}
         <TableRow>
           {/** If hasParents is true, then this row header column cell will have already been rendered. */}
-          {!hasParents && <HeaderCell />}
+          {!hasParents && <RowHeaderColumn />}
           {displayedColumns.map(({ title, key }) => (
             <HeaderCell key={key} aria-label={hideColumnTitles ? title : ''}>
               {!hideColumnTitles && title}


### PR DESCRIPTION
### Issue WAITP-1229:

### Changes:
- Added support for `rowHeaderColumnTitle` in `ui-components/Matrix`
- Moved the search bar to be passed in as `rowHeaderColumnTitle` prop
- Updated placeholder text to be `Search...`

---

### Screenshots:
![Screenshot 2023-07-18 at 1 47 58 pm](https://github.com/beyondessential/tupaia/assets/129009580/4fadce5a-6d8e-4800-9ce4-3260545ac9d0)
