### PR TITLE
No issue: Fixup servers conf

### DIFF
--- a/packages/devops/configs/servers.conf
+++ b/packages/devops/configs/servers.conf
@@ -13,7 +13,7 @@ server {
   # Load configuration files for the default server block.
   include /etc/nginx/default.d/*.conf;
   include /etc/nginx/h5bp/basic.conf;
-  include /etc/nging/h5bp/web_performance/compression.conf;
+  include /etc/nginx/h5bp/web_performance/compression.conf;
 
   location / {
     try_files '' /index.html =404;
@@ -44,7 +44,7 @@ server {
   # Load configuration files for the default server block.
   include /etc/nginx/default.d/*.conf;
   include /etc/nginx/h5bp/basic.conf;
-  include /etc/nging/h5bp/web_performance/compression.conf;
+  include /etc/nginx/h5bp/web_performance/compression.conf;
 
   location / {
     try_files '' /index.html =404;
@@ -75,7 +75,7 @@ server {
   # Load configuration files for the default server block.
   include /etc/nginx/default.d/*.conf;
   include /etc/nginx/h5bp/basic.conf;
-  include /etc/nging/h5bp/web_performance/compression.conf;
+  include /etc/nginx/h5bp/web_performance/compression.conf;
 
   location / {
     try_files '' /index.html =404;
@@ -106,7 +106,7 @@ server {
   # Load configuration files for the default server block.
   include /etc/nginx/default.d/*.conf;
   include /etc/nginx/h5bp/basic.conf;
-  include /etc/nging/h5bp/web_performance/compression.conf;
+  include /etc/nginx/h5bp/web_performance/compression.conf;
 
   location / {
               proxy_pass http://localhost:8040;
@@ -145,7 +145,7 @@ server {
   # Load configuration files for the default server block.
   include /etc/nginx/default.d/*.conf;
   include /etc/nginx/h5bp/basic.conf;
-  include /etc/nging/h5bp/web_performance/compression.conf;
+  include /etc/nginx/h5bp/web_performance/compression.conf;
 
   location / {
     try_files '' /index.html =404;
@@ -176,7 +176,7 @@ server {
   # Load configuration files for the default server block.
   include /etc/nginx/default.d/*.conf;
   include /etc/nginx/h5bp/basic.conf;
-  include /etc/nging/h5bp/web_performance/compression.conf;
+  include /etc/nginx/h5bp/web_performance/compression.conf;
 
   location / {
     try_files '' /index.html =404;
@@ -207,7 +207,7 @@ server {
   # Load configuration files for the default server block.
   include /etc/nginx/default.d/*.conf;
   include /etc/nginx/h5bp/basic.conf;
-  include /etc/nging/h5bp/web_performance/compression.conf;
+  include /etc/nginx/h5bp/web_performance/compression.conf;
 
   location / {
               proxy_pass http://localhost:8060;
@@ -246,7 +246,7 @@ server {
   # Load configuration files for the default server block.
   include /etc/nginx/default.d/*.conf;
   include /etc/nginx/h5bp/basic.conf;
-  include /etc/nging/h5bp/web_performance/compression.conf;
+  include /etc/nginx/h5bp/web_performance/compression.conf;
 
   location / {
               proxy_pass http://localhost:8020;
@@ -285,7 +285,7 @@ server {
   # Load configuration files for the default server block.
   include /etc/nginx/default.d/*.conf;
   include /etc/nginx/h5bp/basic.conf;
-  include /etc/nging/h5bp/web_performance/compression.conf;
+  include /etc/nginx/h5bp/web_performance/compression.conf;
 
   location / {
               proxy_pass http://localhost:8070;
@@ -324,7 +324,7 @@ server {
   # Load configuration files for the default server block.
   include /etc/nginx/default.d/*.conf;
   include /etc/nginx/h5bp/basic.conf;
-  include /etc/nging/h5bp/web_performance/compression.conf;
+  include /etc/nginx/h5bp/web_performance/compression.conf;
 
   location / {
               proxy_pass http://localhost:8030;
@@ -363,7 +363,7 @@ server {
   # Load configuration files for the default server block.
   include /etc/nginx/default.d/*.conf;
   include /etc/nginx/h5bp/basic.conf;
-  include /etc/nging/h5bp/web_performance/compression.conf;
+  include /etc/nginx/h5bp/web_performance/compression.conf;
 
   location / {
               proxy_pass http://localhost:8050;
@@ -403,7 +403,7 @@ server {
   # Load configuration files for the default server block.
   include /etc/nginx/default.d/*.conf;
   include /etc/nginx/h5bp/basic.conf;
-  include /etc/nging/h5bp/web_performance/compression.conf;
+  include /etc/nginx/h5bp/web_performance/compression.conf;
 
   location / {
               proxy_pass http://localhost:8010;
@@ -443,7 +443,7 @@ server {
   # Load configuration files for the default server block.
   include /etc/nginx/default.d/*.conf;
   include /etc/nginx/h5bp/basic.conf;
-  include /etc/nging/h5bp/web_performance/compression.conf;
+  include /etc/nginx/h5bp/web_performance/compression.conf;
 
   location / {
               proxy_pass http://localhost:8100;
@@ -483,7 +483,7 @@ server {
   # Load configuration files for the default server block.
   include /etc/nginx/default.d/*.conf;
   include /etc/nginx/h5bp/basic.conf;
-  include /etc/nging/h5bp/web_performance/compression.conf;
+  include /etc/nginx/h5bp/web_performance/compression.conf;
 
   location / {
               proxy_pass http://localhost:8090;
@@ -523,7 +523,7 @@ server {
   # Load configuration files for the default server block.
   include /etc/nginx/default.d/*.conf;
   include /etc/nginx/h5bp/basic.conf;
-  include /etc/nging/h5bp/web_performance/compression.conf;
+  include /etc/nginx/h5bp/web_performance/compression.conf;
 
   location / {
     try_files '' /index.html =404;
@@ -554,7 +554,7 @@ server {
   # Load configuration files for the default server block.
   include /etc/nginx/default.d/*.conf;
   include /etc/nginx/h5bp/basic.conf;
-  include /etc/nging/h5bp/web_performance/compression.conf;
+  include /etc/nginx/h5bp/web_performance/compression.conf;
 
   location / {
 
@@ -626,7 +626,7 @@ server {
   # Load configuration files for the default server block.
   include /etc/nginx/default.d/*.conf;
   include /etc/nginx/h5bp/basic.conf;
-  include /etc/nging/h5bp/web_performance/compression.conf;
+  include /etc/nginx/h5bp/web_performance/compression.conf;
 
   location / {
     try_files '' /index.html =404;

--- a/packages/devops/scripts/deployment/setupGoldMaster.sh
+++ b/packages/devops/scripts/deployment/setupGoldMaster.sh
@@ -7,7 +7,7 @@
 sudo apt-get install -yqq nginx
 git clone https://github.com/h5bp/server-configs-nginx.git
 cd ./server-configs-nginx
-git checkout tags/2.0.0
+git checkout tags/5.0.1
 cd ..
 sudo cp -R ./server-configs-nginx/h5bp/ /etc/nginx/
 rm -rf server-configs-nginx


### PR DESCRIPTION
### Issue #: None

### Changes:

- Fix `nging` typo
- Update h5bp to latest release
  - Why are we using a version from 2017??
  - I don't know if we want to upgrade to an inbetween version, but upgrading is necessary if we want to use `compression.conf`