### PR TITLE
hotfix: Fix error logging when importing surveys

### DIFF
--- a/packages/central-server/src/apiV2/export/exportSurveys/cellBuilders/EntityConfigCellBuilder.js
+++ b/packages/central-server/src/apiV2/export/exportSurveys/cellBuilders/EntityConfigCellBuilder.js
@@ -8,8 +8,8 @@ import { KeyValueCellBuilder } from './KeyValueCellBuilder';
 const SPECIAL_VALUE_PROCESSORS = {
   type: value => value.join(','),
   createNew: value => (value ? 'Yes' : 'No'),
-  allowScanQrCode: value => (value ? 'Yes' : undefined),
-  generateQrCode: value => (value ? 'Yes' : undefined),
+  allowScanQrCode: value => (value ? 'Yes' : 'No'),
+  generateQrCode: value => (value ? 'Yes' : 'No'),
 };
 const KEY_TRANSLATION = {
   parentId: 'parent',

--- a/packages/central-server/src/apiV2/export/exportSurveys/cellBuilders/EntityConfigCellBuilder.js
+++ b/packages/central-server/src/apiV2/export/exportSurveys/cellBuilders/EntityConfigCellBuilder.js
@@ -8,8 +8,8 @@ import { KeyValueCellBuilder } from './KeyValueCellBuilder';
 const SPECIAL_VALUE_PROCESSORS = {
   type: value => value.join(','),
   createNew: value => (value ? 'Yes' : 'No'),
-  allowScanQrCode: value => (value ? 'Yes' : 'No'),
-  generateQrCode: value => (value ? 'Yes' : 'No'),
+  allowScanQrCode: value => (value ? 'Yes' : undefined),
+  generateQrCode: value => (value ? 'Yes' : undefined),
 };
 const KEY_TRANSLATION = {
   parentId: 'parent',

--- a/packages/central-server/src/apiV2/import/importSurveys/ConfigImporter/processEntityConfig.js
+++ b/packages/central-server/src/apiV2/import/importSurveys/ConfigImporter/processEntityConfig.js
@@ -37,13 +37,19 @@ export const processEntityConfig = async (models, config) => {
   );
 
   const processedConfig = {
-    allowScanQrCode: isYes(config.allowScanQrCode),
     type: splitStringOnComma(config.type),
     createNew: isYes(config.createNew),
-    generateQrCode: isYes(config.generateQrCode),
     ...entityCreationNonJsonFields,
     ...entityCreationJsonFields,
   };
+
+  // Optional configs
+  if (config.generateQrCode !== undefined) {
+    processedConfig.generateQrCode = isYes(config.generateQrCode);
+  }
+  if (config.allowScanQrCode !== undefined) {
+    processedConfig.allowScanQrCode = isYes(config.allowScanQrCode);
+  }
 
   let resultConfig = await replaceQuestionCodesWithIds(
     models,

--- a/packages/utils/src/errors.js
+++ b/packages/utils/src/errors.js
@@ -14,10 +14,14 @@ class LoggedError extends Error {
   constructor(message, originalError = null) {
     super(message);
     this.message = message;
+
+    // We may be in a context where winston is not defined (eg. frontend packages), just console log in that case
+    const logger = winston?.error ? winston.error : console.log;
+
     if (originalError) {
-      winston.error('Original error:', { stack: originalError.stack });
+      logger('Original error:', { stack: originalError.stack });
     }
-    winston.error(this.message, { stack: this.stack });
+    logger(this.message, { stack: this.stack });
   }
 }
 


### PR DESCRIPTION
### Issue: https://beyondessential.slack.com/archives/C01MAA3NKM1/p1693195752875529

Couple issues here to address:
- We always set a value for `generateQrCode` and `allowScanQrCode` when it'd be better for us to default them instead
- There are functions that throw errors that extend from `LoggedError` in the frontend. Figured it'd be easier just to just check if `winston` is available in that exception.