### PR TITLE
RN-664: Updated the meditrak_sync_queue schema

### DIFF
--- a/packages/database/scripts/setupTestDatabase.sh
+++ b/packages/database/scripts/setupTestDatabase.sh
@@ -47,3 +47,6 @@ rm ./src/migrations/*modifies-data.js
 DB_NAME=$DB_NAME yarn migrate
 cp -r ./src/migrations-backup/* ./src/migrations/
 rm -rf ./src/migrations-backup
+
+# ensure that the latest permissions based meditrak sync queue has been built
+yarn workspace @tupaia/central-server create-meditrak-sync-view

--- a/packages/database/scripts/setupTestDatabase.sh
+++ b/packages/database/scripts/setupTestDatabase.sh
@@ -49,4 +49,5 @@ cp -r ./src/migrations-backup/* ./src/migrations/
 rm -rf ./src/migrations-backup
 
 # ensure that the latest permissions based meditrak sync queue has been built
+yarn workspace @tupaia/central-server build
 yarn workspace @tupaia/central-server create-meditrak-sync-view

--- a/packages/database/src/migrations/20230907065531-AddEnumForMeditrakSyncQueueChangeType-modifies-schema.js
+++ b/packages/database/src/migrations/20230907065531-AddEnumForMeditrakSyncQueueChangeType-modifies-schema.js
@@ -1,0 +1,37 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function (db) {
+  return db.runSql(`
+    DROP MATERIALIZED VIEW IF EXISTS permissions_based_meditrak_sync_queue;
+    CREATE TYPE meditrak_sync_queue_change_type AS ENUM ('update', 'delete');
+    ALTER TABLE meditrak_sync_queue ALTER COLUMN type TYPE meditrak_sync_queue_change_type USING type::meditrak_sync_queue_change_type;
+    ALTER TABLE meditrak_sync_queue ALTER COLUMN change_time SET NOT NULL;
+  `);
+};
+
+exports.down = function (db) {
+  return db.runSql(`
+    DROP MATERIALIZED VIEW IF EXISTS permissions_based_meditrak_sync_queue;
+    ALTER TABLE meditrak_sync_queue ALTER COLUMN change_time DROP NOT NULL;
+    ALTER TABLE meditrak_sync_queue ALTER COLUMN type TYPE TEXT;
+    DROP TYPE IF EXISTS meditrak_sync_queue_change_type;
+`);
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/packages/types/src/schemas/schemas.ts
+++ b/packages/types/src/schemas/schemas.ts
@@ -36047,6 +36047,10 @@ export const MeditrakSyncQueueSchema = {
 			"type": "string"
 		},
 		"type": {
+			"enum": [
+				"delete",
+				"update"
+			],
 			"type": "string"
 		}
 	},
@@ -36296,6 +36300,10 @@ export const PermissionsBasedMeditrakSyncQueueSchema = {
 			"type": "string"
 		},
 		"type": {
+			"enum": [
+				"delete",
+				"update"
+			],
 			"type": "string"
 		}
 	},
@@ -37090,6 +37098,14 @@ export const PeriodGranularitySchema = {
 		"quarterly",
 		"weekly",
 		"yearly"
+	],
+	"type": "string"
+} 
+
+export const MeditrakSyncQueueChangeTypeSchema = {
+	"enum": [
+		"delete",
+		"update"
 	],
 	"type": "string"
 } 

--- a/packages/types/src/types/models.ts
+++ b/packages/types/src/types/models.ts
@@ -356,11 +356,11 @@ export interface MeditrakDevice {
   'user_id': string;
 }
 export interface MeditrakSyncQueue {
-  'change_time'?: number | null;
+  'change_time'?: number;
   'id': string;
   'record_id': string;
   'record_type': string;
-  'type': string;
+  'type': MeditrakSyncQueueChangeType;
 }
 export interface Ms1SyncLog {
   'count'?: number | null;
@@ -415,7 +415,7 @@ export interface PermissionsBasedMeditrakSyncQueue {
   'permission_groups'?: string[] | null;
   'record_id'?: string | null;
   'record_type'?: string | null;
-  'type'?: string | null;
+  'type'?: MeditrakSyncQueueChangeType | null;
 }
 export interface Project {
   'code': string;
@@ -632,6 +632,10 @@ export enum PeriodGranularity {
   'monthly' = 'monthly',
   'weekly' = 'weekly',
   'daily' = 'daily',
+}
+export enum MeditrakSyncQueueChangeType {
+  'update' = 'update',
+  'delete' = 'delete',
 }
 export enum EntityType {
   'world' = 'world',


### PR DESCRIPTION
### Issue RN-664:

Added an enum type for the change type (only allowed values are `updated` or `deleted`)

Also set the `change_time` to `NOT NULL`

NOTE: This will require manually re-building the `permissions_based_meditrak_sync_queue` once we've deployed