### PR TITLE
[no-issue]: Remove redudnant .env.example file

### DIFF
--- a/packages/data-broker/.env.example
+++ b/packages/data-broker/.env.example
@@ -1,6 +1,0 @@
-# Used in tests
-DB_URL=
-DB_PORT=
-DB_NAME=
-DB_PASSWORD=
-DB_USER=


### PR DESCRIPTION
It says that its env variables are used in `data-broker` tests, but they're not