### PR TITLE
WAITP-1286 Fixup overlay sort

### DIFF
--- a/packages/tupaia-web-server/package.json
+++ b/packages/tupaia-web-server/package.json
@@ -35,6 +35,13 @@
     "express": "^4.16.2",
     "lodash.groupby": "^4.6.0",
     "lodash.keyby": "^4.6.0",
+    "lodash.sortby": "^4.6.0",
     "winston": "^3.2.1"
+  },
+  "devDependencies": {
+    "@tupaia/types": "1.0.0",
+    "@types/lodash.groupby": "^4.6.0",
+    "@types/lodash.keyby": "^4.6.0",
+    "@types/lodash.sortby": "^4.6.0"
   }
 }

--- a/packages/tupaia-web-server/src/routes/MapOverlaysRoute.ts
+++ b/packages/tupaia-web-server/src/routes/MapOverlaysRoute.ts
@@ -13,6 +13,7 @@ import {
 } from '@tupaia/types';
 import groupBy from 'lodash.groupby';
 import keyBy from 'lodash.keyby';
+import sortBy from 'lodash.sortby';
 
 export type MapOverlaysRequest = Request<
   TupaiaWebMapOverlaysRequest.Params,
@@ -118,11 +119,6 @@ export class MapOverlaysRoute extends Route<MapOverlaysRequest> {
       parentEntry: MapOverlayGroup,
     ): TranslatedMapOverlayGroup => {
       const childRelations = relationsByParentId[parentEntry.id as string] || [];
-      // groupBy does not guarantee order, so we can't sort before this
-      childRelations.sort(
-        (a: MapOverlayGroupRelation, b: MapOverlayGroupRelation) =>
-          (a.sort_order || 0) - (b.sort_order || 0),
-      );
       const nestedChildren: OverlayChild[] = childRelations.map(
         (relation: MapOverlayGroupRelation) => {
           if (relation.child_type === MAP_OVERLAY_CHILD_TYPE) {
@@ -133,21 +129,29 @@ export class MapOverlaysRoute extends Route<MapOverlaysRequest> {
               code: overlay.code,
               reportCode: overlay.report_code,
               legacy: overlay.legacy,
+              sortOrder: relation.sort_order,
               ...overlay.config,
             };
           }
-          return nestOverlayGroups(
-            relationsByParentId,
-            groupsById,
-            overlaysById,
-            groupsById[relation.child_id],
-          );
+          return {
+            ...nestOverlayGroups(
+              relationsByParentId,
+              groupsById,
+              overlaysById,
+              groupsById[relation.child_id],
+            ),
+            sortOrder: relation.sort_order,
+          };
         },
       );
       // Translate Map Overlay Group
       return {
         name: parentEntry.name,
-        children: nestedChildren,
+        children: sortBy(nestedChildren, ['sortOrder', 'name']).map((child: OverlayChild) => {
+          // We only needed the sortOrder for sorting, strip it before we return
+          const { sortOrder, ...restOfChild } = child;
+          return restOfChild;
+        }),
       };
     };
 

--- a/packages/types/src/schemas/schemas.ts
+++ b/packages/types/src/schemas/schemas.ts
@@ -42340,6 +42340,9 @@ export const TranslatedMapOverlaySchema = {
 		},
 		"legacy": {
 			"type": "boolean"
+		},
+		"sortOrder": {
+			"type": "number"
 		}
 	},
 	"type": "object",

--- a/packages/types/src/types/requests/tupaia-web-server/MapOverlaysRequest.ts
+++ b/packages/types/src/types/requests/tupaia-web-server/MapOverlaysRequest.ts
@@ -14,11 +14,13 @@ export interface TranslatedMapOverlay {
   name: string;
   reportCode: string;
   legacy: boolean;
+  sortOrder?: number | null;
   // ...config
 }
 export interface TranslatedMapOverlayGroup {
   name: string;
   children: OverlayChild[];
+  sortOrder?: number | null;
 }
 export type OverlayChild = TranslatedMapOverlayGroup | TranslatedMapOverlay;
 export interface ResBody {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10265,11 +10265,15 @@ __metadata:
     "@tupaia/database": 1.0.0
     "@tupaia/server-boilerplate": 1.0.0
     "@tupaia/types": 1.0.0
+    "@types/lodash.groupby": ^4.6.0
+    "@types/lodash.keyby": ^4.6.0
+    "@types/lodash.sortby": ^4.6.0
     camelcase-keys: ^6.2.2
     dotenv: ^8.2.0
     express: ^4.16.2
     lodash.groupby: ^4.6.0
     lodash.keyby: ^4.6.0
+    lodash.sortby: ^4.6.0
     winston: ^3.2.1
   languageName: unknown
   linkType: soft
@@ -11275,6 +11279,15 @@ __metadata:
   dependencies:
     "@types/lodash": "*"
   checksum: 1a4d85dd4ce371352b65dead78e1c6d89c4d59c440bfd9b27023b1113c8610115f2dda17c056b94697f7bfbd947bd8abfe0afd5195b65e2675b404e0e1542fae
+  languageName: node
+  linkType: hard
+
+"@types/lodash.sortby@npm:^4.6.0":
+  version: 4.7.7
+  resolution: "@types/lodash.sortby@npm:4.7.7"
+  dependencies:
+    "@types/lodash": "*"
+  checksum: 94164b49810e37cc3795c133a6375245cdfc0e6804680e34d7039889954e7201c820d658fff89fcda0a1ce68774286f49ce95f83004d8188c4434cdfc2ca55c4
   languageName: node
   linkType: hard
 
@@ -29507,7 +29520,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash.sortby@npm:^4.7.0":
+"lodash.sortby@npm:^4.6.0, lodash.sortby@npm:^4.7.0":
   version: 4.7.0
   resolution: "lodash.sortby@npm:4.7.0"
   checksum: db170c9396d29d11fe9a9f25668c4993e0c1331bcb941ddbd48fb76f492e732add7f2a47cfdf8e9d740fa59ac41bbfaf931d268bc72aab3ab49e9f89354d718c


### PR DESCRIPTION
### Issue #: WAITP-1286

### Changes:

- Sort by `sort_order`, then by `name`
- Update dev dependencies to use `lodash.sortby`
- Add `sortOrder` to types