### PR TITLE
WAITP-1243 Fixup missing dashboard items

### DIFF
--- a/packages/server-boilerplate/src/orchestrator/api/ApiBuilder.ts
+++ b/packages/server-boilerplate/src/orchestrator/api/ApiBuilder.ts
@@ -82,9 +82,6 @@ export class ApiBuilder {
      */
     this.app.use((req: Request, res: Response, next: NextFunction) => {
       if (options.attachModels) {
-        winston.warn(
-          "Best practices say orchestrator servers shouldn't access the db directly, are you sure you need req.models?",
-        );
         req.models = this.models;
       }
       const context = {}; // context is shared between request and response

--- a/packages/tupaia-web-server/src/routes/DashboardsRoute.ts
+++ b/packages/tupaia-web-server/src/routes/DashboardsRoute.ts
@@ -28,6 +28,7 @@ export type DashboardsRequest = Request<
 
 const NO_DATA_AT_LEVEL_DASHBOARD_ITEM_CODE = 'no_data_at_level';
 const NO_ACCESS_DASHBOARD_ITEM_CODE = 'no_access';
+const DEFAULT_PAGE_SIZE = 'ALL';
 
 export class DashboardsRoute extends Route<DashboardsRequest> {
   private getNoDataDashboard = async (
@@ -104,6 +105,8 @@ export class DashboardsRoute extends Route<DashboardsRequest> {
           comparisonValue: [projectCode],
         },
       },
+      // Override the default limit of 100 records
+      pageSize: DEFAULT_PAGE_SIZE,
     });
 
     const dashboardItems = await ctx.services.central.fetchResources('dashboardItems', {
@@ -113,6 +116,8 @@ export class DashboardsRoute extends Route<DashboardsRequest> {
           comparisonValue: dashboardRelations.map((dr: DashboardRelation) => dr.child_id),
         },
       },
+      // Override the default limit of 100 records
+      pageSize: DEFAULT_PAGE_SIZE,
     });
 
     // Merged and sorted to make mapping easier


### PR DESCRIPTION
### Issue #: WAITP-1243

### Changes:

- Remove the spammy warning that I added
- Override default page size for dashboard requests
  - Since we fetch data for all dashboards on an entity simultaneously, some of our entities have upwards of 20 different dashboards
  - This results in more than 100 items/relations across those dashboards

We used a similar solution for `mapOverlays` that wound up not working because of the sheer volume of values in that case. Map overlay relations are in a hierarchy structure, which means for cases with a lot of layers the numbers blow up exponentially. Those requests were going above 400 records at points, which caused us issues. This is less likely to cause issues in dashboards since they're flat structured. Experimenting on my local, the larger sets of dashboards were giving ranges of 150-200. So I reckon this simpler solution will work in this case (or at the very least is worth testing with)

Separately I've put together [a ticket](https://linear.app/bes/issue/WAITP-1426/allow-central-server-to-support-larger-get-requests) for supporting larger requests in `central-server`