### PR TITLE
WAITP-1210: Allow attaching filter context without entity context

### DIFF
--- a/packages/entity-server/src/app/createApp.ts
+++ b/packages/entity-server/src/app/createApp.ts
@@ -33,6 +33,7 @@ import {
   attachCommonEntityContext,
   attachSingleEntityContext,
   attachMultiEntityContext,
+  attachEntityFilterContext,
 } from '../routes/hierarchy/middleware';
 import { attachRelationshipsContext } from '../routes/hierarchy/relationships/middleware';
 import { HierarchyRequest, HierarchyRoute } from '../routes/hierarchies';
@@ -84,6 +85,7 @@ export function createApp(db = new TupaiaDatabase()) {
       .get<EntitySearchRequest>(
         'hierarchy/:hierarchyName/entitySearch/:searchString',
         attachCommonEntityContext,
+        attachEntityFilterContext,
         handleWith(EntitySearchRoute),
       )
 

--- a/packages/entity-server/src/routes/hierarchy/middleware/index.ts
+++ b/packages/entity-server/src/routes/hierarchy/middleware/index.ts
@@ -4,4 +4,4 @@
  */
 
 export { attachCommonEntityContext } from './attachCommonEntityContext';
-export { attachSingleEntityContext, attachMultiEntityContext } from './attachEntityContext';
+export { attachSingleEntityContext, attachMultiEntityContext, attachEntityFilterContext } from './attachEntityContext';


### PR DESCRIPTION
### Issue #: WAITP-1210

### Changes:

- Allow calculating and attaching the `filter` context to `req` in `entity-server` without a specific entity context
  - This is only useful for the `entitySearch` route at the moment because searches happen within a hierarchy context, but may still require a filter applied
  - Fixes the issue with `frontendExcludedTypes` not being correctly applied to entity search