### PR TITLE
Waitp 1288 mobile map overlay

### DIFF
--- a/packages/tupaia-web/src/constants/constants.ts
+++ b/packages/tupaia-web/src/constants/constants.ts
@@ -24,3 +24,5 @@ export const FORM_FIELD_VALIDATION = {
 };
 
 export const MOBILE_BREAKPOINT = '900px';
+export const TOP_BAR_HEIGHT = '60px';
+export const TOP_BAR_HEIGHT_MOBILE = '50px';

--- a/packages/tupaia-web/src/features/Map/Map.tsx
+++ b/packages/tupaia-web/src/features/Map/Map.tsx
@@ -71,15 +71,17 @@ const TilePickerWrapper = styled.div`
 
 // This contains the map controls (legend, overlay selector, etc, so that they can fit within the map appropriately)
 const MapControlWrapper = styled.div`
-  position: absolute;
-  top: 0;
-  left: 0;
   width: 100%;
-  height: 100%;
   display: flex;
-
   // This is to prevent the wrapper div from blocking clicks on the map overlays
   pointer-events: none;
+  position: relative;
+  @media screen and (min-width: ${MOBILE_BREAKPOINT}) {
+    position: absolute;
+    height: 100%;
+    top: 0;
+    left: 0;
+  }
 `;
 
 const MapControlColumn = styled.div`

--- a/packages/tupaia-web/src/features/Map/Map.tsx
+++ b/packages/tupaia-web/src/features/Map/Map.tsx
@@ -86,6 +86,9 @@ const MapControlColumn = styled.div`
   display: flex;
   flex-direction: column;
   flex: 1;
+  @media screen and (max-width: ${MOBILE_BREAKPOINT}) {
+    flex-direction: column-reverse;
+  }
 `;
 
 export const Map = () => {

--- a/packages/tupaia-web/src/features/Map/MapLegend/MapLegend.tsx
+++ b/packages/tupaia-web/src/features/Map/MapLegend/MapLegend.tsx
@@ -37,7 +37,7 @@ export const MapLegend = ({ hiddenValues, setValueHidden }: LegendProps) => {
   const selectedOverlay = urlSearchParams.get(URL_SEARCH_PARAMS.MAP_OVERLAY);
   const { data: overlayReportData } = useMapOverlayReport();
 
-  if (!selectedOverlay) {
+  if (!selectedOverlay || !overlayReportData) {
     return null;
   }
 

--- a/packages/tupaia-web/src/features/Map/MapLegend/MobileMapLegend.tsx
+++ b/packages/tupaia-web/src/features/Map/MapLegend/MobileMapLegend.tsx
@@ -9,11 +9,13 @@ import styled from 'styled-components';
 import { MOBILE_BREAKPOINT } from '../../../constants';
 
 const Wrapper = styled.div`
-  position: absolute;
   pointer-events: auto;
-  bottom: 0.8rem;
-  right: 1rem;
   padding: 0;
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+  padding-bottom: 0.8rem;
+  padding-right: 0.8rem;
   @media screen and (min-width: ${MOBILE_BREAKPOINT}) {
     display: none;
   }
@@ -33,6 +35,7 @@ const ExpandIcon = styled(ExpandLess)`
 
 const ExpandedLegend = styled.div`
   display: block;
+  position: relative;
   background-color: ${({ theme }) => theme.mobile.background};
   border-radius: 0.5rem;
   padding-top: 0.5rem;

--- a/packages/tupaia-web/src/features/Map/MapLegend/MobileMapLegend.tsx
+++ b/packages/tupaia-web/src/features/Map/MapLegend/MobileMapLegend.tsx
@@ -13,9 +13,13 @@ const Wrapper = styled.div`
   padding: 0;
   width: 100%;
   display: flex;
+  flex-direction: column;
+  align-items: flex-end;
   justify-content: flex-end;
   padding-bottom: 0.8rem;
   padding-right: 0.8rem;
+  position: absolute;
+  bottom: 100%;
   @media screen and (min-width: ${MOBILE_BREAKPOINT}) {
     display: none;
   }

--- a/packages/tupaia-web/src/features/Map/MapOverlaySelector/DesktopMapOverlaySelector.tsx
+++ b/packages/tupaia-web/src/features/Map/MapOverlaySelector/DesktopMapOverlaySelector.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { useParams } from 'react-router';
 import { Accordion, Typography, AccordionSummary, AccordionDetails } from '@material-ui/core';
-import { ExpandMore, Layers } from '@material-ui/icons';
+import { ArrowDropDown, Layers } from '@material-ui/icons';
 import { periodToMoment } from '@tupaia/utils';
 import { MOBILE_BREAKPOINT } from '../../../constants';
 import { Entity } from '../../../types';
@@ -15,6 +15,7 @@ import { useMapOverlays } from '../../../api/queries';
 import { useMapOverlayReport } from '../utils';
 import { MapOverlayList } from './MapOverlayList';
 import { MapOverlaySelectorTitle } from './MapOverlaySelectorTitle';
+import { MapOverlayDatePicker } from './MapOverlayDatePicker';
 
 const MaxHeightContainer = styled.div`
   max-height: 100%;
@@ -53,6 +54,10 @@ const Container = styled(MaxHeightContainer)`
   pointer-events: auto;
 `;
 
+const TitleWrapper = styled.div`
+  background-color: ${({ theme }) => theme.overlaySelector.overlayNameBackground};
+`;
+
 const OverlayLibraryAccordion = styled(Accordion)`
   display: flex;
   flex-direction: column;
@@ -74,6 +79,7 @@ const OverlayLibraryAccordion = styled(Accordion)`
 
 const OverlayLibraryIcon = styled(Layers)`
   margin-right: 0.5rem;
+  width: 1.2rem;
   .Mui-expanded & {
     fill: ${({ theme }) => theme.palette.secondary.main};
   }
@@ -143,7 +149,10 @@ export const DesktopMapOverlaySelector = ({
         <Heading>Map Overlays</Heading>
       </Header>
       <Container>
-        <MapOverlaySelectorTitle />
+        <TitleWrapper>
+          <MapOverlaySelectorTitle />
+          <MapOverlayDatePicker />
+        </TitleWrapper>
         {hasMapOverlays && (
           <OverlayLibraryAccordion
             expanded={overlayLibraryOpen}
@@ -151,7 +160,7 @@ export const DesktopMapOverlaySelector = ({
             square
           >
             <OverlayLibraryHeader
-              expandIcon={<ExpandMore />}
+              expandIcon={<ArrowDropDown />}
               aria-controls="overlay-library-content"
               id="overlay-library-header"
             >

--- a/packages/tupaia-web/src/features/Map/MapOverlaySelector/DesktopMapOverlaySelector.tsx
+++ b/packages/tupaia-web/src/features/Map/MapOverlaySelector/DesktopMapOverlaySelector.tsx
@@ -55,7 +55,11 @@ const Container = styled(MaxHeightContainer)`
 `;
 
 const TitleWrapper = styled.div`
+  padding: 1rem;
   background-color: ${({ theme }) => theme.overlaySelector.overlayNameBackground};
+  div + div {
+    padding-top: 0.5rem;
+  }
 `;
 
 const OverlayLibraryAccordion = styled(Accordion)`

--- a/packages/tupaia-web/src/features/Map/MapOverlaySelector/DesktopMapOverlaySelector.tsx
+++ b/packages/tupaia-web/src/features/Map/MapOverlaySelector/DesktopMapOverlaySelector.tsx
@@ -57,6 +57,7 @@ const Container = styled(MaxHeightContainer)`
 const TitleWrapper = styled.div`
   padding: 1rem;
   background-color: ${({ theme }) => theme.overlaySelector.overlayNameBackground};
+  // Add padding between the title and the date picker when both are present
   div + div {
     padding-top: 0.5rem;
   }

--- a/packages/tupaia-web/src/features/Map/MapOverlaySelector/DesktopMapOverlaySelector.tsx
+++ b/packages/tupaia-web/src/features/Map/MapOverlaySelector/DesktopMapOverlaySelector.tsx
@@ -14,7 +14,7 @@ import { Entity } from '../../../types';
 import { useMapOverlays } from '../../../api/queries';
 import { useMapOverlayReport } from '../utils';
 import { MapOverlayList } from './MapOverlayList';
-import { MapOverlaySelectorTitle } from './MapOverlaySelectorTitleSection';
+import { MapOverlaySelectorTitle } from './MapOverlaySelectorTitle';
 
 const MaxHeightContainer = styled.div`
   max-height: 100%;

--- a/packages/tupaia-web/src/features/Map/MapOverlaySelector/MapOverlayDatePicker.tsx
+++ b/packages/tupaia-web/src/features/Map/MapOverlaySelector/MapOverlayDatePicker.tsx
@@ -13,7 +13,6 @@ import { useDateRanges } from '../../../utils';
 import { URL_SEARCH_PARAMS } from '../../../constants';
 
 const Wrapper = styled.div`
-  padding: 1rem;
   background-color: ${({ theme }) => theme.overlaySelector.overlayNameBackground};
   > div {
     margin-top: 0;

--- a/packages/tupaia-web/src/features/Map/MapOverlaySelector/MapOverlayDatePicker.tsx
+++ b/packages/tupaia-web/src/features/Map/MapOverlaySelector/MapOverlayDatePicker.tsx
@@ -3,6 +3,7 @@
  *  Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
  */
 import React from 'react';
+import styled from 'styled-components';
 import { useParams } from 'react-router-dom';
 import { Skeleton } from '@material-ui/lab';
 import { useMapOverlays } from '../../../api/queries';
@@ -10,6 +11,14 @@ import { useMapOverlayReport } from '../utils';
 import { DateRangePicker } from '../../../components';
 import { useDateRanges } from '../../../utils';
 import { URL_SEARCH_PARAMS } from '../../../constants';
+
+const Wrapper = styled.div`
+  padding: 1rem;
+  background-color: ${({ theme }) => theme.overlaySelector.overlayNameBackground};
+  > div {
+    margin-top: 0;
+  }
+`;
 
 export const MapOverlayDatePicker = () => {
   const { projectCode, entityCode } = useParams();
@@ -28,7 +37,7 @@ export const MapOverlayDatePicker = () => {
 
   if (!showDatePicker) return null;
   return (
-    <div>
+    <Wrapper>
       {isLoadingMapOverlayData ? (
         <>
           <Skeleton animation="wave" width={200} height={20} />
@@ -44,6 +53,6 @@ export const MapOverlayDatePicker = () => {
           onSetDates={setDates}
         />
       )}
-    </div>
+    </Wrapper>
   );
 };

--- a/packages/tupaia-web/src/features/Map/MapOverlaySelector/MapOverlayList.tsx
+++ b/packages/tupaia-web/src/features/Map/MapOverlaySelector/MapOverlayList.tsx
@@ -107,7 +107,7 @@ const MapOverlayAccordion = ({ mapOverlayGroup }: { mapOverlayGroup: MapOverlayG
 export const MapOverlayList = () => {
   const [urlSearchParams, setUrlParams] = useSearchParams();
   const { projectCode, entityCode } = useParams();
-  const { mapOverlayGroups, selectedOverlayCode } = useMapOverlays(projectCode, entityCode);
+  const { mapOverlayGroups = [], selectedOverlayCode } = useMapOverlays(projectCode, entityCode);
 
   const onChangeMapOverlay = (e: ChangeEvent<HTMLInputElement>) => {
     urlSearchParams.set(URL_SEARCH_PARAMS.MAP_OVERLAY, e.target.value);

--- a/packages/tupaia-web/src/features/Map/MapOverlaySelector/MapOverlaySelector.tsx
+++ b/packages/tupaia-web/src/features/Map/MapOverlaySelector/MapOverlaySelector.tsx
@@ -16,7 +16,10 @@ export const MapOverlaySelector = () => {
 
   return (
     <>
-      <MobileMapOverlaySelector />
+      <MobileMapOverlaySelector
+        overlayLibraryOpen={overlayLibraryOpen}
+        toggleOverlayLibrary={toggleOverlayLibrary}
+      />
       <DesktopMapOverlaySelector
         overlayLibraryOpen={overlayLibraryOpen}
         toggleOverlayLibrary={toggleOverlayLibrary}

--- a/packages/tupaia-web/src/features/Map/MapOverlaySelector/MapOverlaySelectorTitle.tsx
+++ b/packages/tupaia-web/src/features/Map/MapOverlaySelector/MapOverlaySelectorTitle.tsx
@@ -5,21 +5,42 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Typography } from '@material-ui/core';
+import { RadioButtonChecked } from '@material-ui/icons';
 import { Skeleton } from '@material-ui/lab';
 import { useParams } from 'react-router';
 import { MapOverlayDatePicker } from './MapOverlayDatePicker';
 import { useEntity, useMapOverlays } from '../../../api/queries';
+import { MOBILE_BREAKPOINT } from '../../../constants';
 
 const Wrapper = styled.div<{
   $hasMapOverlays: boolean;
 }>`
-  padding: 1.3rem 1rem 1rem 1.125rem;
-  background-color: ${({ theme }) => theme.overlaySelector.overlayNameBackground};
+  padding: 0;
+  background-color: ${({ theme }) => theme.overlaySelector.menuBackground};
   border-radius: ${({ $hasMapOverlays }) => ($hasMapOverlays ? '0' : '0 0 5px 5px')};
+  @media screen and (min-width: ${MOBILE_BREAKPOINT}) {
+    background-color: ${({ theme }) => theme.overlaySelector.overlayNameBackground};
+    padding: 1.3rem 1rem 1rem 1.125rem;
+  }
 `;
 
 const MapOverlayName = styled.span`
+  font-size: 0.8rem;
+  display: flex;
+  align-items: center;
   font-weight: ${({ theme }) => theme.typography.fontWeightMedium};
+  @media screen and (min-width: ${MOBILE_BREAKPOINT}) {
+    font-size: 1rem;
+  }
+`;
+
+const MapOverlayDot = styled(RadioButtonChecked)`
+  margin-right: 0.5rem;
+  height: 0.8rem;
+  width: 0.8rem;
+  @media screen and (min-width: ${MOBILE_BREAKPOINT}) {
+    display: none;
+  }
 `;
 
 const MapOverlayLoader = styled(Skeleton).attrs({
@@ -48,7 +69,9 @@ export const MapOverlaySelectorTitle = () => {
       ) : (
         <Typography>
           {hasMapOverlays ? (
-            <MapOverlayName>{selectedOverlay?.name}</MapOverlayName>
+            <MapOverlayName>
+              <MapOverlayDot /> <span>{selectedOverlay?.name}</span>
+            </MapOverlayName>
           ) : (
             `Select an area with valid data. ${
               entity?.name ? `${entity?.name} has no map overlays available.` : ''

--- a/packages/tupaia-web/src/features/Map/MapOverlaySelector/MapOverlaySelectorTitle.tsx
+++ b/packages/tupaia-web/src/features/Map/MapOverlaySelector/MapOverlaySelectorTitle.tsx
@@ -15,9 +15,6 @@ const Wrapper = styled.div<{
   $hasMapOverlays: boolean;
 }>`
   border-radius: ${({ $hasMapOverlays }) => ($hasMapOverlays ? '0' : '0 0 5px 5px')};
-  @media screen and (min-width: ${MOBILE_BREAKPOINT}) {
-    padding: 1rem 1rem 0;
-  }
 `;
 
 const MapOverlayName = styled.span`

--- a/packages/tupaia-web/src/features/Map/MapOverlaySelector/MapOverlaySelectorTitle.tsx
+++ b/packages/tupaia-web/src/features/Map/MapOverlaySelector/MapOverlaySelectorTitle.tsx
@@ -8,19 +8,15 @@ import { Typography } from '@material-ui/core';
 import { RadioButtonChecked } from '@material-ui/icons';
 import { Skeleton } from '@material-ui/lab';
 import { useParams } from 'react-router';
-import { MapOverlayDatePicker } from './MapOverlayDatePicker';
 import { useEntity, useMapOverlays } from '../../../api/queries';
 import { MOBILE_BREAKPOINT } from '../../../constants';
 
 const Wrapper = styled.div<{
   $hasMapOverlays: boolean;
 }>`
-  padding: 0;
-  background-color: ${({ theme }) => theme.overlaySelector.menuBackground};
   border-radius: ${({ $hasMapOverlays }) => ($hasMapOverlays ? '0' : '0 0 5px 5px')};
   @media screen and (min-width: ${MOBILE_BREAKPOINT}) {
-    background-color: ${({ theme }) => theme.overlaySelector.overlayNameBackground};
-    padding: 1.3rem 1rem 1rem 1.125rem;
+    padding: 1rem 1rem 0;
   }
 `;
 
@@ -79,7 +75,6 @@ export const MapOverlaySelectorTitle = () => {
           )}
         </Typography>
       )}
-      <MapOverlayDatePicker />
     </Wrapper>
   );
 };

--- a/packages/tupaia-web/src/features/Map/MapOverlaySelector/MobileMapOverlaySelector.tsx
+++ b/packages/tupaia-web/src/features/Map/MapOverlaySelector/MobileMapOverlaySelector.tsx
@@ -2,15 +2,18 @@
  * Tupaia
  * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
  */
-import React, { useState } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import { ArrowBackIos, ArrowForwardIos } from '@material-ui/icons';
 import { Button } from '@tupaia/ui-components';
 import { MOBILE_BREAKPOINT } from '../../../constants';
+import { MapOverlayList } from './MapOverlayList';
+import { MapOverlaySelectorTitle } from './MapOverlaySelectorTitle';
 
-// Placeholder for MapOverlaySelector component
 const Wrapper = styled.div`
   width: 100%;
+  z-index: 1;
+  pointer-events: auto;
   @media screen and (min-width: ${MOBILE_BREAKPOINT}) {
     display: none;
   }
@@ -23,7 +26,12 @@ const ExpandButton = styled(Button)`
   text-transform: none;
   align-items: center;
   font-size: 0.875rem;
+  border-radius: 0;
+  padding-top: 0.8rem;
+  padding-bottom: 0.8rem;
+  text-align: left;
   background-color: ${({ theme }) => theme.overlaySelector.menuBackground};
+  position: relative;
   &:hover,
   &:focus {
     background-color: ${({ theme }) => theme.overlaySelector.menuBackground};
@@ -44,40 +52,67 @@ const OverlayLibraryHeader = styled.span`
   width: 100%;
 `;
 
+const OverlayListWrapper = styled.div`
+  padding: 1rem;
+`;
+
 const OverlayMenu = styled.div<{
   $expanded: boolean;
 }>`
-  height: ${({ $expanded }) => ($expanded ? '100%' : '0')};
+  height: ${({ $expanded }) => ($expanded ? '95vh' : '0')};
   transition: height 0.3s ease-in-out;
   width: 100%;
   position: absolute;
   bottom: 0;
   background-color: ${({ theme }) => theme.mobile.background};
   ${OverlayLibraryHeaderButton} {
-    display: ${({ $expanded }) => ($expanded ? 'block' : 'none')};
+    display: ${({ $expanded }) => ($expanded ? 'flex' : 'none')};
+  }
+  > * {
+    display: ${({ $expanded }) => ($expanded ? 'flex' : 'none')};
   }
 `;
 
-export const MobileMapOverlaySelector = () => {
-  const [expanded, setExpanded] = useState(false);
-  const toggleExpanded = () => setExpanded(!expanded);
+const ExpandButtonLabel = styled.div`
+  padding-bottom: 0.5rem;
+`;
+
+interface MobileMapOverlaySelectorProps {
+  overlayLibraryOpen: boolean;
+  toggleOverlayLibrary: () => void;
+}
+
+export const MobileMapOverlaySelector = ({
+  overlayLibraryOpen,
+  toggleOverlayLibrary,
+}: MobileMapOverlaySelectorProps) => {
   return (
     <Wrapper>
-      {!expanded && (
-        <ExpandButton onClick={toggleExpanded} aria-controls="overlay-selector">
-          Map Overlay
+      {!overlayLibraryOpen && (
+        <ExpandButton onClick={toggleOverlayLibrary} aria-controls="overlay-selector">
+          <span>
+            <ExpandButtonLabel>Map Overlay</ExpandButtonLabel>
+            <MapOverlaySelectorTitle />
+          </span>
           <ArrowWrapper>
             <ArrowForwardIos />
           </ArrowWrapper>
         </ExpandButton>
       )}
-      <OverlayMenu $expanded={expanded} aria-expanded={expanded} id="overlay-selector">
-        <OverlayLibraryHeaderButton onClick={toggleExpanded} aria-controls="overlay-selector">
+      <OverlayMenu
+        $expanded={overlayLibraryOpen}
+        aria-expanded={overlayLibraryOpen}
+        id="overlay-selector"
+      >
+        <OverlayLibraryHeaderButton onClick={toggleOverlayLibrary} aria-controls="overlay-selector">
           <ArrowWrapper>
             <ArrowBackIos />
           </ArrowWrapper>
           <OverlayLibraryHeader>Overlay Library</OverlayLibraryHeader>
         </OverlayLibraryHeaderButton>
+        <OverlayListWrapper>
+          <MapOverlayList />
+        </OverlayListWrapper>
       </OverlayMenu>
     </Wrapper>
   );

--- a/packages/tupaia-web/src/features/Map/MapOverlaySelector/MobileMapOverlaySelector.tsx
+++ b/packages/tupaia-web/src/features/Map/MapOverlaySelector/MobileMapOverlaySelector.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { ArrowBack, ArrowForwardIos } from '@material-ui/icons';
 import { Button } from '@tupaia/ui-components';
-import { MOBILE_BREAKPOINT } from '../../../constants';
+import { MOBILE_BREAKPOINT, TOP_BAR_HEIGHT_MOBILE } from '../../../constants';
 import { MapOverlayList } from './MapOverlayList';
 import { MapOverlaySelectorTitle } from './MapOverlaySelectorTitle';
 import { MapOverlayDatePicker } from './MapOverlayDatePicker';
@@ -62,7 +62,7 @@ const OverlayListWrapper = styled.div`
 const OverlayMenu = styled.div<{
   $expanded: boolean;
 }>`
-  height: ${({ $expanded }) => ($expanded ? '95vh' : '0')};
+  height: ${({ $expanded }) => ($expanded ? `calc(100vh - ${TOP_BAR_HEIGHT_MOBILE})` : '0')};
   transition: height 0.3s ease-in-out;
   width: 100%;
   position: absolute;

--- a/packages/tupaia-web/src/features/Map/MapOverlaySelector/MobileMapOverlaySelector.tsx
+++ b/packages/tupaia-web/src/features/Map/MapOverlaySelector/MobileMapOverlaySelector.tsx
@@ -81,6 +81,7 @@ const ExpandButtonLabel = styled.div`
 `;
 
 const ButtonWrapper = styled.div`
+  // add padding around the date picker when present
   > div {
     padding: 1rem;
   }

--- a/packages/tupaia-web/src/features/Map/MapOverlaySelector/MobileMapOverlaySelector.tsx
+++ b/packages/tupaia-web/src/features/Map/MapOverlaySelector/MobileMapOverlaySelector.tsx
@@ -80,6 +80,12 @@ const ExpandButtonLabel = styled.div`
   padding-bottom: 0.5rem;
 `;
 
+const ButtonWrapper = styled.div`
+  > div {
+    padding: 1rem;
+  }
+`;
+
 interface MobileMapOverlaySelectorProps {
   overlayLibraryOpen: boolean;
   toggleOverlayLibrary: () => void;
@@ -92,7 +98,7 @@ export const MobileMapOverlaySelector = ({
   return (
     <Wrapper>
       {!overlayLibraryOpen && (
-        <>
+        <ButtonWrapper>
           <MapOverlayDatePicker />
           <ExpandButton onClick={toggleOverlayLibrary} aria-controls="overlay-selector">
             <span>
@@ -103,7 +109,7 @@ export const MobileMapOverlaySelector = ({
               <ArrowForwardIos />
             </ArrowWrapper>
           </ExpandButton>
-        </>
+        </ButtonWrapper>
       )}
       <OverlayMenu
         $expanded={overlayLibraryOpen}

--- a/packages/tupaia-web/src/features/Map/MapOverlaySelector/MobileMapOverlaySelector.tsx
+++ b/packages/tupaia-web/src/features/Map/MapOverlaySelector/MobileMapOverlaySelector.tsx
@@ -4,11 +4,12 @@
  */
 import React from 'react';
 import styled from 'styled-components';
-import { ArrowBackIos, ArrowForwardIos } from '@material-ui/icons';
+import { ArrowBack, ArrowForwardIos } from '@material-ui/icons';
 import { Button } from '@tupaia/ui-components';
 import { MOBILE_BREAKPOINT } from '../../../constants';
 import { MapOverlayList } from './MapOverlayList';
 import { MapOverlaySelectorTitle } from './MapOverlaySelectorTitle';
+import { MapOverlayDatePicker } from './MapOverlayDatePicker';
 
 const Wrapper = styled.div`
   width: 100%;
@@ -27,14 +28,16 @@ const ExpandButton = styled(Button)`
   align-items: center;
   font-size: 0.875rem;
   border-radius: 0;
-  padding-top: 0.8rem;
-  padding-bottom: 0.8rem;
+  padding: 1rem;
   text-align: left;
   background-color: ${({ theme }) => theme.overlaySelector.menuBackground};
   position: relative;
   &:hover,
   &:focus {
     background-color: ${({ theme }) => theme.overlaySelector.menuBackground};
+  }
+  p {
+    margin-left: 1rem;
   }
 `;
 
@@ -89,15 +92,18 @@ export const MobileMapOverlaySelector = ({
   return (
     <Wrapper>
       {!overlayLibraryOpen && (
-        <ExpandButton onClick={toggleOverlayLibrary} aria-controls="overlay-selector">
-          <span>
-            <ExpandButtonLabel>Map Overlay</ExpandButtonLabel>
-            <MapOverlaySelectorTitle />
-          </span>
-          <ArrowWrapper>
-            <ArrowForwardIos />
-          </ArrowWrapper>
-        </ExpandButton>
+        <>
+          <MapOverlayDatePicker />
+          <ExpandButton onClick={toggleOverlayLibrary} aria-controls="overlay-selector">
+            <span>
+              <ExpandButtonLabel>Map Overlay</ExpandButtonLabel>
+              <MapOverlaySelectorTitle />
+            </span>
+            <ArrowWrapper>
+              <ArrowForwardIos />
+            </ArrowWrapper>
+          </ExpandButton>
+        </>
       )}
       <OverlayMenu
         $expanded={overlayLibraryOpen}
@@ -106,7 +112,7 @@ export const MobileMapOverlaySelector = ({
       >
         <OverlayLibraryHeaderButton onClick={toggleOverlayLibrary} aria-controls="overlay-selector">
           <ArrowWrapper>
-            <ArrowBackIos />
+            <ArrowBack />
           </ArrowWrapper>
           <OverlayLibraryHeader>Overlay Library</OverlayLibraryHeader>
         </OverlayLibraryHeaderButton>

--- a/packages/tupaia-web/src/layout/TopBar/TopBar.tsx
+++ b/packages/tupaia-web/src/layout/TopBar/TopBar.tsx
@@ -8,11 +8,14 @@ import { useParams } from 'react-router';
 import { Logo } from './Logo';
 import { UserMenu } from '../UserMenu';
 import { useLandingPage } from '../../api/queries';
-import { MOBILE_BREAKPOINT, TUPAIA_LIGHT_LOGO_SRC } from '../../constants';
+import {
+  MOBILE_BREAKPOINT,
+  TOP_BAR_HEIGHT,
+  TOP_BAR_HEIGHT_MOBILE,
+  TUPAIA_LIGHT_LOGO_SRC,
+} from '../../constants';
 import { EntitySearch } from '../../features';
 
-const TOP_BAR_HEIGHT = 60;
-const TOP_BAR_HEIGHT_MOBILE = 50;
 /* Both min height and height must be specified due to bugs in Firefox flexbox, that means that topbar height will be ignored even if using flex-basis. */
 const Header = styled.header<{
   $primaryColor?: string | null;
@@ -20,8 +23,8 @@ const Header = styled.header<{
 }>`
   background-color: ${({ $primaryColor, theme }) =>
     $primaryColor || theme.palette.background.default};
-  height: ${TOP_BAR_HEIGHT_MOBILE}px;
-  min-height: ${TOP_BAR_HEIGHT_MOBILE}px;
+  height: ${TOP_BAR_HEIGHT_MOBILE};
+  min-height: ${TOP_BAR_HEIGHT_MOBILE};
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -41,8 +44,8 @@ const Header = styled.header<{
     color: ${({ $secondaryColor, theme }) => $secondaryColor || theme.palette.text.primary};
   }
   @media screen and (min-width: ${MOBILE_BREAKPOINT}) {
-    height: ${TOP_BAR_HEIGHT}px;
-    min-height: ${TOP_BAR_HEIGHT}px;
+    height: ${TOP_BAR_HEIGHT};
+    min-height: ${TOP_BAR_HEIGHT};
     align-items: initial;
     border-bottom: 1px solid rgba(151, 151, 151, 0.3);
   }


### PR DESCRIPTION
### Issue WAITP-1288: Mobile overlay selector

### Changes:
- Added overlay library list, title, and datepicker to mobile overlay selector
- Styled mobile overlay selector
- Tweaked styling around map so that attribution is visible on mobile
---

### Screenshots:
![Screenshot 2023-07-21 at 10 58 40 am](https://github.com/beyondessential/tupaia/assets/129009580/760bbcff-c5bb-4a49-b3ea-9d24d1326c3f)

![Screenshot 2023-07-21 at 10 58 50 am](https://github.com/beyondessential/tupaia/assets/129009580/375e6fab-6b55-4585-8360-731013f15c41)

![Screenshot 2023-07-21 at 10 59 29 am](https://github.com/beyondessential/tupaia/assets/129009580/eb6f27fd-05a4-49cd-9349-ae1741bcbcd3)
![Screenshot 2023-07-21 at 11 00 18 am](https://github.com/beyondessential/tupaia/assets/129009580/97c259fd-6414-4e0c-ac55-5e6c0e5eec83)
