### PR TITLE
Add setup-test command to tupaia-web-server

### DIFF
--- a/packages/tupaia-web-server/package.json
+++ b/packages/tupaia-web-server/package.json
@@ -22,6 +22,7 @@
     "start": "node dist",
     "start-dev": "LOG_LEVEL=debug yarn package:start:backend-start-dev 9998 -ts",
     "start-verbose": "LOG_LEVEL=debug yarn start-dev",
+    "setup-test": "yarn workspace @tupaia/database setup-test-database",
     "test": "yarn package:test"
   },
   "dependencies": {


### PR DESCRIPTION
`tupaia-web-server` tests are failing in github actions because we don't correctly run the initial setup for the database, so the base `tupaia` user hasn't been created when it tries to run tests. Add the appropriate line to the `package.json`