### PR TITLE
no-issue: Set winston to ^3.3.3 everywhere

### DIFF
--- a/packages/admin-panel-server/package.json
+++ b/packages/admin-panel-server/package.json
@@ -41,7 +41,7 @@
     "express": "^4.16.2",
     "lodash": "^4.17.4",
     "multer": "^1.4.3",
-    "winston": "^3.2.1"
+    "winston": "^3.3.3"
   },
   "devDependencies": {
     "@tupaia/types": "1.0.0",

--- a/packages/data-table-server/package.json
+++ b/packages/data-table-server/package.json
@@ -36,7 +36,7 @@
     "@tupaia/utils": "1.0.0",
     "dotenv": "^8.2.0",
     "express": "^4.16.2",
-    "winston": "^3.2.1"
+    "winston": "^3.3.3"
   },
   "devDependencies": {
     "mockdate": "^3.0.5"

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -48,7 +48,7 @@
     "pg-pubsub": "0.6.1",
     "rand-token": "^1.0.1",
     "react-autobind": "1.0.6",
-    "winston": "3.3.3"
+    "winston": "^3.3.3"
   },
   "devDependencies": {
     "@babel/node": "^7.10.5",

--- a/packages/entity-server/package.json
+++ b/packages/entity-server/package.json
@@ -38,7 +38,7 @@
     "dotenv": "^8.2.0",
     "express": "^4.16.2",
     "lodash.keyby": "^4.6.0",
-    "winston": "^3.2.1"
+    "winston": "^3.3.3"
   },
   "devDependencies": {
     "@types/lodash.keyby": "^4.6.6"

--- a/packages/lesmis-server/package.json
+++ b/packages/lesmis-server/package.json
@@ -36,6 +36,6 @@
     "dotenv": "^8.2.0",
     "express": "^4.16.2",
     "lodash.uniqby": "^4.7.0",
-    "winston": "^3.2.1"
+    "winston": "^3.3.3"
   }
 }

--- a/packages/meditrak-app-server/package.json
+++ b/packages/meditrak-app-server/package.json
@@ -39,7 +39,7 @@
     "moment": "^2.24.0",
     "moment-timezone": "^0.5.27",
     "semver-compare": "^1.0.0",
-    "winston": "^3.2.1"
+    "winston": "^3.3.3"
   },
   "devDependencies": {
     "@types/lodash.clonedeep": "^4.5.0",

--- a/packages/psss-server/package.json
+++ b/packages/psss-server/package.json
@@ -38,6 +38,6 @@
     "dotenv": "^8.2.0",
     "express": "^4.16.2",
     "lodash.groupby": "^4.6.0",
-    "winston": "^3.2.1"
+    "winston": "^3.3.3"
   }
 }

--- a/packages/report-server/package.json
+++ b/packages/report-server/package.json
@@ -50,7 +50,7 @@
     "lodash.pick": "^4.4.0",
     "mathjs": "^9.4.0",
     "moment": "^2.24.0",
-    "winston": "^3.2.1"
+    "winston": "^3.3.3"
   },
   "devDependencies": {
     "@tupaia/types": "1.0.0",

--- a/packages/server-boilerplate/package.json
+++ b/packages/server-boilerplate/package.json
@@ -40,7 +40,7 @@
     "http-proxy-middleware": "^2.0.1",
     "i18n": "^0.13.3",
     "morgan": "^1.9.0",
-    "winston": "^3.2.1"
+    "winston": "^3.3.3"
   },
   "devDependencies": {
     "@types/api-error-handler": "^1.0.32",

--- a/packages/tupaia-web-server/package.json
+++ b/packages/tupaia-web-server/package.json
@@ -37,7 +37,7 @@
     "lodash.groupby": "^4.6.0",
     "lodash.keyby": "^4.6.0",
     "lodash.sortby": "^4.6.0",
-    "winston": "^3.2.1"
+    "winston": "^3.3.3"
   },
   "devDependencies": {
     "@tupaia/types": "1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9576,7 +9576,7 @@ __metadata:
     express: ^4.16.2
     lodash: ^4.17.4
     multer: ^1.4.3
-    winston: ^3.2.1
+    winston: ^3.3.3
   languageName: unknown
   linkType: soft
 
@@ -9828,7 +9828,7 @@ __metadata:
     dotenv: ^8.2.0
     express: ^4.16.2
     mockdate: ^3.0.5
-    winston: ^3.2.1
+    winston: ^3.3.3
   languageName: unknown
   linkType: soft
 
@@ -9856,7 +9856,7 @@ __metadata:
     pluralize: ^8.0.0
     rand-token: ^1.0.1
     react-autobind: 1.0.6
-    winston: 3.3.3
+    winston: ^3.3.3
   languageName: unknown
   linkType: soft
 
@@ -9924,7 +9924,7 @@ __metadata:
     dotenv: ^8.2.0
     express: ^4.16.2
     lodash.keyby: ^4.6.0
-    winston: ^3.2.1
+    winston: ^3.3.3
   languageName: unknown
   linkType: soft
 
@@ -9976,7 +9976,7 @@ __metadata:
     dotenv: ^8.2.0
     express: ^4.16.2
     lodash.uniqby: ^4.7.0
-    winston: ^3.2.1
+    winston: ^3.3.3
   languageName: unknown
   linkType: soft
 
@@ -10036,7 +10036,7 @@ __metadata:
     moment: ^2.24.0
     moment-timezone: ^0.5.27
     semver-compare: ^1.0.0
-    winston: ^3.2.1
+    winston: ^3.3.3
   languageName: unknown
   linkType: soft
 
@@ -10133,7 +10133,7 @@ __metadata:
     dotenv: ^8.2.0
     express: ^4.16.2
     lodash.groupby: ^4.6.0
-    winston: ^3.2.1
+    winston: ^3.3.3
   languageName: unknown
   linkType: soft
 
@@ -10210,7 +10210,7 @@ __metadata:
     mathjs: ^9.4.0
     mockdate: ^3.0.5
     moment: ^2.24.0
-    winston: ^3.2.1
+    winston: ^3.3.3
   languageName: unknown
   linkType: soft
 
@@ -10239,7 +10239,7 @@ __metadata:
     http-proxy-middleware: ^2.0.1
     i18n: ^0.13.3
     morgan: ^1.9.0
-    winston: ^3.2.1
+    winston: ^3.3.3
   languageName: unknown
   linkType: soft
 
@@ -10294,7 +10294,7 @@ __metadata:
     lodash.groupby: ^4.6.0
     lodash.keyby: ^4.6.0
     lodash.sortby: ^4.6.0
-    winston: ^3.2.1
+    winston: ^3.3.3
   languageName: unknown
   linkType: soft
 
@@ -14007,17 +14007,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"async@npm:^3.1.0, async@npm:^3.2.3":
-  version: 3.2.4
-  resolution: "async@npm:3.2.4"
-  checksum: 43d07459a4e1d09b84a20772414aa684ff4de085cbcaec6eea3c7a8f8150e8c62aa6cd4e699fe8ee93c3a5b324e777d34642531875a0817a35697522c1b02e89
-  languageName: node
-  linkType: hard
-
 "async@npm:^3.2.0":
   version: 3.2.0
   resolution: "async@npm:3.2.0"
   checksum: 6739fae769e6c9f76b272558f118ef041d45c979c573a8fe93f8cfbc32eb9c92da032e9effe6bbcc9b1131292cde6c4a9e61a442894aa06a262addd8dd3adda1
+  languageName: node
+  linkType: hard
+
+"async@npm:^3.2.3":
+  version: 3.2.4
+  resolution: "async@npm:3.2.4"
+  checksum: 43d07459a4e1d09b84a20772414aa684ff4de085cbcaec6eea3c7a8f8150e8c62aa6cd4e699fe8ee93c3a5b324e777d34642531875a0817a35697522c1b02e89
   languageName: node
   linkType: hard
 
@@ -29735,7 +29735,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"logform@npm:^2.2.0, logform@npm:^2.3.2, logform@npm:^2.4.0":
+"logform@npm:^2.3.2, logform@npm:^2.4.0":
   version: 2.5.1
   resolution: "logform@npm:2.5.1"
   dependencies:
@@ -44412,7 +44412,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"winston-transport@npm:^4.4.0, winston-transport@npm:^4.5.0":
+"winston-transport@npm:^4.5.0":
   version: 4.5.0
   resolution: "winston-transport@npm:4.5.0"
   dependencies:
@@ -44438,24 +44438,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"winston@npm:3.3.3":
-  version: 3.3.3
-  resolution: "winston@npm:3.3.3"
-  dependencies:
-    "@dabh/diagnostics": ^2.0.2
-    async: ^3.1.0
-    is-stream: ^2.0.0
-    logform: ^2.2.0
-    one-time: ^1.0.0
-    readable-stream: ^3.4.0
-    stack-trace: 0.0.x
-    triple-beam: ^1.3.0
-    winston-transport: ^4.4.0
-  checksum: 89a0a8db4e577d0df2bee8af67a751663fb80aaa782750b5a0a151a6bf97074dd0eb7c81780e196197735b851c12ea9c176952128fc51fae07a8a5ddba82913a
-  languageName: node
-  linkType: hard
-
-"winston@npm:^3.2.1, winston@npm:^3.3.3":
+"winston@npm:^3.3.3":
   version: 3.9.0
   resolution: "winston@npm:3.9.0"
   dependencies:


### PR DESCRIPTION
This allows us to use the same `winston` instance across all packages. Mainly useful when modifying the default transports when running tests in the root `jest.setup.js`.