### PR TITLE
WAITP-1242 Fixup headers on survey response export

### DIFF
--- a/packages/tupaia-web-server/src/routes/ExportSurveyResponsesRoute.ts
+++ b/packages/tupaia-web-server/src/routes/ExportSurveyResponsesRoute.ts
@@ -30,7 +30,9 @@ export class ExportSurveyResponsesRoute extends Route<ExportSurveyResponsesReque
       easyReadingMode,
     } = query;
     const dashboardItem = (
-      await ctx.services.central.fetchResources('dashboardItems', { code: itemCode })
+      await ctx.services.central.fetchResources('dashboardItems', {
+        filter: { code: itemCode },
+      })
     )[0];
 
     if (!dashboardItem) {


### PR DESCRIPTION
### Issue #: WAITP-1242

### Changes:

- The filter argument was formatted incorrectly, causing an unfiltered request which was causing incorrect (but valid) data to be passed to the next step