### PR TITLE
WAITP-1211: Filter child_codes when fetching entities in tupaia-web-server

### DIFF
--- a/packages/tupaia-web-server/src/routes/EntitiesRoute.ts
+++ b/packages/tupaia-web-server/src/routes/EntitiesRoute.ts
@@ -6,7 +6,7 @@
 import { Request } from 'express';
 import { Route } from '@tupaia/server-boilerplate';
 import camelcaseKeys from 'camelcase-keys';
-import { TupaiaWebEntitiesRequest, Entity } from '@tupaia/types';
+import { TupaiaWebEntitiesRequest } from '@tupaia/types';
 import { generateFrontendExcludedFilter } from '../utils';
 
 export type EntitiesRequest = Request<

--- a/packages/tupaia-web-server/src/routes/EntitiesRoute.ts
+++ b/packages/tupaia-web-server/src/routes/EntitiesRoute.ts
@@ -6,7 +6,7 @@
 import { Request } from 'express';
 import { Route } from '@tupaia/server-boilerplate';
 import camelcaseKeys from 'camelcase-keys';
-import { TupaiaWebEntitiesRequest } from '@tupaia/types';
+import { TupaiaWebEntitiesRequest, Entity } from '@tupaia/types';
 import { generateFrontendExcludedFilter } from '../utils';
 
 export type EntitiesRequest = Request<
@@ -23,7 +23,7 @@ const DEFAULT_FILTER = {
   },
 };
 
-const DEFAULT_FIELDS = ['parent_code', 'code', 'name', 'type'];
+const DEFAULT_FIELDS = ['parent_code', 'code', 'name', 'type', 'child_codes'];
 
 export class EntitiesRoute extends Route<EntitiesRequest> {
   public async buildResponse() {
@@ -54,6 +54,32 @@ export class EntitiesRoute extends Route<EntitiesRequest> {
       query.includeRootEntity || false,
     );
 
-    return camelcaseKeys(flatEntities, { deep: true });
+    // The child_codes aren't filtered for frontendExcludedTypes
+    // So we fetch a layer of filtered descendents and 
+    const childEntities = await ctx.services.entity.getDescendantsOfEntities(
+      projectCode,
+      flatEntities.map((e: any) => e.code),
+      {
+        filter: {
+          generational_distance: {
+            comparator: '<=',
+            comparisonValue: 1,
+          },
+          ...generateFrontendExcludedFilter(config, typesExcludedFromWebFrontend),
+        },
+        fields: ['code'],
+      },
+    );
+    const formattedEntities = flatEntities.map((e: any) => {
+      const filteredChildren = e.child_codes?.filter((code: string) =>
+        childEntities.some((ce: any) => ce.code === code),
+      );
+      return {
+        ...e,
+        child_codes: filteredChildren?.length > 0 ? filteredChildren : undefined,
+      };
+    });
+
+    return camelcaseKeys(formattedEntities, { deep: true });
   }
 }

--- a/packages/tupaia-web-server/src/routes/EntitiesRoute.ts
+++ b/packages/tupaia-web-server/src/routes/EntitiesRoute.ts
@@ -54,28 +54,19 @@ export class EntitiesRoute extends Route<EntitiesRequest> {
       query.includeRootEntity || false,
     );
 
-    // The child_codes aren't filtered for frontendExcludedTypes
-    // So we fetch a layer of filtered descendents and 
-    const childEntities = await ctx.services.entity.getDescendantsOfEntities(
-      projectCode,
-      flatEntities.map((e: any) => e.code),
-      {
-        filter: {
-          generational_distance: {
-            comparator: '<=',
-            comparisonValue: 1,
-          },
-          ...generateFrontendExcludedFilter(config, typesExcludedFromWebFrontend),
-        },
-        fields: ['code'],
-      },
-    );
-    const formattedEntities = flatEntities.map((e: any) => {
-      const filteredChildren = e.child_codes?.filter((code: string) =>
-        childEntities.some((ce: any) => ce.code === code),
+    // The child_codes list won't have been filtered for frontendExcludedTypes
+    // Since we fetch two layers at a time, we can clean up child_codes in the
+    // first layer, by checking the child exists in the second
+    const formattedEntities = flatEntities.map((entity: any) => {
+      // Only the first layer
+      if (entity.parent_code !== rootEntityCode) {
+        return entity;
+      }
+      const filteredChildren = entity.child_codes?.filter((childCode: string) =>
+        flatEntities.some(({ code }: { code: string }) => code === childCode),
       );
       return {
-        ...e,
+        ...entity,
         child_codes: filteredChildren?.length > 0 ? filteredChildren : undefined,
       };
     });


### PR DESCRIPTION
### Issue #: WAITP-1211

### Changes:

- Prevents an issue where drop down arrows appear on entities without children in the entity search list
- We request two layers of entities at a time, and we only filter the first layer in this implementation
  - If we wanted to filter all `child_codes` fields we'd need an additional fetch from `entity-server`, pull the filtered descendants of the entity list and the filter all `child_codes` fields by that list
  - I implemented _that_ version of code in the first commit, then replaced it with this version, which uses less api requests
    - But we the data from that version is more consistent, so we might still prefer it. This might be a tech design sort of discussion