### PR TITLE
WAITP-1397: Tupaia Maps - Auto-zoom out

### DIFF
--- a/packages/tupaia-web/src/api/queries/useEntity.ts
+++ b/packages/tupaia-web/src/api/queries/useEntity.ts
@@ -21,7 +21,7 @@ export const useEntity = (projectCode?: ProjectCode, entityCode?: EntityCode) =>
       const entity = await get(`entity/${projectCode}/${entityCode}`, {
         params: {
           includeRoot: true,
-          fields: ['parent_code', 'code', 'name', 'type', 'bounds', 'region', 'image_url'],
+          fields: ['parent_code', 'code', 'name', 'type', 'point', 'bounds', 'region', 'image_url'],
         },
       });
 

--- a/packages/tupaia-web/src/features/Map/Map.tsx
+++ b/packages/tupaia-web/src/features/Map/Map.tsx
@@ -113,7 +113,12 @@ export const Map = () => {
 
   return (
     <MapContainer>
-      <StyledMap bounds={entity?.bounds as LeafletMapProps['bounds']} shouldSnapToPosition>
+      <StyledMap
+        center={entity?.point as LeafletMapProps['center']}
+        bounds={entity?.bounds as LeafletMapProps['bounds']}
+        zoom={15 as LeafletMapProps['zoom']}
+        shouldSnapToPosition
+      >
         <TileLayer tileSetUrl={activeTileSet.url} showAttribution={false} />
         <PolygonNavigationLayer />
         <DataVisualsLayer hiddenValues={hiddenValues} />

--- a/packages/tupaia-web/src/types/entity.d.ts
+++ b/packages/tupaia-web/src/types/entity.d.ts
@@ -3,9 +3,12 @@
  *  Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
  */
 
+import { Point } from '@tupaia/utils';
+
 // re-type the coordinates to be what the ui-map-components expect, because in the types package they are any | null
 export type Entity = KeysToCamelCase<Omit<TupaiaWebEntityRequest.ResBody, 'region' | 'bounds'>> & {
   region?: ActivePolygonProps['coordinates'];
+  point?: Point;
   bounds?: Position[];
   parentCode: Entity['code'];
   childCodes: Entity['code'][];

--- a/packages/ui-map-components/src/components/LeafletMap.tsx
+++ b/packages/ui-map-components/src/components/LeafletMap.tsx
@@ -134,10 +134,10 @@ export class LeafletMap extends Component<LeafletMapProps> {
   componentDidUpdate = (prevProps: LeafletMapProps) => {
     const { center, bounds, zoom } = this.props;
     if (this.map && this.requiresMoveAnimation(prevProps)) {
-      if (bounds) {
-        this.flyToBounds(bounds);
-      } else if (center) {
+      if (center) {
         this.flyToPoint(center, zoom);
+      } else if (bounds) {
+        this.flyToBounds(bounds);
       }
     }
   };
@@ -216,11 +216,14 @@ export class LeafletMap extends Component<LeafletMapProps> {
 
   flyToPoint = (center: LeafletMapProps['center'], zoom: LeafletMapProps['zoom']) => {
     if (!center) return;
+
     this.map?.setView(center, zoom, { animate: true });
   };
 
   flyToBounds = (bounds: LatLngBoundsExpression) => {
-    if (!areBoundsValid(bounds)) return;
+    if (!areBoundsValid(bounds)) {
+      return;
+    }
     this.map?.fitBounds(bounds, { animate: true });
   };
 

--- a/packages/ui-map-components/src/components/Markers/MeasurePopup.tsx
+++ b/packages/ui-map-components/src/components/Markers/MeasurePopup.tsx
@@ -38,6 +38,7 @@ export const MeasurePopup = React.memo(
     let onDetailButtonClick;
     if (onSeeOrgUnitDashboard) {
       onDetailButtonClick = () => onSeeOrgUnitDashboard(organisationUnitCode!);
+      console.log(organisationUnitCode);
     }
 
     return (

--- a/packages/ui-map-components/src/components/Markers/MeasurePopup.tsx
+++ b/packages/ui-map-components/src/components/Markers/MeasurePopup.tsx
@@ -38,7 +38,6 @@ export const MeasurePopup = React.memo(
     let onDetailButtonClick;
     if (onSeeOrgUnitDashboard) {
       onDetailButtonClick = () => onSeeOrgUnitDashboard(organisationUnitCode!);
-      console.log(organisationUnitCode);
     }
 
     return (


### PR DESCRIPTION
### Issue #:

### Changes:

- Updated useEntity query in tupaia-web to fetch point column. 
- Passed point and zoom from Map to leafletMap component.
- switched if statement priority from bounds to point so the map auto movement will always use setView instead of fitBounds if there is a point available.
