### PR TITLE
WAITP-1287: Misc FE fixes

### DIFF
--- a/packages/tupaia-web-server/src/routes/DashboardsRoute.ts
+++ b/packages/tupaia-web-server/src/routes/DashboardsRoute.ts
@@ -129,7 +129,7 @@ export class DashboardsRoute extends Route<DashboardsRequest> {
       [
         ({ relation }: { relation: DashboardRelation }) => (relation.sort_order === null ? 1 : 0), // Puts null values last
         ({ relation }: { relation: DashboardRelation }) => relation.sort_order,
-        ({ item }: { item: DashboardItem }) => item.code,
+        ({ item }: { item: DashboardItem }) => item.config?.name,
       ],
     );
 

--- a/packages/tupaia-web/src/features/Dashboard/DashboardMenu.tsx
+++ b/packages/tupaia-web/src/features/Dashboard/DashboardMenu.tsx
@@ -34,7 +34,7 @@ const ItemButton = styled(Menu)`
   }
   .MuiMenu-paper {
     max-height: calc(
-      100vh - ${TOP_BAR_HEIGHT} + ${TOP_BAR_HEIGHT}
+      100vh - (${TOP_BAR_HEIGHT} + ${TOP_BAR_HEIGHT})
     ); // 2x top bar height, to make up for any possibly extra in header, e.g. the branch name banner
   }
 

--- a/packages/tupaia-web/src/features/Dashboard/DashboardMenu.tsx
+++ b/packages/tupaia-web/src/features/Dashboard/DashboardMenu.tsx
@@ -34,7 +34,7 @@ const ItemButton = styled(Menu)`
   }
   .MuiMenu-paper {
     max-height: calc(
-      100vh - ${TOP_BAR_HEIGHT * 2}
+      100vh - ${TOP_BAR_HEIGHT} + ${TOP_BAR_HEIGHT}
     ); // 2x top bar height, to make up for any possibly extra in header, e.g. the branch name banner
   }
 

--- a/packages/tupaia-web/src/features/Dashboard/DashboardMenu.tsx
+++ b/packages/tupaia-web/src/features/Dashboard/DashboardMenu.tsx
@@ -33,7 +33,9 @@ const ItemButton = styled(Menu)`
     background: ${({ theme }) => theme.palette.background.default};
   }
   .MuiMenu-paper {
-    max-height: calc(100vh - ${TOP_BAR_HEIGHT});
+    max-height: calc(
+      100vh - ${TOP_BAR_HEIGHT * 2}
+    ); // 2x top bar height, to make up for any possibly extra in header, e.g. the branch name banner
   }
 
   .MuiListItem-root {

--- a/packages/tupaia-web/src/features/EntitySearch/SearchResults.tsx
+++ b/packages/tupaia-web/src/features/EntitySearch/SearchResults.tsx
@@ -105,8 +105,8 @@ export const SearchResults = ({ searchValue, onClose }: SearchResultsProps) => {
   };
 
   const showLoadMoreButton = resultsCount > pageSize;
-  // Remove the extra result
-  const displayResults = searchResults.slice(0, -1);
+  // Remove the extra result only when the load more button is shown, otherwise the last result gets chopped off when there are no more results to load
+  const displayResults = showLoadMoreButton ? searchResults.slice(0, -1) : searchResults;
 
   return (
     <Container>

--- a/packages/tupaia-web/src/features/Map/utils/useMapOverlayTableData.ts
+++ b/packages/tupaia-web/src/features/Map/utils/useMapOverlayTableData.ts
@@ -65,7 +65,7 @@ export const useMapOverlayTableData = ({
     selectedOverlay?.measureLevel,
   );
 
-  const { data, isLoading, isFetched, isFetching } = useMapOverlayReport(
+  const { data, isLoading, isFetched, isFetching, isIdle } = useMapOverlayReport(
     projectCode,
     rootEntityCode,
     selectedOverlay,
@@ -86,7 +86,7 @@ export const useMapOverlayTableData = ({
 
   return {
     ...data,
-    isLoading: isLoading || isFetching || !isFetched,
+    isLoading: isLoading || isFetching || (!isFetched && !isIdle),
     isFetched,
     serieses: data?.serieses,
     measureData,

--- a/packages/tupaia-web/src/features/Visuals/Matrix.tsx
+++ b/packages/tupaia-web/src/features/Visuals/Matrix.tsx
@@ -105,7 +105,7 @@ const parseRows = (
   // if a categoryId is not passed in, then we need to find the top level rows
   if (!categoryId) {
     // get the highest level rows, which are the ones that have a category but no categoryId
-    const highestLevel = rows.filter(row => row.category && !row.categoryId) as MatrixReportRow[];
+    const highestLevel = rows.filter(row => !row.categoryId) as MatrixReportRow[];
     // if there are no highest level rows, then the top level rows are just all of the rows
     topLevelRows = highestLevel.length ? highestLevel : rows;
   } else {

--- a/packages/tupaia-web/src/features/Visuals/View/DownloadFiles.tsx
+++ b/packages/tupaia-web/src/features/Visuals/View/DownloadFiles.tsx
@@ -34,7 +34,7 @@ export const DownloadFiles = ({
 }: DownloadFilesVisualProps) => {
   const [urlSearchParams, setUrlSearchParams] = useSearchParams();
 
-  const { mutate: download, error, reset } = useDownloadFiles();
+  const { mutate: download, error, reset, isLoading } = useDownloadFiles();
 
   const onClose = () => {
     reset();
@@ -52,6 +52,7 @@ export const DownloadFiles = ({
       error={errorObj?.message}
       isEnlarged={isEnlarged}
       onClose={onClose}
+      isLoading={isLoading}
     />
   );
 };

--- a/packages/tupaia-web/src/features/Visuals/View/SingleValue.tsx
+++ b/packages/tupaia-web/src/features/Visuals/View/SingleValue.tsx
@@ -30,15 +30,20 @@ const Title = styled(Typography).attrs({
 interface SingleValueProps {
   report: ViewReport;
   config: ViewConfig;
+  isMultiSingleValue?: boolean;
 }
 
-export const SingleValue = ({ report: { data = [] }, config }: SingleValueProps) => {
+export const SingleValue = ({
+  report: { data = [] },
+  config,
+  isMultiSingleValue,
+}: SingleValueProps) => {
   const { dataColor } = (config || {}) as SingleValueViewConfig;
   const { value, name } = data[0] || {};
-
   return (
     <>
-      {name && <Title>{name}</Title>}
+      {/** only display the name field if is multiSingleValue viewType because the main title does not get displayed in this case */}
+      {name && isMultiSingleValue && <Title>{name}</Title>}
       <Text $dataColor={dataColor}>{value}</Text>
     </>
   );

--- a/packages/tupaia-web/src/features/Visuals/View/View.tsx
+++ b/packages/tupaia-web/src/features/Visuals/View/View.tsx
@@ -118,6 +118,7 @@ export const View = ({ customConfig, customReport }: ViewProps) => {
         }
         config={viewConfig}
         isEnlarged={isEnlarged}
+        isMultiSingleValue={!!customReport} // if this is a multi single value, we need to pass this prop down to the SingleValue component
       />
       {showHoverEffect && <DashboardInfoHover infoText={viewConfig.description} />}
     </>

--- a/packages/tupaia-web/src/features/Visuals/View/View.tsx
+++ b/packages/tupaia-web/src/features/Visuals/View/View.tsx
@@ -104,6 +104,9 @@ export const View = ({ customConfig, customReport }: ViewProps) => {
   if (!Component) return null;
 
   const formattedData = formatData(data, viewConfig);
+
+  // Only show the hover effect if the view is not enlarged and there is no period granularity, because this means that the view is not expandable
+  const showHoverEffect = !isEnlarged && !config?.periodGranularity;
   return (
     <>
       <Component
@@ -116,7 +119,7 @@ export const View = ({ customConfig, customReport }: ViewProps) => {
         config={viewConfig}
         isEnlarged={isEnlarged}
       />
-      <DashboardInfoHover infoText={viewConfig.description} />
+      {showHoverEffect && <DashboardInfoHover infoText={viewConfig.description} />}
     </>
   );
 };


### PR DESCRIPTION
### Issue #WAITP-1287: Misc FE fixes:

### Changes:
- Hide static text hover effect when enlargable
- Fix height of dashboard menu to allow for branch name banner
- Fix sort of dashboard items to use `name` instead of `code` after `sort_order`
- Don't display single value name if is not `multiSingleValue`
- Add disabled button state to download files viz
- Fix loading state of map overlay selector when there are no overlays for an entity
- Fix issue with missing table rows when only some table rows are grouped
- Fix issue with missing search result at end of list
