### PR TITLE
WAITP-1421 Catch errors in forward request handler

### DIFF
--- a/packages/server-boilerplate/src/utils/forwardRequest.ts
+++ b/packages/server-boilerplate/src/utils/forwardRequest.ts
@@ -52,9 +52,13 @@ export const forwardRequest = (
 
   const proxyMiddleware = createProxyMiddleware(proxyOptions);
   return async (req: Request, res: Response, next: NextFunction) => {
-    console.log(`forwarding ${req.path} to ${target}`);
-    const authHandler = authHandlerProvider(req);
-    req.headers.authorization = await authHandler.getAuthHeader();
-    proxyMiddleware(req, res, next);
+    console.log(`forwarding ${req.originalUrl} to ${target}`);
+    try {
+      const authHandler = authHandlerProvider(req);
+      req.headers.authorization = await authHandler.getAuthHeader();
+      proxyMiddleware(req, res, next);
+    } catch (error) {
+      next(error);
+    }
   };
 };


### PR DESCRIPTION
### Issue #:

### Changes:

- Catch errors in the forward request handler
  - All default routes are wrapped in a similar catch and next handler
  - This prevents an issue with crashing on failure to `getAuthHeader`