### PR TITLE
WAITP-1221: Map overlay fixes

### DIFF
--- a/packages/tupaia-web/src/features/Map/MapOverlaysLayer/MarkerLayer.tsx
+++ b/packages/tupaia-web/src/features/Map/MapOverlaysLayer/MarkerLayer.tsx
@@ -10,6 +10,7 @@ import {
   MeasurePopup,
   MeasureData,
   Series,
+  POLYGON_MEASURE_TYPES,
 } from '@tupaia/ui-map-components';
 import { useNavigateToEntity } from '../utils';
 
@@ -19,8 +20,10 @@ interface MarkerLayerProps {
 }
 
 export const MarkerLayer = ({ measureData = [], serieses = [] }: MarkerLayerProps) => {
+  const hasPointSerieses = serieses.some(s => !POLYGON_MEASURE_TYPES.includes(s.type));
   const navigateToEntity = useNavigateToEntity();
-  const markerMeasures = measureData.filter(m => !!m.point).filter(m => !m.isHidden);
+  if (!hasPointSerieses) return null;
+  const markerMeasures = measureData.filter(m => !!m.point && !m.isHidden);
   return (
     <LayerGroup>
       {markerMeasures.map((measure: MeasureData) => {

--- a/packages/tupaia-web/src/features/Map/MapOverlaysLayer/PolygonLayer.tsx
+++ b/packages/tupaia-web/src/features/Map/MapOverlaysLayer/PolygonLayer.tsx
@@ -91,6 +91,10 @@ export const PolygonLayer = ({ measureData = [], serieses = [] }: PolygonLayerPr
   const { selectedOverlay, isPolygonSerieses } = useMapOverlays(projectCode, activeEntityCode);
   const polygons = measureData.filter(m => !!m.region);
 
+  const overlayLevels = Array.isArray(selectedOverlay?.measureLevel)
+    ? selectedOverlay?.measureLevel
+    : [selectedOverlay?.measureLevel].map(level => level?.toLowerCase());
+
   function getDisplayType(measure) {
     const isActive = measure.code === activeEntityCode;
     if (measure.isHidden) {
@@ -99,7 +103,7 @@ export const PolygonLayer = ({ measureData = [], serieses = [] }: PolygonLayerPr
     }
     if (
       isPolygonSerieses &&
-      selectedOverlay?.measureLevel?.toLowerCase() === measure?.type?.toLowerCase().replace('_', '') // handle differences between camelCase and snake_case
+      overlayLevels.includes(measure?.type?.toLowerCase().replace('_', '')) // handle differences between camelCase and snake_case
     ) {
       // The active entity is part of the data visual so display it as a shaded polygon rather
       // than an active polygon

--- a/packages/tupaia-web/src/features/Map/utils/useMapOverlayMapData.ts
+++ b/packages/tupaia-web/src/features/Map/utils/useMapOverlayMapData.ts
@@ -29,9 +29,13 @@ const useNavigationEntities = (projectCode, activeEntity, isPolygonSerieses, mea
   );
 
   // Don't show nav entities for the selected measure level
-  const filteredData = data?.filter(
-    entity => !measureLevel || measureLevel?.toLowerCase() !== entity.type.toLowerCase(),
-  );
+  const filteredData = data?.filter(entity => {
+    if (!measureLevel) return true;
+    // handle edge cases of array measure levels
+    if (Array.isArray(measureLevel))
+      return !measureLevel.map(level => level.toLowerCase()).includes(entity.type.toLowerCase());
+    return measureLevel?.toLowerCase() !== entity.type.toLowerCase();
+  });
 
   // For polygon overlays, show navigation polygons for sibling entities only
   if (isPolygonSerieses) {

--- a/packages/tupaia-web/src/features/Map/utils/useMapOverlayMapData.ts
+++ b/packages/tupaia-web/src/features/Map/utils/useMapOverlayMapData.ts
@@ -72,22 +72,26 @@ export const useMapOverlayMapData = (hiddenValues = {}) => {
     isPolygonSerieses,
     selectedOverlay?.measureLevel,
   );
-
-  // Get the relatives (siblings and immediate children) of the active entity for displaying navigation polygons
-  const relativesMeasureData = entityRelatives?.map(entity => {
-    return {
-      ...entity,
-      organisationUnitCode: entity.code,
-      coordinates: entity.point,
-      region: entity.region,
-      permanentTooltip: !selectedOverlay,
-    };
-  });
-
   const rootEntityCode = getRootEntityCode(entity);
 
   // Get the main visual entities (descendants of root entity for the selected visual) and their data for displaying the visual
   const mapOverlayData = useMapOverlayTableData({ hiddenValues, rootEntityCode });
+
+  // Get the relatives (siblings and immediate children) of the active entity for displaying navigation polygons
+  const relativesMeasureData = entityRelatives
+    ?.filter(
+      entityRelative =>
+        !mapOverlayData?.measureData?.find(item => item.code === entityRelative.code),
+    ) // deduplicate entities so that we don't end up with a navigation entity under a measure entity
+    .map(entityRelative => {
+      return {
+        ...entityRelative,
+        organisationUnitCode: entityRelative.code,
+        coordinates: entityRelative.point,
+        region: entityRelative.region,
+        permanentTooltip: !selectedOverlay,
+      };
+    });
 
   // Combine the main visual entities and relatives for the polygon layer. The entities need to come after the
   // entityRelatives so that the active entity is rendered on top of the relatives


### PR DESCRIPTION
### Issue #WAITP-1221: Map overlay fixes:

### Changes:
- Fixed issue where duplicated entities appeared on the map
- Fixed issue where hidden measures still appeared
- Fixed points appearing when the selected overlay is not a point type overlay
- Handle array type measure levels (likely to be deprecated later though)
