### PR TITLE
no-issue: Fix broken sync queues

### DIFF
--- a/packages/central-server/src/database/meditrakSyncQueue/MeditrakSyncRecordUpdater.js
+++ b/packages/central-server/src/database/meditrakSyncQueue/MeditrakSyncRecordUpdater.js
@@ -3,6 +3,8 @@
  * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
  */
 
+import { getSyncQueueChangeTime } from '@tupaia/tsutils';
+
 // TODO: Tidy this up as part of RN-502
 
 const arraysAreSame = (arr1, arr2) =>
@@ -11,14 +13,14 @@ const arraysAreSame = (arr1, arr2) =>
 export class MeditrakSyncRecordUpdater {
   constructor(models) {
     this.models = models;
-    this.changeBatchIndex = 0;
+    this.changeIndex = 0;
   }
 
   /**
    * @public
    */
   async updateSyncRecords(changes) {
-    this.changeBatchIndex = 0;
+    this.changeIndex = 0;
     for (let i = 0; i < changes.length; i++) {
       const change = changes[i];
       await this.processChange(change);
@@ -88,7 +90,12 @@ export class MeditrakSyncRecordUpdater {
       ...optionChanges,
     ];
 
-    return Promise.all(allChanges.map(change => this.addToSyncQueue(change)));
+    const addedChanges = [];
+    for (let i = 0; i < allChanges.length; i++) {
+      const change = allChanges[i];
+      addedChanges.push(await this.addToSyncQueue(change));
+    }
+    return addedChanges;
   }
 
   /**
@@ -112,7 +119,7 @@ export class MeditrakSyncRecordUpdater {
       },
       {
         ...change,
-        change_time: parseFloat(`${Date.now()}.${this.changeBatchIndex++}`),
+        change_time: getSyncQueueChangeTime(this.changeIndex++),
       },
     );
   }

--- a/packages/central-server/src/externalApiSync/ExternalApiSyncQueue.js
+++ b/packages/central-server/src/externalApiSync/ExternalApiSyncQueue.js
@@ -4,6 +4,7 @@
  */
 import autobind from 'react-autobind';
 import { getIsProductionEnvironment } from '@tupaia/utils';
+import { getSyncQueueChangeTime } from '@tupaia/tsutils';
 
 const LOWEST_PRIORITY = 5;
 const BAD_REQUEST_LIMIT = 7;
@@ -21,6 +22,7 @@ export class ExternalApiSyncQueue {
     syncQueueKey,
   ) {
     autobind(this);
+    this.changeIndex = 0;
     this.models = models;
     this.validator = validator;
     this.syncQueueModel = syncQueueModel;
@@ -42,27 +44,26 @@ export class ExternalApiSyncQueue {
   };
 
   async persistToSyncQueue(changes, changeDetails) {
-    await Promise.all(
-      changes.map(async (change, i) => {
-        const changeRecord = {
-          ...change,
-          // Reset defaults in case this has already been on the sync queue for a while
-          is_deleted: false,
-          is_dead_letter: false,
-          priority: 1,
-          change_time: parseFloat(`${Date.now()}.${i}`),
-        };
-        if (changeDetails) {
-          changeRecord.details = changeDetails[i];
-        }
-        await this.syncQueueModel.updateOrCreate(
-          {
-            record_id: change.record_id,
-          },
-          changeRecord,
-        );
-      }),
-    );
+    for (let i = 0; i < changes.length; i++) {
+      const change = changes[i];
+      const changeRecord = {
+        ...change,
+        // Reset defaults in case this has already been on the sync queue for a while
+        is_deleted: false,
+        is_dead_letter: false,
+        priority: 1,
+        change_time: getSyncQueueChangeTime(this.changeIndex++),
+      };
+      if (changeDetails) {
+        changeRecord.details = changeDetails[i];
+      }
+      await this.syncQueueModel.updateOrCreate(
+        {
+          record_id: change.record_id,
+        },
+        changeRecord,
+      );
+    }
   }
 
   triggerSideEffects = async changes => {
@@ -109,6 +110,7 @@ export class ExternalApiSyncQueue {
       this.processChangesIntoDb();
     } else {
       this.isProcessing = false;
+      this.changeIndex = 0;
     }
   };
 

--- a/packages/tsutils/src/getSyncQueueChangeTime.ts
+++ b/packages/tsutils/src/getSyncQueueChangeTime.ts
@@ -1,0 +1,9 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+/**
+ * Increment Date.now() with a change index in order to prevent clashes when inserting multiple records within 1ms of each other
+ */
+export const getSyncQueueChangeTime = (changeIndex: number) => Date.now() + changeIndex / 1000;

--- a/packages/tsutils/src/index.ts
+++ b/packages/tsutils/src/index.ts
@@ -1,5 +1,6 @@
 export * from './datetime';
 export * from './downloadPageAsPDF';
+export * from './getSyncQueueChangeTime';
 export * from './hashStringToInt';
 export * from './period';
 export * from './typeGuards';


### PR DESCRIPTION
### Issue https://beyondessential.slack.com/archives/C01MAA3NKM1/p1695611754430549:

In this release we are now calculating the sync queue `change_time` in the application. An issue was discovered in the release that there can be clashes with the way we calculate this `change_time`.

Fix this by:
1. Using the same function for determining the change time as we'd been using previously
2. Switch a couple instances of `Promise.all()` to explicit loops in order to preserve change order