### PR TITLE
WAITP-1210 Navigation: Entity navigation via search

### DIFF
--- a/packages/tupaia-web-server/src/routes/EntitySearchRoute.ts
+++ b/packages/tupaia-web-server/src/routes/EntitySearchRoute.ts
@@ -5,6 +5,7 @@
 
 import { Request } from 'express';
 import { Route } from '@tupaia/server-boilerplate';
+import camelcaseKeys from 'camelcase-keys';
 import { TupaiaWebEntitySearchRequest } from '@tupaia/types';
 import { generateFrontendExcludedFilter } from '../utils';
 
@@ -30,12 +31,14 @@ export class EntitySearchRoute extends Route<EntitySearchRequest> {
     )[0];
     const { config } = project;
 
-    return ctx.services.entity.entitySearch(projectCode, searchString, {
+    const entitySearch = await ctx.services.entity.entitySearch(projectCode, searchString, {
       filter: generateFrontendExcludedFilter(config),
       ...query,
       page,
       pageSize,
       fields,
     });
+
+    return camelcaseKeys(entitySearch, { deep: true });
   }
 }

--- a/packages/tupaia-web/src/features/EntitySearch/SearchResults.tsx
+++ b/packages/tupaia-web/src/features/EntitySearch/SearchResults.tsx
@@ -105,7 +105,7 @@ export const SearchResults = ({ searchValue, onClose }: SearchResultsProps) => {
   return (
     <Container>
       <ScrollBody>
-        {searchResults.map(({ code, qualified_name }) => {
+        {searchResults.map(({ code, qualifiedName }) => {
           return (
             <ResultLink
               button
@@ -113,7 +113,7 @@ export const SearchResults = ({ searchValue, onClose }: SearchResultsProps) => {
               onClick={onClose}
               to={{ ...location, pathname: `/${projectCode}/${code}` }}
             >
-              {qualified_name}
+              {qualifiedName}
             </ResultLink>
           );
         })}

--- a/packages/tupaia-web/src/features/EntitySearch/SearchResults.tsx
+++ b/packages/tupaia-web/src/features/EntitySearch/SearchResults.tsx
@@ -105,7 +105,7 @@ export const SearchResults = ({ searchValue, onClose }: SearchResultsProps) => {
   return (
     <Container>
       <ScrollBody>
-        {searchResults.map(({ code, name }) => {
+        {searchResults.map(({ code, qualified_name }) => {
           return (
             <ResultLink
               button
@@ -113,7 +113,7 @@ export const SearchResults = ({ searchValue, onClose }: SearchResultsProps) => {
               onClick={onClose}
               to={{ ...location, pathname: `/${projectCode}/${code}` }}
             >
-              {name}
+              {qualified_name}
             </ResultLink>
           );
         })}


### PR DESCRIPTION
### Issue #: WAITP-1210: Navigation: Entity navigation via search

### Changes:

- Updated searchResults.tsx in tupaia-web to use qualified_name instead of name as this will show the ancestor entities as well as the target entity when searching.
