### PR TITLE
WAITP-1287 Fixup ordering of nulls

### DIFF
--- a/packages/tupaia-web-server/package.json
+++ b/packages/tupaia-web-server/package.json
@@ -37,7 +37,6 @@
     "express": "^4.16.2",
     "lodash.groupby": "^4.6.0",
     "lodash.keyby": "^4.6.0",
-    "lodash.sortby": "^4.6.0",
     "winston": "^3.3.3"
   },
   "devDependencies": {
@@ -45,7 +44,6 @@
     "@tupaia/types": "1.0.0",
     "@tupaia/utils": "1.0.0",
     "@types/lodash.groupby": "^4.6.0",
-    "@types/lodash.keyby": "^4.6.0",
-    "@types/lodash.sortby": "^4.6.0"
+    "@types/lodash.keyby": "^4.6.0"
   }
 }

--- a/packages/tupaia-web-server/src/routes/DashboardsRoute.ts
+++ b/packages/tupaia-web-server/src/routes/DashboardsRoute.ts
@@ -127,6 +127,7 @@ export class DashboardsRoute extends Route<DashboardsRequest> {
         item: dashboardItems.find((item: DashboardItem) => item.id === relation.child_id),
       })),
       [
+        ({ relation }: { relation: DashboardRelation }) => (relation.sort_order === null ? 1 : 0), // Puts null values last
         ({ relation }: { relation: DashboardRelation }) => relation.sort_order,
         ({ item }: { item: DashboardItem }) => item.code,
       ],

--- a/packages/tupaia-web-server/src/routes/MapOverlaysRoute.ts
+++ b/packages/tupaia-web-server/src/routes/MapOverlaysRoute.ts
@@ -115,7 +115,7 @@ export class MapOverlaysRoute extends Route<MapOverlaysRequest> {
       return {
         name: parentEntry.name,
         children: orderBy(nestedChildren, [
-          ({ child }: { child: OverlayChild }) => (child.sortOrder === null ? 1 : 0), // Puts null values last
+          (child: OverlayChild) => (child.sortOrder === null ? 1 : 0), // Puts null values last
           'sortOrder',
           'name',
         ]).map((child: OverlayChild) => {

--- a/packages/tupaia-web-server/src/routes/MapOverlaysRoute.ts
+++ b/packages/tupaia-web-server/src/routes/MapOverlaysRoute.ts
@@ -11,9 +11,9 @@ import {
   MapOverlayGroupRelation,
   TupaiaWebMapOverlaysRequest,
 } from '@tupaia/types';
+import { orderBy } from '@tupaia/utils';
 import groupBy from 'lodash.groupby';
 import keyBy from 'lodash.keyby';
-import orderBy from 'lodash.orderby';
 
 export type MapOverlaysRequest = Request<
   TupaiaWebMapOverlaysRequest.Params,

--- a/packages/tupaia-web-server/src/routes/MapOverlaysRoute.ts
+++ b/packages/tupaia-web-server/src/routes/MapOverlaysRoute.ts
@@ -13,7 +13,7 @@ import {
 } from '@tupaia/types';
 import groupBy from 'lodash.groupby';
 import keyBy from 'lodash.keyby';
-import sortBy from 'lodash.sortby';
+import orderBy from 'lodash.orderby';
 
 export type MapOverlaysRequest = Request<
   TupaiaWebMapOverlaysRequest.Params,
@@ -114,7 +114,11 @@ export class MapOverlaysRoute extends Route<MapOverlaysRequest> {
       // Translate Map Overlay Group
       return {
         name: parentEntry.name,
-        children: sortBy(nestedChildren, ['sortOrder', 'name']).map((child: OverlayChild) => {
+        children: orderBy(nestedChildren, [
+          ({ child }: { child: OverlayChild }) => (child.sortOrder === null ? 1 : 0), // Puts null values last
+          'sortOrder',
+          'name',
+        ]).map((child: OverlayChild) => {
           // We only needed the sortOrder for sorting, strip it before we return
           const { sortOrder, ...restOfChild } = child;
           return restOfChild;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10346,13 +10346,11 @@ __metadata:
     "@tupaia/utils": 1.0.0
     "@types/lodash.groupby": ^4.6.0
     "@types/lodash.keyby": ^4.6.0
-    "@types/lodash.sortby": ^4.6.0
     camelcase-keys: ^6.2.2
     dotenv: ^8.2.0
     express: ^4.16.2
     lodash.groupby: ^4.6.0
     lodash.keyby: ^4.6.0
-    lodash.sortby: ^4.6.0
     winston: ^3.3.3
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
### Issue #: WAITP-1287

### Changes:

- Add a discrete step to sorting visuals to place `null` sort values last