### PR TITLE
Waitp-1287 dashboard minimap no data

### DIFF
--- a/packages/tupaia-web/src/features/Dashboard/Dashboard.tsx
+++ b/packages/tupaia-web/src/features/Dashboard/Dashboard.tsx
@@ -8,6 +8,7 @@ import styled from 'styled-components';
 import { useParams } from 'react-router-dom';
 import { Typography, Button } from '@material-ui/core';
 import GetAppIcon from '@material-ui/icons/GetApp';
+import { DEFAULT_BOUNDS } from '@tupaia/ui-map-components';
 import { MOBILE_BREAKPOINT } from '../../constants';
 import { ExpandButton } from './ExpandButton';
 import { Photo } from './Photo';
@@ -108,7 +109,7 @@ export const Dashboard = () => {
   const [isExpanded, setIsExpanded] = useState(false);
   const [exportModalOpen, setExportModalOpen] = useState(false);
   const { data: entity } = useEntity(projectCode, entityCode);
-  const bounds = entity?.bounds;
+  const bounds = entity?.bounds || DEFAULT_BOUNDS;
 
   const toggleExpanded = () => {
     setIsExpanded(!isExpanded);
@@ -120,17 +121,19 @@ export const Dashboard = () => {
       <ScrollBody>
         <Breadcrumbs />
         <DashboardImageContainer>
-          {bounds ? (
-            <StaticMap bounds={bounds} />
-          ) : (
+          {entity?.photoUrl ? (
             <Photo title={entity?.name} photoUrl={entity?.photoUrl} />
+          ) : (
+            <StaticMap bounds={bounds} />
           )}
         </DashboardImageContainer>
         <TitleBar>
           <Title variant="h3">{entity?.name}</Title>
-          <ExportButton startIcon={<GetAppIcon />} onClick={() => setExportModalOpen(true)}>
-            Export
-          </ExportButton>
+          {activeDashboard && (
+            <ExportButton startIcon={<GetAppIcon />} onClick={() => setExportModalOpen(true)}>
+              Export
+            </ExportButton>
+          )}
         </TitleBar>
         <DashboardMenu activeDashboard={activeDashboard} dashboards={dashboards} />
         <DashboardItemsWrapper $isExpanded={isExpanded}>

--- a/packages/tupaia-web/src/features/Dashboard/DashboardMenu.tsx
+++ b/packages/tupaia-web/src/features/Dashboard/DashboardMenu.tsx
@@ -56,10 +56,13 @@ export const DashboardMenu = ({
 
   return (
     <>
-      <MenuButton onClick={handleClickListItem}>
-        {activeDashboard?.name}
-        <ArrowDropDownIcon />
-      </MenuButton>
+      {activeDashboard && (
+        <MenuButton onClick={handleClickListItem}>
+          {activeDashboard?.name}
+          <ArrowDropDownIcon />
+        </MenuButton>
+      )}
+
       <Menu
         id="dashboards-menu"
         anchorEl={anchorEl}


### PR DESCRIPTION
### Issue WAITP-1287: Handle dashboard when access is denied

### Changes:
- Show minimap with default bounds when no dashboard (ie permission denied)
- Hide dashboard button when no dashboards available (permission denied)
---

### Screenshots:

![image](https://github.com/beyondessential/tupaia/assets/129009580/c087f2f5-2a67-4187-9259-6b03249e71b5)
