### PR TITLE
WAITP-1231: Handle isExpanded params for matrix report

### DIFF
--- a/packages/tupaia-web/src/api/queries/useReport.ts
+++ b/packages/tupaia-web/src/api/queries/useReport.ts
@@ -18,6 +18,7 @@ type QueryParams = Record<string, unknown> & {
   legacy?: DashboardItem['legacy'];
   startDate?: Moment | string | null;
   endDate?: Moment | string | null;
+  isExpanded?: boolean;
 };
 
 export const useReport = (reportCode: DashboardItem['reportCode'], params: QueryParams) => {
@@ -29,6 +30,7 @@ export const useReport = (reportCode: DashboardItem['reportCode'], params: Query
     startDate,
     endDate,
     legacy,
+    isExpanded,
     ...rest
   } = params;
   const timeZone = getBrowserTimeZone();
@@ -45,6 +47,7 @@ export const useReport = (reportCode: DashboardItem['reportCode'], params: Query
       itemCode,
       formattedStartDate,
       formattedEndDate,
+      isExpanded,
       ...Object.values(rest),
     ],
     (): Promise<TupaiaWebReportRequest.ResBody> =>
@@ -57,6 +60,7 @@ export const useReport = (reportCode: DashboardItem['reportCode'], params: Query
           timeZone,
           startDate: formattedStartDate,
           endDate: formattedEndDate,
+          isExpanded,
           ...rest,
         },
       }),

--- a/packages/tupaia-web/src/features/EnlargedDashboardItem/utils/useEnlargedDashboardItem.ts
+++ b/packages/tupaia-web/src/features/EnlargedDashboardItem/utils/useEnlargedDashboardItem.ts
@@ -57,6 +57,7 @@ export const useEnlargedDashboardItem = () => {
       endDate,
       legacy: currentDashboardItem?.legacy,
       itemCode: currentDashboardItem?.code,
+      isExpanded: true,
     };
     if (!isDrillDown) return params;
     // If the report is a drilldown, we want to add the drilldown id to the params, so that correct data is fetched


### PR DESCRIPTION
### Issue WAITP-1231: Handle isExpanded params for matrix report:

### Changes:
- Added `isExpanded` param to query for enlarged reports, so that reports get handled correctly. 

Note: BE piece of this is a separate PR