### PR TITLE
WAITP-1416: Visibility criteria

### DIFF
--- a/packages/datatrak-web/mocks/mockData/surveyScreenComponents.json
+++ b/packages/datatrak-web/mocks/mockData/surveyScreenComponents.json
@@ -1,14 +1,12 @@
 [
   {
-    "id": "6412504dec4eba3085017934",
-    "questionId": "603597d461f76a42af02a366",
+    "id": "1",
+    "questionId": "1",
     "screenId": "6412504dec4eba3085017933",
     "componentNumber": 1,
     "config": {
       "entity": {
-        "type": [
-          "district"
-        ],
+        "type": ["district"],
         "createNew": false
       }
     },
@@ -19,15 +17,13 @@
     "surveyScreenScreenNumber": 1
   },
   {
-    "id": "6412504dec4eba3085017938",
-    "questionId": "603597d461f76a42af02a36b",
+    "id": "2",
+    "questionId": "2",
     "screenId": "6412504dec4eba3085017937",
     "componentNumber": 1,
     "config": {
       "entity": {
-        "type": [
-          "sub_district"
-        ],
+        "type": ["sub_district"],
         "createNew": false,
         "parentId": {
           "questionId": "603597d461f76a42af02a366"
@@ -41,15 +37,13 @@
     "surveyScreenScreenNumber": 2
   },
   {
-    "id": "6412504dec4eba308501793b",
+    "id": "3",
     "questionId": "603597d461f76a42af02a36f",
-    "screenId": "6412504dec4eba308501793a",
+    "screenId": "3",
     "componentNumber": 1,
     "config": {
       "entity": {
-        "type": [
-          "facility"
-        ],
+        "type": ["facility"],
         "createNew": false,
         "parentId": {
           "questionId": ""
@@ -66,8 +60,8 @@
     "surveyScreenScreenNumber": 3
   },
   {
-    "id": "6412504dec4eba3085017948",
-    "questionId": "5ab99eb4820f654f4f221fd4",
+    "id": "4",
+    "questionId": "4",
     "screenId": "6412504dec4eba3085017947",
     "componentNumber": 1,
     "answersEnablingFollowUp": [],
@@ -86,8 +80,8 @@
     "questionOptionSetId": null
   },
   {
-    "id": "6412504dec4eba308501794b",
-    "questionId": "5ab99eb4820f654f4f225d8c",
+    "id": "5",
+    "questionId": "5",
     "screenId": "6412504dec4eba3085017947",
     "componentNumber": 2,
     "answersEnablingFollowUp": [],
@@ -157,8 +151,8 @@
     "questionOptionSetId": null
   },
   {
-    "id": "6412504dec4eba308501794e",
-    "questionId": "5ab99eb4820f654f4f229cfa",
+    "id": "6",
+    "questionId": "6",
     "screenId": "6412504dec4eba3085017947",
     "componentNumber": 3,
     "answersEnablingFollowUp": [],
@@ -176,6 +170,167 @@
     "questionType": "Number",
     "questionOptions": [],
     "surveyScreenScreenNumber": 4,
+    "questionOptionSetId": null
+  },
+  {
+    "id": "7",
+    "questionId": "7",
+    "screenId": "6412504dec4eba3085017948",
+    "componentNumber": 1,
+    "answersEnablingFollowUp": [],
+    "isFollowUp": false,
+    "visibilityCriteria": {},
+    "validationCriteria": {
+      "mandatory": true
+    },
+    "questionLabel": null,
+    "detailLabel": null,
+    "config": {},
+    "questionName": "Is the facility open?",
+    "questionCode": "MCSR9",
+    "questionText": "Is the facility open?",
+    "questionType": "Radio",
+    "questionOptions": [
+      {
+        "label": "Open",
+        "value": "open"
+      },
+      {
+        "label": "Permanently closed",
+        "value": "permanently closed"
+      },
+      {
+        "label": "Temporarily closed",
+        "value": "temporarily closed"
+      }
+    ],
+    "surveyScreenScreenNumber": 5,
+    "questionOptionSetId": null
+  },
+  {
+    "id": "8",
+    "questionId": "8",
+    "screenId": "6412504dec4eba3085017948",
+    "componentNumber": 2,
+    "answersEnablingFollowUp": [],
+    "isFollowUp": false,
+    "visibilityCriteria": {
+      "7": ["permanently closed", "temporarily closed"]
+    },
+    "validationCriteria": {
+      "mandatory": true
+    },
+    "questionLabel": null,
+    "detailLabel": null,
+    "config": {},
+    "questionName": "Why is the facility closed?",
+    "questionCode": "MCSR10",
+    "questionText": "Why is the facility closed?",
+    "questionType": "Radio",
+    "questionOptions": [
+      {
+        "label": "Hazards",
+        "value": "hazards"
+      },
+      {
+        "label": "Lack of staff",
+        "value": "lack of staff"
+      },
+      {
+        "label": "Lack of supplies",
+        "value": "lack of supplies"
+      },
+      {
+        "label": "Other",
+        "value": "other"
+      }
+    ],
+    "surveyScreenScreenNumber": 5,
+    "questionOptionSetId": null
+  },
+  {
+    "id": "9",
+    "questionId": "9",
+    "screenId": "6412504dec4eba3085017948",
+    "componentNumber": 3,
+    "answersEnablingFollowUp": [],
+    "isFollowUp": false,
+    "visibilityCriteria": {
+      "7": ["temporarily closed"],
+      "8": ["lack of staff"],
+      "_conjunction": "and"
+    },
+    "validationCriteria": {
+      "mandatory": true
+    },
+    "questionLabel": null,
+    "detailLabel": null,
+    "config": {},
+    "questionName": "How many staff do you have?",
+    "questionCode": "MCSR10a",
+    "questionText": "How many staff do you have?",
+    "questionType": "Number",
+    "questionOptions": [],
+    "surveyScreenScreenNumber": 5,
+    "questionOptionSetId": null
+  },
+  {
+    "id": "10",
+    "questionId": "10",
+    "screenId": "6412504dec4eba3085017948",
+    "componentNumber": 4,
+    "answersEnablingFollowUp": [],
+    "isFollowUp": false,
+    "visibilityCriteria": {
+      "7": ["temporarily closed"],
+      "8": ["lack of staff"],
+      "_conjunction": "and"
+    },
+    "validationCriteria": {
+      "mandatory": true
+    },
+    "questionLabel": null,
+    "detailLabel": null,
+    "config": {},
+    "questionName": "How many staff do you need?",
+    "questionCode": "MCSR10b",
+    "questionText": "How many staff do you need?",
+    "questionType": "Number",
+    "questionOptions": [],
+    "surveyScreenScreenNumber": 5,
+    "questionOptionSetId": null
+  },
+  {
+    "id": "11",
+    "questionId": "11",
+    "screenId": "6412504dec4eba3085017949",
+    "componentNumber": 1,
+    "answersEnablingFollowUp": [],
+    "isFollowUp": false,
+    "visibilityCriteria": {
+      "7": ["open"]
+    },
+    "validationCriteria": {
+      "mandatory": true
+    },
+    "questionLabel": null,
+    "detailLabel": null,
+    "config": {},
+    "questionName": "Does the facility have staff housing?",
+    "questionCode": "MCSR10",
+    "questionText": "Does the facility have staff housing?",
+    "questionType": "Binary",
+    "questionOptions": [
+      {
+        "label": "Yes",
+        "value": "yes"
+      },
+      {
+        "label": "No",
+        "value": "no"
+      }
+    ],
+    "surveyScreenScreenNumber": 6,
     "questionOptionSetId": null
   }
 ]

--- a/packages/datatrak-web/mocks/mockData/surveyScreenComponents.json
+++ b/packages/datatrak-web/mocks/mockData/surveyScreenComponents.json
@@ -283,7 +283,7 @@
     "isFollowUp": false,
     "visibilityCriteria": {
       "7": ["temporarily closed"],
-      "8": ["lack of staff"],
+      "8": "lack of staff",
       "_conjunction": "and"
     },
     "validationCriteria": {

--- a/packages/datatrak-web/src/Routes.tsx
+++ b/packages/datatrak-web/src/Routes.tsx
@@ -32,7 +32,7 @@ import {
 import { useUser } from './api/queries';
 import { ROUTES } from './constants';
 import { CentredLayout, BackgroundPageLayout, MainPageLayout } from './layout';
-import { SurveyLayout } from './features';
+import { SurveyLayout, useSurveyForm } from './features';
 
 /**
  * If the user is logged in and tries to access the login page, redirect to the home page
@@ -77,13 +77,30 @@ const SurveyStartRedirect = () => {
  *
  * **/
 
+// This is to redirect the user to the start of the survey if they try to access a screen that is not visible on the survey
+const SurveyPageRedirect = ({ children }) => {
+  const { screenNumber } = useParams();
+  const { visibleScreens } = useSurveyForm();
+  if (visibleScreens && visibleScreens.length && visibleScreens.length < Number(screenNumber)) {
+    return <SurveyStartRedirect />;
+  }
+  return children;
+};
+
 export const SurveyPageRoutes = (
   <Route path={ROUTES.SURVEY} element={<SurveyPage />}>
     <Route index element={<SurveyStartRedirect />} />
     <Route path={ROUTES.SURVEY_SUCCESS} element={<SurveySuccessScreen />} />
     <Route element={<SurveyLayout />}>
       <Route path={ROUTES.SURVEY_REVIEW} element={<SurveyReviewScreen />} />
-      <Route path={ROUTES.SURVEY_SCREEN} element={<SurveyScreen />} />
+      <Route
+        path={ROUTES.SURVEY_SCREEN}
+        element={
+          <SurveyPageRedirect>
+            <SurveyScreen />
+          </SurveyPageRedirect>
+        }
+      />
     </Route>
   </Route>
 );

--- a/packages/datatrak-web/src/__tests__/survey.test.tsx
+++ b/packages/datatrak-web/src/__tests__/survey.test.tsx
@@ -34,7 +34,6 @@ describe('Survey', () => {
 
   it('renders only visible questions when visibility criteria is applicable', async () => {
     renderSurveyPage('/survey/test/5');
-    await waitForElementToBeRemoved(() => screen.queryByRole(/progressbar*/i));
     // has 1 question to start with
     expect(screen.getAllByRole('radiogroup').length).toBe(1);
     expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('Is the facility open?');
@@ -61,7 +60,6 @@ describe('Survey', () => {
 
   it('updates the sidebar page list based on visible questions on a screen', async () => {
     renderSurveyPage('/survey/test/5');
-    await waitForElementToBeRemoved(() => screen.queryByRole(/progressbar*/i));
 
     // this current page starts off as the last page, so the next page should not be in the list of survey screens, and the submit button should be the 'review and submit' button
     expect(screen.queryByText('Does the facility have staff housing?')).not.toBeInTheDocument();

--- a/packages/datatrak-web/src/__tests__/survey.test.tsx
+++ b/packages/datatrak-web/src/__tests__/survey.test.tsx
@@ -31,4 +31,47 @@ describe('Survey', () => {
     await screen.findByText('Select Kiribati Council');
     expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('Select Kiribati Council');
   });
+
+  it.only('renders only visible questions when visibility criteria is applicable', async () => {
+    renderSurveyPage('/survey/test/5');
+    await waitForElementToBeRemoved(() => screen.queryByRole(/progressbar*/i));
+    // has 1 question to start with
+    expect(screen.getAllByRole('radiogroup').length).toBe(1);
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('Is the facility open?');
+
+    // after selecting 'permanently closed' option, the next question, 'why is the facility closed?' should appear
+    fireEvent.click(screen.getByRole('radio', { name: /permanently closed*/i }));
+    expect(screen.getAllByRole('radiogroup').length).toBe(2);
+    expect(screen.getByText('Why is the facility closed?')).toBeInTheDocument();
+
+    // after selecting 'permanently closed' option, the next question, 'why is the facility closed?' should appear
+    fireEvent.click(screen.getByRole('radio', { name: /temporarily closed*/i }));
+    expect(screen.getAllByRole('radiogroup').length).toBe(2);
+    expect(screen.getByText('Why is the facility closed?')).toBeInTheDocument();
+
+    // after selecting 'lack of staff' option, 2 more questions should appear
+    fireEvent.click(screen.getByRole('radio', { name: /lack of staff*/i }));
+    expect(screen.getByLabelText('How many staff do you have?')).toBeInTheDocument();
+    expect(screen.getByLabelText('How many staff do you need?')).toBeInTheDocument();
+
+    // change the answer to 'open' and the other 3 questions should disappear
+    fireEvent.click(screen.getByRole('radio', { name: /open*/i }));
+    expect(screen.getAllByRole('radiogroup').length).toBe(1);
+  });
+
+  it('updates the sidebar page list based on visible questions on a screen', async () => {
+    renderSurveyPage('/survey/test/5');
+    await waitForElementToBeRemoved(() => screen.queryByRole(/progressbar*/i));
+
+    // this current page starts off as the last page, so the next page should not be in the list of survey screens, and the submit button should be the 'review and submit' button
+    expect(screen.queryByText('Does the facility have staff housing?')).not.toBeInTheDocument();
+    expect(screen.queryByText('Next')).not.toBeInTheDocument();
+    expect(screen.queryByText('Review and submit')).toBeInTheDocument();
+
+    // after selecting the 'open' option, the next page, 'does the facility have staff housing?' should appear in the menu and the submit button should be the 'next' button
+    fireEvent.click(screen.getByRole('radio', { name: /open*/i }));
+    expect(screen.queryByText('Does the facility have staff housing?')).toBeInTheDocument();
+    expect(screen.queryByText('Next')).toBeInTheDocument();
+    expect(screen.queryByText('Review and submit')).not.toBeInTheDocument();
+  });
 });

--- a/packages/datatrak-web/src/__tests__/survey.test.tsx
+++ b/packages/datatrak-web/src/__tests__/survey.test.tsx
@@ -32,7 +32,7 @@ describe('Survey', () => {
     expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('Select Kiribati Council');
   });
 
-  it.only('renders only visible questions when visibility criteria is applicable', async () => {
+  it('renders only visible questions when visibility criteria is applicable', async () => {
     renderSurveyPage('/survey/test/5');
     await waitForElementToBeRemoved(() => screen.queryByRole(/progressbar*/i));
     // has 1 question to start with

--- a/packages/datatrak-web/src/api/mutations/useSubmitSurvey.ts
+++ b/packages/datatrak-web/src/api/mutations/useSubmitSurvey.ts
@@ -11,7 +11,7 @@ import { getBrowserTimeZone } from '@tupaia/utils';
 import { post } from '../api';
 import { Entity, Survey, SurveyScreenComponent } from '../../types';
 import { ROUTES } from '../../constants';
-import { useSurveyForm } from '../../features';
+import { getAllSurveyComponents, useSurveyForm } from '../../features';
 import { useSurvey, useUser } from '../queries';
 import { successToast } from '../../utils';
 
@@ -137,7 +137,7 @@ export const useSurveyResponseData = () => {
   return {
     surveyStartTime,
     surveyId: survey?.id,
-    questions: Object.values(surveyScreenComponents!).reduce((acc, val) => acc.concat(val), []), // flattened array of survey questions
+    questions: getAllSurveyComponents(surveyScreenComponents), // flattened array of survey questions
     countryId: user?.country?.id,
   };
 };

--- a/packages/datatrak-web/src/api/queries/useSurveyScreenComponents.ts
+++ b/packages/datatrak-web/src/api/queries/useSurveyScreenComponents.ts
@@ -16,5 +16,5 @@ export const useSurveyScreenComponents = surveyCode => {
 
   const mappedData = groupBy(sortBy(data, 'componentNumber'), 'surveyScreenScreenNumber');
 
-  return { ...query, data: mappedData };
+  return { ...query, data: Object.values(mappedData) };
 };

--- a/packages/datatrak-web/src/features/Survey/Components/SurveyQuestionGroup.tsx
+++ b/packages/datatrak-web/src/features/Survey/Components/SurveyQuestionGroup.tsx
@@ -41,6 +41,7 @@ export const SurveyQuestionGroup = ({ questions }: { questions: SurveyScreenComp
           detailLabel,
           questionOptionSetId,
           questionNumber,
+          updateFormDataOnChange,
         }) => {
           if (validationCriteria?.mandatory === true) {
             console.log('mandatory question', questionCode);
@@ -63,6 +64,7 @@ export const SurveyQuestionGroup = ({ questions }: { questions: SurveyScreenComp
                 config={config}
                 label={questionLabel || questionText}
                 optionSetId={questionOptionSetId}
+                updateFormDataOnChange={updateFormDataOnChange}
               />
             </QuestionWrapper>
           );

--- a/packages/datatrak-web/src/features/Survey/Components/SurveySideMenu/SurveySideMenu.tsx
+++ b/packages/datatrak-web/src/features/Survey/Components/SurveySideMenu/SurveySideMenu.tsx
@@ -73,7 +73,7 @@ export const SurveySideMenu = () => {
   const {
     sideMenuOpen,
     toggleSideMenu,
-    surveyScreenComponents,
+    visibleScreens,
     screenNumber,
     setFormData,
     isReviewScreen,
@@ -87,17 +87,20 @@ export const SurveySideMenu = () => {
       <SideMenuButton />
       <Drawer open={sideMenuOpen} onClose={toggleSideMenu}>
         <SurveyMenuContent>
-          {Object.entries(surveyScreenComponents!).map(([key, screen]) => (
-            <SurveyMenuItem
-              key={screen[0].questionId}
-              to={`../${key}`}
-              $active={screenNumber === Number(key)}
-              onClick={onChangeScreen}
-            >
-              <SurveyScreenNumber>{key}:</SurveyScreenNumber>
-              <SurveyScreenTitle>{screen[0].questionText}</SurveyScreenTitle>
-            </SurveyMenuItem>
-          ))}
+          {visibleScreens?.map((screen, i) => {
+            const num = i + 1;
+            return (
+              <SurveyMenuItem
+                key={screen[0].questionId}
+                to={`../${num}`}
+                $active={screenNumber === num}
+                onClick={onChangeScreen}
+              >
+                <SurveyScreenNumber>{num}:</SurveyScreenNumber>
+                <SurveyScreenTitle>{screen[0].questionText}</SurveyScreenTitle>
+              </SurveyMenuItem>
+            );
+          })}
         </SurveyMenuContent>
       </Drawer>
     </>

--- a/packages/datatrak-web/src/features/Survey/Screens/SurveyReviewScreen.tsx
+++ b/packages/datatrak-web/src/features/Survey/Screens/SurveyReviewScreen.tsx
@@ -44,25 +44,24 @@ const Fieldset = styled.fieldset.attrs({
 `;
 
 export const SurveyReviewScreen = () => {
-  const { surveyScreenComponents } = useSurveyForm();
-  if (!surveyScreenComponents) return null;
+  const { visibleScreens } = useSurveyForm();
+  if (!visibleScreens || !visibleScreens.length) return null;
 
   // split the questions into sections by screen so it's easier to read the long form
-  const questionSections = Object.entries(surveyScreenComponents!).map(
-    ([screenNumber, screenComponents]) => {
-      const heading = screenComponents[0].questionText;
-      const firstQuestionIsInstruction = screenComponents[0].questionType === 'Instruction';
+  const questionSections = visibleScreens.map((screenComponents, i) => {
+    const screenNumber = i + 1;
+    const heading = screenComponents[0].questionText;
+    const firstQuestionIsInstruction = screenComponents[0].questionType === 'Instruction';
 
-      // if the first question is an instruction, don't display it, because it will be displayed as the heading
-      const questionsToDisplay = firstQuestionIsInstruction
-        ? screenComponents.slice(1)
-        : screenComponents;
-      return {
-        heading,
-        questions: formatSurveyScreenQuestions(questionsToDisplay, screenNumber),
-      };
-    },
-  );
+    // if the first question is an instruction, don't display it, because it will be displayed as the heading
+    const questionsToDisplay = firstQuestionIsInstruction
+      ? screenComponents.slice(1)
+      : screenComponents;
+    return {
+      heading,
+      questions: formatSurveyScreenQuestions(questionsToDisplay, screenNumber),
+    };
+  });
 
   return (
     <>

--- a/packages/datatrak-web/src/features/Survey/SurveyContext.tsx
+++ b/packages/datatrak-web/src/features/Survey/SurveyContext.tsx
@@ -111,7 +111,8 @@ const getIsQuestionVisible = (question: SurveyScreenComponent, formData: Record<
 
   return Object.entries(dependantQuestions)[operator](([questionId, validAnswers]) => {
     const answer = formData[questionId];
-    return validAnswers.includes(answer);
+    if (answer === undefined) return false;
+    return Array.isArray(validAnswers) ? validAnswers?.includes(answer) : validAnswers === answer;
   });
 };
 

--- a/packages/datatrak-web/src/features/Survey/SurveySideMenu/SurveySideMenu.tsx
+++ b/packages/datatrak-web/src/features/Survey/SurveySideMenu/SurveySideMenu.tsx
@@ -73,8 +73,8 @@ export const SurveySideMenu = () => {
   const {
     sideMenuOpen,
     toggleSideMenu,
-    surveyScreenComponents,
-    screenNumber,
+    visibleScreens,
+    screenNumber: currentScreenNumber,
     setFormData,
   } = useSurveyForm();
   const onChangeScreen = () => {
@@ -85,17 +85,20 @@ export const SurveySideMenu = () => {
       <SideMenuButton />
       <Drawer open={sideMenuOpen} onClose={toggleSideMenu}>
         <SurveyMenuContent>
-          {Object.entries(surveyScreenComponents!).map(([key, screen]) => (
-            <SurveyMenuItem
-              key={screen[0].questionId}
-              to={`../${key}`}
-              $active={screenNumber === Number(key)}
-              onClick={onChangeScreen}
-            >
-              <SurveyScreenNumber>{key}:</SurveyScreenNumber>
-              <SurveyScreenTitle>{screen[0].questionText}</SurveyScreenTitle>
-            </SurveyMenuItem>
-          ))}
+          {visibleScreens?.map((screen, i) => {
+            const screenNumber = i + 1;
+            return (
+              <SurveyMenuItem
+                key={screen[0].questionId}
+                to={`../${screenNumber}`}
+                $active={currentScreenNumber === screenNumber}
+                onClick={onChangeScreen}
+              >
+                <SurveyScreenNumber>{screenNumber}:</SurveyScreenNumber>
+                <SurveyScreenTitle>{screen[0].questionText}</SurveyScreenTitle>
+              </SurveyMenuItem>
+            );
+          })}
         </SurveyMenuContent>
       </Drawer>
     </>

--- a/packages/datatrak-web/src/features/Survey/index.ts
+++ b/packages/datatrak-web/src/features/Survey/index.ts
@@ -7,3 +7,4 @@ export * from './Screens';
 export { SurveyContext, useSurveyForm } from './SurveyContext';
 export { SurveyLayout } from './SurveyLayout';
 export { SurveyToolbar } from './Components';
+export { getAllSurveyComponents } from './utils';

--- a/packages/datatrak-web/src/features/Survey/utils.ts
+++ b/packages/datatrak-web/src/features/Survey/utils.ts
@@ -30,3 +30,7 @@ export const formatSurveyScreenQuestions = (
     };
   });
 };
+
+export const getAllSurveyComponents = (surveyScreens?: SurveyScreenComponent[][]) => {
+  return surveyScreens?.flat() ?? [];
+};

--- a/packages/datatrak-web/src/features/index.ts
+++ b/packages/datatrak-web/src/features/index.ts
@@ -12,5 +12,6 @@ export {
   SurveyLayout,
   SurveyToolbar,
   useSurveyForm,
+  getAllSurveyComponents,
 } from './Survey';
 export { RequestProjectAccess } from './RequestProjectAccess';

--- a/packages/datatrak-web/src/types/surveys.ts
+++ b/packages/datatrak-web/src/types/surveys.ts
@@ -30,6 +30,7 @@ export type SurveyQuestionFieldProps = {
   detailLabel?: string | null;
   options?: SurveyScreenComponent['questionOptions'];
   optionSetId?: SurveyScreenComponent['questionOptionSetId'];
+  updateOnBlur?: boolean;
 };
 
 export type SurveyQuestionInputProps = SurveyQuestionFieldProps & {

--- a/packages/datatrak-web/src/types/surveys.ts
+++ b/packages/datatrak-web/src/types/surveys.ts
@@ -10,6 +10,7 @@ export type Survey = DatatrakWebSurveysRequest.ResBody[number];
 
 export type SurveyScreenComponent = DatatrakWebSurveyScreenComponentsRequest.ResBody[number] & {
   questionNumber?: string;
+  updateFormDataOnChange?: boolean;
 };
 
 export type SurveyParams = {
@@ -19,7 +20,7 @@ export type SurveyParams = {
   screenNumber: string;
 };
 
-export type SurveyQuestionFieldProps = {
+export type SurveyQuestionFieldProps = Pick<SurveyScreenComponent, 'updateFormDataOnChange'> & {
   id: string;
   name: SurveyScreenComponent['questionCode'];
   label?: string;
@@ -30,7 +31,6 @@ export type SurveyQuestionFieldProps = {
   detailLabel?: string | null;
   options?: SurveyScreenComponent['questionOptions'];
   optionSetId?: SurveyScreenComponent['questionOptionSetId'];
-  updateOnBlur?: boolean;
 };
 
 export type SurveyQuestionInputProps = SurveyQuestionFieldProps & {

--- a/packages/types/src/schemas/schemas.ts
+++ b/packages/types/src/schemas/schemas.ts
@@ -37857,6 +37857,16 @@ export const ProjectResponseSchema = {
 	]
 } 
 
+export const VisibilityCriteriaSchema = {
+	"properties": {
+		"_conjunction": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"type": "object"
+} 
+
 export const InitialResponseSchema = {
 	"properties": {
 		"id": {
@@ -37895,8 +37905,13 @@ export const InitialResponseSchema = {
 			"additionalProperties": false
 		},
 		"visibility_criteria": {
+			"additionalProperties": false,
 			"type": "object",
-			"additionalProperties": false
+			"properties": {
+				"_conjunction": {
+					"type": "string"
+				}
+			}
 		},
 		"question.name": {
 			"type": "string"
@@ -37990,6 +38005,11 @@ export const CamelCasedInitialResponseSchema = {
 		},
 		"visibilityCriteria": {
 			"type": "object",
+			"properties": {
+				"Conjunction": {
+					"type": "string"
+				}
+			},
 			"additionalProperties": false
 		},
 		"questionName": {

--- a/packages/types/src/types/requests/datatrak-web-server/SurveyScreenComponentsRequest.ts
+++ b/packages/types/src/types/requests/datatrak-web-server/SurveyScreenComponentsRequest.ts
@@ -10,13 +10,17 @@ export interface Params {
   surveyCode: string;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type VisibilityCriteria = Record<Question['id'], any> & {
+  _conjunction?: string;
+};
 export type InitialResponse = Omit<
   SurveyScreenComponent,
   'config' | 'validation_criteria' | 'visibility_criteria'
 > & {
   config?: Record<string, unknown> | null;
   validation_criteria?: Record<string, unknown> | null;
-  visibility_criteria?: Record<string, unknown> | null;
+  visibility_criteria?: VisibilityCriteria | null;
   ['question.name']?: Question['name'];
   ['question.code']?: Question['code'];
   ['question.text']?: Question['text'];


### PR DESCRIPTION
### Issue WAITP-1416: Visibility criteria:

### Changes:
- Added filtering to questions and screens based on visibility criteria
- Added ability to save values to formData when questions depend on answers being updated
- Removed logic around changing question numbers based on screens with only instructions, because the question numbers don't match the side menu numbers in this case
- Tidied up context methods to try make more readable
- Changed survey components to be an array of arrays in the FE so is easier to work with visibility
- Added logic to redirect the user to the first survey question if they attempt to access a survey screen that is not available
- Added logic to reset the survey questions that have changed to being invisible
