### PR TITLE
WAITP-1289 Allow requesting qualified name from entity server

### DIFF
--- a/packages/entity-server/src/models/Entity.ts
+++ b/packages/entity-server/src/models/Entity.ts
@@ -31,6 +31,7 @@ export interface EntityType extends EntityFields, Omit<BaseEntityType, 'id'> {
   getChildren: (hierarchyId: string, criteria?: EntityFilter) => Promise<EntityType[]>;
   getParent: (hierarchyId: string) => Promise<EntityType | undefined>;
   getDescendants: (hierarchyId: string, criteria?: EntityFilter) => Promise<EntityType[]>;
+  getAncestors: (hierarchyId: string, criteria?: EntityFilter) => Promise<EntityType[]>;
   getAncestorOfType: (hierarchyId: string, type: string) => Promise<EntityType | undefined>;
   getRelatives: (hierarchyId: string, criteria?: EntityFilter) => Promise<EntityType[]>;
 }

--- a/packages/entity-server/src/routes/hierarchy/extendedFieldFunctions.ts
+++ b/packages/entity-server/src/routes/hierarchy/extendedFieldFunctions.ts
@@ -58,6 +58,20 @@ const getBounds = async (
   return entity.getBounds();
 };
 
+const getQualifiedName = async (
+  entity: EntityType,
+  context: {
+    hierarchyId: string;
+  },
+) => {
+  // Qualified name is a comma separated list of the entity's parent tree
+  const ancestors = await entity.getAncestors(context.hierarchyId);
+  return [entity, ...ancestors]
+    .filter(e => e.type !== 'project') // Don't include the project name
+    .map(e => e.name)
+    .join(', ');
+};
+
 export const extendedFieldFunctions = {
   parent_code: getParentCode,
   child_codes: getChildrenCodes,
@@ -65,6 +79,7 @@ export const extendedFieldFunctions = {
   point: getPoint,
   region: getRegion,
   bounds: getBounds,
+  qualified_name: getQualifiedName,
 };
 
 export const isExtendedField = (field: string): field is keyof typeof extendedFieldFunctions =>

--- a/packages/tupaia-web-server/src/routes/EntitySearchRoute.ts
+++ b/packages/tupaia-web-server/src/routes/EntitySearchRoute.ts
@@ -7,7 +7,7 @@ import { Request } from 'express';
 import { Route } from '@tupaia/server-boilerplate';
 import { TupaiaWebEntitySearchRequest } from '@tupaia/types';
 
-const DEFAULT_FIELDS = ['code', 'name'];
+const DEFAULT_FIELDS = ['code', 'name', 'qualified_name'];
 
 export type EntitySearchRequest = Request<
   TupaiaWebEntitySearchRequest.Params,


### PR DESCRIPTION
### Issue #: WAITP-1289

### Changes:

- Allow requesting a qualified name from entity server as an extended field
- Request qualified name by default in `tupaia-web-server` search route