### PR TITLE
WAITP-1210 Sort entity searches with higher hierarchy entities first

### DIFF
--- a/packages/entity-server/src/__tests__/__integration__/EntitySearchRoute.test.ts
+++ b/packages/entity-server/src/__tests__/__integration__/EntitySearchRoute.test.ts
@@ -31,7 +31,7 @@ describe('entitySearch', () => {
       );
     });
 
-    it('group entities that start with the string first', async () => {
+    it('sort entities searchString -> hierarchy -> alphabetical', async () => {
       const { body: entities } = await app.get('hierarchy/goldsilver/entitySearch/la', {
         query: { fields: 'code,name' },
       });
@@ -39,9 +39,9 @@ describe('entitySearch', () => {
       expect(entities).toBeArray();
       expect(entities).toEqual(
         getEntitiesWithFields(
-          // 'La'vender Radio Tower, 'La'vender Town, B'la'ckthorn City,
+          // 'La'vender Town, 'La'vender Radio Tower, B'la'ckthorn City,
           // Ce'la'don City, Ce'la'don Game Corner
-          ['LAVENDER_RADIO_TOWER', 'LAVENDER', 'BLACKTHORN', 'CELADON', 'CELADON_GAME'],
+          ['LAVENDER', 'LAVENDER_RADIO_TOWER', 'BLACKTHORN', 'CELADON', 'CELADON_GAME'],
           ['code', 'name'],
         ),
       );
@@ -55,8 +55,8 @@ describe('entitySearch', () => {
       expect(entities).toBeArray();
       expect(entities).toEqual(
         getEntitiesWithFields(
-          // 'La'vender Radio Tower, 'La'vender Town
-          ['LAVENDER_RADIO_TOWER', 'LAVENDER'],
+          // 'La'vender Town, 'La'vender Radio Tower
+          ['LAVENDER', 'LAVENDER_RADIO_TOWER'],
           ['code', 'name'],
         ),
       );


### PR DESCRIPTION
### Issue #: WAITP-1210

### Changes:

- Put entities that are higher in the hierarchy order higher in the search results