### PR TITLE
Waitp 1222 point overlay fix

### DIFF
--- a/packages/tupaia-web/src/api/queries/useMapOverlayReport.ts
+++ b/packages/tupaia-web/src/api/queries/useMapOverlayReport.ts
@@ -115,6 +115,7 @@ export const useMapOverlayReport = (
     },
     {
       enabled: !!projectCode && !!entityCode && !!mapOverlayCode,
+      keepPreviousData: false,
     },
   );
 };

--- a/packages/tupaia-web/src/api/queries/useMapOverlayReport.ts
+++ b/packages/tupaia-web/src/api/queries/useMapOverlayReport.ts
@@ -97,6 +97,7 @@ export const useMapOverlayReport = (
   const isLegacy = mapOverlay?.legacy;
   const endpoint = isLegacy ? 'legacyMapOverlayReport' : 'report';
 
+  const enabled = !!projectCode && !!entityCode && !!mapOverlayCode;
   return useQuery(
     ['mapOverlayReport', projectCode, entityCode, mapOverlayCode, startDate, endDate],
     async () => {
@@ -114,8 +115,8 @@ export const useMapOverlayReport = (
       return formatMapOverlayData(responseData);
     },
     {
-      enabled: !!projectCode && !!entityCode && !!mapOverlayCode,
-      keepPreviousData: false,
+      enabled,
+      keepPreviousData: enabled, // Only keep previous data if this is still enabled. This fixes an issue where going back to an entity with no map overlays would show the previous entity's map overlay data
     },
   );
 };


### PR DESCRIPTION
### Issue WAITP-1222: Fix map overlay data bug

### Changes:
- Only keep previous data for map overlay when query is enabled. Fixes issue where going back to an entity where there were no map overlays would keep the previous entity's data
