### PR TITLE
WAITP-1215 Increase proxy_buffer_size for central-server

### DIFF
--- a/packages/devops/configs/servers.conf
+++ b/packages/devops/configs/servers.conf
@@ -480,6 +480,7 @@ server {
               proxy_send_timeout 100;
               proxy_read_timeout 100;
               proxy_buffers 4 32k;
+              proxy_buffer_size 16k;
               client_max_body_size 50m;
               client_body_buffer_size 128k;
       }


### PR DESCRIPTION
### Issue #: WAITP-1215

### Changes:

- Increase the `proxy_buffer_size` for `central-server`
  - Default is usually `8k`, double it to `16k`
  - This buffer is used for processing http headers when we proxy to the central-server
  - `tupaia-web-server` is making some large requests that blow out the original buffer size