### PR TITLE
WAITP-1239: Add export survey responses route to tupaia-web-server

### DIFF
--- a/packages/api-client/src/connections/ApiConnection.ts
+++ b/packages/api-client/src/connections/ApiConnection.ts
@@ -76,7 +76,12 @@ export class ApiConnection {
 
     const response = await this.fetchWithTimeout(queryUrl, fetchConfig);
     await this.verifyResponse(response);
-    return response.json();
+    const contentType = response.headers.get('content-type');
+    if (contentType && contentType.includes('application/json')) {
+      return response.json();
+    }
+    // If the response isn't json, it's most likely a file export
+    return response.buffer();
   }
 
   private async fetchWithTimeout(
@@ -92,7 +97,9 @@ export class ApiConnection {
       const responseJson = await response.json();
       throw new CustomError(
         {
-          responseText: `API error ${response.status}: ${responseJson.error || responseJson.message}`,
+          responseText: `API error ${response.status}: ${
+            responseJson.error || responseJson.message
+          }`,
           responseStatus: response.status,
         },
         {},

--- a/packages/api-client/src/connections/ApiConnection.ts
+++ b/packages/api-client/src/connections/ApiConnection.ts
@@ -77,11 +77,11 @@ export class ApiConnection {
     const response = await this.fetchWithTimeout(queryUrl, fetchConfig);
     await this.verifyResponse(response);
     const contentType = response.headers.get('content-type');
-    if (contentType && contentType.includes('application/json')) {
+    if (contentType && contentType.indexOf('application/json') !== -1) {
       return response.json();
     }
-    // If the response isn't json, it's most likely a file export
-    return response.buffer();
+    // If the content isn't json we expect the receiving code to parse it
+    return response;
   }
 
   private async fetchWithTimeout(

--- a/packages/server-boilerplate/src/orchestrator/api/ApiBuilder.ts
+++ b/packages/server-boilerplate/src/orchestrator/api/ApiBuilder.ts
@@ -16,7 +16,6 @@ import {
 import { ModelRegistry, TupaiaDatabase } from '@tupaia/database';
 import { AccessPolicy } from '@tupaia/access-policy';
 import { UnauthenticatedError } from '@tupaia/utils';
-import winston from 'winston';
 
 import { handleWith, handleError, emptyMiddleware } from '../../utils';
 import { TestRoute } from '../../routes';

--- a/packages/tupaia-web-server/src/app/createApp.ts
+++ b/packages/tupaia-web-server/src/app/createApp.ts
@@ -13,34 +13,7 @@ import {
   forwardRequest,
 } from '@tupaia/server-boilerplate';
 import { TupaiaWebSessionModel } from '../models';
-import {
-  DashboardsRoute,
-  DashboardsRequest,
-  EntitiesRoute,
-  EntitiesRequest,
-  EntityAncestorsRoute,
-  EntityAncestorsRequest,
-  ReportRoute,
-  ReportRequest,
-  LegacyDashboardReportRoute,
-  LegacyDashboardReportRequest,
-  LegacyMapOverlayReportRoute,
-  LegacyMapOverlayReportRequest,
-  MapOverlaysRoute,
-  MapOverlaysRequest,
-  UserRoute,
-  UserRequest,
-  ProjectRoute,
-  ProjectRequest,
-  CountryAccessListRoute,
-  CountryAccessListRequest,
-  RequestCountryAccessRoute,
-  EntitySearchRoute,
-  EntitySearchRequest,
-  RequestCountryAccessRequest,
-  EntityRoute,
-  EntityRequest,
-} from '../routes';
+import * as routes from '../routes';
 
 const {
   WEB_CONFIG_API_URL = 'http://localhost:8000/api/v1',
@@ -54,30 +27,45 @@ export function createApp(db: TupaiaDatabase = new TupaiaDatabase()) {
     .useSessionModel(TupaiaWebSessionModel)
     .useAttachSession(attachSessionIfAvailable)
     .attachApiClientToContext(authHandlerProvider)
-    .get<ReportRequest>('report/:reportCode', handleWith(ReportRoute))
-    .get<LegacyDashboardReportRequest>(
+    .get<routes.ReportRequest>('report/:reportCode', handleWith(routes.ReportRoute))
+    .get<routes.LegacyDashboardReportRequest>(
       'legacyDashboardReport/:reportCode',
-      handleWith(LegacyDashboardReportRoute),
+      handleWith(routes.LegacyDashboardReportRoute),
     )
-    .get<LegacyMapOverlayReportRequest>(
+    .get<routes.LegacyMapOverlayReportRequest>(
       'legacyMapOverlayReport/:mapOverlayCode',
-      handleWith(LegacyMapOverlayReportRoute),
+      handleWith(routes.LegacyMapOverlayReportRoute),
     )
-    .get<MapOverlaysRequest>('mapOverlays/:projectCode/:entityCode', handleWith(MapOverlaysRoute))
-    .get<ProjectRequest>('project/:projectCode', handleWith(ProjectRoute))
-    .get<UserRequest>('getUser', handleWith(UserRoute))
-    .get<DashboardsRequest>('dashboards/:projectCode/:entityCode', handleWith(DashboardsRoute))
-    .get<CountryAccessListRequest>('countryAccessList', handleWith(CountryAccessListRoute))
-    .post<RequestCountryAccessRequest>(
+    .get<routes.MapOverlaysRequest>(
+      'mapOverlays/:projectCode/:entityCode',
+      handleWith(routes.MapOverlaysRoute),
+    )
+    .get<routes.ProjectRequest>('project/:projectCode', handleWith(routes.ProjectRoute))
+    .get<routes.UserRequest>('getUser', handleWith(routes.UserRoute))
+    .get<routes.DashboardsRequest>(
+      'dashboards/:projectCode/:entityCode',
+      handleWith(routes.DashboardsRoute),
+    )
+    .get<routes.CountryAccessListRequest>(
+      'countryAccessList',
+      handleWith(routes.CountryAccessListRoute),
+    )
+    .post<routes.RequestCountryAccessRequest>(
       'requestCountryAccess',
-      handleWith(RequestCountryAccessRoute),
+      handleWith(routes.RequestCountryAccessRoute),
     )
-    .get<EntityRequest>('entity/:projectCode/:entityCode', handleWith(EntityRoute))
-    .get<EntitiesRequest>('entities/:projectCode/:rootEntityCode', handleWith(EntitiesRoute))
-    .get<EntitySearchRequest>('entitySearch/:projectCode', handleWith(EntitySearchRoute))
-    .get<EntityAncestorsRequest>(
+    .get<routes.EntityRequest>('entity/:projectCode/:entityCode', handleWith(routes.EntityRoute))
+    .get<routes.EntitiesRequest>(
+      'entities/:projectCode/:rootEntityCode',
+      handleWith(routes.EntitiesRoute),
+    )
+    .get<routes.EntitySearchRequest>(
+      'entitySearch/:projectCode',
+      handleWith(routes.EntitySearchRoute),
+    )
+    .get<routes.EntityAncestorsRequest>(
       'entityAncestors/:projectCode/:rootEntityCode',
-      handleWith(EntityAncestorsRoute),
+      handleWith(routes.EntityAncestorsRoute),
     )
     .use('downloadFiles', forwardRequest(CENTRAL_API_URL, { authHandlerProvider }))
     // Forward everything else to webConfigApi

--- a/packages/tupaia-web-server/src/app/createApp.ts
+++ b/packages/tupaia-web-server/src/app/createApp.ts
@@ -67,6 +67,10 @@ export function createApp(db: TupaiaDatabase = new TupaiaDatabase()) {
       'entityAncestors/:projectCode/:rootEntityCode',
       handleWith(routes.EntityAncestorsRoute),
     )
+    .get<routes.ExportSurveyResponsesRequest>(
+      'export/surveyResponses',
+      handleWith(routes.ExportSurveyResponsesRoute),
+    )
     .use('downloadFiles', forwardRequest(CENTRAL_API_URL, { authHandlerProvider }))
     // Forward everything else to webConfigApi
     .use('*', forwardRequest(WEB_CONFIG_API_URL, { authHandlerProvider }))

--- a/packages/tupaia-web-server/src/routes/ExportSurveyResponsesRoute.ts
+++ b/packages/tupaia-web-server/src/routes/ExportSurveyResponsesRoute.ts
@@ -51,7 +51,7 @@ export class ExportSurveyResponsesRoute extends Route<ExportSurveyResponsesReque
       easyReadingMode,
     };
 
-    if (organisationUnitCode.length === 2) {
+    if (organisationUnitCode?.length === 2) {
       // The code is only two characters, must be the 2 character country ISO code
       centralQuery.countryCode = organisationUnitCode;
     } else {
@@ -66,7 +66,7 @@ export class ExportSurveyResponsesRoute extends Route<ExportSurveyResponsesReque
     // Extract the filename from the content-disposition header
     const contentDispositionHeader = response.headers.get('content-disposition');
     const regex = /filename="(?<filename>.*)"/; // Find the value between quotes after filename=
-    const filePath: string | null = regex.exec(contentDispositionHeader)?.groups?.filename ?? null;
+    const filePath: string | undefined = regex.exec(contentDispositionHeader)?.groups?.filename;
 
     return {
       contents: await response.buffer(),

--- a/packages/tupaia-web-server/src/routes/ExportSurveyResponsesRoute.ts
+++ b/packages/tupaia-web-server/src/routes/ExportSurveyResponsesRoute.ts
@@ -1,0 +1,68 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+import { Request } from 'express';
+import { Route } from '@tupaia/server-boilerplate';
+import { TupaiaWebExportSurveyResponsesRequest } from '@tupaia/types';
+
+export type ExportSurveyResponsesRequest = Request<
+  TupaiaWebExportSurveyResponsesRequest.Params,
+  TupaiaWebExportSurveyResponsesRequest.ResBody,
+  TupaiaWebExportSurveyResponsesRequest.ReqBody,
+  TupaiaWebExportSurveyResponsesRequest.ReqQuery
+>;
+
+export class ExportSurveyResponsesRoute extends Route<ExportSurveyResponsesRequest> {
+  protected readonly type = 'download';
+
+  public async buildResponse() {
+    const { query, ctx } = this.req;
+    const {
+      organisationUnitCode,
+      surveyCodes,
+      latest,
+      startDate,
+      endDate,
+      timeZone,
+      itemCode,
+      easyReadingMode,
+    } = query;
+    const dashboardItem = (
+      await ctx.services.central.fetchResources('dashboardItems', { code: itemCode })
+    )[0];
+
+    if (!dashboardItem) {
+      throw new Error(`Invalid itemCode ${itemCode}`);
+    }
+
+    const centralParams: Record<string, any> = {
+      latest,
+      surveyCodes,
+      startDate,
+      endDate,
+      timeZone,
+      reportName: dashboardItem.config?.name,
+      easyReadingMode,
+    };
+
+    if (organisationUnitCode.length === 2) {
+      // The code is only two characters, must be the 2 character country ISO code
+      centralParams.countryCode = organisationUnitCode;
+    } else {
+      centralParams.entityCode = organisationUnitCode;
+    }
+
+    const response = await ctx.services.central.fetchResources(
+      'export/surveyResponses',
+      centralParams,
+    );
+
+    return {
+      contents: { ...response.body },
+      filePath: 'test.xlsx',
+      type: '.xlsx',
+    };
+  }
+}

--- a/packages/tupaia-web-server/src/routes/ExportSurveyResponsesRoute.ts
+++ b/packages/tupaia-web-server/src/routes/ExportSurveyResponsesRoute.ts
@@ -60,7 +60,7 @@ export class ExportSurveyResponsesRoute extends Route<ExportSurveyResponsesReque
     );
 
     return {
-      contents: { ...response.body },
+      contents: response,
       filePath: 'test.xlsx',
       type: '.xlsx',
     };

--- a/packages/tupaia-web-server/src/routes/index.ts
+++ b/packages/tupaia-web-server/src/routes/index.ts
@@ -25,3 +25,7 @@ export {
   RequestCountryAccessRequest,
   RequestCountryAccessRoute,
 } from './RequestCountryAccessRoute';
+export {
+  ExportSurveyResponsesRequest,
+  ExportSurveyResponsesRoute,
+} from './ExportSurveyResponsesRoute';

--- a/packages/types/src/types/requests/tupaia-web-server/ExportSurveyResponsesRequest.ts
+++ b/packages/types/src/types/requests/tupaia-web-server/ExportSurveyResponsesRequest.ts
@@ -6,7 +6,7 @@
 export type Params = Record<string, never>;
 export type ResBody = {
   contents: Buffer;
-  filePath: string;
+  filePath?: string;
   type: string;
 };
 export type ReqBody = Record<string, never>;

--- a/packages/types/src/types/requests/tupaia-web-server/ExportSurveyResponsesRequest.ts
+++ b/packages/types/src/types/requests/tupaia-web-server/ExportSurveyResponsesRequest.ts
@@ -1,0 +1,9 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+export type Params = Record<string, never>;
+export type ResBody = any;
+export type ReqBody = any;
+export type ReqQuery = any;

--- a/packages/types/src/types/requests/tupaia-web-server/ExportSurveyResponsesRequest.ts
+++ b/packages/types/src/types/requests/tupaia-web-server/ExportSurveyResponsesRequest.ts
@@ -4,6 +4,25 @@
  */
 
 export type Params = Record<string, never>;
-export type ResBody = any;
-export type ReqBody = any;
-export type ReqQuery = any;
+export type ResBody = {
+  contents: Buffer;
+  filePath: string;
+  type: string;
+};
+export type ReqBody = Record<string, never>;
+export type ReqQuery = {
+  organisationUnitCode?: string;
+  surveyCodes?: string[];
+  latest?: boolean;
+  /**
+   * @format iso-date-time
+   */
+  startDate?: string;
+  /**
+   * @format iso-date-time
+   */
+  endDate?: string;
+  timeZone?: string;
+  itemCode?: string;
+  easyReadingMode?: boolean;
+};

--- a/packages/types/src/types/requests/tupaia-web-server/index.ts
+++ b/packages/types/src/types/requests/tupaia-web-server/index.ts
@@ -8,6 +8,7 @@ export * as TupaiaWebDashboardsRequest from './DashboardsRequest';
 export * as TupaiaWebEntitiesRequest from './EntitiesRequest';
 export * as TupaiaWebEntityRequest from './EntityRequest';
 export * as TupaiaWebEntitySearchRequest from './EntitySearchRequest';
+export * as TupaiaWebExportSurveyResponsesRequest from './ExportSurveyResponsesRequest';
 export * as TupaiaWebLegacyDashboardReportRequest from './LegacyDashboardReportRequest';
 export * as TupaiaWebLegacyMapOverlayReportRequest from './LegacyMapOverlayReportRequest';
 export * as TupaiaWebMapOverlaysRequest from './MapOverlaysRequest';


### PR DESCRIPTION
### Issue #: WAITP-1239

I initially intended to do multiple routes on this branch, but this change bloated a bit beyond initial scope

### Changes:

- Clean up some imports
- Add `ExportSurveyResponsesRoute`
  - Add request type to `types` package
- Allow `ApiClient` to return non-json responses