### PR TITLE
RN-988: Switched PSSS survey response CRUD over to using /surveyResponse endpoint

### DIFF
--- a/packages/central-server/src/apiV2/surveyResponse.js
+++ b/packages/central-server/src/apiV2/surveyResponse.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2019 Beyond Essential Systems Pty Ltd
  */
 
+import { AnalyticsRefresher } from '@tupaia/database';
 import {
   ValidationError,
   MultiValidationError,
@@ -135,6 +136,11 @@ export async function surveyResponse(req, res) {
     );
 
     results = await saveResponsesToDatabase(transactingModels, userId, responses);
+
+    if (req.query.waitForAnalyticsRebuild) {
+      const { database } = transactingModels;
+      await AnalyticsRefresher.refreshAnalytics(database);
+    }
   });
   res.send({ count: responses.length, results });
 }

--- a/packages/central-server/src/apiV2/surveyResponses/ResubmitSurveyResponse.js
+++ b/packages/central-server/src/apiV2/surveyResponses/ResubmitSurveyResponse.js
@@ -5,6 +5,7 @@
  */
 
 import { S3, S3Client } from '@tupaia/utils';
+import { AnalyticsRefresher } from '@tupaia/database';
 import fs from 'fs';
 import { EditHandler } from '../EditHandler';
 import {
@@ -27,10 +28,6 @@ import { validateResubmission } from './resubmission/validateResubmission';
  */
 
 export class ResubmitSurveyResponse extends EditHandler {
-  constructor(req, res) {
-    super(req, res);
-  }
-
   async assertUserHasAccess() {
     // Check the user has either:
     // - BES admin access
@@ -82,6 +79,11 @@ export class ResubmitSurveyResponse extends EditHandler {
           const s3Client = this.getS3client();
           await s3Client.uploadFile(uniqueFileName, readableStream);
         }
+      }
+
+      if (this.req.query.waitForAnalyticsRebuild) {
+        const { database } = transactingModels;
+        await AnalyticsRefresher.refreshAnalytics(database);
       }
     });
   }

--- a/packages/psss-server/package.json
+++ b/packages/psss-server/package.json
@@ -30,6 +30,7 @@
     "@tupaia/access-policy": "3.0.0",
     "@tupaia/database": "1.0.0",
     "@tupaia/server-boilerplate": "1.0.0",
+    "@tupaia/types": "1.0.0",
     "@tupaia/utils": "1.0.0",
     "api-error-handler": "^1.0.0",
     "body-parser": "^1.18.3",

--- a/packages/psss-server/src/routes/alerts/ProcessAlertActionRoute.ts
+++ b/packages/psss-server/src/routes/alerts/ProcessAlertActionRoute.ts
@@ -44,7 +44,6 @@ export class ProcessAlertActionRoute extends Route<ProcessAlertActionRequest> {
 
     return this.centralConnection.updateSurveyResponseByObject(alertSurveyResponse, [
       {
-        type: 'Binary',
         code: 'PSSS_Alert_Archived',
         value: ACTION_TO_ANSWER[action],
       },

--- a/packages/psss-server/src/routes/reports/ConfirmWeeklyReportRoute.ts
+++ b/packages/psss-server/src/routes/reports/ConfirmWeeklyReportRoute.ts
@@ -19,12 +19,6 @@ const WEEKLY_REPORT_CODE = 'PSSS_Weekly_Cases';
 const ACTIVE_ALERTS_REPORT_CODE = 'PSSS_Active_Alerts';
 const CONFIRMED_WEEKLY_REPORT_CODE = 'PSSS_Confirmed_Weekly_Report';
 
-type ConfirmedWeeklyReportAnswer = {
-  type: string;
-  code: string;
-  value: number;
-};
-
 type AlertResponseData = {
   createdAlerts: {
     id: string;
@@ -150,8 +144,8 @@ export class ConfirmWeeklyReportRoute extends Route<ConfirmWeeklyReportRequest> 
     if (!this.centralConnection) throw new UnauthenticatedError('Unauthenticated');
 
     return this.centralConnection.createSurveyResponse(ALERT_SURVEY, countryCode, week, [
-      { code: 'PSSS_Alert_Syndrome', type: 'Radio', value: syndromeCode },
-      { code: 'PSSS_Alert_Archived', type: 'Binary', value: 'No' },
+      { code: 'PSSS_Alert_Syndrome', value: syndromeCode },
+      { code: 'PSSS_Alert_Archived', value: 'No' },
     ]);
   }
 
@@ -159,14 +153,12 @@ export class ConfirmWeeklyReportRoute extends Route<ConfirmWeeklyReportRequest> 
     if (!this.centralConnection) throw new UnauthenticatedError('Unauthenticated');
 
     return this.centralConnection.updateSurveyResponse(alertId, countryCode, ALERT_SURVEY, week, [
-      { code: 'PSSS_Alert_Archived', type: 'Binary', value: 'Yes' },
+      { code: 'PSSS_Alert_Archived', value: 'Yes' },
     ]);
   }
 }
 
-const mapUnconfirmedReportToConfirmedAnswers = (
-  reportValues: Record<string, unknown>,
-): ConfirmedWeeklyReportAnswer[] => {
+const mapUnconfirmedReportToConfirmedAnswers = (reportValues: Record<string, unknown>) => {
   const {
     Sites: sites,
     'Sites Reported': sitesReported,
@@ -185,37 +177,30 @@ const mapUnconfirmedReportToConfirmedAnswers = (
 
   return [
     {
-      type: 'Number',
       code: 'PSSS_Confirmed_Sites',
       value: validateIsNumber(sites, errorHandler('Sites')),
     },
     {
-      type: 'Number',
       code: 'PSSS_Confirmed_Sites_Reported',
       value: validateIsNumber(sitesReported, errorHandler('Sites Reported')),
     },
     {
-      type: 'Number',
       code: 'PSSS_Confirmed_AFR_Cases',
       value: validateIsNumber(afr, errorHandler('AFR')),
     },
     {
-      type: 'Number',
       code: 'PSSS_Confirmed_DIA_Cases',
       value: validateIsNumber(dia, errorHandler('DIA')),
     },
     {
-      type: 'Number',
       code: 'PSSS_Confirmed_ILI_Cases',
       value: validateIsNumber(ili, errorHandler('ILI')),
     },
     {
-      type: 'Number',
       code: 'PSSS_Confirmed_PF_Cases',
       value: validateIsNumber(pf, errorHandler('PF')),
     },
     {
-      type: 'Number',
       code: 'PSSS_Confirmed_DLI_Cases',
       value: validateIsNumber(dli, errorHandler('DLI')),
     },

--- a/packages/psss-server/src/routes/reports/SaveWeeklyReportRoute.ts
+++ b/packages/psss-server/src/routes/reports/SaveWeeklyReportRoute.ts
@@ -17,12 +17,6 @@ export type SaveWeeklyReportRequest = Request<
   { week: string }
 >;
 
-type WeeklyReportAnswer = {
-  type: string;
-  code: string;
-  value: number;
-};
-
 export class SaveWeeklyReportRoute extends Route<SaveWeeklyReportRequest> {
   public async buildResponse() {
     if (!this.centralConnection) throw new UnauthenticatedError('Unauthenticated');
@@ -51,29 +45,24 @@ const mapReqBodyToAnswers = (body: Record<string, unknown>, isSiteSurvey: boolea
       500,
     );
 
-  const answers: WeeklyReportAnswer[] = [
+  const answers = [
     {
-      type: 'Number',
       code: 'PSSS_AFR_Cases',
       value: validateIsNumber(afr, errorHandler('afr')),
     },
     {
-      type: 'Number',
       code: 'PSSS_DIA_Cases',
       value: validateIsNumber(dia, errorHandler('dia')),
     },
     {
-      type: 'Number',
       code: 'PSSS_ILI_Cases',
       value: validateIsNumber(ili, errorHandler('ili')),
     },
     {
-      type: 'Number',
       code: 'PSSS_PF_Cases',
       value: validateIsNumber(pf, errorHandler('pf')),
     },
     {
-      type: 'Number',
       code: 'PSSS_DLI_Cases',
       value: validateIsNumber(dli, errorHandler('dli')),
     },
@@ -81,12 +70,10 @@ const mapReqBodyToAnswers = (body: Record<string, unknown>, isSiteSurvey: boolea
 
   if (!isSiteSurvey) {
     answers.push({
-      type: 'Number',
       code: 'PSSS_Sites',
       value: validateIsNumber(sites, errorHandler('sites')),
     });
     answers.push({
-      type: 'Number',
       code: 'PSSS_Sites_Reported',
       value: validateIsNumber(sitesReported, errorHandler('sitesReported')),
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -10191,6 +10191,7 @@ __metadata:
     "@tupaia/access-policy": 3.0.0
     "@tupaia/database": 1.0.0
     "@tupaia/server-boilerplate": 1.0.0
+    "@tupaia/types": 1.0.0
     "@tupaia/utils": 1.0.0
     api-error-handler: ^1.0.0
     body-parser: ^1.18.3


### PR DESCRIPTION
### Issue RN-988:

Previously PSSS has been using the `POST /changes` endpoint in the `central-server` for survey response submission. This endpoint really ought to just be used by meditrak, and will shortly be moved over to the `meditrak-app-server`.

So this change is just to switch PSSS over to the more appropriate `/surveyResponse` endpoints