### PR TITLE
[no-issue]: Split pull API for data-broker services

### DIFF
--- a/packages/data-broker/src/__tests__/DataBroker/DataBroker.stubs.ts
+++ b/packages/data-broker/src/__tests__/DataBroker/DataBroker.stubs.ts
@@ -3,6 +3,7 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
+import pickBy from 'lodash.pickby';
 import { reduceToDictionary } from '@tupaia/utils';
 import { createModelsStub as baseCreateModelsStub } from '@tupaia/database';
 import * as CreateService from '../../services/createService';
@@ -15,8 +16,7 @@ import {
   MockServiceData,
   SYNC_GROUPS,
 } from './DataBroker.fixtures';
-import { DataBrokerModelRegistry, DataSource, DataSourceType } from '../../types';
-import pickBy from 'lodash.pickby';
+import { DataBrokerModelRegistry, DataElement, DataGroup, DataServiceSyncGroup } from '../../types';
 
 export const stubCreateService = (services: Record<string, Service>) =>
   jest.spyOn(CreateService, 'createService').mockImplementation((_, type) => {
@@ -43,55 +43,50 @@ export class MockService extends Service {
     return this;
   }
 
-  public pull = jest
+  public pullAnalytics = jest
     .fn()
     .mockImplementation(
-      (
-        dataSources: DataSource[],
-        type: DataSourceType,
-        options: { organisationUnitCodes?: string[] },
-      ) => {
-        const { analytics, eventsByProgram, dataElements } = this.mockData;
+      (dataElements: DataElement[], options: { organisationUnitCodes?: string[] }) => {
+        const { analytics, dataElements: availableDataElements } = this.mockData;
         const { organisationUnitCodes } = options;
-        const dataSourceCodes = dataSources.map(({ code }) => code);
+        const dataElementCodes = dataElements.map(({ code }) => code);
 
-        switch (type) {
-          case 'dataElement': {
-            let results = analytics.filter(({ dataElement }) =>
-              dataSourceCodes.includes(dataElement),
-            );
-            if (organisationUnitCodes) {
-              results = results.filter(({ organisationUnit }) =>
-                organisationUnitCodes.includes(organisationUnit),
-              );
-            }
-            const selectedDataElements = dataElements.filter(({ code }) =>
-              dataSourceCodes.includes(code),
-            );
-            const dataElementCodeToName = reduceToDictionary(selectedDataElements, 'code', 'name');
-
-            return {
-              results,
-              metadata: {
-                dataElementCodeToName,
-              },
-            };
-          }
-          case 'dataGroup': {
-            return Object.entries(eventsByProgram)
-              .filter(([program]) => dataSourceCodes.includes(program))
-              .flatMap(([, events]) => events);
-          }
-          case 'syncGroup': {
-            return pickBy(eventsByProgram, (_, programCode) =>
-              dataSourceCodes.includes(programCode),
-            );
-          }
-          default:
-            throw new Error(`Invalid data source type: ${type}`);
+        let results = analytics.filter(({ dataElement }) => dataElementCodes.includes(dataElement));
+        if (organisationUnitCodes) {
+          results = results.filter(({ organisationUnit }) =>
+            organisationUnitCodes.includes(organisationUnit),
+          );
         }
+        const selectedDataElements = availableDataElements.filter(({ code }) =>
+          dataElementCodes.includes(code),
+        );
+        const dataElementCodeToName = reduceToDictionary(selectedDataElements, 'code', 'name');
+
+        return {
+          results,
+          metadata: {
+            dataElementCodeToName,
+          },
+        };
       },
     );
+
+  public pullEvents = jest.fn().mockImplementation((dataGroups: DataGroup[]) => {
+    const { eventsByProgram } = this.mockData;
+    const dataSourceCodes = dataGroups.map(({ code }) => code);
+
+    return Object.entries(eventsByProgram)
+      .filter(([program]) => dataSourceCodes.includes(program))
+      .flatMap(([, events]) => events);
+  });
+
+  public pullSyncGroupResults = jest
+    .fn()
+    .mockImplementation((syncGroups: DataServiceSyncGroup[]) => {
+      const { eventsByProgram } = this.mockData;
+      const dataSourceCodes = syncGroups.map(({ code }) => code);
+      return pickBy(eventsByProgram, (_, programCode) => dataSourceCodes.includes(programCode));
+    });
 
   public push = jest.fn();
 

--- a/packages/data-broker/src/__tests__/DataBroker/DataBroker.test.ts
+++ b/packages/data-broker/src/__tests__/DataBroker/DataBroker.test.ts
@@ -173,24 +173,28 @@ describe('DataBroker', () => {
         { dataSource: DATA_ELEMENTS.DHIS_01, service_type: 'dhis', config: {} },
       ]);
 
-      const testData: [MethodUnderTest, any[], DataServiceMapping][] = [
-        ['push', [{ code: 'DHIS_01', type: 'dataElement' }, [{ value: 2 }], TO_OPTIONS], mapping],
-        ['delete', [{ code: 'DHIS_01', type: 'dataElement' }, { value: 2 }, TO_OPTIONS], mapping],
-        ['pullAnalytics', ['DHIS_01', TO_OPTIONS], mapping],
-        ['pullMetadata', [{ code: 'DHIS_01', type: 'dataElement' }, TO_OPTIONS], mapping],
+      const testData: [MethodUnderTest, any[]][] = [
+        ['push', [{ code: 'DHIS_01', type: 'dataElement' }, [{ value: 2 }], TO_OPTIONS]],
+        ['delete', [{ code: 'DHIS_01', type: 'dataElement' }, { value: 2 }, TO_OPTIONS]],
+        ['pullMetadata', [{ code: 'DHIS_01', type: 'dataElement' }, TO_OPTIONS]],
       ];
 
-      testData.forEach(([methodUnderTest, inputArgs, expectedMapping]) =>
-        it(`passes mapping to service: ${methodUnderTest}`, async () => {
-          await dataBroker[methodUnderTest](inputArgs[0], inputArgs[1], inputArgs[2]);
-          const serviceMethod =
-            methodUnderTest === 'pullAnalytics' || methodUnderTest === 'pullEvents'
-              ? 'pull'
-              : methodUnderTest;
-          expect(SERVICES.dhis[serviceMethod]).toHaveBeenCalledOnceWith(
+      testData.forEach(
+        ([methodUnderTest, inputArgs]) =>
+          it(`passes mapping to service: ${methodUnderTest}`, async () => {
+            await dataBroker[methodUnderTest](inputArgs[0], inputArgs[1], inputArgs[2]);
+            expect(SERVICES.dhis[methodUnderTest]).toHaveBeenCalledOnceWith(
+              expect.anything(),
+              expect.anything(),
+              expect.objectContaining({ dataServiceMapping: mapping }),
+            );
+          }),
+
+        it('passes mapping to service: pullAnalytics', async () => {
+          await dataBroker.pullAnalytics(['DHIS_01'], TO_OPTIONS);
+          expect(SERVICES.dhis.pullAnalytics).toHaveBeenCalledOnceWith(
             expect.anything(),
-            expect.anything(),
-            expect.objectContaining({ dataServiceMapping: expectedMapping }),
+            expect.objectContaining({ dataServiceMapping: mapping }),
           );
         }),
       );
@@ -215,9 +219,8 @@ describe('DataBroker', () => {
         dataElements: DataElement[],
         expectedOrganisationUnitCodes: string[],
       ) =>
-        expect(service.pull).toHaveBeenCalledOnceWith(
+        expect(service.pullAnalytics).toHaveBeenCalledOnceWith(
           dataElements,
-          'dataElement',
           expect.objectContaining({
             organisationUnitCodes: expect.arrayContaining(expectedOrganisationUnitCodes),
           }),
@@ -307,103 +310,100 @@ describe('DataBroker', () => {
     });
   });
 
-  describe('pull()', () => {
-    describe('permissions', () => {
-      it("throws an error if fetching for a data element the user doesn't have required permissions for", async () => {
-        await expect(
-          new DataBroker({ accessPolicy: new AccessPolicy({ DL: ['Public'] }) }).pullAnalytics(
-            ['RESTRICTED_01'],
-            {},
-          ),
-        ).toBeRejectedWith('Missing permissions to the following data elements: RESTRICTED_01');
-      });
+  describe('pull permissions', () => {
+    it("throws an error if fetching for a data element the user doesn't have required permissions for", async () => {
+      await expect(
+        new DataBroker({ accessPolicy: new AccessPolicy({ DL: ['Public'] }) }).pullAnalytics(
+          ['RESTRICTED_01'],
+          {},
+        ),
+      ).toBeRejectedWith('Missing permissions to the following data elements: RESTRICTED_01');
+    });
 
-      it("throws an error if fetching for a data element in an entity the user doesn't have required permissions for", async () => {
-        await expect(
-          new DataBroker({ accessPolicy: new AccessPolicy({ DL: ['Admin'] }) }).pullAnalytics(
-            ['RESTRICTED_01'],
-            { organisationUnitCodes: ['TO'] },
-          ),
-        ).toBeRejectedWith('Missing permissions to the following data elements:\nRESTRICTED_01');
-      });
+    it("throws an error if fetching for a data element in an entity the user doesn't have required permissions for", async () => {
+      await expect(
+        new DataBroker({ accessPolicy: new AccessPolicy({ DL: ['Admin'] }) }).pullAnalytics(
+          ['RESTRICTED_01'],
+          { organisationUnitCodes: ['TO'] },
+        ),
+      ).toBeRejectedWith('Missing permissions to the following data elements:\nRESTRICTED_01');
+    });
 
-      it("throws an error if any of data elements in fetch the user doesn't have required permissions for", async () => {
-        await expect(
-          new DataBroker({ accessPolicy: new AccessPolicy({ TO: ['Public'] }) }).pullAnalytics(
-            ['TUPAIA_01', 'RESTRICTED_01'],
-            { organisationUnitCodes: ['TO'] },
-          ),
-        ).toBeRejectedWith(`Missing permissions to the following data elements:\nRESTRICTED_01`);
-      });
+    it("throws an error if any of data elements in fetch the user doesn't have required permissions for", async () => {
+      await expect(
+        new DataBroker({ accessPolicy: new AccessPolicy({ TO: ['Public'] }) }).pullAnalytics(
+          ['TUPAIA_01', 'RESTRICTED_01'],
+          { organisationUnitCodes: ['TO'] },
+        ),
+      ).toBeRejectedWith(`Missing permissions to the following data elements:\nRESTRICTED_01`);
+    });
 
-      it("doesn't throw if the user has BES Admin access", async () => {
-        await expect(
-          new DataBroker({ accessPolicy: new AccessPolicy({ DL: ['BES Admin'] }) }).pullAnalytics(
-            ['RESTRICTED_01'],
-            { organisationUnitCodes: ['TO'] },
-          ),
-        ).toResolve();
-      });
+    it("doesn't throw if the user has BES Admin access", async () => {
+      await expect(
+        new DataBroker({ accessPolicy: new AccessPolicy({ DL: ['BES Admin'] }) }).pullAnalytics(
+          ['RESTRICTED_01'],
+          { organisationUnitCodes: ['TO'] },
+        ),
+      ).toResolve();
+    });
 
-      it("doesn't throw if the user has access to the data element in the requested entity", async () => {
-        const results = await new DataBroker({
-          accessPolicy: new AccessPolicy({ TO: ['Admin'] }),
-        }).pullAnalytics(['RESTRICTED_01'], { organisationUnitCodes: ['TO'] });
-        expect(results).toEqual({
-          results: [
-            {
-              analytics: [
-                {
-                  dataElement: 'RESTRICTED_01',
-                  organisationUnit: 'TO',
-                  period: '20210101',
-                  value: 4,
-                },
-              ],
-              numAggregationsProcessed: 0,
-            },
-          ],
-          metadata: {
-            dataElementCodeToName: {},
+    it("doesn't throw if the user has access to the data element in the requested entity", async () => {
+      const results = await new DataBroker({
+        accessPolicy: new AccessPolicy({ TO: ['Admin'] }),
+      }).pullAnalytics(['RESTRICTED_01'], { organisationUnitCodes: ['TO'] });
+      expect(results).toEqual({
+        results: [
+          {
+            analytics: [
+              {
+                dataElement: 'RESTRICTED_01',
+                organisationUnit: 'TO',
+                period: '20210101',
+                value: 4,
+              },
+            ],
+            numAggregationsProcessed: 0,
           },
-        });
+        ],
+        metadata: {
+          dataElementCodeToName: {},
+        },
       });
+    });
 
-      it('just returns data for entities that the user have appropriate access to', async () => {
-        const results = await new DataBroker({
-          accessPolicy: new AccessPolicy({ FJ: ['Admin'] }),
-        }).pullAnalytics(['RESTRICTED_01'], { organisationUnitCodes: ['TO', 'FJ'] });
-        expect(results).toEqual({
-          results: [
-            {
-              analytics: [
-                {
-                  dataElement: 'RESTRICTED_01',
-                  organisationUnit: 'FJ',
-                  period: '20210101',
-                  value: 5,
-                },
-              ],
-              numAggregationsProcessed: 0,
-            },
-          ],
-          metadata: {
-            dataElementCodeToName: {},
+    it('just returns data for entities that the user have appropriate access to', async () => {
+      const results = await new DataBroker({
+        accessPolicy: new AccessPolicy({ FJ: ['Admin'] }),
+      }).pullAnalytics(['RESTRICTED_01'], { organisationUnitCodes: ['TO', 'FJ'] });
+      expect(results).toEqual({
+        results: [
+          {
+            analytics: [
+              {
+                dataElement: 'RESTRICTED_01',
+                organisationUnit: 'FJ',
+                period: '20210101',
+                value: 5,
+              },
+            ],
+            numAggregationsProcessed: 0,
           },
-        });
+        ],
+        metadata: {
+          dataElementCodeToName: {},
+        },
       });
     });
   });
 
-  describe('pullAnalytics', () => {
+  describe('pullAnalytics()', () => {
     it('same service', async () => {
       const dataBroker = new DataBroker();
       const data = await dataBroker.pullAnalytics(['DHIS_01', 'DHIS_02'], options);
 
       expect(createServiceMock).toHaveBeenCalledOnceWith(mockModels, 'dhis', dataBroker);
-      expect(SERVICES.dhis.pull).toHaveBeenCalledOnceWith(
+      expect(SERVICES.dhis.pullAnalytics).toHaveBeenCalledOnceWith(
         [DATA_ELEMENTS.DHIS_01, DATA_ELEMENTS.DHIS_02],
-        'dataElement',
         expect.objectContaining(options),
       );
       expect(data).toStrictEqual({
@@ -429,14 +429,12 @@ describe('DataBroker', () => {
       expect(createServiceMock).toHaveBeenCalledTimes(2);
       expect(createServiceMock).toHaveBeenCalledWith(mockModels, 'dhis', dataBroker);
       expect(createServiceMock).toHaveBeenCalledWith(mockModels, 'tupaia', dataBroker);
-      expect(SERVICES.dhis.pull).toHaveBeenCalledOnceWith(
+      expect(SERVICES.dhis.pullAnalytics).toHaveBeenCalledOnceWith(
         [DATA_ELEMENTS.DHIS_01, DATA_ELEMENTS.DHIS_02],
-        'dataElement',
         expect.objectContaining(options),
       );
-      expect(SERVICES.tupaia.pull).toHaveBeenCalledOnceWith(
+      expect(SERVICES.tupaia.pullAnalytics).toHaveBeenCalledOnceWith(
         [DATA_ELEMENTS.TUPAIA_01],
-        'dataElement',
         expect.objectContaining(options),
       );
       expect(data).toStrictEqual({
@@ -461,15 +459,14 @@ describe('DataBroker', () => {
     });
   });
 
-  describe('pullEvents', () => {
+  describe('pullEvents()', () => {
     it('same service', async () => {
       const dataBroker = new DataBroker();
       const data = await dataBroker.pullEvents(['DHIS_PROGRAM_01', 'DHIS_PROGRAM_02'], options);
 
       expect(createServiceMock).toHaveBeenCalledOnceWith(mockModels, 'dhis', dataBroker);
-      expect(SERVICES.dhis.pull).toHaveBeenCalledOnceWith(
+      expect(SERVICES.dhis.pullEvents).toHaveBeenCalledOnceWith(
         [DATA_GROUPS.DHIS_PROGRAM_01, DATA_GROUPS.DHIS_PROGRAM_02],
-        'dataGroup',
         expect.objectContaining(options),
       );
       expect(data).toStrictEqual([
@@ -488,14 +485,12 @@ describe('DataBroker', () => {
       expect(createServiceMock).toHaveBeenCalledTimes(2);
       expect(createServiceMock).toHaveBeenCalledWith(mockModels, 'dhis', dataBroker);
       expect(createServiceMock).toHaveBeenCalledWith(mockModels, 'tupaia', dataBroker);
-      expect(SERVICES.dhis.pull).toHaveBeenCalledOnceWith(
+      expect(SERVICES.dhis.pullEvents).toHaveBeenCalledOnceWith(
         [DATA_GROUPS.DHIS_PROGRAM_01, DATA_GROUPS.DHIS_PROGRAM_02],
-        'dataGroup',
         expect.objectContaining(options),
       );
-      expect(SERVICES.tupaia.pull).toHaveBeenCalledOnceWith(
+      expect(SERVICES.tupaia.pullEvents).toHaveBeenCalledOnceWith(
         [DATA_GROUPS.TUPAIA_PROGRAM_01],
-        'dataGroup',
         expect.objectContaining(options),
       );
       expect(data).toStrictEqual([
@@ -506,7 +501,7 @@ describe('DataBroker', () => {
     });
   });
 
-  describe('pullSyncGroupResults', () => {
+  describe('pullSyncGroupResults()', () => {
     it('same service', async () => {
       const dataBroker = new DataBroker();
       const data = await dataBroker.pullSyncGroupResults(
@@ -515,9 +510,8 @@ describe('DataBroker', () => {
       );
 
       expect(createServiceMock).toHaveBeenCalledOnceWith(mockModels, 'dhis', dataBroker);
-      expect(SERVICES.dhis.pull).toHaveBeenCalledOnceWith(
+      expect(SERVICES.dhis.pullSyncGroupResults).toHaveBeenCalledOnceWith(
         [SYNC_GROUPS.DHIS_SYNC_GROUP_01, SYNC_GROUPS.DHIS_SYNC_GROUP_02],
-        'syncGroup',
         expect.objectContaining(options),
       );
       expect(data).toStrictEqual({
@@ -536,14 +530,12 @@ describe('DataBroker', () => {
       expect(createServiceMock).toHaveBeenCalledTimes(2);
       expect(createServiceMock).toHaveBeenCalledWith(mockModels, 'dhis', dataBroker);
       expect(createServiceMock).toHaveBeenCalledWith(mockModels, 'tupaia', dataBroker);
-      expect(SERVICES.dhis.pull).toHaveBeenCalledOnceWith(
+      expect(SERVICES.dhis.pullSyncGroupResults).toHaveBeenCalledOnceWith(
         [SYNC_GROUPS.DHIS_SYNC_GROUP_01, SYNC_GROUPS.DHIS_SYNC_GROUP_02],
-        'syncGroup',
         expect.objectContaining(options),
       );
-      expect(SERVICES.tupaia.pull).toHaveBeenCalledOnceWith(
+      expect(SERVICES.tupaia.pullSyncGroupResults).toHaveBeenCalledOnceWith(
         [SYNC_GROUPS.TUPAIA_SYNC_GROUP_01],
-        'syncGroup',
         expect.objectContaining(options),
       );
       expect(data).toStrictEqual({

--- a/packages/data-broker/src/__tests__/services/dhis/DhisService.test.ts
+++ b/packages/data-broker/src/__tests__/services/dhis/DhisService.test.ts
@@ -248,108 +248,176 @@ describe('DhisService', () => {
     });
   });
 
-  describe('pull()', () => {
-    describe('pull functionality', () => {
-      const basicEventOptions = {
+  describe('pullAnalytics()', () => {
+    const getApisForDataSourcesSpy = jest.spyOn(GetDhisApi, 'getApisForDataSources');
+
+    it('uses AnalyticsPuller to fetch data', async () => {
+      await dhisService.pullAnalytics([DATA_ELEMENTS.POP01], {
         dataServiceMapping: DEFAULT_DATA_SERVICE_MAPPING,
+      });
+
+      getApisForDataSourcesSpy.mockResolvedValue([dhisApi]);
+
+      expect(mockPullAnalytics).toHaveBeenCalledOnceWith([dhisApi], [DATA_ELEMENTS.POP01], {
+        dataServiceMapping: DEFAULT_DATA_SERVICE_MAPPING,
+      });
+    });
+
+    it('looks up the api from the given data source', async () => {
+      const dataElements = [DATA_ELEMENTS.POP01];
+      const options = {
         organisationUnitCodes: ['TO'],
+        dataServiceMapping: DEFAULT_DATA_SERVICE_MAPPING,
       };
 
-      it('uses AnalyticsPuller for dataElements', async () => {
-        await dhisService.pull([DATA_ELEMENTS.POP01], 'dataElement', {
-          dataServiceMapping: DEFAULT_DATA_SERVICE_MAPPING,
-        });
-        expect(mockPullAnalytics).toHaveBeenCalledOnceWith([dhisApi], [DATA_ELEMENTS.POP01], {
-          dataServiceMapping: DEFAULT_DATA_SERVICE_MAPPING,
-        });
-      });
+      const mockedDhisApi1 = createMockDhisApi({ serverName: 'myDhisApi1' });
+      getApisForDataSourcesSpy.mockResolvedValue([mockedDhisApi1]);
 
-      it('uses EventsPuller for dataGroups', async () => {
-        const eventOptions = {
-          ...basicEventOptions,
-          dataServiceMapping: DEFAULT_DATA_SERVICE_MAPPING,
-        };
+      await dhisService.pullAnalytics(dataElements, options);
 
-        await dhisService.pull([DATA_GROUPS.POP01_GROUP], 'dataGroup', eventOptions);
-        expect(mockPullEvents).toHaveBeenCalledOnceWith(
-          [dhisApi],
-          [DATA_GROUPS.POP01_GROUP],
-          eventOptions,
-        );
-      });
+      // expect DhisService to ask for the apis for the given data sources
+      expect(getApisForDataSourcesSpy).toHaveBeenCalledOnceWith(
+        expect.anything(),
+        dataElements,
+        DEFAULT_DATA_SERVICE_MAPPING,
+      );
 
-      it('uses the modern EventsPuller by default', async () => {
-        await dhisService.pull([DATA_GROUPS.POP01_GROUP], 'dataGroup', basicEventOptions);
-        expect(mockPullEvents).toHaveBeenCalledTimes(1);
-        expect(mockPullDeprecatedEvents).not.toHaveBeenCalled();
-      });
-
-      it('uses the deprecated EventsPuller if flag passed', async () => {
-        await dhisService.pull([DATA_GROUPS.POP01_GROUP], 'dataGroup', {
-          ...basicEventOptions,
-          useDeprecatedApi: true,
-        });
-        expect(mockPullEvents).not.toHaveBeenCalled();
-        expect(mockPullDeprecatedEvents).toHaveBeenCalledTimes(1);
-      });
+      // expect those apis to be passed to pull
+      expect(mockPullAnalytics).toHaveBeenCalledOnceWith(
+        [mockedDhisApi1],
+        expect.anything(),
+        expect.anything(),
+      );
     });
 
-    describe('pull api resolution', () => {
-      const getApisForDataSourcesSpy = jest.spyOn(GetDhisApi, 'getApisForDataSources');
+    it('ignores non-dhis data elements', async () => {
+      const dataElements = [DATA_ELEMENTS.POP01, DATA_ELEMENTS.NON_DHIS_1];
+      const options = {
+        organisationUnitCodes: ['TO'],
+        dataServiceMapping: DEFAULT_DATA_SERVICE_MAPPING,
+      };
 
-      it('looks up the api from the given data source', async () => {
-        const dataSources = [DATA_ELEMENTS.POP01];
-        const options = {
-          organisationUnitCodes: ['TO'],
-          dataServiceMapping: DEFAULT_DATA_SERVICE_MAPPING,
-        };
+      const mockedDhisApi1 = createMockDhisApi({ serverName: 'myDhisApi1' });
+      getApisForDataSourcesSpy.mockResolvedValue([mockedDhisApi1]);
 
-        const mockedDhisApi1 = createMockDhisApi({ serverName: 'myDhisApi1' });
-        getApisForDataSourcesSpy.mockResolvedValue([mockedDhisApi1]);
+      await dhisService.pullAnalytics(dataElements, options);
 
-        await dhisService.pull(dataSources, 'dataElement', options);
+      // expect DhisService to ask for the apis for the given data sources, except non-DHIS ones
+      expect(getApisForDataSourcesSpy).toHaveBeenCalledOnceWith(
+        expect.anything(),
+        [DATA_ELEMENTS.POP01],
+        DEFAULT_DATA_SERVICE_MAPPING,
+      );
 
-        // expect DhisService to ask for the apis for the given data sources
-        expect(getApisForDataSourcesSpy).toHaveBeenCalledOnceWith(
-          expect.anything(),
-          dataSources,
-          DEFAULT_DATA_SERVICE_MAPPING,
-        );
-
-        // expect those apis to be passed to pull
-        expect(mockPullAnalytics).toHaveBeenCalledOnceWith(
-          [mockedDhisApi1],
-          expect.anything(),
-          expect.anything(),
-        );
-      });
-
-      it('ignores non-dhis data elements', async () => {
-        const dataSources = [DATA_ELEMENTS.POP01, DATA_ELEMENTS.NON_DHIS_1];
-        const options = {
-          organisationUnitCodes: ['TO'],
-          dataServiceMapping: DEFAULT_DATA_SERVICE_MAPPING,
-        };
-
-        const mockedDhisApi1 = createMockDhisApi({ serverName: 'myDhisApi1' });
-        getApisForDataSourcesSpy.mockResolvedValue([mockedDhisApi1]);
-
-        await dhisService.pull(dataSources, 'dataElement', options);
-
-        // expect DhisService to ask for the apis for the given data sources, except non-DHIS ones
-        expect(getApisForDataSourcesSpy).toHaveBeenCalledOnceWith(
-          expect.anything(),
-          [DATA_ELEMENTS.POP01],
-          DEFAULT_DATA_SERVICE_MAPPING,
-        );
-
-        // expect pull to have been called with the given data sources, except non-DHIS ones
-        expect(mockPullAnalytics).toHaveBeenCalledOnceWith(
-          [mockedDhisApi1],
-          [DATA_ELEMENTS.POP01],
-          expect.anything(),
-        );
-      });
+      // expect pull to have been called with the given data sources, except non-DHIS ones
+      expect(mockPullAnalytics).toHaveBeenCalledOnceWith(
+        [mockedDhisApi1],
+        [DATA_ELEMENTS.POP01],
+        expect.anything(),
+      );
     });
+  });
+
+  describe('pullEvents()', () => {
+    const basicEventOptions = {
+      dataServiceMapping: DEFAULT_DATA_SERVICE_MAPPING,
+      organisationUnitCodes: ['TO'],
+    };
+
+    const getApisForDataSourcesSpy = jest.spyOn(GetDhisApi, 'getApisForDataSources');
+
+    beforeEach(() => {
+      getApisForDataSourcesSpy.mockClear();
+    });
+
+    it('uses EventsPuller to fetch data', async () => {
+      const eventOptions = {
+        ...basicEventOptions,
+        dataServiceMapping: DEFAULT_DATA_SERVICE_MAPPING,
+      };
+
+      getApisForDataSourcesSpy.mockResolvedValue([dhisApi]);
+
+      await dhisService.pullEvents([DATA_GROUPS.POP01_GROUP], eventOptions);
+      expect(mockPullEvents).toHaveBeenCalledOnceWith(
+        [dhisApi],
+        [DATA_GROUPS.POP01_GROUP],
+        eventOptions,
+      );
+    });
+
+    it('uses the modern EventsPuller by default', async () => {
+      await dhisService.pullEvents([DATA_GROUPS.POP01_GROUP], basicEventOptions);
+      expect(mockPullEvents).toHaveBeenCalledTimes(1);
+      expect(mockPullDeprecatedEvents).not.toHaveBeenCalled();
+    });
+
+    it('uses the deprecated EventsPuller if flag passed', async () => {
+      await dhisService.pullEvents([DATA_GROUPS.POP01_GROUP], {
+        ...basicEventOptions,
+        useDeprecatedApi: true,
+      });
+      expect(mockPullEvents).not.toHaveBeenCalled();
+      expect(mockPullDeprecatedEvents).toHaveBeenCalledTimes(1);
+    });
+
+    it('looks up the api from the given data source', async () => {
+      const dataGroups = [DATA_GROUPS.POP01_GROUP];
+      const options = {
+        organisationUnitCodes: ['TO'],
+        dataServiceMapping: DEFAULT_DATA_SERVICE_MAPPING,
+      };
+
+      const mockedDhisApi1 = createMockDhisApi({ serverName: 'myDhisApi1' });
+      getApisForDataSourcesSpy.mockResolvedValue([mockedDhisApi1]);
+
+      await dhisService.pullEvents(dataGroups, options);
+
+      // expect DhisService to ask for the apis for the given data sources
+      expect(getApisForDataSourcesSpy).toHaveBeenCalledOnceWith(
+        expect.anything(),
+        dataGroups,
+        DEFAULT_DATA_SERVICE_MAPPING,
+      );
+
+      // expect those apis to be passed to pull
+      expect(mockPullEvents).toHaveBeenCalledOnceWith(
+        [mockedDhisApi1],
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+
+    it('ignores non-dhis data groups', async () => {
+      const dataGroups = [DATA_GROUPS.POP01_GROUP, DATA_GROUPS.NON_DHIS_2];
+      const options = {
+        organisationUnitCodes: ['TO'],
+        dataServiceMapping: DEFAULT_DATA_SERVICE_MAPPING,
+      };
+
+      const mockedDhisApi1 = createMockDhisApi({ serverName: 'myDhisApi1' });
+      getApisForDataSourcesSpy.mockResolvedValue([mockedDhisApi1]);
+
+      await dhisService.pullEvents(dataGroups, options);
+
+      // expect DhisService to ask for the apis for the given data sources, except non-DHIS ones
+      expect(getApisForDataSourcesSpy).toHaveBeenCalledOnceWith(
+        expect.anything(),
+        [DATA_GROUPS.POP01_GROUP],
+        DEFAULT_DATA_SERVICE_MAPPING,
+      );
+
+      // expect pull to have been called with the given data sources, except non-DHIS ones
+      expect(mockPullEvents).toHaveBeenCalledOnceWith(
+        [mockedDhisApi1],
+        [DATA_GROUPS.POP01_GROUP],
+        expect.anything(),
+      );
+    });
+  });
+
+  describe('pullSyncGroupResults()', () => {
+    it('throws an error', async () =>
+      expect(dhisService.pullSyncGroupResults()).toBeRejectedWith('not supported'));
   });
 });

--- a/packages/data-broker/src/__tests__/services/kobo/KoBoService.test.ts
+++ b/packages/data-broker/src/__tests__/services/kobo/KoBoService.test.ts
@@ -22,28 +22,22 @@ describe('KoBoService', () => {
       expect(koboService.delete()).toBeRejectedWith('not supported'));
   });
 
-  describe('pull()', () => {
+  describe('pullAnalytics()', () => {
+    it('throws an error', async () =>
+      expect(koboService.pullAnalytics()).toBeRejectedWith('not supported'));
+  });
+
+  describe('pullEvents()', () => {
+    it('throws an error', async () =>
+      expect(koboService.pullEvents()).toBeRejectedWith('not supported'));
+  });
+
+  describe('pullSyncGroupResults()', () => {
     const dataServiceMapping = new DataServiceMapping();
 
-    describe('pullAnalytics()', () => {
-      it('throws an error', async () =>
-        expect(koboService.pull([], 'dataElement', { dataServiceMapping })).toBeRejectedWith(
-          'not supported',
-        ));
-    });
-
-    describe('pullEvents()', () => {
-      it('throws an error', async () =>
-        expect(koboService.pull([], 'dataGroup', { dataServiceMapping })).toBeRejectedWith(
-          'not supported',
-        ));
-    });
-
-    describe('pullSyncGroups()', () => {
-      it('pull and translate from api correctly', () =>
-        expect(
-          koboService.pull([MOCK_DATA_SOURCE], 'syncGroup', { dataServiceMapping }),
-        ).resolves.toHaveProperty('xyz', [TRANSLATED_DATA]));
-    });
+    it('pull and translate from api correctly', async () =>
+      expect(
+        koboService.pullSyncGroupResults([MOCK_DATA_SOURCE], { dataServiceMapping }),
+      ).resolves.toHaveProperty('xyz', [TRANSLATED_DATA]));
   });
 });

--- a/packages/data-broker/src/__tests__/services/superset/SupersetService.test.ts
+++ b/packages/data-broker/src/__tests__/services/superset/SupersetService.test.ts
@@ -41,149 +41,139 @@ describe('SupersetService', () => {
     it('throws an error', () => expect(supersetService.delete()).toBeRejectedWith('not supported'));
   });
 
-  describe('pull()', () => {
-    describe('pullAnalytics()', () => {
-      it('pulls', () =>
-        expect(
-          supersetService.pull([DATA_ELEMENTS.ITEM_1], 'dataElement', DEFAULT_PULL_OPTIONS),
-        ).resolves.toEqual({
-          metadata: {
-            dataElementCodeToName: {},
+  describe('pullAnalytics()', () => {
+    it('pulls', () =>
+      expect(
+        supersetService.pullAnalytics([DATA_ELEMENTS.ITEM_1], DEFAULT_PULL_OPTIONS),
+      ).resolves.toEqual({
+        metadata: {
+          dataElementCodeToName: {},
+        },
+        results: [
+          {
+            dataElement: 'ITEM_1',
+            organisationUnit: 'STORE_1',
+            period: '20200101',
+            value: 1,
           },
-          results: [
-            {
-              dataElement: 'ITEM_1',
-              organisationUnit: 'STORE_1',
-              period: '20200101',
-              value: 1,
-            },
-            {
-              dataElement: 'ITEM_1',
-              organisationUnit: 'STORE_2',
-              period: '20200101',
-              value: 2,
-            },
-          ],
-        }));
+          {
+            dataElement: 'ITEM_1',
+            organisationUnit: 'STORE_2',
+            period: '20200101',
+            value: 2,
+          },
+        ],
+      }));
 
-      it('uses mapping to find which superset instance to use', async () => {
-        await supersetService.pull([DATA_ELEMENTS.ITEM_1], 'dataElement', {
-          dataServiceMapping: new DataServiceMapping([
-            {
-              dataSource: DATA_ELEMENTS.ITEM_1,
-              service_type: 'superset',
-              config: { supersetInstanceCode: 'SUPERSET_INSTANCE_B', supersetChartId: 456 }, // different
-            },
-          ]),
-          organisationUnitCodes: DEFAULT_ORG_UNIT_CODES,
-        });
-
-        expect(getSupersetApiInstance).toHaveBeenCalledWith(
-          expect.anything(),
-          expect.objectContaining({
-            code: 'SUPERSET_INSTANCE_B',
-          }),
-        );
+    it('uses mapping to find which superset instance to use', async () => {
+      await supersetService.pullAnalytics([DATA_ELEMENTS.ITEM_1], {
+        dataServiceMapping: new DataServiceMapping([
+          {
+            dataSource: DATA_ELEMENTS.ITEM_1,
+            service_type: 'superset',
+            config: { supersetInstanceCode: 'SUPERSET_INSTANCE_B', supersetChartId: 456 }, // different
+          },
+        ]),
+        organisationUnitCodes: DEFAULT_ORG_UNIT_CODES,
       });
 
-      it('uses supersetItemCode as a fallback', () =>
-        expect(
-          supersetService.pull(
-            [DATA_ELEMENTS.ITEM_2_CUSTOM_CODE],
-            'dataElement',
-            DEFAULT_PULL_OPTIONS,
-          ),
-        ).resolves.toEqual({
-          metadata: expect.anything(),
-          results: [
-            {
-              dataElement: 'ITEM_2_CUSTOM_CODE',
-              organisationUnit: 'STORE_1',
-              period: '20200101',
-              value: 3,
-            },
-            {
-              dataElement: 'ITEM_2_CUSTOM_CODE',
-              organisationUnit: 'STORE_2',
-              period: '20200101',
-              value: 4,
-            },
-          ],
-        }));
+      expect(getSupersetApiInstance).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          code: 'SUPERSET_INSTANCE_B',
+        }),
+      );
+    });
 
-      it('throws if supersetChartId not set', () =>
-        expect(
-          supersetService.pull([DATA_ELEMENTS.DE_NO_CHART_ID], 'dataElement', DEFAULT_PULL_OPTIONS),
-        ).toBeRejectedWith('Data Element DE_NO_CHART_ID missing supersetChartId'));
-
-      it('filters by the org units you specify', () =>
-        expect(
-          supersetService.pull([DATA_ELEMENTS.ITEM_1], 'dataElement', {
-            dataServiceMapping: DEFAULT_DATA_SERVICE_MAPPING,
-            organisationUnitCode: 'STORE_1',
-          }),
-        ).resolves.toEqual({
-          metadata: expect.anything(),
-          results: [
-            {
-              dataElement: 'ITEM_1',
-              organisationUnit: 'STORE_1',
-              period: '20200101',
-              value: 1,
-            },
-          ],
-        }));
-
-      it('returns data for all org units if no org units specified', () =>
-        expect(
-          supersetService.pull([DATA_ELEMENTS.ITEM_1], 'dataElement', {
-            dataServiceMapping: DEFAULT_DATA_SERVICE_MAPPING,
-            organisationUnitCodes: [],
-          }),
-        ).resolves.toEqual({
-          metadata: expect.anything(),
-          results: [
-            {
-              dataElement: 'ITEM_1',
-              organisationUnit: 'STORE_1',
-              period: '20200101',
-              value: 1,
-            },
-            {
-              dataElement: 'ITEM_1',
-              organisationUnit: 'STORE_2',
-              period: '20200101',
-              value: 2,
-            },
-          ],
-        }));
-
-      it('ignores non-superset data elements', () =>
-        expect(
-          supersetService.pull([DATA_ELEMENTS.DE_NOT_SUPERSET], 'dataElement', {
-            dataServiceMapping: DEFAULT_DATA_SERVICE_MAPPING,
-          }),
-        ).resolves.toEqual({
-          metadata: {
-            dataElementCodeToName: {},
+    it('uses supersetItemCode as a fallback', () =>
+      expect(
+        supersetService.pullAnalytics([DATA_ELEMENTS.ITEM_2_CUSTOM_CODE], DEFAULT_PULL_OPTIONS),
+      ).resolves.toEqual({
+        metadata: expect.anything(),
+        results: [
+          {
+            dataElement: 'ITEM_2_CUSTOM_CODE',
+            organisationUnit: 'STORE_1',
+            period: '20200101',
+            value: 3,
           },
-          results: [],
-        }));
-    });
+          {
+            dataElement: 'ITEM_2_CUSTOM_CODE',
+            organisationUnit: 'STORE_2',
+            period: '20200101',
+            value: 4,
+          },
+        ],
+      }));
 
-    describe('pullEvents()', () => {
-      it('throws an error', () =>
-        expect(
-          supersetService.pull([], 'dataGroup', { dataServiceMapping: new DataServiceMapping() }),
-        ).toBeRejectedWith('not supported'));
-    });
+    it('throws if supersetChartId not set', () =>
+      expect(
+        supersetService.pullAnalytics([DATA_ELEMENTS.DE_NO_CHART_ID], DEFAULT_PULL_OPTIONS),
+      ).toBeRejectedWith('Data Element DE_NO_CHART_ID missing supersetChartId'));
 
-    describe('pullSyncGroups()', () => {
-      it('throws an error', () =>
-        expect(
-          supersetService.pull([], 'dataGroup', { dataServiceMapping: new DataServiceMapping() }),
-        ).toBeRejectedWith('not supported'));
-    });
+    it('filters by the org units you specify', () =>
+      expect(
+        supersetService.pullAnalytics([DATA_ELEMENTS.ITEM_1], {
+          dataServiceMapping: DEFAULT_DATA_SERVICE_MAPPING,
+          organisationUnitCode: 'STORE_1',
+        }),
+      ).resolves.toEqual({
+        metadata: expect.anything(),
+        results: [
+          {
+            dataElement: 'ITEM_1',
+            organisationUnit: 'STORE_1',
+            period: '20200101',
+            value: 1,
+          },
+        ],
+      }));
+
+    it('returns data for all org units if no org units specified', () =>
+      expect(
+        supersetService.pullAnalytics([DATA_ELEMENTS.ITEM_1], {
+          dataServiceMapping: DEFAULT_DATA_SERVICE_MAPPING,
+          organisationUnitCodes: [],
+        }),
+      ).resolves.toEqual({
+        metadata: expect.anything(),
+        results: [
+          {
+            dataElement: 'ITEM_1',
+            organisationUnit: 'STORE_1',
+            period: '20200101',
+            value: 1,
+          },
+          {
+            dataElement: 'ITEM_1',
+            organisationUnit: 'STORE_2',
+            period: '20200101',
+            value: 2,
+          },
+        ],
+      }));
+
+    it('ignores non-superset data elements', () =>
+      expect(
+        supersetService.pullAnalytics([DATA_ELEMENTS.DE_NOT_SUPERSET], {
+          dataServiceMapping: DEFAULT_DATA_SERVICE_MAPPING,
+        }),
+      ).resolves.toEqual({
+        metadata: {
+          dataElementCodeToName: {},
+        },
+        results: [],
+      }));
+  });
+
+  describe('pullEvents()', () => {
+    it('throws an error', async () =>
+      expect(supersetService.pullEvents()).toBeRejectedWith('not supported'));
+  });
+
+  describe('pullSyncGroupResults()', () => {
+    it('throws an error', async () =>
+      expect(supersetService.pullSyncGroupResults()).toBeRejectedWith('not supported'));
   });
 
   describe('pullMetadata()', () => {

--- a/packages/data-broker/src/__tests__/services/tupaia/TupaiaService.test.ts
+++ b/packages/data-broker/src/__tests__/services/tupaia/TupaiaService.test.ts
@@ -32,114 +32,32 @@ describe('TupaiaService', () => {
     it('throws an error', () => expect(tupaiaService.delete()).toBeRejectedWith('not supported'));
   });
 
-  describe('pull()', () => {
-    describe('data element', () => {
-      describe('Tupaia data API invocation', () => {
-        it('single data element', async () => {
-          await tupaiaService.pull([DATA_ELEMENTS.POP01], 'dataElement', { dataServiceMapping });
-          expect(tupaiaDataApi.fetchAnalytics).toHaveBeenCalledOnceWith(
-            expect.objectContaining({ dataElementCodes: ['POP01'] }),
-          );
+  describe('pullAnalytics', () => {
+    describe('Tupaia data API invocation', () => {
+      it('single data element', async () => {
+        await tupaiaService.pullAnalytics([DATA_ELEMENTS.POP01], {
+          dataServiceMapping,
         });
-
-        it('multiple data elements', async () => {
-          await tupaiaService.pull([DATA_ELEMENTS.POP01, DATA_ELEMENTS.POP02], 'dataElement', {
-            dataServiceMapping,
-          });
-          expect(tupaiaDataApi.fetchAnalytics).toHaveBeenCalledOnceWith(
-            expect.objectContaining({ dataElementCodes: ['POP01', 'POP02'] }),
-          );
-        });
-
-        it('converts period to start and end dates', async () => {
-          await tupaiaService.pull([DATA_ELEMENTS.POP01, DATA_ELEMENTS.POP02], 'dataElement', {
-            dataServiceMapping,
-            period: '20200822',
-          });
-          expect(tupaiaDataApi.fetchAnalytics).toHaveBeenCalledOnceWith(
-            expect.objectContaining({ startDate: '2020-08-22', endDate: '2020-08-22' }),
-          );
-        });
-
-        it('supports various API options', async () => {
-          const options = {
-            dataServiceMapping,
-            organisationUnitCodes: ['TO', 'PG'],
-            startDate: '20200731',
-            endDate: '20200904',
-          };
-
-          await tupaiaService.pull([DATA_ELEMENTS.POP01], 'dataElement', options);
-          expect(tupaiaDataApi.fetchAnalytics).toHaveBeenCalledOnceWith(
-            expect.objectContaining(options),
-          );
-        });
+        expect(tupaiaDataApi.fetchAnalytics).toHaveBeenCalledOnceWith(
+          expect.objectContaining({ dataElementCodes: ['POP01'] }),
+        );
       });
 
-      describe('data pulling', () => {
-        it('returns a { results, metadata, numAggregationsProcessed } response', async () => {
-          const response = await tupaiaService.pull(
-            [DATA_ELEMENTS.POP01, DATA_ELEMENTS.POP02],
-            'dataElement',
-            { dataServiceMapping },
-          );
-          expect(response).toHaveProperty('results');
-          expect(response).toHaveProperty('metadata');
-          expect(response).toHaveProperty('numAggregationsProcessed');
+      it('multiple data elements', async () => {
+        await tupaiaService.pullAnalytics([DATA_ELEMENTS.POP01, DATA_ELEMENTS.POP02], {
+          dataServiceMapping,
         });
-
-        it('returns the analytics API response in the `results` field', () =>
-          expect(
-            tupaiaService.pull([DATA_ELEMENTS.POP01, DATA_ELEMENTS.POP02], 'dataElement', {
-              dataServiceMapping,
-            }),
-          ).resolves.toHaveProperty('results', ANALYTICS.analytics));
-
-        it('correctly builds the `metadata` field', () =>
-          expect(
-            tupaiaService.pull([DATA_ELEMENTS.POP01, DATA_ELEMENTS.POP02], 'dataElement', {
-              dataServiceMapping,
-            }),
-          ).resolves.toHaveProperty('metadata', {
-            dataElementCodeToName: {
-              POP01: 'Population 1',
-              POP02: 'Population 2',
-            },
-          }));
-
-        it('returns the analytics API aggregations processed in the `numAggregationsProcessed` field', () =>
-          expect(
-            tupaiaService.pull([DATA_ELEMENTS.POP01, DATA_ELEMENTS.POP02], 'dataElement', {
-              dataServiceMapping,
-            }),
-          ).resolves.toHaveProperty(
-            'numAggregationsProcessed',
-            ANALYTICS.numAggregationsProcessed,
-          ));
-      });
-    });
-
-    describe('data group', () => {
-      it('throws an error if multiple data groups are provided', () =>
-        expect(
-          tupaiaService.pull([DATA_GROUPS.POP01_GROUP, DATA_GROUPS.POP02_GROUP], 'dataGroup', {
-            dataServiceMapping,
-          }),
-        ).toBeRejectedWith(/Cannot .*multiple programs/));
-
-      it('uses the data group code as `dataGroupCode`', async () => {
-        await tupaiaService.pull([DATA_GROUPS.POP01_GROUP], 'dataGroup', { dataServiceMapping });
-        expect(tupaiaDataApi.fetchEvents).toHaveBeenCalledOnceWith(
-          expect.objectContaining({ dataGroupCode: 'POP01' }),
+        expect(tupaiaDataApi.fetchAnalytics).toHaveBeenCalledOnceWith(
+          expect.objectContaining({ dataElementCodes: ['POP01', 'POP02'] }),
         );
       });
 
       it('converts period to start and end dates', async () => {
-        await tupaiaService.pull([DATA_GROUPS.POP01_GROUP], 'dataGroup', {
+        await tupaiaService.pullAnalytics([DATA_ELEMENTS.POP01, DATA_ELEMENTS.POP02], {
           dataServiceMapping,
           period: '20200822',
         });
-        expect(tupaiaDataApi.fetchEvents).toHaveBeenCalledOnceWith(
+        expect(tupaiaDataApi.fetchAnalytics).toHaveBeenCalledOnceWith(
           expect.objectContaining({ startDate: '2020-08-22', endDate: '2020-08-22' }),
         );
       });
@@ -147,23 +65,106 @@ describe('TupaiaService', () => {
       it('supports various API options', async () => {
         const options = {
           dataServiceMapping,
-          dataElementCodes: ['POP01', 'POP02'],
           organisationUnitCodes: ['TO', 'PG'],
           startDate: '20200731',
           endDate: '20200904',
         };
 
-        await tupaiaService.pull([DATA_GROUPS.POP01_GROUP], 'dataGroup', options);
-        expect(tupaiaDataApi.fetchEvents).toHaveBeenCalledOnceWith(
+        await tupaiaService.pullAnalytics([DATA_ELEMENTS.POP01], options);
+        expect(tupaiaDataApi.fetchAnalytics).toHaveBeenCalledOnceWith(
           expect.objectContaining(options),
         );
       });
-
-      it('directly returns the event API response', () =>
-        expect(
-          tupaiaService.pull([DATA_GROUPS.POP01_GROUP], 'dataGroup', { dataServiceMapping }),
-        ).resolves.toStrictEqual(EVENTS));
     });
+
+    describe('data pulling', () => {
+      it('returns a { results, metadata, numAggregationsProcessed } response', async () => {
+        const response = await tupaiaService.pullAnalytics(
+          [DATA_ELEMENTS.POP01, DATA_ELEMENTS.POP02],
+          { dataServiceMapping },
+        );
+        expect(response).toHaveProperty('results');
+        expect(response).toHaveProperty('metadata');
+        expect(response).toHaveProperty('numAggregationsProcessed');
+      });
+
+      it('returns the analytics API response in the `results` field', () =>
+        expect(
+          tupaiaService.pullAnalytics([DATA_ELEMENTS.POP01, DATA_ELEMENTS.POP02], {
+            dataServiceMapping,
+          }),
+        ).resolves.toHaveProperty('results', ANALYTICS.analytics));
+
+      it('correctly builds the `metadata` field', () =>
+        expect(
+          tupaiaService.pullAnalytics([DATA_ELEMENTS.POP01, DATA_ELEMENTS.POP02], {
+            dataServiceMapping,
+          }),
+        ).resolves.toHaveProperty('metadata', {
+          dataElementCodeToName: {
+            POP01: 'Population 1',
+            POP02: 'Population 2',
+          },
+        }));
+
+      it('returns the analytics API aggregations processed in the `numAggregationsProcessed` field', () =>
+        expect(
+          tupaiaService.pullAnalytics([DATA_ELEMENTS.POP01, DATA_ELEMENTS.POP02], {
+            dataServiceMapping,
+          }),
+        ).resolves.toHaveProperty('numAggregationsProcessed', ANALYTICS.numAggregationsProcessed));
+    });
+  });
+
+  describe('pullEvents', () => {
+    it('throws an error if multiple data groups are provided', () =>
+      expect(
+        tupaiaService.pullEvents([DATA_GROUPS.POP01_GROUP, DATA_GROUPS.POP02_GROUP], {
+          dataServiceMapping,
+        }),
+      ).toBeRejectedWith(/Cannot .*multiple programs/));
+
+    it('uses the data group code as `dataGroupCode`', async () => {
+      await tupaiaService.pullEvents([DATA_GROUPS.POP01_GROUP], {
+        dataServiceMapping,
+      });
+      expect(tupaiaDataApi.fetchEvents).toHaveBeenCalledOnceWith(
+        expect.objectContaining({ dataGroupCode: 'POP01' }),
+      );
+    });
+
+    it('converts period to start and end dates', async () => {
+      await tupaiaService.pullEvents([DATA_GROUPS.POP01_GROUP], {
+        dataServiceMapping,
+        period: '20200822',
+      });
+      expect(tupaiaDataApi.fetchEvents).toHaveBeenCalledOnceWith(
+        expect.objectContaining({ startDate: '2020-08-22', endDate: '2020-08-22' }),
+      );
+    });
+
+    it('supports various API options', async () => {
+      const options = {
+        dataServiceMapping,
+        dataElementCodes: ['POP01', 'POP02'],
+        organisationUnitCodes: ['TO', 'PG'],
+        startDate: '20200731',
+        endDate: '20200904',
+      };
+
+      await tupaiaService.pullEvents([DATA_GROUPS.POP01_GROUP], options);
+      expect(tupaiaDataApi.fetchEvents).toHaveBeenCalledOnceWith(expect.objectContaining(options));
+    });
+
+    it('directly returns the event API response', () =>
+      expect(
+        tupaiaService.pullEvents([DATA_GROUPS.POP01_GROUP], { dataServiceMapping }),
+      ).resolves.toStrictEqual(EVENTS));
+  });
+
+  describe('pullSyncGroupResults()', () => {
+    it('throws an error', async () =>
+      expect(tupaiaService.pullSyncGroupResults()).toBeRejectedWith('not supported'));
   });
 
   describe('pullMetadata()', () => {

--- a/packages/data-broker/src/__tests__/services/weather/WeatherService.test.ts
+++ b/packages/data-broker/src/__tests__/services/weather/WeatherService.test.ts
@@ -41,7 +41,7 @@ describe('WeatherService', () => {
 
       const service = new WeatherService(mockModels, mockApi);
 
-      const actual = await service.pull(
+      const actual = await service.pullAnalytics(
         [
           {
             code: 'WTHR_PRECIP',
@@ -51,7 +51,6 @@ describe('WeatherService', () => {
             permission_groups: ['*'],
           },
         ],
-        'dataElement',
         getMockOptionsArg({
           startDate: '2019-01-01', // historic data request requires these, but api is mocked so these are ignored
           endDate: '2019-01-02',
@@ -89,7 +88,7 @@ describe('WeatherService', () => {
 
       const service = new WeatherService(mockModels, mockApi);
 
-      const actual = await service.pull(
+      const actual = await service.pullEvents(
         [
           {
             code: 'SOME_DATA_GROUP_CODE',
@@ -97,7 +96,6 @@ describe('WeatherService', () => {
             config: {},
           },
         ],
-        'dataGroup',
         getMockOptionsArg({
           startDate: '2019-01-01', // historic data request requires these, but api is mocked so these are ignored
           endDate: '2019-01-02',
@@ -134,9 +132,8 @@ describe('WeatherService', () => {
       const service = new WeatherService(mockModels, mockApi);
 
       const functionCall = async () =>
-        service.pull(
+        service.pullAnalytics(
           getMockDataSourcesArg(),
-          'dataElement',
           getMockOptionsArg({
             startDate: undefined,
             endDate: undefined,
@@ -174,11 +171,10 @@ describe('WeatherService', () => {
 
       const service = new WeatherService(mockModels, mockApi);
 
-      await service.pull(
+      await service.pullAnalytics(
         getMockDataSourcesArg({
           code: 'WTHR_FORECAST_PRECIP',
         }),
-        'dataElement',
         getMockOptionsArg({
           startDate: '2019-02-05',
           endDate: '2019-02-07',
@@ -202,9 +198,8 @@ describe('WeatherService', () => {
 
       const service = new WeatherService(mockModels, mockApi);
 
-      await service.pull(
+      await service.pullAnalytics(
         getMockDataSourcesArg(),
-        'dataElement',
         getMockOptionsArg({
           startDate: '2019-01-07',
           endDate: '2019-01-10',
@@ -219,6 +214,15 @@ describe('WeatherService', () => {
         '2019-01-07',
         '2019-01-11', // (same as input, changed to be exclusive end date)
       );
+    });
+  });
+
+  describe('pullSyncGroupResults()', () => {
+    it('throws an error', async () => {
+      const mockModels = await createMockModelsStubWithMockEntity();
+      const mockApi = createWeatherApiStubWithMockResponse();
+      const service = new WeatherService(mockModels, mockApi);
+      await expect(service.pullSyncGroupResults()).toBeRejectedWith('not supported');
     });
   });
 });

--- a/packages/data-broker/src/services/Service.ts
+++ b/packages/data-broker/src/services/Service.ts
@@ -6,6 +6,9 @@
 import {
   AnalyticResults,
   DataBrokerModelRegistry,
+  DataElement,
+  DataGroup,
+  DataServiceSyncGroup,
   DataSource,
   DataSourceType,
   Diagnostics,
@@ -24,11 +27,6 @@ export type PushOptions = {
 export type DeleteOptions = {
   type: DataSourceType;
   dataServiceMapping: DataServiceMapping;
-};
-
-export type PullOptions = {
-  dataServiceMapping: DataServiceMapping;
-  organisationUnitCodes?: string[];
 };
 
 export type PullMetadataOptions = {
@@ -62,11 +60,20 @@ export abstract class Service {
     options: DeleteOptions,
   ): Promise<Diagnostics>;
 
-  public abstract pull(
-    dataSources: DataSource[],
-    type: DataSourceType,
-    options: PullOptions,
-  ): Promise<AnalyticResults | EventResults | SyncGroupResults> | never;
+  public abstract pullAnalytics(
+    dataElements: DataElement[],
+    options: Record<string, unknown>,
+  ): Promise<AnalyticResults>;
+
+  public abstract pullEvents(
+    dataGroups: DataGroup[],
+    options: Record<string, unknown>,
+  ): Promise<EventResults>;
+
+  public abstract pullSyncGroupResults(
+    syncGroups: DataServiceSyncGroup[],
+    options: Record<string, unknown>,
+  ): Promise<SyncGroupResults>;
 
   /**
    * The default pullMetadata behaviour is to return no metadata

--- a/packages/data-broker/src/services/data-lake/DataLakeService.ts
+++ b/packages/data-broker/src/services/data-lake/DataLakeService.ts
@@ -4,56 +4,39 @@
  */
 
 import type { DataLakeApi } from '@tupaia/data-lake-api';
-import {
-  AnalyticResults,
-  DataBrokerModelRegistry,
-  DataElement,
-  DataGroup,
-  DataSource,
-  DataSourceType,
-  EventResults,
-} from '../../types';
-import type { PullOptions as BasePullOptions } from '../Service';
+import { DataBrokerModelRegistry, DataElement, DataGroup } from '../../types';
+import { DataServiceMapping } from '../DataServiceMapping';
 import { Service } from '../Service';
 import { translateOptionsForApi } from './translation';
 
-type PullAnalyticsOptions = BasePullOptions &
-  Partial<{
-    organisationUnitCodes: string[];
-    period: string;
-    startDate: string;
-    endDate: string;
-    dataElementCodes: string[];
-    dataGroupCode: string;
-    eventId: string;
-  }>;
+type PullAnalyticsOptions = {
+  dataServiceMapping: DataServiceMapping;
+  organisationUnitCodes?: string[];
+  period?: string;
+  startDate?: string;
+  endDate?: string;
+  dataElementCodes?: string[];
+  dataGroupCode?: string;
+  eventId?: string;
+};
 
-type PullEventsOptions = BasePullOptions &
-  Partial<{
-    organisationUnitCodes: string[];
-    period: string;
-    startDate: string;
-    endDate: string;
-    dataElementCodes: string[];
-  }>;
-
-type Puller =
-  | ((dataSources: DataElement[], options: PullAnalyticsOptions) => Promise<AnalyticResults>)
-  | ((dataSources: DataGroup[], options: PullEventsOptions) => Promise<EventResults>);
+type PullEventsOptions = {
+  dataServiceMapping: DataServiceMapping;
+  organisationUnitCodes?: string[];
+  period?: string;
+  startDate?: string;
+  endDate?: string;
+  dataElementCodes?: string[];
+};
 
 // used for internal Tupaia apis: TupaiaDataApi and IndicatorApi
 export class DataLakeService extends Service {
   private readonly api: DataLakeApi;
-  private readonly pullers: Record<string, Puller>;
 
   public constructor(models: DataBrokerModelRegistry, api: DataLakeApi) {
     super(models);
 
     this.api = api;
-    this.pullers = {
-      [this.dataSourceTypes.DATA_ELEMENT]: this.pullAnalytics.bind(this),
-      [this.dataSourceTypes.DATA_GROUP]: this.pullEvents.bind(this),
-    };
   }
 
   public async push(): Promise<never> {
@@ -64,23 +47,8 @@ export class DataLakeService extends Service {
     throw new Error('Data deletion is not supported in DataLakeService');
   }
 
-  public async pull(
-    dataSources: DataElement[],
-    type: 'dataElement',
-    options: PullAnalyticsOptions,
-  ): Promise<AnalyticResults>;
-  public async pull(
-    dataSources: DataGroup[],
-    type: 'dataGroup',
-    options: PullEventsOptions,
-  ): Promise<EventResults>;
-  public async pull(dataSources: DataSource[], type: DataSourceType, options: BasePullOptions) {
-    const pullData = this.pullers[type];
-    return pullData(dataSources as any, options);
-  }
-
-  private async pullAnalytics(dataSources: DataElement[], options: PullAnalyticsOptions) {
-    const dataElementCodes = dataSources.map(({ code }) => code);
+  public async pullAnalytics(dataElements: DataElement[], options: PullAnalyticsOptions) {
+    const dataElementCodes = dataElements.map(({ code }) => code);
     const { analytics, numAggregationsProcessed } = await this.api.fetchAnalytics({
       ...translateOptionsForApi(options),
       dataElementCodes,
@@ -93,13 +61,17 @@ export class DataLakeService extends Service {
     };
   }
 
-  private async pullEvents(dataSources: DataGroup[], options: PullEventsOptions) {
-    if (dataSources.length > 1) {
+  public async pullEvents(dataGroups: DataGroup[], options: PullEventsOptions) {
+    if (dataGroups.length > 1) {
       throw new Error('Cannot pull from multiple programs at the same time');
     }
-    const [dataSource] = dataSources;
-    const { code: dataGroupCode } = dataSource;
+    const [dataGroup] = dataGroups;
+    const { code: dataGroupCode } = dataGroup;
 
     return this.api.fetchEvents({ ...translateOptionsForApi(options), dataGroupCode });
+  }
+
+  public async pullSyncGroupResults(): Promise<never> {
+    throw new Error('pullSyncGroupResults is not supported in DataLakeService');
   }
 }

--- a/packages/data-broker/src/services/dhis/DhisService.ts
+++ b/packages/data-broker/src/services/dhis/DhisService.ts
@@ -6,19 +6,16 @@
 import type { DhisApi } from '@tupaia/dhis-api';
 import { getApiForDataSource, getApiFromServerName, getApisForDataSources } from './getDhisApi';
 import {
-  AnalyticResults,
   DataBrokerModelRegistry,
   DataElementMetadata,
   DataGroupMetadata,
   DataSourceType,
   DataValue,
   Diagnostics,
-  EventResults,
   OutboundEvent,
 } from '../../types';
 import type {
   PullMetadataOptions as BasePullMetadataOptions,
-  PullOptions as BasePullOptions,
   PushOptions as BasePushOptions,
   DeleteOptions as BaseDeleteOptions,
 } from '../Service';
@@ -44,14 +41,6 @@ type DataElementPushOptions = BasePushOptions & {
 type DataGroupPushOptions = BasePushOptions & {
   type: 'dataGroup';
 };
-
-type PullOptions = BasePullOptions &
-  Partial<{
-    organisationUnitCode: string;
-    organisationUnitCodes: string[];
-    detectDataServices: boolean;
-    useDeprecatedApi: boolean;
-  }>;
 
 type DeleteOptions = BaseDeleteOptions & {
   serverName?: string;
@@ -81,18 +70,6 @@ type Deleter =
   | ((api: DhisApi, dataValue: DataValue, dataSource: DataElement) => Promise<Diagnostics>)
   | ((api: DhisApi, data: DeleteEventData) => Promise<Diagnostics>);
 
-type Puller =
-  | ((
-      apis: DhisApi[],
-      dataSources: DataElement[],
-      options: PullAnalyticsOptions,
-    ) => Promise<AnalyticResults>)
-  | ((
-      apis: DhisApi[],
-      dataSources: DataGroup[],
-      options: PullEventsOptions,
-    ) => Promise<EventResults>);
-
 type MetadataPuller =
   | ((
       api: DhisApi,
@@ -119,7 +96,6 @@ export class DhisService extends Service {
   private readonly deprecatedEventsPuller: DeprecatedEventsPuller;
   private readonly pushers: Record<string, Pusher>;
   private readonly deleters: Record<string, Deleter>;
-  private readonly pullers: Record<string, Puller>;
   private readonly metadataPullers: Record<string, MetadataPuller>;
   private readonly metadataMergers: Record<string, MetadataMerger>;
 
@@ -144,7 +120,6 @@ export class DhisService extends Service {
     this.deprecatedEventsPuller = new DeprecatedEventsPuller(this.models, this.translator);
     this.pushers = this.getPushers();
     this.deleters = this.getDeleters();
-    this.pullers = this.getPullers();
     this.metadataPullers = this.getMetadataPullers();
     this.metadataMergers = this.getMetadataMergers();
   }
@@ -160,16 +135,6 @@ export class DhisService extends Service {
     return {
       [this.dataSourceTypes.DATA_ELEMENT]: this.deleteAggregateData.bind(this),
       [this.dataSourceTypes.DATA_GROUP]: this.deleteEvent.bind(this),
-    };
-  }
-
-  private getPullers() {
-    return {
-      [this.dataSourceTypes.DATA_ELEMENT]: this.analyticsPuller.pull.bind(this),
-      [this.dataSourceTypes.DATA_GROUP]: this.eventsPuller.pull.bind(this),
-      [`${this.dataSourceTypes.DATA_GROUP}_deprecated`]: this.deprecatedEventsPuller.pull.bind(
-        this,
-      ),
     };
   }
 
@@ -295,28 +260,32 @@ export class DhisService extends Service {
   private deleteEvent = async (api: DhisApi, data: DeleteEventData) =>
     api.deleteEvent(data.dhisReference);
 
-  public async pull(
-    dataSources: DataElement[],
-    type: 'dataElement',
-    options: PullAnalyticsOptions,
-  ): Promise<AnalyticResults>;
-  public async pull(
-    dataSources: DataGroup[],
-    type: 'dataGroup',
-    options: PullEventsOptions,
-  ): Promise<EventResults>;
-  public async pull(dataSources: DataSource[], type: DataSourceType, options: PullOptions) {
-    const { dataServiceMapping, useDeprecatedApi = false } = options;
+  public async pullAnalytics(dataElements: DataElement[], options: PullAnalyticsOptions) {
+    const { dataServiceMapping } = options;
 
-    const dhisDataSources = dataSources.filter(
+    const dhisDataElements = dataElements.filter(
       ds => dataServiceMapping.mappingForDataSource(ds)?.service_type === 'dhis',
     );
+    const apis = await getApisForDataSources(this.models, dhisDataElements, dataServiceMapping);
 
-    const apis = await getApisForDataSources(this.models, dhisDataSources, dataServiceMapping);
-    const pullerKey = `${type}${useDeprecatedApi ? '_deprecated' : ''}`;
+    return this.analyticsPuller.pull.bind(this)(apis, dhisDataElements, options);
+  }
 
-    const pullData = this.pullers[pullerKey];
-    return pullData(apis, dhisDataSources as any, options as any);
+  public async pullEvents(dataGroups: DataGroup[], options: PullEventsOptions) {
+    const { dataServiceMapping, useDeprecatedApi = false } = options;
+
+    const dhisDataGroups = dataGroups.filter(
+      ds => dataServiceMapping.mappingForDataSource(ds)?.service_type === 'dhis',
+    );
+    const apis = await getApisForDataSources(this.models, dhisDataGroups, dataServiceMapping);
+
+    return useDeprecatedApi
+      ? this.deprecatedEventsPuller.pull.bind(this)(apis, dhisDataGroups, options)
+      : this.eventsPuller.pull.bind(this)(apis, dhisDataGroups, options);
+  }
+
+  public async pullSyncGroupResults(): Promise<never> {
+    throw new Error('pullSyncGroupResults is not supported in DhisService');
   }
 
   public async pullMetadata(

--- a/packages/data-broker/src/services/dhis/pullers/AnalyticsPuller.ts
+++ b/packages/data-broker/src/services/dhis/pullers/AnalyticsPuller.ts
@@ -9,21 +9,21 @@ import keyBy from 'lodash.keyby';
 import type { DhisApi } from '@tupaia/dhis-api';
 import { AnalyticResults, DataBrokerModelRegistry } from '../../../types';
 import { buildAnalyticsFromDhisAnalytics, buildAnalyticsFromDhisEventAnalytics } from '../builders';
+import { DataServiceMapping } from '../../DataServiceMapping';
 import { DataElement, DataType, DhisAnalytics, DhisEventAnalytics } from '../types';
 import { DataElementsMetadataPuller } from './DataElementsMetadataPuller';
-import { PullOptions } from '../../Service';
 import { DhisTranslator } from '../translators';
 
-export type PullAnalyticsOptions = PullOptions &
-  Partial<{
-    programCodes?: string[];
-    organisationUnitCode: string;
-    organisationUnitCodes: string[];
-    period: string;
-    startDate: string;
-    endDate: string;
-    dataPeriodType: string;
-  }>;
+export type PullAnalyticsOptions = {
+  dataServiceMapping: DataServiceMapping;
+  organisationUnitCode?: string;
+  organisationUnitCodes?: string[];
+  programCodes?: string[];
+  period?: string;
+  startDate?: string;
+  endDate?: string;
+  dataPeriodType?: string;
+};
 
 export class AnalyticsPuller {
   private readonly models;

--- a/packages/data-broker/src/services/dhis/pullers/DeprecatedEventsPuller.ts
+++ b/packages/data-broker/src/services/dhis/pullers/DeprecatedEventsPuller.ts
@@ -4,20 +4,20 @@
  */
 
 import type { DhisApi } from '@tupaia/dhis-api';
-import type { PullOptions as BasePullOptions } from '../../Service';
 import { DataGroup } from '../types';
 import { DataBrokerModelRegistry, Event } from '../../../types';
+import { DataServiceMapping } from '../../DataServiceMapping';
 import { DhisTranslator } from '../translators';
 
-export type DeprecatedPullEventsOptions = BasePullOptions &
-  Partial<{
-    organisationUnitCodes: string[];
-    orgUnitIdScheme: 'uid' | 'code';
-    startDate: string;
-    endDate: string;
-    eventId: string;
-    trackedEntityInstance: string;
-  }>;
+export type DeprecatedPullEventsOptions = {
+  dataServiceMapping: DataServiceMapping;
+  organisationUnitCodes?: string[];
+  orgUnitIdScheme?: 'uid' | 'code';
+  startDate?: string;
+  endDate?: string;
+  eventId?: string;
+  trackedEntityInstance?: string;
+};
 
 /**
  * This is a deprecated puller which invokes a slow DHIS2 api ('/events')

--- a/packages/data-broker/src/services/dhis/pullers/EventsPuller.ts
+++ b/packages/data-broker/src/services/dhis/pullers/EventsPuller.ts
@@ -7,13 +7,14 @@ import type { DhisApi } from '@tupaia/dhis-api';
 import { getSortByKey } from '@tupaia/utils';
 import { buildEventsFromDhisEventAnalytics } from '../builders';
 import { DataBrokerModelRegistry, Event } from '../../../types';
+import { DataServiceMapping } from '../../DataServiceMapping';
 import { DhisTranslator } from '../translators';
 import { DataGroup } from '../types';
-import type { PullOptions as BasePullOptions } from '../../Service';
 
-export type PullEventsOptions = BasePullOptions & {
+export type PullEventsOptions = {
+  dataServiceMapping: DataServiceMapping;
+  organisationUnitCodes?: string[];
   dataElementCodes?: string[];
-  organisationUnitCodes: string[];
   period?: string;
   startDate?: string;
   endDate?: string;

--- a/packages/data-broker/src/services/kobo/KoBoService.ts
+++ b/packages/data-broker/src/services/kobo/KoBoService.ts
@@ -4,43 +4,27 @@
  */
 
 import type { KoBoApi } from '@tupaia/kobo-api';
-import {
-  DataBrokerModelRegistry,
-  DataSource,
-  DataSourceType,
-  Event,
-  SyncGroupResults,
-} from '../../types';
+import { DataBrokerModelRegistry, Event, SyncGroupResults } from '../../types';
+import { DataServiceMapping } from '../DataServiceMapping';
 import { Service } from '../Service';
-import type { PullOptions as BasePullOptions } from '../Service';
 import { KoBoTranslator } from './KoBoTranslator';
 import { KoboSubmission, DataServiceSyncGroup } from './types';
 
-type PullOptions = BasePullOptions &
-  Partial<{
-    startSubmissionTime: string;
-  }>;
-
-type Puller = (
-  dataSources: DataServiceSyncGroup[],
-  options: PullOptions,
-) => Promise<Record<string, Event[]>>;
+type PullSyncGroupResultsOptions = {
+  dataServiceMapping: DataServiceMapping;
+  organisationUnitCodes?: string[];
+  startSubmissionTime?: string;
+};
 
 export class KoBoService extends Service {
   private readonly api: KoBoApi;
   private readonly translator: KoBoTranslator;
-  private readonly pullers: Record<DataSourceType, Puller>;
 
   public constructor(models: DataBrokerModelRegistry, api: KoBoApi) {
     super(models);
 
     this.api = api;
     this.translator = new KoBoTranslator(this.models);
-    this.pullers = {
-      [this.dataSourceTypes.DATA_ELEMENT]: this.pullAnalytics,
-      [this.dataSourceTypes.DATA_GROUP]: this.pullEvents,
-      [this.dataSourceTypes.SYNC_GROUP]: this.pullSyncGroups,
-    };
   }
 
   public async push(): Promise<never> {
@@ -51,31 +35,21 @@ export class KoBoService extends Service {
     throw new Error('Data deletion is not supported in KoBoService');
   }
 
-  public async pull(
-    dataSources: DataServiceSyncGroup[],
-    type: DataSourceType,
-    options: PullOptions,
-  ): Promise<SyncGroupResults>;
-  public async pull(dataSources: DataSource[], type: DataSourceType, options: PullOptions) {
-    const puller = this.pullers[type];
-    return puller(dataSources as any, options);
+  public async pullAnalytics(): Promise<never> {
+    throw new Error('pullAnalytics is not supported in KoBoService');
   }
 
-  private pullAnalytics = (): Promise<never> => {
-    throw new Error('pullAnalytics is not supported in KoBoService');
-  };
-
-  private pullEvents = (): Promise<never> => {
+  public async pullEvents(): Promise<never> {
     throw new Error('pullEvents is not supported in KoBoService');
-  };
+  }
 
-  private pullSyncGroups = async (
-    dataSources: DataServiceSyncGroup[],
-    options: PullOptions,
+  public pullSyncGroupResults = async (
+    syncGroups: DataServiceSyncGroup[],
+    options: PullSyncGroupResultsOptions,
   ): Promise<SyncGroupResults> => {
     const resultsByDataGroupCode: Record<string, Event[]> = {};
 
-    for (const source of dataSources) {
+    for (const source of syncGroups) {
       const { koboSurveyCode, questionMapping, entityQuestionCode } = source.config;
       if (!koboSurveyCode) {
         throw new Error(`Missing 'koboSurveyCode' in sync group config`);

--- a/packages/data-broker/src/services/superset/SupersetService.ts
+++ b/packages/data-broker/src/services/superset/SupersetService.ts
@@ -7,40 +7,19 @@ import moment from 'moment';
 
 import { SupersetApi } from '@tupaia/superset-api';
 import { Service } from '../Service';
-import type { PullOptions as BasePullOptions } from '../Service';
 import { getSupersetApiInstance } from './getSupersetApi';
-import {
-  Analytic,
-  AnalyticResults,
-  DataBrokerModelRegistry,
-  DataElement,
-  DataSource,
-  DataSourceType,
-  EventResults,
-  SyncGroupResults,
-} from '../../types';
+import { Analytic, AnalyticResults, DataElement } from '../../types';
 import { DataServiceMapping, DataServiceMappingEntry } from '../DataServiceMapping';
 
-type PullOptions = BasePullOptions &
-  Partial<{
-    startDate: string;
-    endDate: string;
-    organisationUnitCode: string;
-    organisationUnitCodes: string[];
-  }>;
+type PullOptions = {
+  dataServiceMapping: DataServiceMapping;
+  organisationUnitCode?: string;
+  organisationUnitCodes?: string[];
+  startDate?: string;
+  endDate?: string;
+};
 
 export class SupersetService extends Service {
-  private readonly pullers: Record<string, any>;
-
-  public constructor(models: DataBrokerModelRegistry) {
-    super(models);
-    this.pullers = {
-      [this.dataSourceTypes.DATA_ELEMENT]: this.pullAnalytics.bind(this),
-      [this.dataSourceTypes.DATA_GROUP]: this.pullEvents.bind(this),
-      [this.dataSourceTypes.SYNC_GROUP]: this.pullSyncGroups.bind(this),
-    };
-  }
-
   public async push(): Promise<never> {
     throw new Error('Data push is not supported in SupersetService');
   }
@@ -49,16 +28,7 @@ export class SupersetService extends Service {
     throw new Error('Data deletion is not supported in SupersetService');
   }
 
-  public async pull(
-    dataSources: DataSource[],
-    type: DataSourceType,
-    options: PullOptions,
-  ): Promise<AnalyticResults | EventResults | SyncGroupResults> | never {
-    const puller = this.pullers[type];
-    return puller(dataSources, options);
-  }
-
-  private async pullAnalytics(
+  public async pullAnalytics(
     dataSources: DataElement[],
     options: PullOptions,
   ): Promise<AnalyticResults> {
@@ -199,11 +169,11 @@ export class SupersetService extends Service {
     return dataSourcesByChartId;
   }
 
-  private async pullEvents() {
+  public async pullEvents(): Promise<never> {
     throw new Error('pullEvents is not supported in SupersetService');
   }
 
-  private async pullSyncGroups() {
-    throw new Error('pullSyncGroups is not supported in SupersetService');
+  public async pullSyncGroupResults(): Promise<never> {
+    throw new Error('pullSyncGroupResults is not supported in SupersetService');
   }
 }

--- a/packages/data-broker/src/services/tupaia/TupaiaService.ts
+++ b/packages/data-broker/src/services/tupaia/TupaiaService.ts
@@ -6,7 +6,6 @@
 import type { TupaiaDataApi } from '@tupaia/data-api';
 import { reduceToDictionary } from '@tupaia/utils';
 import {
-  AnalyticResults,
   DataBrokerModelRegistry,
   DataElement,
   DataElementMetadata,
@@ -14,37 +13,32 @@ import {
   DataGroupMetadata,
   DataSource,
   DataSourceType,
-  EventResults,
 } from '../../types';
+import { DataServiceMapping } from '../DataServiceMapping';
 import { Service } from '../Service';
-import type {
-  PullOptions as BasePullOptions,
-  PullMetadataOptions as BasePullMetadataOptions,
-} from '../Service';
+import type { PullMetadataOptions as BasePullMetadataOptions } from '../Service';
 import { translateOptionsForApi } from './translation';
 
-export type PullAnalyticsOptions = BasePullOptions &
-  Partial<{
-    period: string;
-    startDate: string;
-    endDate: string;
-    includeOptions: boolean;
-  }>;
+type PullAnalyticsOptions = {
+  dataServiceMapping: DataServiceMapping;
+  organisationUnitCodes?: string[];
+  period?: string;
+  startDate?: string;
+  endDate?: string;
+  includeOptions?: boolean;
+};
 
-export type PullEventsOptions = BasePullOptions &
-  Partial<{
-    period: string;
-    startDate: string;
-    endDate: string;
-  }>;
+type PullEventsOptions = {
+  dataServiceMapping: DataServiceMapping;
+  organisationUnitCodes?: string[];
+  period?: string;
+  startDate?: string;
+  endDate?: string;
+};
 
 type PullMetadataOptions = BasePullMetadataOptions & {
   includeOptions?: boolean;
 };
-
-type Puller =
-  | ((dataSources: DataElement[], options: PullAnalyticsOptions) => Promise<AnalyticResults>)
-  | ((dataSources: DataGroup[], options: PullEventsOptions) => Promise<EventResults>);
 
 type MetadataPuller =
   | ((dataSources: DataElement[], options: PullMetadataOptions) => Promise<DataElementMetadata[]>)
@@ -53,17 +47,12 @@ type MetadataPuller =
 // used for internal Tupaia apis: TupaiaDataApi and IndicatorApi
 export class TupaiaService extends Service {
   private readonly api: TupaiaDataApi;
-  private readonly pullers: Record<string, Puller>;
   private readonly metadataPullers: Record<string, MetadataPuller>;
 
   public constructor(models: DataBrokerModelRegistry, api: TupaiaDataApi) {
     super(models);
 
     this.api = api;
-    this.pullers = {
-      [this.dataSourceTypes.DATA_ELEMENT]: this.pullAnalytics.bind(this),
-      [this.dataSourceTypes.DATA_GROUP]: this.pullEvents.bind(this),
-    };
     this.metadataPullers = {
       [this.dataSourceTypes.DATA_ELEMENT]: this.pullDataElementMetadata.bind(this),
       [this.dataSourceTypes.DATA_GROUP]: this.pullDataGroupMetadata.bind(this),
@@ -78,22 +67,7 @@ export class TupaiaService extends Service {
     throw new Error('Data deletion is not supported in TupaiaService');
   }
 
-  public async pull(
-    dataSources: DataElement[],
-    type: 'dataElement',
-    options: PullAnalyticsOptions,
-  ): Promise<AnalyticResults>;
-  public async pull(
-    dataSources: DataGroup[],
-    type: 'dataGroup',
-    options: PullEventsOptions,
-  ): Promise<EventResults>;
-  public async pull(dataSources: DataSource[], type: DataSourceType, options: BasePullOptions) {
-    const pullData = this.pullers[type];
-    return pullData(dataSources as any, options);
-  }
-
-  private async pullAnalytics(dataSources: DataElement[], options: PullAnalyticsOptions) {
+  public async pullAnalytics(dataSources: DataElement[], options: PullAnalyticsOptions) {
     const dataElementCodes = dataSources.map(({ code }) => code);
     const { analytics, numAggregationsProcessed } = await this.api.fetchAnalytics({
       ...translateOptionsForApi(options),
@@ -110,7 +84,7 @@ export class TupaiaService extends Service {
     };
   }
 
-  private async pullEvents(dataSources: DataGroup[], options: PullEventsOptions) {
+  public async pullEvents(dataSources: DataGroup[], options: PullEventsOptions) {
     if (dataSources.length > 1) {
       throw new Error('Cannot pull from multiple programs at the same time');
     }
@@ -118,6 +92,10 @@ export class TupaiaService extends Service {
     const { code: dataGroupCode } = dataSource;
 
     return this.api.fetchEvents({ ...translateOptionsForApi(options), dataGroupCode });
+  }
+
+  public async pullSyncGroupResults(): Promise<never> {
+    throw new Error('pullSyncGroupResults is not supported in TupaiaService');
   }
 
   public async pullMetadata(

--- a/packages/data-broker/src/services/weather/WeatherService.ts
+++ b/packages/data-broker/src/services/weather/WeatherService.ts
@@ -1,5 +1,6 @@
 import { ValidationError } from '@tupaia/utils';
 import type { WeatherApi } from '@tupaia/weather-api';
+import { DataServiceMapping } from '../DataServiceMapping';
 import {
   AnalyticResults,
   DataBrokerModelRegistry,
@@ -14,17 +15,14 @@ import { Service } from '../Service';
 import { ApiResultTranslator } from './ApiResultTranslator';
 import { DateSanitiser } from './DateSanitiser';
 import { DataElement, WeatherResult } from './types';
-import type {
-  PullOptions as BasePullOptions,
-  PullMetadataOptions as BasePullMetadataOptions,
-} from '../Service';
+import type { PullMetadataOptions as BasePullMetadataOptions } from '../Service';
 
-export type PullOptions = BasePullOptions &
-  Partial<{
-    organisationUnitCodes: string[];
-    startDate: string;
-    endDate: string;
-  }>;
+export type PullOptions = {
+  dataServiceMapping: DataServiceMapping;
+  organisationUnitCodes?: string[];
+  startDate?: string;
+  endDate?: string;
+};
 
 export class WeatherService extends Service {
   private readonly api: WeatherApi;
@@ -36,20 +34,32 @@ export class WeatherService extends Service {
     this.dateSanitiser = new DateSanitiser();
   }
 
+  public pullAnalytics(dataElements: DataElement[], options: PullOptions) {
+    return this.pull(dataElements, 'dataElement', options);
+  }
+
+  public pullEvents(dataGroups: DataGroup[], options: PullOptions) {
+    return this.pull(dataGroups, 'dataGroup', options);
+  }
+
+  public async pullSyncGroupResults(): Promise<never> {
+    throw new Error('pullSyncGroupResults is not supported in WeatherService');
+  }
+
   /**
    * Note, if no period specified will return current weather
    */
-  public async pull(
+  private async pull(
     dataSources: DataElement[],
     type: 'dataElement',
     options: PullOptions,
   ): Promise<AnalyticResults>;
-  public async pull(
+  private async pull(
     dataSources: DataGroup[],
     type: 'dataGroup',
     options: PullOptions,
   ): Promise<EventResults>;
-  public async pull(dataSources: DataSource[], type: DataSourceType, options: PullOptions) {
+  private async pull(dataSources: DataSource[], type: DataSourceType, options: PullOptions) {
     this.validateOptions(options);
 
     const { startDate, endDate } = options;
@@ -60,7 +70,7 @@ export class WeatherService extends Service {
       options.organisationUnitCodes as string[],
     );
 
-    const dataElementTypeDataSources = await this.extractDataSources(type, dataSources);
+    const dataElementTypeDataSources = await this.extractDataElements(type, dataSources);
 
     const forecastDataElementCodes = dataElementTypeDataSources
       .filter(dataSource => dataSource.config.weatherForecastData === true)
@@ -131,7 +141,7 @@ export class WeatherService extends Service {
     throw new Error('Not supported');
   }
 
-  private async extractDataSources(
+  private async extractDataElements(
     requestType: DataSourceType,
     requestDataSources: DataSource[],
   ): Promise<DataElement[]> {

--- a/packages/data-broker/src/types/models.ts
+++ b/packages/data-broker/src/types/models.ts
@@ -141,10 +141,7 @@ export type EntityHierarchy = {
   canonical_types: string[];
 };
 
-export type DataSourceTypeInstance = {
-  code: string;
-  service_type: ServiceType;
-  config: Record<string, DbValue>;
+export type DataSourceTypeInstance = DataSource & {
   databaseType:
     | typeof TYPES.DATA_ELEMENT
     | typeof TYPES.DATA_GROUP


### PR DESCRIPTION
This PR continues the work that started in https://github.com/beyondessential/tupaia/pull/4704 by splitting the pull API for `data-broker` services into `pullAnalytics()`, `pullEvents()`, `pullSyncGroupsResults()`