### PR TITLE
WAITP-1215 Filter out overlays with hideFromMenu set

### DIFF
--- a/packages/tupaia-web-server/src/routes/MapOverlaysRoute.ts
+++ b/packages/tupaia-web-server/src/routes/MapOverlaysRoute.ts
@@ -65,7 +65,9 @@ export class MapOverlaysRoute extends Route<MapOverlaysRequest> {
 
     // Breaking orchestration server convention and accessing the db directly
     const mapOverlayRelations = await this.req.models.mapOverlayGroupRelation.findParentRelationTree(
-      mapOverlays.map((overlay: MapOverlay) => overlay.id),
+      mapOverlays
+        .filter((overlay: MapOverlay) => !overlay.config?.hideFromMenu)
+        .map((overlay: MapOverlay) => overlay.id),
     );
 
     // Fetch all the groups we've used


### PR DESCRIPTION
### Issue #: WAITP-1215

### Changes:

- Filter overlays before the relations fetch
  - This way no relations will match and it won't get attached to the final return object