### PR TITLE
WAITP-1366 Update dashboard permissions

### DIFF
--- a/packages/database/src/modelClasses/DashboardRelation.js
+++ b/packages/database/src/modelClasses/DashboardRelation.js
@@ -7,7 +7,7 @@ import { DatabaseModel } from '../DatabaseModel';
 import { DatabaseType } from '../DatabaseType';
 import { TYPES } from '../types';
 
-class DashboardRelationType extends DatabaseType {
+export class DashboardRelationType extends DatabaseType {
   static databaseType = TYPES.DASHBOARD_RELATION;
 
   static joins = [

--- a/packages/database/src/modelClasses/index.js
+++ b/packages/database/src/modelClasses/index.js
@@ -168,3 +168,4 @@ export { UserEntityPermissionModel } from './UserEntityPermission';
 export { UserModel, UserType } from './User';
 export { SupersetInstanceModel } from './SupersetInstance';
 export { DashboardItemType, DashboardItemModel } from './DashboardItem';
+export { DashboardRelationType, DashboardRelationModel } from './DashboardRelation';

--- a/packages/server-boilerplate/src/models/types.ts
+++ b/packages/server-boilerplate/src/models/types.ts
@@ -6,7 +6,7 @@
 import { DatabaseModel, DatabaseType } from '@tupaia/database';
 import { ObjectLikeKeys, ObjectLikeFields, Flatten } from '@tupaia/types';
 
-type FilterComparators = '!=' | 'ilike' | '=' | '>' | '<' | '<=' | '>=' | 'in' | 'not in';
+type FilterComparators = '!=' | 'ilike' | '=' | '>' | '<' | '<=' | '>=' | 'in' | 'not in' | '@>';
 type ComparisonTypes = 'where' | 'whereBetween' | 'whereIn' | 'orWhere';
 
 export type AdvancedFilterValue<T> = {

--- a/packages/tupaia-web-server/package.json
+++ b/packages/tupaia-web-server/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@tupaia/access-policy": "3.0.0",
     "@tupaia/api-client": "3.1.0",
+    "@tupaia/auth": "1.0.0",
     "@tupaia/database": "1.0.0",
     "@tupaia/server-boilerplate": "1.0.0",
     "@tupaia/types": "1.0.0",
@@ -40,7 +41,6 @@
     "winston": "^3.3.3"
   },
   "devDependencies": {
-    "@tupaia/auth": "1.0.0",
     "@tupaia/types": "1.0.0",
     "@tupaia/utils": "1.0.0",
     "@types/lodash.groupby": "^4.6.0",

--- a/packages/tupaia-web-server/src/__tests__/testUtilities/setup.ts
+++ b/packages/tupaia-web-server/src/__tests__/testUtilities/setup.ts
@@ -5,7 +5,7 @@
 
 import { hashAndSaltPassword } from '@tupaia/auth';
 import { createBasicHeader } from '@tupaia/utils';
-import { TestableServer } from '@tupaia/server-boilerplate';
+import { TestableServer, emptyMiddleware } from '@tupaia/server-boilerplate';
 
 import {
   findOrCreateDummyRecord,
@@ -23,7 +23,9 @@ import { createApp } from '../../app';
 jest.mock('http-proxy-middleware');
 
 // Skip the accessPolicy attach since we don't have tests for that yet
-jest.mock('../../app/middleware/attachAccessPolicy');
+jest.mock('../../app/middleware/attachAccessPolicy', () => ({
+  attachAccessPolicy: emptyMiddleware,
+}));
 
 const models = getTestModels() as TestModelRegistry;
 const hierarchyCacher = new EntityHierarchyCacher(models);

--- a/packages/tupaia-web-server/src/__tests__/testUtilities/setup.ts
+++ b/packages/tupaia-web-server/src/__tests__/testUtilities/setup.ts
@@ -22,6 +22,9 @@ import { createApp } from '../../app';
 // Don't generate the proxy middlewares while we're testing
 jest.mock('http-proxy-middleware');
 
+// Skip the accessPolicy attach since we don't have tests for that yet
+jest.mock('../../app/middleware/attachAccessPolicy');
+
 const models = getTestModels() as TestModelRegistry;
 const hierarchyCacher = new EntityHierarchyCacher(models);
 hierarchyCacher.setDebounceTime(50); // short debounce time so tests run more quickly

--- a/packages/tupaia-web-server/src/app/createApp.ts
+++ b/packages/tupaia-web-server/src/app/createApp.ts
@@ -12,6 +12,7 @@ import {
   SessionSwitchingAuthHandler,
   forwardRequest,
 } from '@tupaia/server-boilerplate';
+import { attachAccessPolicy } from './middleware';
 import { TupaiaWebSessionModel } from '../models';
 import * as routes from '../routes';
 
@@ -27,6 +28,7 @@ export function createApp(db: TupaiaDatabase = new TupaiaDatabase()) {
     .useSessionModel(TupaiaWebSessionModel)
     .useAttachSession(attachSessionIfAvailable)
     .attachApiClientToContext(authHandlerProvider)
+    .use('*', attachAccessPolicy)
     .get<routes.ReportRequest>('report/:reportCode', handleWith(routes.ReportRoute))
     .get<routes.LegacyDashboardReportRequest>(
       'legacyDashboardReport/:reportCode',

--- a/packages/tupaia-web-server/src/app/middleware/attachAccessPolicy.ts
+++ b/packages/tupaia-web-server/src/app/middleware/attachAccessPolicy.ts
@@ -20,7 +20,7 @@ export const attachAccessPolicy: RequestHandler = async (req, res, next) => {
   // The session accessPolicy is the raw user access policy
   // We need to merge with the api access policy for full access
   req.accessPolicy = req.session
-    ? mergeAccessPolicies(req.accessPolicy, apiAccessPolicy)
+    ? mergeAccessPolicies(req.session.accessPolicy, apiAccessPolicy)
     : apiAccessPolicy;
 
   next();

--- a/packages/tupaia-web-server/src/app/middleware/attachAccessPolicy.ts
+++ b/packages/tupaia-web-server/src/app/middleware/attachAccessPolicy.ts
@@ -1,0 +1,25 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+import { RequestHandler } from 'express';
+import { AccessPolicyBuilder } from '@tupaia/auth';
+import { AccessPolicy } from '@tupaia/access-policy';
+
+const { API_CLIENT_NAME } = process.env;
+
+export const attachAccessPolicy: RequestHandler = async (req, res, next) => {
+  if (req.session) {
+    req.accessPolicy = req.session.accessPolicy;
+  } else {
+    const accessPolicyBuilder = new AccessPolicyBuilder(req.models);
+    const apiUser = await req.models.user.findOne({ email: API_CLIENT_NAME });
+    if (!apiUser) {
+      throw new Error('API Client not found');
+    }
+    req.accessPolicy = new AccessPolicy(await accessPolicyBuilder.getPolicyForUser(apiUser.id));
+  }
+
+  next();
+};

--- a/packages/tupaia-web-server/src/app/middleware/attachAccessPolicy.ts
+++ b/packages/tupaia-web-server/src/app/middleware/attachAccessPolicy.ts
@@ -4,22 +4,24 @@
  */
 
 import { RequestHandler } from 'express';
-import { AccessPolicyBuilder } from '@tupaia/auth';
+import { AccessPolicyBuilder, mergeAccessPolicies } from '@tupaia/auth';
 import { AccessPolicy } from '@tupaia/access-policy';
 
 const { API_CLIENT_NAME } = process.env;
 
 export const attachAccessPolicy: RequestHandler = async (req, res, next) => {
-  if (req.session) {
-    req.accessPolicy = req.session.accessPolicy;
-  } else {
-    const accessPolicyBuilder = new AccessPolicyBuilder(req.models);
-    const apiUser = await req.models.user.findOne({ email: API_CLIENT_NAME });
-    if (!apiUser) {
-      throw new Error('API Client not found');
-    }
-    req.accessPolicy = new AccessPolicy(await accessPolicyBuilder.getPolicyForUser(apiUser.id));
+  const accessPolicyBuilder = new AccessPolicyBuilder(req.models);
+  const apiUser = await req.models.user.findOne({ email: API_CLIENT_NAME });
+  if (!apiUser) {
+    throw new Error('API Client not found');
   }
+  const apiAccessPolicy = new AccessPolicy(await accessPolicyBuilder.getPolicyForUser(apiUser.id));
+
+  // The session accessPolicy is the raw user access policy
+  // We need to merge with the api access policy for full access
+  req.accessPolicy = req.session
+    ? mergeAccessPolicies(req.accessPolicy, apiAccessPolicy)
+    : apiAccessPolicy;
 
   next();
 };

--- a/packages/tupaia-web-server/src/app/middleware/attachAccessPolicy.ts
+++ b/packages/tupaia-web-server/src/app/middleware/attachAccessPolicy.ts
@@ -15,13 +15,15 @@ export const attachAccessPolicy: RequestHandler = async (req, res, next) => {
   if (!apiUser) {
     throw new Error('API Client not found');
   }
-  const apiAccessPolicy = new AccessPolicy(await accessPolicyBuilder.getPolicyForUser(apiUser.id));
+  const apiAccessPolicy = await accessPolicyBuilder.getPolicyForUser(apiUser.id);
 
-  // The session accessPolicy is the raw user access policy
-  // We need to merge with the api access policy for full access
-  req.accessPolicy = req.session
-    ? mergeAccessPolicies(req.session.accessPolicy, apiAccessPolicy)
-    : apiAccessPolicy;
+  // If we have a session, merge it with the api user
+  // Otherwise just use the api user policy
+  req.accessPolicy = new AccessPolicy(
+    req.session
+      ? mergeAccessPolicies(req.session.accessPolicy.policy, apiAccessPolicy)
+      : apiAccessPolicy,
+  );
 
   next();
 };

--- a/packages/tupaia-web-server/src/app/middleware/index.ts
+++ b/packages/tupaia-web-server/src/app/middleware/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+export { attachAccessPolicy } from './attachAccessPolicy';

--- a/packages/tupaia-web-server/src/models/DashboardRelation.ts
+++ b/packages/tupaia-web-server/src/models/DashboardRelation.ts
@@ -14,7 +14,7 @@ type DashboardRelationFields = Readonly<{
   child_id: string;
   entity_types: string[];
   project_codes: string[];
-  permission_groups: string;
+  permission_groups: string[];
   sort_order: number;
 }>;
 

--- a/packages/tupaia-web-server/src/models/DashboardRelation.ts
+++ b/packages/tupaia-web-server/src/models/DashboardRelation.ts
@@ -1,0 +1,26 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+import {
+  DashboardRelationModel as BaseDashboardRelationModel,
+  DashboardRelationType as BaseDashboardRelationType,
+} from '@tupaia/database';
+import { Model } from '@tupaia/server-boilerplate';
+
+type DashboardRelationFields = Readonly<{
+  id: string;
+  dashboard_id: string;
+  child_id: string;
+  entity_types: string[];
+  project_codes: string[];
+  permission_groups: string;
+  sort_order: number;
+}>;
+
+export interface DashboardRelationType
+  extends DashboardRelationFields,
+    Omit<BaseDashboardRelationType, 'id'> {}
+
+export interface DashboardRelationModel
+  extends Model<BaseDashboardRelationModel, DashboardRelationFields, DashboardRelationType> {}

--- a/packages/tupaia-web-server/src/models/User.ts
+++ b/packages/tupaia-web-server/src/models/User.ts
@@ -1,0 +1,9 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+import { UserModel as BaseUserModel, UserType } from '@tupaia/database';
+import { UserAccount } from '@tupaia/types';
+import { Model } from '@tupaia/server-boilerplate';
+
+export interface UserModel extends Model<BaseUserModel, UserAccount, UserType> {}

--- a/packages/tupaia-web-server/src/models/index.ts
+++ b/packages/tupaia-web-server/src/models/index.ts
@@ -7,4 +7,5 @@ export { TupaiaWebSessionModel, TupaiaWebSessionType } from './TupaiaWebSession'
 export { MapOverlayGroupRelationModel } from './MapOverlayGroupRelation';
 export { MapOverlayGroupModel } from './MapOverlayGroups';
 export { DashboardItemModel } from './DashboardItems';
+export { DashboardRelationModel } from './DashboardRelation';
 export { EntityModel } from './Entity';

--- a/packages/tupaia-web-server/src/models/index.ts
+++ b/packages/tupaia-web-server/src/models/index.ts
@@ -9,3 +9,4 @@ export { MapOverlayGroupModel } from './MapOverlayGroups';
 export { DashboardItemModel } from './DashboardItems';
 export { DashboardRelationModel } from './DashboardRelation';
 export { EntityModel } from './Entity';
+export { UserModel } from './User';

--- a/packages/tupaia-web-server/src/routes/DashboardsRoute.ts
+++ b/packages/tupaia-web-server/src/routes/DashboardsRoute.ts
@@ -6,14 +6,10 @@
 import { Request } from 'express';
 import camelcaseKeys from 'camelcase-keys';
 import { Route } from '@tupaia/server-boilerplate';
-import {
-  Entity,
-  DashboardItem,
-  DashboardRelation,
-  Dashboard,
-  TupaiaWebDashboardsRequest,
-} from '@tupaia/types';
+import { Entity, DashboardItem, Dashboard, TupaiaWebDashboardsRequest } from '@tupaia/types';
 import { orderBy } from '@tupaia/utils';
+
+import { DashboardRelationType } from '../models/DashboardRelation';
 
 interface DashboardWithItems extends Dashboard {
   items: DashboardItem[];
@@ -87,33 +83,27 @@ export class DashboardsRoute extends Route<DashboardsRequest> {
     }
 
     // Fetch all dashboard relations
-    const dashboardRelations = await ctx.services.central.fetchResources('dashboardRelations', {
-      filter: {
-        // Attached to the given dashboards
-        dashboard_id: {
-          comparator: 'IN',
-          comparisonValue: dashboards.map((d: Dashboard) => d.id),
-        },
-        // For the root entity type
-        entity_types: {
-          comparator: '@>',
-          comparisonValue: [rootEntity.type],
-        },
-        // Within the selected project
-        project_codes: {
-          comparator: '@>',
-          comparisonValue: [projectCode],
-        },
+    const dashboardRelations = await this.req.models.dashboardRelation.find({
+      // Attached to the given dashboards
+      dashboard_id: dashboards.map((d: Dashboard) => d.id),
+      // For the root entity type
+      entity_types: {
+        comparator: '@>',
+        comparisonValue: [rootEntity.type],
       },
-      // Override the default limit of 100 records
-      pageSize: DEFAULT_PAGE_SIZE,
+      // Within the selected project
+      project_codes: {
+        comparator: '@>',
+        comparisonValue: [projectCode],
+      },
     });
 
+    // The dashboards themselves are fetched from central to ensure permission checking
     const dashboardItems = await ctx.services.central.fetchResources('dashboardItems', {
       filter: {
         id: {
           comparator: 'IN',
-          comparisonValue: dashboardRelations.map((dr: DashboardRelation) => dr.child_id),
+          comparisonValue: dashboardRelations.map((dr: DashboardRelationType) => dr.child_id),
         },
       },
       // Override the default limit of 100 records
@@ -122,13 +112,14 @@ export class DashboardsRoute extends Route<DashboardsRequest> {
 
     // Merged and sorted to make mapping easier
     const mergedItemRelations = orderBy(
-      dashboardRelations.map((relation: DashboardRelation) => ({
+      dashboardRelations.map((relation: DashboardRelationType) => ({
         relation,
         item: dashboardItems.find((item: DashboardItem) => item.id === relation.child_id),
       })),
       [
-        ({ relation }: { relation: DashboardRelation }) => (relation.sort_order === null ? 1 : 0), // Puts null values last
-        ({ relation }: { relation: DashboardRelation }) => relation.sort_order,
+        ({ relation }: { relation: DashboardRelationType }) =>
+          relation.sort_order === null ? 1 : 0, // Puts null values last
+        ({ relation }: { relation: DashboardRelationType }) => relation.sort_order,
         ({ item }: { item: DashboardItem }) => item.code,
       ],
     );
@@ -139,7 +130,7 @@ export class DashboardsRoute extends Route<DashboardsRequest> {
         // Filter by the relations, map to the items
         items: mergedItemRelations
           .filter(
-            ({ relation }: { relation: DashboardRelation }) =>
+            ({ relation }: { relation: DashboardRelationType }) =>
               relation.dashboard_id === dashboard.id,
           )
           .map(({ item }: { item: DashboardItem }) => ({

--- a/packages/tupaia-web-server/src/routes/DashboardsRoute.ts
+++ b/packages/tupaia-web-server/src/routes/DashboardsRoute.ts
@@ -105,6 +105,10 @@ export class DashboardsRoute extends Route<DashboardsRequest> {
           comparator: 'IN',
           comparisonValue: dashboardRelations.map((dr: DashboardRelationType) => dr.child_id),
         },
+        permission_groups: {
+          comparator: '&&',
+          comparisonValue: ['BES Admin'],
+        },
       },
       // Override the default limit of 100 records
       pageSize: DEFAULT_PAGE_SIZE,

--- a/packages/tupaia-web-server/src/types.ts
+++ b/packages/tupaia-web-server/src/types.ts
@@ -8,6 +8,7 @@ import {
   MapOverlayGroupRelationModel,
   MapOverlayGroupModel,
   DashboardItemModel,
+  DashboardRelationModel,
   EntityModel,
 } from './models';
 
@@ -15,5 +16,6 @@ export interface TupaiaWebServerModelRegistry extends ModelRegistry {
   readonly mapOverlayGroupRelation: MapOverlayGroupRelationModel;
   readonly mapOverlayGroup: MapOverlayGroupModel;
   readonly dashboardItem: DashboardItemModel;
+  readonly dashboardRelation: DashboardRelationModel;
   readonly entity: EntityModel;
 }

--- a/packages/tupaia-web-server/src/types.ts
+++ b/packages/tupaia-web-server/src/types.ts
@@ -10,6 +10,7 @@ import {
   DashboardItemModel,
   DashboardRelationModel,
   EntityModel,
+  UserModel,
 } from './models';
 
 export interface TupaiaWebServerModelRegistry extends ModelRegistry {
@@ -18,4 +19,5 @@ export interface TupaiaWebServerModelRegistry extends ModelRegistry {
   readonly dashboardItem: DashboardItemModel;
   readonly dashboardRelation: DashboardRelationModel;
   readonly entity: EntityModel;
+  readonly user: UserModel;
 }


### PR DESCRIPTION
### Issue #: WAITP-1366

### Changes:

- Allow fetching `dashboardRelations` from the db to skip permissions checking
  - This is because we use the difference between `relations` and `items` to decide whether we show the "No access" or "No data" default dashboard
- Attach access policy to req object in `tupaia-web-server`
- Filter dashboard items by `accessPolicy`
  - `central-server` checks you can access the item in _any_ of its countries, so we need a more specific check against the requested entity to make sure we're not showing you dashboard items that you can't access data for