### PR TITLE
WAITP-1301: Fix Get Projects Endpoint

### DIFF
--- a/packages/central-server/src/apiV2/mapOverlayGroupRelations/GETMapOverlayGroupRelations.js
+++ b/packages/central-server/src/apiV2/mapOverlayGroupRelations/GETMapOverlayGroupRelations.js
@@ -31,7 +31,7 @@ export class GETMapOverlayGroupRelations extends GETHandler {
       farTableKey: 'map_overlay_group.id',
     },
     map_overlay: {
-      nearTableKeyKey: 'map_overlay_group_relation.child_id',
+      nearTableKey: 'map_overlay_group_relation.child_id',
       farTableKey: 'map_overlay.id',
     },
   };

--- a/packages/central-server/src/apiV2/projects/GETProjects.js
+++ b/packages/central-server/src/apiV2/projects/GETProjects.js
@@ -37,7 +37,7 @@ export class GETProjects extends GETHandler {
   customJoinConditions = {
     entity: {
       nearTableKey: 'project.entity_id',
-      farTableTable: 'entity.id',
+      farTableKey: 'entity.id',
     },
     entity_hierarchy: {
       nearTableKey: 'project.entity_hierarchy_id',


### PR DESCRIPTION
### Issue #: WAITP-1301: Fix Get Projects Endpoint

The regression was caused in WAITP-1310 so just marking it against that ticket. The change isn't deployed yet so no need for a hotfix.



