### PR TITLE
Waitp 1299 link to project new tab

### DIFF
--- a/packages/tupaia-web/src/components/RouterButton.tsx
+++ b/packages/tupaia-web/src/components/RouterButton.tsx
@@ -25,6 +25,7 @@ export const RouterButton = ({
   modal,
   searchParamsToRemove,
   children,
+  url,
   ...props
 }: RouterButtonProps) => {
   const location = useLocation();
@@ -44,7 +45,7 @@ export const RouterLink = ({ to, modal, children, ...props }: RouterButtonProps)
   const link = modal ? { ...location, hash: modal } : to;
 
   return (
-    <Link to={link} {...props}>
+    <Link to={link} {...props} target='_newtab'>
       {children}
     </Link>
   );

--- a/packages/tupaia-web/src/components/RouterButton.tsx
+++ b/packages/tupaia-web/src/components/RouterButton.tsx
@@ -45,7 +45,7 @@ export const RouterLink = ({ to, modal, children, ...props }: RouterButtonProps)
   const link = modal ? { ...location, hash: modal } : to;
 
   return (
-    <Link to={link} {...props} target='_newtab'>
+    <Link to={link} {...props}>
       {children}
     </Link>
   );

--- a/packages/tupaia-web/src/components/RouterButton.tsx
+++ b/packages/tupaia-web/src/components/RouterButton.tsx
@@ -25,7 +25,6 @@ export const RouterButton = ({
   modal,
   searchParamsToRemove,
   children,
-  url,
   ...props
 }: RouterButtonProps) => {
   const location = useLocation();

--- a/packages/tupaia-web/src/layout/ProjectCardList/ProjectCard.tsx
+++ b/packages/tupaia-web/src/layout/ProjectCardList/ProjectCard.tsx
@@ -13,7 +13,6 @@ import { MODAL_ROUTES } from '../../constants';
 import { RouterButton } from '../../components';
 import { useLandingPage } from '../../api/queries';
 import { useParams } from 'react-router';
-import { LandingPage } from '../../views';
 
 const Card = styled.div`
   display: flex;

--- a/packages/tupaia-web/src/layout/ProjectCardList/ProjectCard.tsx
+++ b/packages/tupaia-web/src/layout/ProjectCardList/ProjectCard.tsx
@@ -128,7 +128,7 @@ export const ProjectPendingLink = () => (
   </OutlineLink>
 );
 export const ProjectAllowedLink = ({ url }: LinkProps) => (
-  <BaseLink to={url}>View project</BaseLink>
+  <BaseLink to={url} target= '_newTab'>View project</BaseLink>
 );
 
 interface ProjectCardProps extends Partial<SingleProject> {

--- a/packages/tupaia-web/src/layout/ProjectCardList/ProjectCard.tsx
+++ b/packages/tupaia-web/src/layout/ProjectCardList/ProjectCard.tsx
@@ -11,6 +11,7 @@ import { Typography } from '@material-ui/core';
 import { SingleProject } from '../../types';
 import { MODAL_ROUTES } from '../../constants';
 import { RouterButton } from '../../components';
+import { useLandingPage } from '../../api/queries';
 
 const Card = styled.div`
   display: flex;
@@ -127,8 +128,9 @@ export const ProjectPendingLink = () => (
     Approval in progress
   </OutlineLink>
 );
+
 export const ProjectAllowedLink = ({ url }: LinkProps) => (
-  <BaseLink to={url} target= '_newProjectTab'>View project</BaseLink>
+  <BaseLink to={url} target={`${useLandingPage(url)}`}>View project</BaseLink>
 );
 
 interface ProjectCardProps extends Partial<SingleProject> {

--- a/packages/tupaia-web/src/layout/ProjectCardList/ProjectCard.tsx
+++ b/packages/tupaia-web/src/layout/ProjectCardList/ProjectCard.tsx
@@ -12,6 +12,8 @@ import { SingleProject } from '../../types';
 import { MODAL_ROUTES } from '../../constants';
 import { RouterButton } from '../../components';
 import { useLandingPage } from '../../api/queries';
+import { useParams } from 'react-router';
+import { LandingPage } from '../../views';
 
 const Card = styled.div`
   display: flex;
@@ -129,9 +131,17 @@ export const ProjectPendingLink = () => (
   </OutlineLink>
 );
 
-export const ProjectAllowedLink = ({ url }: LinkProps) => (
-  <BaseLink to={url} target={`${useLandingPage(url)}`}>View project</BaseLink>
-);
+export const ProjectAllowedLink = ({ url }: LinkProps) => {
+  const { landingPageUrlSegment } = useParams();
+
+  const { isLandingPage } = useLandingPage(landingPageUrlSegment);
+
+  return (
+    <BaseLink to={url} target={isLandingPage ? '_blank' : '_self'}>
+      View project
+    </BaseLink>
+  );
+};
 
 interface ProjectCardProps extends Partial<SingleProject> {
   ProjectButton: ComponentType;

--- a/packages/tupaia-web/src/layout/ProjectCardList/ProjectCard.tsx
+++ b/packages/tupaia-web/src/layout/ProjectCardList/ProjectCard.tsx
@@ -11,8 +11,6 @@ import { Typography } from '@material-ui/core';
 import { SingleProject } from '../../types';
 import { MODAL_ROUTES } from '../../constants';
 import { RouterButton } from '../../components';
-import { useLandingPage } from '../../api/queries';
-import { useParams } from 'react-router';
 
 const Card = styled.div`
   display: flex;

--- a/packages/tupaia-web/src/layout/ProjectCardList/ProjectCard.tsx
+++ b/packages/tupaia-web/src/layout/ProjectCardList/ProjectCard.tsx
@@ -114,6 +114,7 @@ const OutlineLink = styled(RouterButton).attrs({
 
 interface LinkProps {
   url: string;
+  isLandingPage: string;
 }
 
 export const ProjectDeniedLink = ({ url }: LinkProps) => (
@@ -130,17 +131,11 @@ export const ProjectPendingLink = () => (
   </OutlineLink>
 );
 
-export const ProjectAllowedLink = ({ url }: LinkProps) => {
-  const { landingPageUrlSegment } = useParams();
-
-  const { isLandingPage } = useLandingPage(landingPageUrlSegment);
-
-  return (
-    <BaseLink to={url} target={isLandingPage ? '_blank' : '_self'}>
-      View project
-    </BaseLink>
-  );
-};
+export const ProjectAllowedLink = ({ url, isLandingPage }: LinkProps) => (
+  <BaseLink to={url} target={isLandingPage}>
+    View project
+  </BaseLink>
+);
 
 interface ProjectCardProps extends Partial<SingleProject> {
   ProjectButton: ComponentType;

--- a/packages/tupaia-web/src/layout/ProjectCardList/ProjectCard.tsx
+++ b/packages/tupaia-web/src/layout/ProjectCardList/ProjectCard.tsx
@@ -128,7 +128,7 @@ export const ProjectPendingLink = () => (
   </OutlineLink>
 );
 export const ProjectAllowedLink = ({ url }: LinkProps) => (
-  <BaseLink to={url} target= '_newTab'>View project</BaseLink>
+  <BaseLink to={url} target= '_newProjectTab'>View project</BaseLink>
 );
 
 interface ProjectCardProps extends Partial<SingleProject> {

--- a/packages/tupaia-web/src/layout/ProjectCardList/ProjectCard.tsx
+++ b/packages/tupaia-web/src/layout/ProjectCardList/ProjectCard.tsx
@@ -112,7 +112,7 @@ const OutlineLink = styled(RouterButton).attrs({
 
 interface LinkProps {
   url: string;
-  isLandingPage: string;
+  isLandingPage: boolean;
 }
 
 export const ProjectDeniedLink = ({ url }: LinkProps) => (
@@ -130,7 +130,7 @@ export const ProjectPendingLink = () => (
 );
 
 export const ProjectAllowedLink = ({ url, isLandingPage }: LinkProps) => (
-  <BaseLink to={url} target={isLandingPage}>
+  <BaseLink to={url} target={isLandingPage ? '_blank' : '_self'}>
     View project
   </BaseLink>
 );

--- a/packages/tupaia-web/src/views/LandingPage/MultiProjectLandingPage.tsx
+++ b/packages/tupaia-web/src/views/LandingPage/MultiProjectLandingPage.tsx
@@ -7,8 +7,6 @@ import styled from 'styled-components';
 import { Typography } from '@material-ui/core';
 import { URL_SEARCH_PARAMS, TRANSPARENT_BLACK } from '../../constants';
 import { SingleLandingPage } from '../../types';
-import { useParams } from 'react-router';
-import { useLandingPage } from '../../api/queries';
 import { PROJECT_ACCESS_TYPES, MODAL_ROUTES } from '../../constants';
 import {
   ProjectCardList,

--- a/packages/tupaia-web/src/views/LandingPage/MultiProjectLandingPage.tsx
+++ b/packages/tupaia-web/src/views/LandingPage/MultiProjectLandingPage.tsx
@@ -15,7 +15,6 @@ import {
   ProjectAllowedLink,
   ProjectPendingLink,
 } from '../../layout';
-import { isPlainObject } from '@tupaia/utils';
 import { useLandingPage } from '../../api/queries';
 import { useParams } from 'react-router';
 const ProjectsWrapper = styled.div`

--- a/packages/tupaia-web/src/views/LandingPage/MultiProjectLandingPage.tsx
+++ b/packages/tupaia-web/src/views/LandingPage/MultiProjectLandingPage.tsx
@@ -15,8 +15,6 @@ import {
   ProjectAllowedLink,
   ProjectPendingLink,
 } from '../../layout';
-import { useLandingPage } from '../../api/queries';
-import { useParams } from 'react-router';
 const ProjectsWrapper = styled.div`
   width: 100%;
   max-width: ${({ theme }) => theme.breakpoints.values.lg}px;
@@ -75,9 +73,6 @@ export function MultiProjectLandingPage({
   projects,
   includeNameInHeader,
 }: MultiProjectLandingPageProps) {
-  const { landingPageUrlSegment } = useParams();
-  const { isLandingPage } = useLandingPage(landingPageUrlSegment);
-  const newTabCondition = isLandingPage ? '_blank' : '_self';
   return (
     <Wrapper>
       <Title variant={includeNameInHeader ? 'h2' : 'h1'}>Select a project below to view.</Title>
@@ -93,7 +88,7 @@ export function MultiProjectLandingPage({
                   url={`/${code}/${homeEntityCode}${
                     dashboardGroupName ? `/${dashboardGroupName}` : ''
                   }`}
-                  isLandingPage={newTabCondition}
+                  isLandingPage
                 />
               ),
               [PROJECT_ACCESS_TYPES.PENDING]: () => <ProjectPendingLink />,
@@ -102,7 +97,7 @@ export function MultiProjectLandingPage({
                   return (
                     <ProjectDeniedLink
                       url={`?${URL_SEARCH_PARAMS.PROJECT}=${code}#${MODAL_ROUTES.REQUEST_PROJECT_ACCESS}`}
-                      isLandingPage={newTabCondition}
+                      isLandingPage
                     />
                   );
                 }

--- a/packages/tupaia-web/src/views/LandingPage/MultiProjectLandingPage.tsx
+++ b/packages/tupaia-web/src/views/LandingPage/MultiProjectLandingPage.tsx
@@ -15,6 +15,7 @@ import {
   ProjectAllowedLink,
   ProjectPendingLink,
 } from '../../layout';
+import { useLandingPage } from '../../api/queries';
 
 const ProjectsWrapper = styled.div`
   width: 100%;
@@ -89,7 +90,7 @@ export function MultiProjectLandingPage({
                   url={`/${code}/${homeEntityCode}${
                     dashboardGroupName ? `/${dashboardGroupName}` : ''
                   }`}
-                />
+                 />
               ),
               [PROJECT_ACCESS_TYPES.PENDING]: () => <ProjectPendingLink />,
               [PROJECT_ACCESS_TYPES.DENIED]: ({ project: { code } }) => {
@@ -97,6 +98,7 @@ export function MultiProjectLandingPage({
                   return (
                     <ProjectDeniedLink
                       url={`?${URL_SEARCH_PARAMS.PROJECT}=${code}#${MODAL_ROUTES.REQUEST_PROJECT_ACCESS}`}
+                      
                     />
                   );
                 }

--- a/packages/tupaia-web/src/views/LandingPage/MultiProjectLandingPage.tsx
+++ b/packages/tupaia-web/src/views/LandingPage/MultiProjectLandingPage.tsx
@@ -98,7 +98,6 @@ export function MultiProjectLandingPage({
                   return (
                     <ProjectDeniedLink
                       url={`?${URL_SEARCH_PARAMS.PROJECT}=${code}#${MODAL_ROUTES.REQUEST_PROJECT_ACCESS}`}
-                      
                     />
                   );
                 }

--- a/packages/tupaia-web/src/views/LandingPage/MultiProjectLandingPage.tsx
+++ b/packages/tupaia-web/src/views/LandingPage/MultiProjectLandingPage.tsx
@@ -7,6 +7,8 @@ import styled from 'styled-components';
 import { Typography } from '@material-ui/core';
 import { URL_SEARCH_PARAMS, TRANSPARENT_BLACK } from '../../constants';
 import { SingleLandingPage } from '../../types';
+import { useParams } from 'react-router';
+import { useLandingPage } from '../../api/queries';
 import { PROJECT_ACCESS_TYPES, MODAL_ROUTES } from '../../constants';
 import {
   ProjectCardList,
@@ -15,8 +17,6 @@ import {
   ProjectAllowedLink,
   ProjectPendingLink,
 } from '../../layout';
-import { useLandingPage } from '../../api/queries';
-
 const ProjectsWrapper = styled.div`
   width: 100%;
   max-width: ${({ theme }) => theme.breakpoints.values.lg}px;
@@ -90,7 +90,7 @@ export function MultiProjectLandingPage({
                   url={`/${code}/${homeEntityCode}${
                     dashboardGroupName ? `/${dashboardGroupName}` : ''
                   }`}
-                 />
+                />
               ),
               [PROJECT_ACCESS_TYPES.PENDING]: () => <ProjectPendingLink />,
               [PROJECT_ACCESS_TYPES.DENIED]: ({ project: { code } }) => {

--- a/packages/tupaia-web/src/views/LandingPage/MultiProjectLandingPage.tsx
+++ b/packages/tupaia-web/src/views/LandingPage/MultiProjectLandingPage.tsx
@@ -15,6 +15,9 @@ import {
   ProjectAllowedLink,
   ProjectPendingLink,
 } from '../../layout';
+import { isPlainObject } from '@tupaia/utils';
+import { useLandingPage } from '../../api/queries';
+import { useParams } from 'react-router';
 const ProjectsWrapper = styled.div`
   width: 100%;
   max-width: ${({ theme }) => theme.breakpoints.values.lg}px;
@@ -73,6 +76,9 @@ export function MultiProjectLandingPage({
   projects,
   includeNameInHeader,
 }: MultiProjectLandingPageProps) {
+  const { landingPageUrlSegment } = useParams();
+  const { isLandingPage } = useLandingPage(landingPageUrlSegment);
+  const newTabCondition = isLandingPage ? '_blank' : '_self';
   return (
     <Wrapper>
       <Title variant={includeNameInHeader ? 'h2' : 'h1'}>Select a project below to view.</Title>
@@ -88,6 +94,7 @@ export function MultiProjectLandingPage({
                   url={`/${code}/${homeEntityCode}${
                     dashboardGroupName ? `/${dashboardGroupName}` : ''
                   }`}
+                  isLandingPage={newTabCondition}
                 />
               ),
               [PROJECT_ACCESS_TYPES.PENDING]: () => <ProjectPendingLink />,
@@ -96,6 +103,7 @@ export function MultiProjectLandingPage({
                   return (
                     <ProjectDeniedLink
                       url={`?${URL_SEARCH_PARAMS.PROJECT}=${code}#${MODAL_ROUTES.REQUEST_PROJECT_ACCESS}`}
+                      isLandingPage={newTabCondition}
                     />
                   );
                 }

--- a/packages/tupaia-web/src/views/LandingPage/SingleProjectLandingPage.tsx
+++ b/packages/tupaia-web/src/views/LandingPage/SingleProjectLandingPage.tsx
@@ -77,10 +77,6 @@ export function SingleProjectLandingPage({
 
   const { homeEntityCode, code, dashboardGroupName } = project;
 
-  const { landingPageUrlSegment } = useParams();
-
-  const {isLandingPage} = useLandingPage(landingPageUrlSegment);
-
   const urls = {
     [PROJECT_ACCESS_TYPES.PENDING]: '',
     [PROJECT_ACCESS_TYPES.ALLOWED]: `/${code}/${homeEntityCode}${
@@ -106,7 +102,7 @@ export function SingleProjectLandingPage({
       {accessType && (
         <ActionLink
           variant="contained"
-          target= "_blank"
+          target={accessType === PROJECT_ACCESS_TYPES.ALLOWED ? '_blank' : '_self'}
           component={Link}
           to={urls[accessType]}
           disabled={accessType === PROJECT_ACCESS_TYPES.PENDING}

--- a/packages/tupaia-web/src/views/LandingPage/SingleProjectLandingPage.tsx
+++ b/packages/tupaia-web/src/views/LandingPage/SingleProjectLandingPage.tsx
@@ -12,6 +12,7 @@ import { PROJECT_ACCESS_TYPES, MODAL_ROUTES, URL_SEARCH_PARAMS } from '../../con
 import { getProjectAccessType } from '../../utils';
 import { SingleLandingPage, SingleProject } from '../../types';
 import { useLandingPage } from '../../api/queries';
+import { useParams } from 'react-router';
 
 /**
  * This is the template for the content of a landing page if there is only one project
@@ -76,6 +77,10 @@ export function SingleProjectLandingPage({
 
   const { homeEntityCode, code, dashboardGroupName } = project;
 
+  const { landingPageUrlSegment } = useParams();
+
+  const {isLandingPage} = useLandingPage(landingPageUrlSegment);
+
   const urls = {
     [PROJECT_ACCESS_TYPES.PENDING]: '',
     [PROJECT_ACCESS_TYPES.ALLOWED]: `/${code}/${homeEntityCode}${
@@ -101,7 +106,7 @@ export function SingleProjectLandingPage({
       {accessType && (
         <ActionLink
           variant="contained"
-          target= {`${useLandingPage()}`}
+          target= "_blank"
           component={Link}
           to={urls[accessType]}
           disabled={accessType === PROJECT_ACCESS_TYPES.PENDING}

--- a/packages/tupaia-web/src/views/LandingPage/SingleProjectLandingPage.tsx
+++ b/packages/tupaia-web/src/views/LandingPage/SingleProjectLandingPage.tsx
@@ -100,6 +100,7 @@ export function SingleProjectLandingPage({
       {accessType && (
         <ActionLink
           variant="contained"
+          target= "_newProjectTab"
           component={Link}
           to={urls[accessType]}
           disabled={accessType === PROJECT_ACCESS_TYPES.PENDING}

--- a/packages/tupaia-web/src/views/LandingPage/SingleProjectLandingPage.tsx
+++ b/packages/tupaia-web/src/views/LandingPage/SingleProjectLandingPage.tsx
@@ -11,8 +11,6 @@ import { Button } from '@tupaia/ui-components';
 import { PROJECT_ACCESS_TYPES, MODAL_ROUTES, URL_SEARCH_PARAMS } from '../../constants';
 import { getProjectAccessType } from '../../utils';
 import { SingleLandingPage, SingleProject } from '../../types';
-import { useLandingPage } from '../../api/queries';
-import { useParams } from 'react-router';
 
 /**
  * This is the template for the content of a landing page if there is only one project

--- a/packages/tupaia-web/src/views/LandingPage/SingleProjectLandingPage.tsx
+++ b/packages/tupaia-web/src/views/LandingPage/SingleProjectLandingPage.tsx
@@ -11,6 +11,7 @@ import { Button } from '@tupaia/ui-components';
 import { PROJECT_ACCESS_TYPES, MODAL_ROUTES, URL_SEARCH_PARAMS } from '../../constants';
 import { getProjectAccessType } from '../../utils';
 import { SingleLandingPage, SingleProject } from '../../types';
+import { useLandingPage } from '../../api/queries';
 
 /**
  * This is the template for the content of a landing page if there is only one project
@@ -100,7 +101,7 @@ export function SingleProjectLandingPage({
       {accessType && (
         <ActionLink
           variant="contained"
-          target= "_newProjectTab"
+          target= {`${useLandingPage()}`}
           component={Link}
           to={urls[accessType]}
           disabled={accessType === PROJECT_ACCESS_TYPES.PENDING}


### PR DESCRIPTION
### Issue #:
WAITP-1299 Custom landing page: Open link to project in new tab
### Changes:

- Added target to BaseLink component in tupaia-web/src/layout/ProjectCardList/ProjectCard.tsx line 133,

- Added target to ActionLink component in tupaia-web/src/views/LandingPage/SingleProjectLandingPage.tsx line 104

### Screenshots:
![image](https://github.com/beyondessential/tupaia/assets/122791168/5ec674aa-2dfa-4b7a-992b-6cfc2ce29f83)
