### PR TITLE
RN-664: Move calculation of change_time for sync queues into application logic

### DIFF
--- a/packages/central-server/src/database/meditrakSyncQueue/MeditrakSyncRecordUpdater.js
+++ b/packages/central-server/src/database/meditrakSyncQueue/MeditrakSyncRecordUpdater.js
@@ -11,12 +11,14 @@ const arraysAreSame = (arr1, arr2) =>
 export class MeditrakSyncRecordUpdater {
   constructor(models) {
     this.models = models;
+    this.changeBatchIndex = 0;
   }
 
   /**
    * @public
    */
   async updateSyncRecords(changes) {
+    this.changeBatchIndex = 0;
     for (let i = 0; i < changes.length; i++) {
       const change = changes[i];
       await this.processChange(change);
@@ -110,7 +112,7 @@ export class MeditrakSyncRecordUpdater {
       },
       {
         ...change,
-        change_time: Math.random(), // Force an update, after which point the trigger will update the change_time to more complicated now() + sequence
+        change_time: parseFloat(`${Date.now()}.${this.changeBatchIndex++}`),
       },
     );
   }

--- a/packages/central-server/src/externalApiSync/ExternalApiSyncQueue.js
+++ b/packages/central-server/src/externalApiSync/ExternalApiSyncQueue.js
@@ -50,7 +50,7 @@ export class ExternalApiSyncQueue {
           is_deleted: false,
           is_dead_letter: false,
           priority: 1,
-          change_time: Math.random(), // Force an update, after which point the trigger will update the change_time to more complicated now() + sequence
+          change_time: parseFloat(`${Date.now()}.${i}`),
         };
         if (changeDetails) {
           changeRecord.details = changeDetails[i];

--- a/packages/database/src/migrations/20230915002216-DropMeditrakSyncQueueChangeTimeTrigger-modifies-schema.js
+++ b/packages/database/src/migrations/20230915002216-DropMeditrakSyncQueueChangeTimeTrigger-modifies-schema.js
@@ -1,0 +1,34 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function (db) {
+  return db.runSql(`DROP TRIGGER IF EXISTS meditrak_sync_queue_trigger ON meditrak_sync_queue`);
+};
+
+exports.down = function (db) {
+  return db.runSql(`
+  create trigger meditrak_sync_queue_trigger before
+  insert
+      or
+  update
+      on
+      public.meditrak_sync_queue for each row execute function update_change_time()
+  `);
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/packages/meditrak-app-server/src/sync/MeditrakSyncRecordUpdater.ts
+++ b/packages/meditrak-app-server/src/sync/MeditrakSyncRecordUpdater.ts
@@ -11,12 +11,15 @@ const arraysAreSame = (arr1: unknown[], arr2: unknown[]) =>
 
 export class MeditrakSyncRecordUpdater {
   private readonly models: MeditrakAppServerModelRegistry;
+  private changeBatchIndex: number;
 
   public constructor(models: MeditrakAppServerModelRegistry) {
     this.models = models;
+    this.changeBatchIndex = 0;
   }
 
   public async updateSyncRecords(changes: Change[]) {
+    this.changeBatchIndex = 0; // Reset the batch index before updating records
     for (let i = 0; i < changes.length; i++) {
       const change = changes[i];
       await this.processChange(change);
@@ -114,7 +117,7 @@ export class MeditrakSyncRecordUpdater {
       },
       {
         ...change,
-        change_time: Math.random(), // Force an update, after which point the trigger will update the change_time to more complicated now() + sequence
+        change_time: parseFloat(`${Date.now()}.${this.changeBatchIndex++}`),
       },
     );
   }


### PR DESCRIPTION
### Issue RN-664:

This change is primarily motivated by testing interests. Having the `change_time` being calculated by db trigger means it's really hard to accurately await for when the sync queues have been properly updated.

I guess the other motivation is to reduce complexity a little.

Having the database be responsible for this though is a more resilient approach, so happy to drop this if we feel the cons outweigh the pros.

@edmofro wouldn't mind getting your perspective on this 🙏 