### PR TITLE
RN-899: Make the CheckboxList component generic

### DIFF
--- a/packages/tupaia-web/src/api/mutations/useExportDashboard.tsx
+++ b/packages/tupaia-web/src/api/mutations/useExportDashboard.tsx
@@ -4,7 +4,7 @@
  */
 import { useMutation } from 'react-query';
 import { stringifyQuery } from '@tupaia/utils';
-import { post } from '../api';
+import { API_URL, post } from '../api';
 import { DashboardItem, DashboardName, EntityCode, ProjectCode } from '../../types';
 
 type ExportDashboardBody = {
@@ -24,7 +24,7 @@ export const useExportDashboard = ({ onSuccess }: { onSuccess?: (data: Blob) => 
         selectedDashboardItems: selectedDashboardItems?.join(','),
       });
       // Auth cookies are saved against this domain. Pass this to server, so that when it pretends to be us, it can do the same.
-      const cookieDomain = new URL(import.meta.env.REACT_APP_TUPAIA_WEB_API_URL).hostname;
+      const cookieDomain = new URL(API_URL).hostname;
       return post('pdf', {
         responseType: 'blob',
         data: {

--- a/packages/tupaia-web/src/features/Dashboard/ExportDashboard.tsx
+++ b/packages/tupaia-web/src/features/Dashboard/ExportDashboard.tsx
@@ -50,14 +50,18 @@ const ButtonGroup = styled.div`
 interface ExportDashboardProps {
   isOpen: boolean;
   onClose: () => void;
-  dashboardItems?: DashboardItem[];
+  dashboardItems: DashboardItem[];
 }
 
-export const ExportDashboard = ({ isOpen, onClose, dashboardItems }: ExportDashboardProps) => {
+interface ListItem extends ListItemProps {
+  code: string;
+}
+
+export const ExportDashboard = ({ isOpen, onClose, dashboardItems = [] }: ExportDashboardProps) => {
   const { projectCode, entityCode, dashboardName } = useParams();
   const { data: project } = useProject(projectCode);
   const { data: entity } = useEntity(projectCode, entityCode);
-  const [selectedItems, setSelectedItems] = useState<ListItemProps[]>([]);
+  const [selectedItems, setSelectedItems] = useState<ListItem[]>([]);
 
   const handleExportSuccess = (data: Blob) => {
     downloadJs(data, `${exportFileName}.pdf`);
@@ -67,13 +71,12 @@ export const ExportDashboard = ({ isOpen, onClose, dashboardItems }: ExportDashb
     onSuccess: handleExportSuccess,
   });
 
-  const list =
-    dashboardItems?.map(({ config, code }) => ({
-      name: config?.name,
-      code,
-      disabled: config?.type !== 'chart',
-      tooltip: config?.type !== 'chart' ? 'PDF export coming soon' : undefined,
-    })) ?? [];
+  const list = dashboardItems.map(({ config, code }) => ({
+    name: config?.name,
+    code,
+    disabled: config?.type !== 'chart',
+    tooltip: config?.type !== 'chart' ? 'PDF export coming soon' : undefined,
+  }));
 
   const exportFileName = `${project?.name}-${entity?.name}-${dashboardName}-dashboard-export`;
 
@@ -82,7 +85,7 @@ export const ExportDashboard = ({ isOpen, onClose, dashboardItems }: ExportDashb
       projectCode,
       entityCode,
       dashboardName,
-      selectedDashboardItems: selectedItems.map(({ code }) => code!),
+      selectedDashboardItems: selectedItems.map(({ code }) => code),
     });
 
   return (

--- a/packages/ui-components/src/components/CheckboxList.tsx
+++ b/packages/ui-components/src/components/CheckboxList.tsx
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
  */
 
-import React, { Key } from 'react';
+import React, { Key, ReactElement } from 'react';
 import {
   FormControl as BaseFormControl,
   FormControlLabel,
@@ -89,47 +89,47 @@ export interface ListItemProps extends Record<string, unknown> {
   tooltip?: string;
 }
 
-function not(a: ListItemProps[], b: ListItemProps[]): ListItemProps[] {
-  return a.filter(
-    item => b.findIndex(i => i[i.valueKey || 'code'] === item[item.valueKey || 'code']) === -1,
-  );
-}
-
-function intersection(a: ListItemProps[], b: ListItemProps[]): ListItemProps[] {
-  return a.filter(
-    item => b.findIndex(i => i[i.valueKey || 'code'] === item[item.valueKey || 'code']) !== -1,
-  );
-}
-
-function union(a: ListItemProps[], b: ListItemProps[]): ListItemProps[] {
-  return [...a, ...not(b, a)];
-}
-
-interface CheckboxListProps {
-  list: ListItemProps[];
+interface CheckboxListProps<ListItem extends ListItemProps> {
+  list: ListItem[];
   title?: string;
-  selectedItems: ListItemProps[];
-  setSelectedItems: (items: ListItemProps[]) => void;
+  selectedItems: ListItem[];
+  setSelectedItems: (items: ListItem[]) => void;
 }
 
-export const CheckboxList = ({
+export const CheckboxList = <ListItem extends ListItemProps>({
   list,
   title = 'Choices',
   selectedItems,
   setSelectedItems,
-}: CheckboxListProps) => {
-  const numberOfChecked = (items: ListItemProps[]) => intersection(selectedItems, items).length;
+}: CheckboxListProps<ListItem>) => {
+  const not = (a: ListItem[], b: ListItem[]) => {
+    return a.filter(
+      item => b.findIndex(i => i[i.valueKey || 'code'] === item[item.valueKey || 'code']) === -1,
+    );
+  };
+
+  const intersection = (a: ListItem[], b: ListItem[]) => {
+    return a.filter(
+      item => b.findIndex(i => i[i.valueKey || 'code'] === item[item.valueKey || 'code']) !== -1,
+    );
+  };
+
+  const union = (a: ListItem[], b: ListItem[]) => {
+    return [...a, ...not(b, a)];
+  };
+
+  const numberOfChecked = (items: ListItem[]) => intersection(selectedItems, items).length;
 
   const enabledItems = list.filter(item => !item.disabled);
 
-  const handleCheckAll = (items: ListItemProps[]) => () => {
+  const handleCheckAll = (items: ListItem[]) => () => {
     if (numberOfChecked(items) === enabledItems.length) {
       setSelectedItems(not(selectedItems, items));
     } else {
       setSelectedItems(union(selectedItems, items));
     }
   };
-  const handleCheck = (item: ListItemProps) => () => {
+  const handleCheck = (item: ListItem) => () => {
     const currentIndex = selectedItems.findIndex(selectedItem => selectedItem.code === item.code);
     const newChecked = [...selectedItems];
 
@@ -142,8 +142,7 @@ export const CheckboxList = ({
     setSelectedItems(newChecked);
   };
   // If the list item has a tooltip, wrap it in a tooltip, otherwise just return the list item
-  // @ts-ignore
-  const CheckboxWrapper = ({ tooltip, children }) =>
+  const CheckboxWrapper = ({ tooltip, children }: { tooltip?: string; children: ReactElement }) =>
     tooltip ? (
       <Tooltip title={tooltip} placement="bottom">
         {children}


### PR DESCRIPTION
Making this component generic allows us to override the base `ListItem` type when using the `CheckboxList`.

Just to address this comment thread: https://github.com/beyondessential/tupaia/pull/4848/files#r1296553278

