### PR TITLE
No Issue: Use handleError correctly with the new auth middleware

### DIFF
--- a/packages/central-server/src/createApp.js
+++ b/packages/central-server/src/createApp.js
@@ -11,6 +11,7 @@ import morgan from 'morgan';
 
 import { Authenticator } from '@tupaia/auth';
 import { buildBasicBearerAuthMiddleware } from '@tupaia/server-boilerplate';
+import { handleError } from './apiV2/middleware';
 
 import { apiV2 } from './apiV2';
 
@@ -48,7 +49,7 @@ export function createApp(database, models) {
   /**
    * Add the basic authenticator to all routes
    */
-  app.use(buildBasicBearerAuthMiddleware('central-server', authenticator));
+  app.use(buildBasicBearerAuthMiddleware('central-server', authenticator), handleError);
   app.use((req, res, next) => {
     req.userId = req.user.id;
     next();


### PR DESCRIPTION
### Issue #: No Issue

### Changes:

- Run the `handleError` middleware after the `auth` middleware
  - I believe because the existing `handleError` in within the scope of the `apiV2` express router, errors from this layer weren't hitting it correctly
  - The error response is used to signal to the `web-config-server` to refresh the access token, so without the errors returning correctly, your access token stayed expired for extended periods and broke normal behaviour