### PR TITLE
WAITP-1283: Fix broken server config

### DIFF
--- a/packages/devops/configs/servers.conf
+++ b/packages/devops/configs/servers.conf
@@ -3,7 +3,7 @@ server {
   listen       80;
   listen       [::]:80;
   server_name  ~^.*admin\.tupaia\.org$;
-  root         /home/ubuntu/tupaia/packages/admin-panel/build;
+  root         /home/ubuntu/tupaia/packages/admin-panel/dist;
 
   # Redirect to HTTPs when behind a proxy
   if ($http_x_forwarded_proto = "http") {
@@ -33,7 +33,7 @@ server {
   listen       80;
   listen       [::]:80;
   server_name  ~^.*psss\.tupaia\.org$;
-  root         /home/ubuntu/tupaia/packages/psss/build;
+  root         /home/ubuntu/tupaia/packages/psss/dist;
 
   # Redirect to HTTPs when behind a proxy
   if ($http_x_forwarded_proto = "http") {
@@ -131,7 +131,7 @@ server {
   listen       80;
   listen       [::]:80;
   server_name  ~^.*lesmis\.tupaia\.org$;
-  root         /home/ubuntu/tupaia/packages/lesmis/build;
+  root         /home/ubuntu/tupaia/packages/lesmis/dist;
 
   # Redirect to HTTPs when behind a proxy
   if ($http_x_forwarded_proto = "http") {
@@ -161,7 +161,7 @@ server {
   listen       80;
   listen       [::]:80;
   server_name  www.lesmis.la lesmis.la;
-  root         /home/ubuntu/tupaia/packages/lesmis/build;
+  root         /home/ubuntu/tupaia/packages/lesmis/dist;
 
   # Redirect to HTTPs when behind a proxy
   if ($http_x_forwarded_proto = "http") {


### PR DESCRIPTION
### Issue #: WAITP-1283: Fix broken server config

### Changes:

- Vite builds to dist instead of build and we need to updated the server config to match

---

