### PR TITLE
WAITP-1286 Use direct db access for MapOverlayRoute

### DIFF
--- a/packages/central-server/src/apiV2/mapOverlayGroupRelations/GETMapOverlayGroupRelations.js
+++ b/packages/central-server/src/apiV2/mapOverlayGroupRelations/GETMapOverlayGroupRelations.js
@@ -49,7 +49,6 @@ export class GETMapOverlayGroupRelations extends GETHandler {
   }
 
   async getPermissionsFilter(criteria, options) {
-    console.log('permissions filter criteria', criteria);
     const dbConditions = await createMapOverlayGroupRelationDBFilter(
       this.accessPolicy,
       this.models,
@@ -59,7 +58,6 @@ export class GETMapOverlayGroupRelations extends GETHandler {
   }
 
   async getPermissionsViaParentFilter(criteria, options) {
-    console.log('permissions via parent filter criteria', criteria);
     switch (this.parentRecordType) {
       case TYPES.MAP_OVERLAY_GROUP:
         return this.getPermissionsViaParentMapOverlayGroupFilter(criteria, options);

--- a/packages/database/src/TupaiaDatabase.js
+++ b/packages/database/src/TupaiaDatabase.js
@@ -276,9 +276,9 @@ export class TupaiaDatabase {
     const sql = `
      with recursive findParents as (
        select * from ${recordType}
-         where ${idKey} = '${id}'
+         where ${idKey} in ('${Array.isArray(id) ? id.join("','") : id}')
        union
-         select ${recordType}.* from ${recordType}
+         select distinct(${recordType}.*) from ${recordType}
            join findParents on findParents.${parentIdKey} = ${recordType}.${idKey}
      )
 

--- a/packages/database/src/modelClasses/MapOverlayGroupRelation.js
+++ b/packages/database/src/modelClasses/MapOverlayGroupRelation.js
@@ -48,4 +48,13 @@ export class MapOverlayGroupRelationModel extends DatabaseModel {
       },
     });
   }
+
+  async findParentRelationTree(childIds) {
+    return this.database.findWithParents(
+      this.databaseType,
+      childIds,
+      'child_id',
+      'map_overlay_group_id',
+    );
+  }
 }

--- a/packages/database/src/modelClasses/MapOverlayGroupRelation.js
+++ b/packages/database/src/modelClasses/MapOverlayGroupRelation.js
@@ -14,7 +14,7 @@ const RELATION_CHILD_TYPES = {
   MAP_OVERLAY_GROUP,
 };
 
-class MapOverlayGroupRelationType extends DatabaseType {
+export class MapOverlayGroupRelationType extends DatabaseType {
   static databaseType = TYPES.MAP_OVERLAY_GROUP_RELATION;
 
   async findChildRelations() {

--- a/packages/database/src/modelClasses/index.js
+++ b/packages/database/src/modelClasses/index.js
@@ -146,6 +146,10 @@ export {
 export { FacilityModel } from './Facility';
 export { FeedItemModel, FeedItemType } from './FeedItem';
 export { GeographicalAreaModel } from './GeographicalArea';
+export {
+  MapOverlayGroupRelationModel,
+  MapOverlayGroupRelationType,
+} from './MapOverlayGroupRelation';
 export { MeditrakDeviceModel } from './MeditrakDevice';
 export { MeditrakSyncQueueModel, MeditrakSyncQueueType } from './MeditrakSyncQueue';
 export { OptionModel } from './Option';

--- a/packages/tupaia-web-server/src/@types/express/index.d.ts
+++ b/packages/tupaia-web-server/src/@types/express/index.d.ts
@@ -7,6 +7,7 @@ import { AccessPolicy } from '@tupaia/access-policy';
 import { TupaiaApiClient } from '@tupaia/api-client';
 import { SessionCookie } from '@tupaia/server-boilerplate';
 
+import { TupaiaWebServerModelRegistry } from '../../types';
 import { TupaiaWebSessionType, TupaiaWebSessionModel } from '../../models';
 
 declare global {
@@ -19,6 +20,7 @@ declare global {
       ctx: {
         services: TupaiaApiClient;
       };
+      models: TupaiaWebServerModelRegistry;
     }
   }
 }

--- a/packages/tupaia-web-server/src/app/createApp.ts
+++ b/packages/tupaia-web-server/src/app/createApp.ts
@@ -50,7 +50,7 @@ const {
 const authHandlerProvider = (req: Request) => new SessionSwitchingAuthHandler(req);
 
 export function createApp() {
-  const app = new OrchestratorApiBuilder(new TupaiaDatabase(), 'tupaia-web')
+  const app = new OrchestratorApiBuilder(new TupaiaDatabase(), 'tupaia-web', { attachModels: true })
     .useSessionModel(TupaiaWebSessionModel)
     .useAttachSession(attachSessionIfAvailable)
     .attachApiClientToContext(authHandlerProvider)

--- a/packages/tupaia-web-server/src/models/MapOverlayGroupRelation.ts
+++ b/packages/tupaia-web-server/src/models/MapOverlayGroupRelation.ts
@@ -1,0 +1,27 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+import {
+  MapOverlayGroupRelationModel as BaseRelationModel,
+  MapOverlayGroupRelationType as BaseRelationType,
+} from '@tupaia/database';
+import { Model } from '@tupaia/server-boilerplate';
+
+type MapOverlayGroupRelationFields = Readonly<{
+  id: string;
+  map_overlay_group_id: string;
+  child_id: string;
+  child_type: 'mapOverlay' | 'mapOverlayGroup';
+  sort_order: number | null;
+}>;
+
+interface MapOverlayGroupRelationType
+  extends MapOverlayGroupRelationFields,
+    Omit<BaseRelationType, 'id'> {} // Omit base `id: any` type as we explicity define as a string here
+
+export interface MapOverlayGroupRelationModel
+  extends Model<BaseRelationModel, MapOverlayGroupRelationFields, MapOverlayGroupRelationType> {
+  findParentRelationTree: (childIds: string[]) => Promise<MapOverlayGroupRelationType[]>;
+}

--- a/packages/tupaia-web-server/src/models/index.ts
+++ b/packages/tupaia-web-server/src/models/index.ts
@@ -4,3 +4,4 @@
  */
 
 export { TupaiaWebSessionModel, TupaiaWebSessionType } from './TupaiaWebSession';
+export { MapOverlayGroupRelationModel } from './MapOverlayGroupRelation';

--- a/packages/tupaia-web-server/src/routes/MapOverlaysRoute.ts
+++ b/packages/tupaia-web-server/src/routes/MapOverlaysRoute.ts
@@ -48,7 +48,7 @@ export class MapOverlaysRoute extends Route<MapOverlaysRequest> {
           comparisonValue: [projectCode],
         },
       },
-      pageSize: pageSize,
+      pageSize,
     });
 
     if (mapOverlays.length === 0) {

--- a/packages/tupaia-web-server/src/routes/MapOverlaysRoute.ts
+++ b/packages/tupaia-web-server/src/routes/MapOverlaysRoute.ts
@@ -27,8 +27,6 @@ type OverlayChild = TupaiaWebMapOverlaysRequest.OverlayChild;
 // TODO: Can these be moved into types?
 const ROOT_MAP_OVERLAY_CODE = 'Root';
 const MAP_OVERLAY_CHILD_TYPE = 'mapOverlay';
-// Central server defaults to 100 record limit, this overrides that
-const DEFAULT_PAGE_SIZE = 'ALL';
 
 export class MapOverlaysRoute extends Route<MapOverlaysRequest> {
   public async buildResponse() {
@@ -50,7 +48,7 @@ export class MapOverlaysRoute extends Route<MapOverlaysRequest> {
           comparisonValue: [projectCode],
         },
       },
-      pageSize: pageSize || DEFAULT_PAGE_SIZE,
+      pageSize: pageSize,
     });
 
     if (mapOverlays.length === 0) {

--- a/packages/tupaia-web-server/src/types.ts
+++ b/packages/tupaia-web-server/src/types.ts
@@ -1,0 +1,11 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+import { ModelRegistry } from '@tupaia/database';
+import { MapOverlayGroupRelationModel } from './models';
+
+export interface TupaiaWebServerModelRegistry extends ModelRegistry {
+  readonly mapOverlayGroupRelation: MapOverlayGroupRelationModel;
+}


### PR DESCRIPTION
### Issue #: WAITP-1286

### Changes:

- Remove some debug logs
- Allow `TupaiaDatabase.findRecursiveTree` to search for multiple ids at once
- Add a recursive parent search to `MapOverlayGroupRelationModel`
- Allow orchestration servers to attach models to req in `server-boilerplate`
  - This isn't best practice, so generates a warning on startup
- Add model and modelRegistry types to `tupaia-web-server`
  - Attach those to the default request type
- Update `MapOverlaysRoute` to fetch relations from the db directly