### PR TITLE
No-issue: fix lesmis build error

### DIFF
--- a/packages/lesmis/src/routes/PageRoutes.jsx
+++ b/packages/lesmis/src/routes/PageRoutes.jsx
@@ -3,10 +3,10 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  *
  */
-import React, { lazy, Suspense } from 'react';
+import React from 'react';
 import { Switch, Route, useRouteMatch } from 'react-router-dom';
 import { AdminPanelDataProviders } from '@tupaia/admin-panel';
-import { NavBar, Footer, FullPageLoader } from '../components';
+import { NavBar, Footer } from '../components';
 import { HomeView } from '../views/HomeView';
 import { ProfileView } from '../views/ProfileView';
 import { PageView, TwoColumnPageView } from '../views/PageView';
@@ -31,65 +31,63 @@ export const PageRoutes = React.memo(() => {
   const { path } = useRouteMatch();
 
   return (
-    <Suspense fallback={<FullPageLoader />}>
-      <Switch>
-        <Route exact path={`${path}/`}>
-          <NavBar hideSearch />
-          <HomeView />
-        </Route>
-        <Route path={`${path}/login`}>
-          <LoginView />
-        </Route>
-        <Route path={`${path}/verify-email`}>
-          <VerifyEmailView />
-        </Route>
-        <Route path={`${path}/register`}>
-          <RegisterView />
-        </Route>
-        <Route path={`${path}/profile`}>
-          <NavBar />
-          <ProfileView />
+    <Switch>
+      <Route exact path={`${path}/`}>
+        <NavBar hideSearch />
+        <HomeView />
+      </Route>
+      <Route path={`${path}/login`}>
+        <LoginView />
+      </Route>
+      <Route path={`${path}/verify-email`}>
+        <VerifyEmailView />
+      </Route>
+      <Route path={`${path}/register`}>
+        <RegisterView />
+      </Route>
+      <Route path={`${path}/profile`}>
+        <NavBar />
+        <ProfileView />
+        <Footer />
+      </Route>
+      <Route path={`${path}/admin`}>
+        <AdminPanelDataProviders config={adminPanelConfig}>
+          <AdminPanel />
           <Footer />
-        </Route>
-        <Route path={`${path}/admin`}>
-          <AdminPanelDataProviders config={adminPanelConfig}>
-            <AdminPanel />
-            <Footer />
-          </AdminPanelDataProviders>
-        </Route>
-        <Route path={`${path}/about`}>
-          <NavBar />
-          <PageView content={ABOUT_PAGE} />
-          <Footer />
-        </Route>
-        <Route path={`${path}/fundamental-quality-standards`}>
-          <NavBar />
-          <TwoColumnPageView content={FQS_PAGE} />
-          <Footer />
-        </Route>
-        <Route path={`${path}/contact`}>
-          <NavBar />
-          <PageView content={CONTACT_PAGE} />
-          <Footer />
-        </Route>
-        <Route path={`${path}/page-not-found`}>
-          <NavBar />
-          <NotFoundView />
-          <Footer />
-        </Route>
-        <Route path={`${path}/not-authorised`}>
-          <NavBar />
-          <NotAuthorisedView />
-          <Footer />
-        </Route>
-        <Route path={`${path}/pdf-export/:entityCode?`}>
-          <ExportView viewType={PDF_DOWNLOAD_VIEW} />
-        </Route>
-        <Route path={`${path}/:entityCode/:view?`}>
-          <NavBar />
-          <EntityView />
-        </Route>
-      </Switch>
-    </Suspense>
+        </AdminPanelDataProviders>
+      </Route>
+      <Route path={`${path}/about`}>
+        <NavBar />
+        <PageView content={ABOUT_PAGE} />
+        <Footer />
+      </Route>
+      <Route path={`${path}/fundamental-quality-standards`}>
+        <NavBar />
+        <TwoColumnPageView content={FQS_PAGE} />
+        <Footer />
+      </Route>
+      <Route path={`${path}/contact`}>
+        <NavBar />
+        <PageView content={CONTACT_PAGE} />
+        <Footer />
+      </Route>
+      <Route path={`${path}/page-not-found`}>
+        <NavBar />
+        <NotFoundView />
+        <Footer />
+      </Route>
+      <Route path={`${path}/not-authorised`}>
+        <NavBar />
+        <NotAuthorisedView />
+        <Footer />
+      </Route>
+      <Route path={`${path}/pdf-export/:entityCode?`}>
+        <ExportView viewType={PDF_DOWNLOAD_VIEW} />
+      </Route>
+      <Route path={`${path}/:entityCode/:view?`}>
+        <NavBar />
+        <EntityView />
+      </Route>
+    </Switch>
   );
 });

--- a/packages/lesmis/src/routes/PageRoutes.jsx
+++ b/packages/lesmis/src/routes/PageRoutes.jsx
@@ -19,8 +19,8 @@ import { VerifyEmailView } from '../views/VerifyEmailView';
 import { ABOUT_PAGE, FQS_PAGE, CONTACT_PAGE } from '../constants';
 import { ExportView, PDF_DOWNLOAD_VIEW } from '../views/ExportView';
 import { getAdminApiUrl } from '../utils/getAdminApiUrl';
+import AdminPanel from './AdminPanelApp';
 
-const AdminPanel = lazy(() => import('./AdminPanelApp'));
 const adminPanelConfig = { apiUrl: `${getAdminApiUrl()}` };
 
 /**


### PR DESCRIPTION
### Issue #: No-issue: fix lesmis build error

### Changes:
Fixes this issue on the dev builds.
```
er-compatibility for more details.
\Tue Aug 29 00:43:59 UTC 2023 \✓ 11625 modules transformed.
\Tue Aug 29 00:44:00 UTC 2023 \Export "ExportModal" of module "../../node_modules/@tupaia/admin-panel/lib/importExport/ExportModal.js" was reexported through module "../../node_modules/@tupaia/admin-panel/lib/importExport/index.js" while both modules are dependencies of each otherand will end up in different chunks by current Rollup settings. This scenario is not well supported at the moment as it will produce a circular dependency between chunks and will likely lead to broken execution order.
\Tue Aug 29 00:44:00 UTC 2023 \Either change the import in "src/views/AdminPanel/components/getSurveyResponsesExportModal.jsx" to point directly to the exporting module or reconfigure "output.manualChunks" to ensure these modules end up in the same chunk.