### PR TITLE
Waitp 1419 remove unused entity bounds data

### DIFF
--- a/packages/database/src/migrations/20230814030728-RemoveUnusedEntityBoundsData.js
+++ b/packages/database/src/migrations/20230814030728-RemoveUnusedEntityBoundsData.js
@@ -1,0 +1,29 @@
+'use strict';
+
+import { updateValues } from '../utilities';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = async function (db) {
+  await updateValues(db, 'entity', { bounds: null }, 'point IS NOT NULL');
+};
+
+exports.down = function (db) {
+  return null;
+};
+
+exports._meta = {
+  version: 1,
+};


### PR DESCRIPTION
### Issue #: WAITP-1419 remove unused entity bounds data

### Changes:

- Added migration to remove all bounds records in the entity table where there is a point record



