### PR TITLE
WAITP-1242: Tupaia- web FE fixes

### DIFF
--- a/packages/tupaia-web/src/features/Dashboard/Dashboard.tsx
+++ b/packages/tupaia-web/src/features/Dashboard/Dashboard.tsx
@@ -37,6 +37,7 @@ const Panel = styled.div<{
   width: 100%;
   overflow: visible;
   min-height: 100%;
+
   @media screen and (min-width: ${MOBILE_BREAKPOINT}) {
     width: ${({ $isExpanded }) => ($isExpanded ? 50 : 25)}%;
     height: 100%;
@@ -54,15 +55,28 @@ const ScrollBody = styled.div`
   }
 `;
 
-const TitleBar = styled.div`
+const StickyBar = styled.div<{
+  $isExpanded: boolean;
+}>`
   position: sticky;
   top: 0;
+  z-index: 1;
+
+  h3 {
+    padding-left: ${({ $isExpanded }) => ($isExpanded ? '1rem' : '0rem')};
+  }
+
+  > .MuiButtonBase-root {
+    padding-left: ${({ $isExpanded }) => ($isExpanded ? '2rem' : '1.2rem')};
+  }
+`;
+
+const TitleBar = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
   padding: 1rem;
   background-color: ${({ theme }) => theme.palette.background.default};
-  z-index: 1;
 
   @media screen and (max-width: ${MOBILE_BREAKPOINT}) {
     display: none;
@@ -73,7 +87,6 @@ const ExportButton = styled(Button).attrs({
   variant: 'outlined',
 })`
   font-size: 0.6875rem;
-  margin: 0 1rem;
 `;
 
 const Title = styled(Typography)`
@@ -81,7 +94,6 @@ const Title = styled(Typography)`
   font-weight: 400;
   font-size: 1.625rem;
   line-height: 1.4;
-  padding: 0 1rem;
 `;
 
 const DashboardItemsWrapper = styled.div<{
@@ -182,15 +194,17 @@ export const Dashboard = () => {
               <StaticMap bounds={bounds} />
             )}
           </DashboardImageContainer>
-          <TitleBar>
-            <Title variant="h3">{entity?.name}</Title>
-            {activeDashboard && (
-              <ExportButton startIcon={<GetAppIcon />} onClick={() => setExportModalOpen(true)}>
-                Export
-              </ExportButton>
-            )}
+          <StickyBar $isExpanded={isExpanded}>
+            <TitleBar>
+              <Title variant="h3">{entity?.name}</Title>
+              {activeDashboard && (
+                <ExportButton startIcon={<GetAppIcon />} onClick={() => setExportModalOpen(true)}>
+                  Export
+                </ExportButton>
+              )}
+            </TitleBar>
             <DashboardMenu activeDashboard={activeDashboard} dashboards={dashboards} />
-          </TitleBar>
+          </StickyBar>
           <DashboardItemsWrapper $isExpanded={isExpanded}>
             {visibleDashboards?.map(item => (
               <DashboardItem key={item.code} dashboardItem={item as DashboardItemType} />

--- a/packages/tupaia-web/src/features/Dashboard/Dashboard.tsx
+++ b/packages/tupaia-web/src/features/Dashboard/Dashboard.tsx
@@ -63,6 +63,7 @@ const TitleBar = styled.div`
   padding: 1rem;
   background-color: ${({ theme }) => theme.palette.background.default};
   z-index: 1;
+
   @media screen and (max-width: ${MOBILE_BREAKPOINT}) {
     display: none;
   }
@@ -188,8 +189,8 @@ export const Dashboard = () => {
                 Export
               </ExportButton>
             )}
+            <DashboardMenu activeDashboard={activeDashboard} dashboards={dashboards} />
           </TitleBar>
-          <DashboardMenu activeDashboard={activeDashboard} dashboards={dashboards} />
           <DashboardItemsWrapper $isExpanded={isExpanded}>
             {visibleDashboards?.map(item => (
               <DashboardItem key={item.code} dashboardItem={item as DashboardItemType} />

--- a/packages/tupaia-web/src/features/Dashboard/DashboardMenu.tsx
+++ b/packages/tupaia-web/src/features/Dashboard/DashboardMenu.tsx
@@ -11,18 +11,22 @@ import { Dashboard } from '../../types';
 
 const MenuButton = styled(ButtonBase)`
   display: flex;
+  align-items: center;
   justify-content: flex-start;
-  align-items: flex-end;
   background-color: ${({ theme }) => theme.palette.background.paper};
   width: 100%;
   padding: 1rem 2rem;
-  font-size: 1rem;
+  font-size: 1.125rem;
+  font-weight: 500;
+  line-height: 1.4;
+
+  .MuiSvgIcon-root {
+    margin-left: 0.5rem;
+  }
 `;
 
 const ItemButton = styled(Menu)`
-  margin: 0 auto;
-  margin-top: 3.125rem;
-  margin-left: 2rem;
+  margin: 3.125rem auto 0 2rem;
 
   .MuiPaper-root {
     background: ${({ theme }) => theme.palette.background.default};

--- a/packages/tupaia-web/src/features/Dashboard/ExpandButton.tsx
+++ b/packages/tupaia-web/src/features/Dashboard/ExpandButton.tsx
@@ -22,6 +22,10 @@ const SemiCircle = styled(Button)`
   border-bottom-left-radius: 60px;
   cursor: pointer;
   padding: 0;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.palette.background.paper};
+  }
 `;
 
 const CloseArrowIcon = styled(KeyboardArrowRight)`

--- a/packages/tupaia-web/src/features/Dashboard/StaticMap.tsx
+++ b/packages/tupaia-web/src/features/Dashboard/StaticMap.tsx
@@ -61,7 +61,7 @@ const makeStaticMapUrl = (polygonBounds: Position[]) => {
 
   const zoomLevel = longitude === 180 ? 1 : 2;
 
-  return `${MAPBOX_BASE_URL}${boundingBoxPath}/${longitude},${latitude},${zoomLevel}/${size}@2x?access_token=${MAPBOX_TOKEN}&attribution=false`;
+  return `${MAPBOX_BASE_URL}${boundingBoxPath}/${longitude},${latitude},${zoomLevel}/${size}@2x?access_token=${MAPBOX_TOKEN}&attribution=false&logo=false`;
 };
 
 export const StaticMap = ({ bounds }: { bounds: Position[] }) => {
@@ -70,5 +70,5 @@ export const StaticMap = ({ bounds }: { bounds: Position[] }) => {
   }
 
   const url = makeStaticMapUrl(bounds);
-  return <Media $backgroundImage={url}/>;
+  return <Media $backgroundImage={url} />;
 };

--- a/packages/tupaia-web/src/features/DashboardItem/DashboardInfoHover.tsx
+++ b/packages/tupaia-web/src/features/DashboardItem/DashboardInfoHover.tsx
@@ -22,6 +22,11 @@ const Wrapper = styled.div`
   flex-direction: column;
   gap: 0.3rem;
   margin-top: 1rem;
+
+  svg {
+    font-size: 1.4rem;
+  }
+
   @media screen and (min-width: ${MOBILE_BREAKPOINT}) {
     .MuiButton-label {
       display: flex;
@@ -30,6 +35,7 @@ const Wrapper = styled.div`
       align-items: center;
     }
     position: absolute;
+    padding: 1rem;
     width: 100%;
     height: 100%;
     background-color: ${({ theme }) => theme.palette.common.black};
@@ -38,8 +44,10 @@ const Wrapper = styled.div`
     left: 0;
     opacity: 0;
     margin-top: 0;
+    text-align: center;
     &:hover,
     &:focus-visible {
+      cursor: auto;
       opacity: 0.9;
       background-color: ${({ theme }) => theme.palette.common.black};
     }
@@ -47,7 +55,7 @@ const Wrapper = styled.div`
 `;
 
 const DashboardInfoHoverText = styled(Typography)`
-  font-size: 1rem;
+  font-size: 0.9rem;
 `;
 
 interface DashboardInfoHoverProps {
@@ -56,11 +64,10 @@ interface DashboardInfoHoverProps {
 
 export const DashboardInfoHover = ({ infoText }: DashboardInfoHoverProps) => {
   if (!infoText) return null;
-  const content = <DashboardInfoHoverText>{infoText}</DashboardInfoHoverText>;
   return (
     <Wrapper>
       <MuiInfoIcon />
-      {content}
+      <DashboardInfoHoverText>{infoText}</DashboardInfoHoverText>
     </Wrapper>
   );
 };

--- a/packages/tupaia-web/src/features/DashboardItem/DashboardInfoHover.tsx
+++ b/packages/tupaia-web/src/features/DashboardItem/DashboardInfoHover.tsx
@@ -59,7 +59,7 @@ const ExpandButton = styled(Button).attrs({
 }>`
   font-weight: ${({ theme }) => theme.typography.fontWeightRegular};
   text-transform: none;
-  color: ${({ theme }) => theme.palette.common.white};
+  color: ${({ theme }) => theme.palette.text.primary};
   border-color: ${({ theme }) => theme.palette.common.white};
   padding: 0.3rem;
   width: 100%;

--- a/packages/tupaia-web/src/features/DashboardItem/DashboardInfoHover.tsx
+++ b/packages/tupaia-web/src/features/DashboardItem/DashboardInfoHover.tsx
@@ -3,59 +3,76 @@
  * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import MuiInfoIcon from '@material-ui/icons/Info';
-import { MOBILE_BREAKPOINT } from '../../constants';
+import { Button } from '@tupaia/ui-components';
 import { Typography } from '@material-ui/core';
+import { MOBILE_BREAKPOINT } from '../../constants';
 
-const Wrapper = styled.div`
-  text-transform: none;
-  font-weight: ${({ theme }) => theme.typography.fontWeightRegular};
-  cursor: pointer;
-  color: ${({ theme }) => theme.palette.common.white};
-  border-color: ${({ theme }) => theme.palette.common.white};
-  padding: 0.3rem;
+const DesktopWrapper = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+  color: ${({ theme }) => theme.palette.common.white};
   flex-direction: column;
-  gap: 0.3rem;
-  margin-top: 1rem;
+  position: absolute;
+  padding: 1rem;
+  width: 100%;
+  height: 100%;
+  background-color: ${({ theme }) => theme.palette.common.black};
+  top: 0;
+  left: 0;
+  opacity: 0;
 
   svg {
     font-size: 1.4rem;
   }
 
-  @media screen and (min-width: ${MOBILE_BREAKPOINT}) {
-    .MuiButton-label {
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-      align-items: center;
-    }
-    position: absolute;
-    padding: 1rem;
-    width: 100%;
-    height: 100%;
+  p {
+    font-size: 0.9rem;
+  }
+
+  &:hover,
+  &:focus-visible {
+    cursor: auto;
+    opacity: 0.9;
     background-color: ${({ theme }) => theme.palette.common.black};
-    border: none;
-    top: 0;
-    left: 0;
-    opacity: 0;
-    margin-top: 0;
-    text-align: center;
-    &:hover,
-    &:focus-visible {
-      cursor: auto;
-      opacity: 0.9;
-      background-color: ${({ theme }) => theme.palette.common.black};
-    }
+  }
+
+  @media screen and (max-width: ${MOBILE_BREAKPOINT}) {
+    display: none;
   }
 `;
 
-const DashboardInfoHoverText = styled(Typography)`
-  font-size: 0.9rem;
+const MobileWrapper = styled.div`
+  @media screen and (min-width: ${MOBILE_BREAKPOINT}) {
+    display: none;
+  }
+`;
+
+const ExpandButton = styled(Button).attrs({
+  variant: 'outlined',
+  color: 'default',
+})<{
+  $active: boolean;
+}>`
+  font-weight: ${({ theme }) => theme.typography.fontWeightRegular};
+  text-transform: none;
+  color: ${({ theme }) => theme.palette.common.white};
+  border-color: ${({ theme }) => theme.palette.common.white};
+  padding: 0.3rem;
+  width: 100%;
+  margin-top: 1rem;
+
+  .MuiButton-label span {
+    display: ${props => (props.$active ? 'none' : 'flex')};
+  }
+
+  .MuiTypography-root {
+    display: ${props => (props.$active ? 'block' : 'none')};
+    padding: 0.3rem;
+  }
 `;
 
 interface DashboardInfoHoverProps {
@@ -63,11 +80,26 @@ interface DashboardInfoHoverProps {
 }
 
 export const DashboardInfoHover = ({ infoText }: DashboardInfoHoverProps) => {
+  const [isInfoBoxOpen, setIsInfoBoxOpen] = useState(false);
+
   if (!infoText) return null;
+
+  const toggleInfoBox = () => {
+    setIsInfoBoxOpen(!isInfoBoxOpen);
+  };
+
   return (
-    <Wrapper>
-      <MuiInfoIcon />
-      <DashboardInfoHoverText>{infoText}</DashboardInfoHoverText>
-    </Wrapper>
+    <>
+      <DesktopWrapper>
+        <MuiInfoIcon />
+        <Typography>{infoText}</Typography>
+      </DesktopWrapper>
+      <MobileWrapper>
+        <ExpandButton startIcon={<MuiInfoIcon />} onClick={toggleInfoBox} $active={isInfoBoxOpen}>
+          <span>View more info</span>
+          <Typography>{infoText}</Typography>
+        </ExpandButton>
+      </MobileWrapper>
+    </>
   );
 };

--- a/packages/tupaia-web/src/features/DashboardItem/ExpandItemButton.tsx
+++ b/packages/tupaia-web/src/features/DashboardItem/ExpandItemButton.tsx
@@ -51,11 +51,9 @@ const ExpandButtonText = styled.span`
 `;
 
 const ZoomInIcon = styled(MuiZoomIcon)`
-  margin-right: 1rem;
   @media screen and (min-width: ${MOBILE_BREAKPOINT}) {
     width: 1.5rem;
     height: 1.5rem;
-    margin-right: 0;
   }
 `;
 
@@ -99,8 +97,7 @@ export const ExpandItemButton = () => {
   const text = getText();
 
   return (
-    <ExpandableButton onClick={handleExpandDashboardItem}>
-      <ZoomInIcon />
+    <ExpandableButton onClick={handleExpandDashboardItem} startIcon={<ZoomInIcon />}>
       <ExpandButtonText>{text}</ExpandButtonText>
     </ExpandableButton>
   );

--- a/packages/tupaia-web/src/features/Visuals/View/DataDownload.tsx
+++ b/packages/tupaia-web/src/features/Visuals/View/DataDownload.tsx
@@ -16,7 +16,6 @@ import { URL_SEARCH_PARAMS } from '../../../constants';
 const ListItem = styled.li`
   text-align: center;
   font-size: 1.25rem;
-  background-color: red;
   &:not(:last-child) {
     margin-bottom: 0.625rem;
   }

--- a/packages/tupaia-web/src/layout/ProjectCardList/ProjectCard.tsx
+++ b/packages/tupaia-web/src/layout/ProjectCardList/ProjectCard.tsx
@@ -151,7 +151,7 @@ export const ProjectPendingLink = () => (
 
 export const ProjectAllowedLink = ({ url, isLandingPage }: LinkProps) => (
   <BaseLink to={url} target={isLandingPage ? '_blank' : '_self'}>
-    View Project
+    View project
   </BaseLink>
 );
 

--- a/packages/tupaia-web/src/layout/TopBar/TopBar.tsx
+++ b/packages/tupaia-web/src/layout/TopBar/TopBar.tsx
@@ -30,8 +30,7 @@ const Header = styled.header<{
   z-index: 1000;
   position: relative;
   padding: 0 0.625em;
-
-  border-bottom: 1px solid #202124;
+  border-bottom: 1px solid ${({ theme }) => theme.palette.background.paper};
 
   > * {
     background-color: ${({ theme }) => theme.palette.background.default};
@@ -47,7 +46,6 @@ const Header = styled.header<{
     height: ${TOP_BAR_HEIGHT};
     min-height: ${TOP_BAR_HEIGHT};
     align-items: initial;
-    border-bottom: 1px solid rgba(151, 151, 151, 0.3);
   }
 `;
 

--- a/packages/tupaia-web/src/layout/TopBar/TopBar.tsx
+++ b/packages/tupaia-web/src/layout/TopBar/TopBar.tsx
@@ -21,7 +21,7 @@ const Header = styled.header<{
   $primaryColor?: string | null;
   $secondaryColor?: string | null;
 }>`
-  background-color: ${({theme}) => theme.palette.background.default};
+  background-color: ${({ theme }) => theme.palette.background.default};
   height: ${TOP_BAR_HEIGHT_MOBILE};
   min-height: ${TOP_BAR_HEIGHT_MOBILE};
   display: flex;
@@ -30,6 +30,8 @@ const Header = styled.header<{
   z-index: 1000;
   position: relative;
   padding: 0 0.625em;
+
+  border-bottom: 1px solid #202124;
 
   > * {
     background-color: ${({ theme }) => theme.palette.background.default};


### PR DESCRIPTION
### Issue #: WAITP-1242: FE fixes

### Changes:

- Remove red background test code
- Update dashboard and project card styles to match design
- Update Dashboard item more info action to match existing behaviour

---

### Screenshots:

Update dashboard colours and padding to match design 

<img width="1440" alt="image" src="https://github.com/beyondessential/tupaia/assets/12807916/040a34f8-215c-44ff-bed0-d632af66ef25">

Dashboard item more info hover on desktop
<img width="1026" alt="image" src="https://github.com/beyondessential/tupaia/assets/12807916/b543b82f-c64e-40c9-9741-a5a294e242f8">

Dashboard item more info on mobile
<img width="416" alt="image" src="https://github.com/beyondessential/tupaia/assets/12807916/99b9fa0f-1f8d-4e69-b3f5-ffd6d36db48c">

<img width="390" alt="image" src="https://github.com/beyondessential/tupaia/assets/12807916/1cfc0b10-0bef-42b6-9d25-5f8c2eb8de99">
