### PR TITLE
WAITP-1221: Polygon overlay fixes

### DIFF
--- a/packages/tupaia-web/src/features/Map/Map.tsx
+++ b/packages/tupaia-web/src/features/Map/Map.tsx
@@ -134,13 +134,15 @@ export const Map = () => {
     gaEvent('Map', 'Change Tile Set', activeTileSet.label);
   };
 
+  const zoom = entity?.bounds ? undefined : 10;
+
   return (
     <ErrorBoundary>
       <MapContainer>
         <StyledMap
           center={entity?.point as LeafletMapProps['center']}
           bounds={entity?.bounds as LeafletMapProps['bounds']}
-          zoom={15 as LeafletMapProps['zoom']}
+          zoom={zoom as LeafletMapProps['zoom']}
           shouldSnapToPosition
         >
           <TileLayer tileSetUrl={activeTileSet.url} showAttribution={false} />

--- a/packages/tupaia-web/src/features/Map/MapOverlays/DataVisualsLayer.tsx
+++ b/packages/tupaia-web/src/features/Map/MapOverlays/DataVisualsLayer.tsx
@@ -65,14 +65,10 @@ export const DataVisualsLayer = ({
       <LayerGroup>
         {measureData.map((measure: MeasureData) => {
           const { region, organisationUnitCode: entity, color, name, code } = measure;
-
           if (region) {
-            if (code === entityCode) {
-              return <ActiveEntityPolygon key={entity} entity={measure} />; // this is so that the polygon is displayed as the active entity, i.e correctly shaded etc.
-            }
-
             // To match with the color in markerIcon.js which uses BREWER_PALETTE
             const shade = BREWER_PALETTE[color as keyof typeof BREWER_PALETTE] || color;
+
             return (
               <ShadedPolygon
                 key={entity}

--- a/packages/tupaia-web/src/features/Map/MapOverlays/DataVisualsLayer.tsx
+++ b/packages/tupaia-web/src/features/Map/MapOverlays/DataVisualsLayer.tsx
@@ -15,6 +15,7 @@ import {
   BasePolygon,
   AreaTooltip,
   MeasureData,
+  BREWER_PALETTE,
 } from '@tupaia/ui-map-components';
 import { ErrorBoundary } from '@tupaia/ui-components';
 import { useEntity } from '../../../api/queries';
@@ -64,17 +65,21 @@ export const DataVisualsLayer = ({
       <LayerGroup>
         {measureData.map((measure: MeasureData) => {
           const { region, organisationUnitCode: entity, color, name, code } = measure;
+
           if (region) {
             if (code === entityCode) {
               return <ActiveEntityPolygon key={entity} entity={measure} />; // this is so that the polygon is displayed as the active entity, i.e correctly shaded etc.
             }
+
+            // To match with the color in markerIcon.js which uses BREWER_PALETTE
+            const shade = BREWER_PALETTE[color as keyof typeof BREWER_PALETTE] || color;
             return (
               <ShadedPolygon
                 key={entity}
                 positions={region}
                 pathOptions={{
-                  color: color,
-                  fillColor: color,
+                  color: shade,
+                  fillColor: shade,
                 }}
                 eventHandlers={{
                   click: () => {

--- a/packages/tupaia-web/src/features/Map/MapOverlays/DataVisualsLayer.tsx
+++ b/packages/tupaia-web/src/features/Map/MapOverlays/DataVisualsLayer.tsx
@@ -20,7 +20,6 @@ import {
 import { ErrorBoundary } from '@tupaia/ui-components';
 import { useEntity } from '../../../api/queries';
 import { useMapOverlayData, useNavigateToEntity } from '../utils';
-import { ActiveEntityPolygon } from './ActiveEntityPolygon';
 import { gaEvent } from '../../../utils';
 
 const ShadedPolygon = styled(BasePolygon)`
@@ -64,7 +63,7 @@ export const DataVisualsLayer = ({
     <ErrorBoundary>
       <LayerGroup>
         {measureData.map((measure: MeasureData) => {
-          const { region, organisationUnitCode: entity, color, name, code } = measure;
+          const { region, organisationUnitCode: entity, color, name } = measure;
           if (region) {
             // To match with the color in markerIcon.js which uses BREWER_PALETTE
             const shade = BREWER_PALETTE[color as keyof typeof BREWER_PALETTE] || color;

--- a/packages/tupaia-web/src/features/Map/MapOverlays/InteractivePolygon.tsx
+++ b/packages/tupaia-web/src/features/Map/MapOverlays/InteractivePolygon.tsx
@@ -4,23 +4,23 @@
  */
 
 import React from 'react';
-import { Polygon } from 'react-leaflet';
 import styled from 'styled-components';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Entity } from '@tupaia/types';
-import { AreaTooltip, MAP_COLORS } from '@tupaia/ui-map-components';
+import { AreaTooltip, MAP_COLORS, Polygon } from '@tupaia/ui-map-components';
 import { useEntityLink } from '../../../utils';
 import { useProject } from '../../../api/queries';
 import { ErrorBoundary } from '@tupaia/ui-components';
 
-const { POLYGON_BLUE } = MAP_COLORS;
+const { POLYGON_HIGHLIGHT } = MAP_COLORS;
 
 const BasicPolygon = styled(Polygon)`
-  fill: ${POLYGON_BLUE};
   fill-opacity: 0.04;
   stroke-width: 1;
   &:hover {
     fill-opacity: 0.5;
+    stroke: ${POLYGON_HIGHLIGHT};
+    fill: ${POLYGON_HIGHLIGHT};
   }
 `;
 

--- a/packages/tupaia-web/src/features/Map/MapOverlays/PolygonNavigationLayer.tsx
+++ b/packages/tupaia-web/src/features/Map/MapOverlays/PolygonNavigationLayer.tsx
@@ -4,11 +4,11 @@
  */
 
 import React from 'react';
-import {  POLYGON_MEASURE_TYPES,   } from '@tupaia/ui-map-components';
+import { POLYGON_MEASURE_TYPES } from '@tupaia/ui-map-components';
 import { useParams } from 'react-router-dom';
 import { Entity, EntityCode } from '../../../types';
 import { InteractivePolygon } from './InteractivePolygon';
-import { useEntitiesWithLocation, useEntity, useMapOverlays } from '../../../api/queries'; 
+import { useEntitiesWithLocation, useEntity, useMapOverlays } from '../../../api/queries';
 import { ActiveEntityPolygon } from './ActiveEntityPolygon';
 
 const SiblingEntities = ({
@@ -57,9 +57,8 @@ export const PolygonNavigationLayer = () => {
   const showChildEntities = !isPolygonOverlay && childEntities?.length > 0;
 
   const showActiveEntity =
-    !isPolygonOverlay &&
     activeEntity &&
-    activeEntity?.type !== selectedOverlay?.measureLevel?.toLowerCase();
+    activeEntity?.type?.replace('_', '') !== selectedOverlay?.measureLevel?.toLowerCase();
 
   return (
     <>


### PR DESCRIPTION
### Issue WAITP-1221: Polygon overlay fixes

### Changes:
- Fix issue of zoom level being incorrect on selection of an entity
- Fix issue with polygon shades being wrong
- Fix issue with country outlines not showing on map
- Fix issue where child entities were not showing while map overlay report data was loading