### PR TITLE
WAITP-1340 Entity server don't filter out projects

### DIFF
--- a/packages/entity-server/src/routes/hierarchy/middleware/filter.ts
+++ b/packages/entity-server/src/routes/hierarchy/middleware/filter.ts
@@ -150,6 +150,9 @@ export const extractFilterFromQuery = (
     return {
       [QueryConjunctions.AND]: {
         country_code: allowedCountries,
+        [QueryConjunctions.OR]: {
+          country_code: null,
+        },
       },
     };
   }
@@ -165,6 +168,9 @@ export const extractFilterFromQuery = (
   // To always force returning only entities in allowed countries, even if there is country_code filter in the query params.
   filter[QueryConjunctions.AND] = {
     country_code: allowedCountries,
+    [QueryConjunctions.OR]: {
+      country_code: null,
+    },
   };
 
   return filter;


### PR DESCRIPTION
### Issue #: WAITP-1340

### Changes:

- When generating the permission filter, also allow for `country_code IS NULL`