### PR TITLE
WAITP-1346: Survey contents menu

### DIFF
--- a/packages/datatrak-web/src/components/Button.tsx
+++ b/packages/datatrak-web/src/components/Button.tsx
@@ -2,30 +2,54 @@
  * Tupaia
  *  Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
  */
-import React, { ReactNode, Fragment } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 import { To, Link as RouterLink } from 'react-router-dom';
-import { Tooltip, Button as UIButton } from '@tupaia/ui-components';
+import { Tooltip as BaseTooltip, Button as UIButton } from '@tupaia/ui-components';
 import styled from 'styled-components';
 
+const TOOLTIP_COLOR = '#002d47';
 const StyledButton = styled(UIButton)`
   &.Mui-disabled {
     pointer-events: auto; // this is to allow the hover effect of a tooltip to work
   }
 `;
 
+const Tooltip = styled(BaseTooltip).attrs({
+  disablePortal: true,
+})`
+  .MuiTooltip-tooltip {
+    background-color: ${TOOLTIP_COLOR};
+    .MuiTooltip-arrow {
+      color: ${TOOLTIP_COLOR};
+    }
+  }
+`;
 interface ButtonProps extends Record<string, any> {
   tooltip?: string;
   children?: ReactNode;
   to?: To;
 }
-export const Button = ({ tooltip, children, to, ...restOfProps }: ButtonProps) => {
-  const Wrapper = tooltip ? Tooltip : Fragment;
 
+const ButtonWrapper = ({
+  children,
+  tooltip,
+}: {
+  children: ReactElement<any, any>;
+  tooltip?: ButtonProps['tooltip'];
+}) => {
+  if (!tooltip) return children;
   return (
-    <Wrapper title={tooltip!} arrow>
+    <Tooltip title={tooltip} arrow>
+      {children}
+    </Tooltip>
+  );
+};
+export const Button = ({ tooltip, children, to, ...restOfProps }: ButtonProps) => {
+  return (
+    <ButtonWrapper tooltip={tooltip}>
       <StyledButton component={to ? RouterLink : undefined} to={to} {...restOfProps}>
         {children}
       </StyledButton>
-    </Wrapper>
+    </ButtonWrapper>
   );
 };

--- a/packages/datatrak-web/src/components/TopProgressBar.tsx
+++ b/packages/datatrak-web/src/components/TopProgressBar.tsx
@@ -13,7 +13,7 @@ const Wrapper = styled.div`
 const ProgressBar = styled.div<{
   $progress: number;
 }>`
-  background: ${({ theme }) => theme.progressBar.main};
+  background: ${({ theme }) => theme.palette.primary.dark};
   display: flex;
   justify-content: flex-start;
   align-items: flex-start;

--- a/packages/datatrak-web/src/features/Survey/SurveyContext.tsx
+++ b/packages/datatrak-web/src/features/Survey/SurveyContext.tsx
@@ -3,7 +3,7 @@
  *  Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
  */
 
-import React, { Dispatch, createContext, useContext, useReducer, useState } from 'react';
+import React, { Dispatch, createContext, useContext, useReducer } from 'react';
 import { useParams } from 'react-router-dom';
 import { sortBy } from 'lodash';
 import { SurveyParams, SurveyScreenComponent } from '../../types';

--- a/packages/datatrak-web/src/features/Survey/SurveyContext.tsx
+++ b/packages/datatrak-web/src/features/Survey/SurveyContext.tsx
@@ -66,7 +66,10 @@ export const surveyReducer = (
     case ACTION_TYPES.SET_FORM_DATA:
       return {
         ...state,
-        formData: action.payload as Record<string, any>,
+        formData: {
+          ...state.formData,
+          ...(action.payload as Record<string, any>),
+        },
       };
     case ACTION_TYPES.TOGGLE_SIDE_MENU:
       return {

--- a/packages/datatrak-web/src/features/Survey/SurveyScreen.tsx
+++ b/packages/datatrak-web/src/features/Survey/SurveyScreen.tsx
@@ -153,11 +153,11 @@ export const SurveyScreen = () => {
   return (
     <>
       <SurveyToolbar />
-      <Wrapper>
-        <SurveySideMenu />
-        <Container $sideMenuOpen={sideMenuOpen}>
-          <Paper>
-            <FormProvider {...formContext}>
+      <FormProvider {...formContext}>
+        <Wrapper>
+          <SurveySideMenu />
+          <Container $sideMenuOpen={sideMenuOpen}>
+            <Paper>
               <StyledForm onSubmit={onStepForward} noValidate>
                 <FormScrollBody>
                   <ScreenHeading variant="h2">{screenHeader}</ScreenHeading>
@@ -222,10 +222,10 @@ export const SurveyScreen = () => {
                   </ButtonGroup>
                 </FormActions>
               </StyledForm>
-            </FormProvider>
-          </Paper>
-        </Container>
-      </Wrapper>
+            </Paper>
+          </Container>
+        </Wrapper>
+      </FormProvider>
     </>
   );
 };

--- a/packages/datatrak-web/src/features/Survey/SurveyScreen.tsx
+++ b/packages/datatrak-web/src/features/Survey/SurveyScreen.tsx
@@ -14,26 +14,34 @@ import { ROUTES, MOBILE_BREAKPOINT } from '../../constants';
 import { SurveyParams } from '../../types';
 import { SurveyToolbar } from './SurveyToolbar';
 import { Button } from '../../components';
+import { SurveySideMenu, SIDE_MENU_WIDTH } from './SurveySideMenu';
 
-const Container = styled.div`
+const Wrapper = styled.div`
   display: flex;
-  justify-content: flex-start;
+  margin-left: -1rem;
   padding-top: 2rem;
   padding-bottom: 2rem;
-  flex: 1;
   overflow: hidden;
+  flex: 1;
+  align-items: flex-start;
+`;
+
+const Container = styled.div<{
+  $sideMenuOpen?: boolean;
+}>`
+  display: flex;
+  justify-content: flex-start;
+  height: 100%;
+  flex: 1;
+  position: relative;
+  padding: 0 1rem;
+  margin-left: ${({ $sideMenuOpen }) => ($sideMenuOpen ? 0 : `-${SIDE_MENU_WIDTH}`)};
+  transition: margin 195ms cubic-bezier(0.4, 0, 0.6, 1) 0ms;
 
   @media (max-width: ${MOBILE_BREAKPOINT}) {
     overflow: auto;
     flex-direction: column;
   }
-`;
-
-const SideMenu = styled.div`
-  background: rgba(0, 65, 103, 0.3);
-  width: 30rem;
-  margin-right: 1rem;
-  max-width: 100%;
 `;
 
 const Paper = styled(MuiPaper).attrs({
@@ -110,6 +118,7 @@ export const SurveyScreen = () => {
     displayQuestions,
     screenHeader,
     screenNumber,
+    sideMenuOpen,
   } = useSurveyForm();
   const formContext = useForm({ defaultValues: formData });
   const { handleSubmit } = formContext;
@@ -144,77 +153,79 @@ export const SurveyScreen = () => {
   return (
     <>
       <SurveyToolbar />
-      <Container>
-        <SideMenu />
-        <Paper>
-          <FormProvider {...formContext}>
-            <StyledForm onSubmit={onStepForward} noValidate>
-              <FormScrollBody>
-                <ScreenHeading variant="h2">{screenHeader}</ScreenHeading>
-                {displayQuestions.map(
-                  ({
-                    questionId,
-                    questionCode,
-                    questionText,
-                    questionType,
-                    questionOptions,
-                    config,
-                    questionLabel,
-                    validationCriteria,
-                    detailLabel,
-                    questionOptionSetId,
-                    questionNumber,
-                  }) => {
-                    if (validationCriteria?.mandatory === true) {
-                      console.log('mandatory question', questionCode);
-                    }
-                    return (
-                      <QuestionWrapper
-                        key={questionId}
-                        $isInstruction={questionType === 'Instruction'}
-                      >
-                        {questionNumber && (
-                          <QuestionNumber id={`question_number_${questionId}`}>
-                            {questionNumber}
-                          </QuestionNumber>
-                        )}
-                        <SurveyQuestion
-                          detailLabel={detailLabel}
-                          id={questionId}
-                          code={questionCode}
-                          name={questionCode}
-                          type={questionType}
-                          text={detailLabel || questionText}
-                          options={questionOptions}
-                          config={config}
-                          label={questionLabel || questionText}
-                          optionSetId={questionOptionSetId}
-                        />
-                      </QuestionWrapper>
-                    );
-                  },
-                )}
-              </FormScrollBody>
-              <FormActions>
-                <Button
-                  onClick={onStepPrevious}
-                  startIcon={<ArrowBackIosIcon />}
-                  variant="text"
-                  color="default"
-                >
-                  Back
-                </Button>
-                <ButtonGroup>
-                  <Button variant="outlined" to={ROUTES.SURVEY_SELECT}>
-                    Cancel
+      <Wrapper>
+        <SurveySideMenu />
+        <Container $sideMenuOpen={sideMenuOpen}>
+          <Paper>
+            <FormProvider {...formContext}>
+              <StyledForm onSubmit={onStepForward} noValidate>
+                <FormScrollBody>
+                  <ScreenHeading variant="h2">{screenHeader}</ScreenHeading>
+                  {displayQuestions.map(
+                    ({
+                      questionId,
+                      questionCode,
+                      questionText,
+                      questionType,
+                      questionOptions,
+                      config,
+                      questionLabel,
+                      validationCriteria,
+                      detailLabel,
+                      questionOptionSetId,
+                      questionNumber,
+                    }) => {
+                      if (validationCriteria?.mandatory === true) {
+                        console.log('mandatory question', questionCode);
+                      }
+                      return (
+                        <QuestionWrapper
+                          key={questionId}
+                          $isInstruction={questionType === 'Instruction'}
+                        >
+                          {questionNumber && (
+                            <QuestionNumber id={`question_number_${questionId}`}>
+                              {questionNumber}
+                            </QuestionNumber>
+                          )}
+                          <SurveyQuestion
+                            detailLabel={detailLabel}
+                            id={questionId}
+                            code={questionCode}
+                            name={questionCode}
+                            type={questionType}
+                            text={detailLabel || questionText}
+                            options={questionOptions}
+                            config={config}
+                            label={questionLabel || questionText}
+                            optionSetId={questionOptionSetId}
+                          />
+                        </QuestionWrapper>
+                      );
+                    },
+                  )}
+                </FormScrollBody>
+                <FormActions>
+                  <Button
+                    onClick={onStepPrevious}
+                    startIcon={<ArrowBackIosIcon />}
+                    variant="text"
+                    color="default"
+                  >
+                    Back
                   </Button>
-                  <Button type="submit">Next</Button>
-                </ButtonGroup>
-              </FormActions>
-            </StyledForm>
-          </FormProvider>
-        </Paper>
-      </Container>
+                  <ButtonGroup>
+                    <Button variant="outlined" to={ROUTES.SURVEY_SELECT}>
+                      Cancel
+                    </Button>
+                    <Button type="submit">Next</Button>
+                  </ButtonGroup>
+                </FormActions>
+              </StyledForm>
+            </FormProvider>
+          </Paper>
+        </Container>
+      </Wrapper>
     </>
   );
 };

--- a/packages/datatrak-web/src/features/Survey/SurveySideMenu/SideMenuButton.tsx
+++ b/packages/datatrak-web/src/features/Survey/SurveySideMenu/SideMenuButton.tsx
@@ -1,0 +1,36 @@
+/*
+ * Tupaia
+ *  Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+import React from 'react';
+import styled from 'styled-components';
+import { FormatListBulleted, KeyboardArrowLeft } from '@material-ui/icons';
+import { useSurveyForm } from '../SurveyContext';
+import { Button } from '../../../components';
+
+const MenuButton = styled(Button).attrs({
+  variant: 'contained',
+})`
+  padding: 0.5rem 0.8rem 0.5rem 0.3rem;
+  border-radius: 0 3rem 3rem 0;
+  min-width: 0;
+  background-color: ${({ theme }) => theme.palette.primary.dark};
+  color: ${({ theme }) => theme.palette.background.paper};
+  &:hover {
+    background-color: ${({ theme }) => theme.palette.primary.dark};
+    color: ${({ theme }) => theme.palette.background.paper};
+  }
+`;
+
+export const SideMenuButton = () => {
+  const { toggleSideMenu, sideMenuOpen } = useSurveyForm();
+  return (
+    <MenuButton
+      onClick={toggleSideMenu}
+      tooltip={`${sideMenuOpen ? 'Close' : 'Expand'} survey contents`}
+    >
+      {sideMenuOpen ? <KeyboardArrowLeft /> : <FormatListBulleted />}
+    </MenuButton>
+  );
+};

--- a/packages/datatrak-web/src/features/Survey/SurveySideMenu/SurveySideMenu.tsx
+++ b/packages/datatrak-web/src/features/Survey/SurveySideMenu/SurveySideMenu.tsx
@@ -4,11 +4,12 @@
  */
 import React from 'react';
 import styled from 'styled-components';
+import { To } from 'react-router';
+import { useFormContext } from 'react-hook-form';
 import { Drawer as BaseDrawer, ListItem, List, ButtonProps } from '@material-ui/core';
 import { useSurveyForm } from '../SurveyContext';
 import { SideMenuButton } from './SideMenuButton';
 import { ButtonLink } from '../../../components';
-import { To } from 'react-router';
 
 export const SIDE_MENU_WIDTH = '20rem';
 
@@ -68,7 +69,17 @@ const SurveyScreenTitle = styled.span`
 `;
 
 export const SurveySideMenu = () => {
-  const { sideMenuOpen, toggleSideMenu, surveyScreenComponents, screenNumber } = useSurveyForm();
+  const { getValues } = useFormContext();
+  const {
+    sideMenuOpen,
+    toggleSideMenu,
+    surveyScreenComponents,
+    screenNumber,
+    setFormData,
+  } = useSurveyForm();
+  const onChangeScreen = () => {
+    setFormData(getValues());
+  };
   return (
     <>
       <SideMenuButton />
@@ -79,6 +90,7 @@ export const SurveySideMenu = () => {
               key={screen[0].questionId}
               to={`../${key}`}
               $active={screenNumber === Number(key)}
+              onClick={onChangeScreen}
             >
               <SurveyScreenNumber>{key}:</SurveyScreenNumber>
               <SurveyScreenTitle>{screen[0].questionText}</SurveyScreenTitle>

--- a/packages/datatrak-web/src/features/Survey/SurveySideMenu/SurveySideMenu.tsx
+++ b/packages/datatrak-web/src/features/Survey/SurveySideMenu/SurveySideMenu.tsx
@@ -1,0 +1,91 @@
+/*
+ * Tupaia
+ *  Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+import React from 'react';
+import styled from 'styled-components';
+import { Drawer as BaseDrawer, ListItem, List, ButtonProps } from '@material-ui/core';
+import { useSurveyForm } from '../SurveyContext';
+import { SideMenuButton } from './SideMenuButton';
+import { ButtonLink } from '../../../components';
+import { To } from 'react-router';
+
+export const SIDE_MENU_WIDTH = '20rem';
+
+const Drawer = styled(BaseDrawer).attrs({
+  anchor: 'left',
+  variant: 'persistent',
+  elevation: 0,
+})`
+  flex-shrink: 0;
+  width: ${SIDE_MENU_WIDTH};
+  position: relative;
+  height: 100%;
+  .MuiPaper-root {
+    width: 100%;
+    position: absolute;
+    background-color: transparent;
+    border-right: none;
+    height: 100%;
+  }
+`;
+
+const SurveyMenuContent = styled(List)`
+  padding: 0 0.5rem;
+`;
+
+const SurveyMenuItem = styled(ListItem).attrs({
+  button: true,
+  component: ButtonLink,
+  variant: 'text',
+  color: 'default',
+})<
+  ButtonProps & {
+    to: To;
+    $active?: boolean;
+  }
+>`
+  padding: 0.5rem;
+  align-items: flex-start;
+  justify-content: flex-start;
+  background-color: ${({ theme, $active }) =>
+    $active ? `${theme.palette.primary.main}55` : 'transparent'};
+  & ~ & {
+    margin-left: 0; // overwrite styles from elsewhere
+  }
+  &:hover {
+    background-color: ${({ theme }) => `${theme.palette.grey[400]}4d`};
+  }
+`;
+
+const SurveyScreenNumber = styled.span`
+  width: 2rem;
+`;
+
+const SurveyScreenTitle = styled.span`
+  width: 100%;
+  font-weight: ${({ theme }) => theme.typography.fontWeightRegular};
+`;
+
+export const SurveySideMenu = () => {
+  const { sideMenuOpen, toggleSideMenu, surveyScreenComponents, screenNumber } = useSurveyForm();
+  return (
+    <>
+      <SideMenuButton />
+      <Drawer open={sideMenuOpen} onClose={toggleSideMenu}>
+        <SurveyMenuContent>
+          {Object.entries(surveyScreenComponents!).map(([key, screen]) => (
+            <SurveyMenuItem
+              key={screen[0].questionId}
+              to={`../${key}`}
+              $active={screenNumber === Number(key)}
+            >
+              <SurveyScreenNumber>{key}:</SurveyScreenNumber>
+              <SurveyScreenTitle>{screen[0].questionText}</SurveyScreenTitle>
+            </SurveyMenuItem>
+          ))}
+        </SurveyMenuContent>
+      </Drawer>
+    </>
+  );
+};

--- a/packages/datatrak-web/src/features/Survey/SurveySideMenu/index.ts
+++ b/packages/datatrak-web/src/features/Survey/SurveySideMenu/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Tupaia
+ *  Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+export { SurveySideMenu, SIDE_MENU_WIDTH } from './SurveySideMenu';

--- a/packages/datatrak-web/src/theme/theme.ts
+++ b/packages/datatrak-web/src/theme/theme.ts
@@ -5,54 +5,51 @@
 
 import { createMuiTheme } from '@material-ui/core';
 
-export const theme = createMuiTheme(
-  {
-    palette: {
-      type: 'light',
-      primary: {
-        main: '#328DE5', // Main blue (as seen on primary buttons)
-      },
-      secondary: {
-        main: '#EC642D', // Tupaia orange
-      },
-      background: {
-        default: '#F9F9F9', // Off white background
-        paper: '#ffffff', // White background
-      },
-      text: {
-        primary: '#2E2F33', // dark text color
-        secondary: '#898989', // light grey text color
-      },
-      divider: '#DFDFDF',
+export const theme = createMuiTheme({
+  palette: {
+    type: 'light',
+    primary: {
+      main: '#328DE5', // Main blue (as seen on primary buttons)
+      dark: '#004167',
     },
-    overrides: {
-      MuiDialogActions: {
-        root: {
-          padding: '1.5rem 0 0 0',
-        },
+    secondary: {
+      main: '#EC642D', // Tupaia orange
+    },
+    background: {
+      default: '#F9F9F9', // Off white background
+      paper: '#ffffff', // White background
+    },
+    text: {
+      primary: '#2E2F33', // dark text color
+      secondary: '#898989', // light grey text color
+    },
+    divider: '#DFDFDF',
+    grey: {
+      400: '#B8B8B8',
+    },
+  },
+  overrides: {
+    MuiDialogActions: {
+      root: {
+        padding: '1.5rem 0 0 0',
       },
-      MuiButton: {
-        root: {
-          textTransform: 'none',
-        },
-        label: {
-          fontSize: '0.875rem',
-        },
+    },
+    MuiButton: {
+      root: {
+        textTransform: 'none',
       },
-      MuiTypography: {
-        h1: {
-          fontSize: '1.125rem', // page titles
-          fontWeight: 500,
-        },
-        h2: {
-          fontSize: '1.125rem', // survey page titles
-        },
+      label: {
+        fontSize: '0.875rem',
+      },
+    },
+    MuiTypography: {
+      h1: {
+        fontSize: '1.125rem', // page titles
+        fontWeight: 500,
+      },
+      h2: {
+        fontSize: '1.125rem', // survey page titles
       },
     },
   },
-  {
-    progressBar: {
-      main: '#004167',
-    },
-  },
-);
+});

--- a/packages/ui-components/src/components/Inputs/RadioGroup.tsx
+++ b/packages/ui-components/src/components/Inputs/RadioGroup.tsx
@@ -121,7 +121,7 @@ export const RadioGroup = ({
           }
           key={option[valueKey].toString()}
           value={option[valueKey]}
-          label={<InputLabel label={option[labelKey]} tooltip={option[tooltipKey]} />}
+          label={<InputLabel label={option[labelKey]} tooltip={option[tooltipKey]} as="span" />}
         />
       ))}
     </StyledRadioGroup>


### PR DESCRIPTION
### Issue WAITP-1346: Survey contents menu:

### Changes:
- Changed `SurveyContext` to use a reducer instead of state, now that we have more than 1 action
- Created survey contents menu and added to view

Note: I haven't included mobile styling here, as not sure of design yet
---

### Screenshots:
Closed  
![Screenshot 2023-09-06 at 12 20 58 pm](https://github.com/beyondessential/tupaia/assets/129009580/3391a60d-ba23-47cc-b86f-f9211eae94c1) 

Open
![Screenshot 2023-09-06 at 12 20 46 pm](https://github.com/beyondessential/tupaia/assets/129009580/bfac1584-2db1-4693-98d2-1640998293f5)

