### PR TITLE
WAITP-1345:Core question updates

### DIFF
--- a/packages/datatrak-web-server/src/routes/SurveyRoute.ts
+++ b/packages/datatrak-web-server/src/routes/SurveyRoute.ts
@@ -41,9 +41,11 @@ const formatComponent = (component: any) => {
     validationCriteria,
     visibilityCriteria,
     config,
+    detailLabel,
+    questionText,
     ...restOfComponent
   } = component;
-  const { options } = question;
+  const { options, detail, text } = question;
 
   // parse stringified fields
   const formattedComponent = {
@@ -51,6 +53,8 @@ const formatComponent = (component: any) => {
     // include the component and the question fields all in one object
     ...question,
     questionId: question.id,
+    text: questionText || text, // on some occasions, the screen component overrides the question text with the field question_text
+    detailLabel: detailLabel || detail, // on some occasions, the screen component overrides the question detail with the field detail_label
     validationCriteria: validationCriteria ? JSON.parse(validationCriteria) : null,
     visibilityCriteria: visibilityCriteria ? JSON.parse(visibilityCriteria) : null,
     config: config ? JSON.parse(config) : null,

--- a/packages/datatrak-web/src/components/Icons/RadioIcon.tsx
+++ b/packages/datatrak-web/src/components/Icons/RadioIcon.tsx
@@ -1,0 +1,50 @@
+/*
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+import React from 'react';
+import { SvgIcon, SvgIconProps } from '@material-ui/core';
+import styled from 'styled-components';
+
+const CheckCircle = styled.circle<{
+  $optionColor?: string;
+}>`
+  fill: ${({ $optionColor, theme }) => $optionColor || theme.palette.primary.main};
+`;
+
+const OuterCircle = styled.circle<{
+  $optionColor?: string;
+  $checked?: boolean;
+}>`
+  stroke: ${({ $optionColor, $checked, theme }) => {
+    if ($optionColor) return $optionColor;
+    if ($checked) return theme.palette.primary.main;
+    return theme.palette.text.primary;
+  }};
+`;
+
+/**
+ * Custom radio icon so that we can control the fill when radio inputs have a background color, as the MUI default one is a 'path' so can't have a fill
+ */
+export const RadioIcon = ({
+  checked,
+  optionColor,
+  ...props
+}: SvgIconProps & {
+  checked?: boolean;
+  optionColor?: string;
+}) => {
+  return (
+    <SvgIcon
+      {...props}
+      width="20"
+      height="20"
+      viewBox="0 0 20 20"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <OuterCircle cx="10" cy="10" r="9.5" $checked={checked} $optionColor={optionColor} />
+      {checked && <CheckCircle cx="10" cy="10" r="5" $optionColor={optionColor} />}
+    </SvgIcon>
+  );
+};

--- a/packages/datatrak-web/src/components/Icons/index.ts
+++ b/packages/datatrak-web/src/components/Icons/index.ts
@@ -6,3 +6,4 @@ export { Coconut } from './Coconut';
 export { Pig } from './Pig';
 export { SurveyIcon } from './SurveyIcon';
 export { SurveyFolderIcon } from './SurveyFolderIcon';
+export { RadioIcon } from './RadioIcon';

--- a/packages/datatrak-web/src/features/Questions/AutocompleteQuestion.tsx
+++ b/packages/datatrak-web/src/features/Questions/AutocompleteQuestion.tsx
@@ -11,6 +11,7 @@ import { Option } from '@tupaia/types';
 import { SurveyQuestionInputProps } from '../../types';
 import { useAutocompleteOptions } from '../../api/queries';
 import { MOBILE_BREAKPOINT } from '../../constants';
+import { QuestionHelperText } from './QuestionHelperText';
 
 const Autocomplete = styled(BaseAutocomplete)`
   width: calc(100% - 3.5rem);
@@ -40,6 +41,7 @@ const Autocomplete = styled(BaseAutocomplete)`
   .MuiInputBase-root {
     border-bottom: 1px solid ${({ theme }) => theme.palette.text.primary};
     border-radius: 0;
+    order: 2; // make the helper text appear above the input
     &.Mui-focused {
       border-bottom-color: ${({ theme }) => theme.palette.primary.main};
     }
@@ -83,6 +85,7 @@ export const AutocompleteQuestion = ({
   label,
   name,
   optionSetId,
+  detailLabel,
   config = {},
   controllerProps: { value: selectedValue = null, onChange, ref, invalid },
 }: SurveyQuestionInputProps) => {
@@ -145,29 +148,37 @@ export const AutocompleteQuestion = ({
   };
 
   return (
-    <Autocomplete
-      id={id}
-      label={label!}
-      name={name!}
-      value={selectedValue?.value || null}
-      onChange={(_e, newSelectedOption) => handleSelectOption(newSelectedOption)}
-      onInputChange={(_e, value) => setInputValue(value)}
-      inputValue={inputValue}
-      inputRef={ref}
-      options={options}
-      getOptionLabel={option =>
-        typeof option === 'string' ? option : option.label || option.value
-      }
-      getOptionSelected={getOptionSelected}
-      loading={isLoading || !isFetched}
-      error={isError || invalid}
-      helperText={error ? (error as Error).message : ''}
-      placeholder="Search..."
-      muiProps={{
-        PaperComponent: StyledPaper,
-        freeSolo: !!createNew,
-        getOptionDisabled: option => getOptionSelected(option, selectedValue),
-      }}
-    />
+    <>
+      <Autocomplete
+        id={id}
+        label={label!}
+        name={name!}
+        value={selectedValue?.value || null}
+        onChange={(_e, newSelectedOption) => handleSelectOption(newSelectedOption)}
+        onInputChange={(_e, value) => setInputValue(value)}
+        inputValue={inputValue}
+        inputRef={ref}
+        options={options}
+        getOptionLabel={option =>
+          typeof option === 'string' ? option : option.label || option.value
+        }
+        getOptionSelected={getOptionSelected}
+        loading={isLoading || !isFetched}
+        error={isError || invalid}
+        helperText={detailLabel as string}
+        textFieldProps={{
+          FormHelperTextProps: {
+            component: QuestionHelperText,
+          },
+        }}
+        placeholder="Search..."
+        muiProps={{
+          PaperComponent: StyledPaper,
+          freeSolo: !!createNew,
+          getOptionDisabled: option => getOptionSelected(option, selectedValue),
+        }}
+      />
+      {error && <QuestionHelperText error>{(error as Error).message}</QuestionHelperText>}
+    </>
   );
 };

--- a/packages/datatrak-web/src/features/Questions/CheckboxQuestion.tsx
+++ b/packages/datatrak-web/src/features/Questions/CheckboxQuestion.tsx
@@ -17,11 +17,17 @@ const Checkbox = styled(BaseCheckbox)`
   .MuiButtonBase-root:has([aria-invalid='true']) {
     color: ${props => props.theme.palette.error.main};
   }
+  .MuiFormHelperText-root {
+    margin-left: -0.5rem;
+    margin-top: 0.25rem;
+    font-size: 0.875rem;
+  }
 `;
 export const CheckboxQuestion = ({
   id,
   label,
   name,
+  detailLabel,
   required,
   controllerProps: { value, onChange, ref, invalid },
 }: SurveyQuestionInputProps) => {
@@ -35,6 +41,7 @@ export const CheckboxQuestion = ({
       checked={value === 'Yes'}
       onChange={e => onChange(e.target.checked ? 'Yes' : 'No')}
       inputRef={ref}
+      helperText={detailLabel as string}
       inputProps={{
         ['aria-invalid']: invalid,
       }}

--- a/packages/datatrak-web/src/features/Questions/DateQuestion.tsx
+++ b/packages/datatrak-web/src/features/Questions/DateQuestion.tsx
@@ -8,6 +8,7 @@ import styled from 'styled-components';
 import { TextField } from '@material-ui/core';
 import { DatePicker as BaseDatePicker } from '@tupaia/ui-components';
 import { SurveyQuestionInputProps } from '../../types';
+import { QuestionHelperText } from './QuestionHelperText';
 
 const DatePicker = styled(BaseDatePicker).attrs({
   InputAdornmentProps: {
@@ -34,12 +35,16 @@ const DatePicker = styled(BaseDatePicker).attrs({
   .MuiInputBase-input {
     color: ${props => props.theme.palette.text.primary};
   }
+  .MuiInputBase-root {
+    order: 2; // make the helper text appear above the input
+  }
 `;
 
 export const DateQuestion = ({
   label,
   id,
   required,
+  detailLabel,
   controllerProps: { onChange, value, name, ref, invalid },
 }: SurveyQuestionInputProps) => {
   return (
@@ -52,6 +57,8 @@ export const DateQuestion = ({
       inputRef={ref}
       error={invalid}
       required={required}
+      helperText={detailLabel}
+      FormHelperTextProps={{ component: QuestionHelperText }}
     />
   );
 };

--- a/packages/datatrak-web/src/features/Questions/DateTimeQuestion.tsx
+++ b/packages/datatrak-web/src/features/Questions/DateTimeQuestion.tsx
@@ -34,12 +34,16 @@ const DateTimePicker = styled(BaseDateTimePicker).attrs({
   .MuiInputBase-input {
     color: ${props => props.theme.palette.text.primary};
   }
+  .MuiInputBase-root {
+    order: 2; // make the helper text appear above the input
+  }
 `;
 
 export const DateTimeQuestion = ({
   label,
   id,
   required,
+  detailLabel,
   controllerProps: { value, onChange, name, ref, invalid },
 }: SurveyQuestionInputProps) => {
   return (
@@ -52,6 +56,7 @@ export const DateTimeQuestion = ({
       inputRef={ref}
       error={invalid}
       required={required}
+      helperText={detailLabel}
     />
   );
 };

--- a/packages/datatrak-web/src/features/Questions/EntityQuestion/EntityQuestion.tsx
+++ b/packages/datatrak-web/src/features/Questions/EntityQuestion/EntityQuestion.tsx
@@ -42,6 +42,7 @@ const useSearchResults = (searchValue, config) => {
 export const EntityQuestion = ({
   id,
   label,
+  detailLabel,
   name,
   controllerProps: { onChange, value, ref, invalid },
   config,
@@ -85,6 +86,7 @@ export const EntityQuestion = ({
         id={id}
         isDirty={isDirty}
         label={label}
+        detailLabel={detailLabel}
         name={name!}
         ref={ref}
         onChangeSearch={onChangeSearch}

--- a/packages/datatrak-web/src/features/Questions/EntityQuestion/SearchField.tsx
+++ b/packages/datatrak-web/src/features/Questions/EntityQuestion/SearchField.tsx
@@ -8,16 +8,27 @@ import { TextField } from '@tupaia/ui-components';
 import styled from 'styled-components';
 import { Search, Clear } from '@material-ui/icons';
 import { InputAdornment, IconButton, TextFieldProps } from '@material-ui/core';
+import { QuestionHelperText } from '../QuestionHelperText';
 
 const StyledField = styled(TextField)<TextFieldProps>`
   margin-bottom: 0;
+  display: flex;
 
+  .MuiFormLabel-root {
+    color: ${({ theme }) => theme.palette.text.primary};
+  }
+  .MuiFormHelperText-root {
+    margin-bottom: 0.6rem;
+  }
   .MuiOutlinedInput-notchedOutline {
     border-color: ${({ theme }) => theme.palette.divider};
   }
 
   .MuiInputBase-root.Mui-error {
     background: initial;
+  }
+  .MuiInputBase-root {
+    order: 2;
   }
 
   .MuiInputBase-input {
@@ -48,10 +59,11 @@ type SearchFieldProps = TextFieldProps & {
   onChangeSearch: (value: string) => void;
   isDirty: boolean;
   invalid: boolean;
+  detailLabel?: string;
 };
 
 export const SearchField = React.forwardRef<HTMLDivElement, SearchFieldProps>((props, ref) => {
-  const { name, label, id, searchValue, onChangeSearch, isDirty, invalid } = props;
+  const { name, label, id, searchValue, onChangeSearch, isDirty, invalid, detailLabel } = props;
 
   const displayValue = isDirty ? searchValue : '';
 
@@ -72,6 +84,10 @@ export const SearchField = React.forwardRef<HTMLDivElement, SearchFieldProps>((p
       onChange={handleChange}
       value={displayValue}
       error={invalid}
+      helperText={detailLabel}
+      FormHelperTextProps={{
+        component: QuestionHelperText,
+      }}
       placeholder="Search..."
       // disable browser autofill
       autoComplete="one-time-code"

--- a/packages/datatrak-web/src/features/Questions/GeolocateQuestion/GeolocateQuestion.tsx
+++ b/packages/datatrak-web/src/features/Questions/GeolocateQuestion/GeolocateQuestion.tsx
@@ -10,6 +10,7 @@ import { MapModal } from './MapModal';
 import { LatLongFields } from './LatLongFields';
 import { SurveyQuestionInputProps } from '../../../types';
 import { Button } from '../../../components';
+import { QuestionHelperText } from '../QuestionHelperText';
 
 const Container = styled.div`
   display: flex;
@@ -48,6 +49,7 @@ const ButtonText = styled.span`
 export const GeolocateQuestion = ({
   text,
   required,
+  detailLabel,
   controllerProps: { value, onChange, name, invalid },
 }: SurveyQuestionInputProps) => {
   const [mapModalOpen, setMapModalOpen] = useState(false);
@@ -58,6 +60,7 @@ export const GeolocateQuestion = ({
   return (
     <Wrapper>
       {text && <Typography component="legend">{text}</Typography>}
+      {detailLabel && <QuestionHelperText>{detailLabel}</QuestionHelperText>}
       <Container>
         <LatLongFields
           geolocation={value}

--- a/packages/datatrak-web/src/features/Questions/InstructionQuestion.tsx
+++ b/packages/datatrak-web/src/features/Questions/InstructionQuestion.tsx
@@ -5,15 +5,16 @@
 import React from 'react';
 import { Typography } from '@material-ui/core';
 import { SurveyQuestionInputProps } from '../../types';
+import { QuestionHelperText } from './QuestionHelperText';
 
 export const InstructionQuestion = ({ text, detailLabel }: SurveyQuestionInputProps) => {
   if (!text && !detailLabel) {
     return null;
   }
   return (
-    <>
+    <div>
       {text && <Typography variant="h3">{text}</Typography>}
-      {detailLabel && <Typography>{detailLabel}</Typography>}
-    </>
+      {detailLabel && <QuestionHelperText>{detailLabel}</QuestionHelperText>}
+    </div>
   );
 };

--- a/packages/datatrak-web/src/features/Questions/QuestionHelperText.tsx
+++ b/packages/datatrak-web/src/features/Questions/QuestionHelperText.tsx
@@ -1,0 +1,11 @@
+/*
+ * Tupaia
+ *  Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+import { FormHelperText } from '@material-ui/core';
+import styled from 'styled-components';
+
+export const QuestionHelperText = styled(FormHelperText)`
+  font-size: 0.875rem;
+`;

--- a/packages/datatrak-web/src/features/Questions/RadioQuestion.tsx
+++ b/packages/datatrak-web/src/features/Questions/RadioQuestion.tsx
@@ -5,14 +5,15 @@
 
 import React from 'react';
 import styled from 'styled-components';
-import { lighten } from '@material-ui/core';
-import { RadioGroup } from '@tupaia/ui-components';
+import { FormControlLabel, FormLabel, Radio, RadioGroup, lighten } from '@material-ui/core';
 import { SurveyQuestionInputProps } from '../../types';
+import { RadioIcon } from '../../components';
 
 const StyledRadioGroup = styled(RadioGroup)`
   width: 100%;
-
   margin-bottom: 0;
+  display: flex;
+  flex-direction: column;
   legend {
     color: ${({ theme }) => theme.palette.text.primary};
     margin-bottom: 1rem;
@@ -24,44 +25,49 @@ const StyledRadioGroup = styled(RadioGroup)`
       font-weight: ${({ theme }) => theme.typography.fontWeightRegular};
     }
   }
-  .MuiFormGroup-root {
-    display: flex;
-    flex-direction: column;
-    border: none;
-    max-width: 25rem;
-  }
-  .MuiRadio-root {
-    color: ${({ theme }) => theme.palette.text.primary};
-    &.Mui-checked {
-      color: ${({ theme }) => theme.palette.primary.main};
-    }
-  }
-  .MuiFormControlLabel-root {
-    border: 1px solid ${({ theme }) => theme.palette.text.primary};
-    border-radius: 4px;
+`;
 
-    &:has(.Mui-checked) {
-      border-color: ${({ theme }) => theme.palette.primary.main};
-      background-color: ${({ theme }) => lighten(theme.palette.primary.main, 0.9)};
-    }
-    &:not(:last-child) {
-      margin-bottom: 0.5rem;
-    }
-    &:last-child {
-      border-right: 1px solid ${({ theme }) => theme.palette.text.primary}; // overwrite styles that remove this
-    }
-    .MuiFormControlLabel-label {
-      font-size: 0.875rem;
-    }
-    &:has([aria-invalid='true']) {
-      border-color: ${({ theme }) => theme.palette.error.main};
-      .MuiSvgIcon-root {
-        color: ${({ theme }) => theme.palette.error.main};
-      }
-    }
+const RadioItem = styled(FormControlLabel)<{
+  $color?: string;
+}>`
+  border: 1px solid ${({ theme }) => theme.palette.text.primary};
+  border-radius: 4px;
+  background-color: ${({ $color }) => ($color ? `${$color}33` : 'transparent')};
+  max-width: 25rem;
+  margin-left: 0;
+  padding: 0.3rem 0.69rem;
+  .MuiFormControlLabel-label {
+    font-size: 0.875rem;
   }
+  &:not(:last-child) {
+    margin-bottom: 0.5rem;
+  }
+  &:has(.Mui-checked) {
+    border-color: ${({ theme, $color }) => $color || theme.palette.primary.main};
+    background-color: ${({ theme, $color }) =>
+      $color ? `${$color}33` : lighten(theme.palette.primary.main, 0.9)};
+  }
+  [aria-invalid='true'] & {
+    border-color: ${({ theme }) => theme.palette.error.main};
+  }
+`;
+
+const RadioButton = styled(Radio)<{
+  $color?: string;
+}>`
+  color: ${({ theme }) => theme.palette.text.primary};
+
   .MuiSvgIcon-root {
     font-size: 1.25rem;
+    fill: ${({ $color }) => ($color ? 'white' : 'transparent')};
+  }
+  &.Mui-checked {
+    color: ${({ theme }) => theme.palette.primary.main};
+  }
+  [aria-invalid='true'] & {
+    .MuiSvgIcon-root {
+      color: ${({ theme }) => theme.palette.error.main};
+    }
   }
 `;
 
@@ -76,18 +82,31 @@ export const RadioQuestion = ({
   // This is a controlled component because value and onChange are required props
   return (
     <StyledRadioGroup
+      aria-describedby={`question_number_${id}`}
+      name={name!}
       onChange={onChange}
       id={id}
-      label={label?.replace(/\xA0/g, ' ')} // replace non-breaking spaces that are returned with the label with normal spaces to prevent unwanted wrapping
-      name={name!}
-      inputRef={ref}
-      options={options || []}
+      aria-invalid={invalid}
+      ref={ref}
       value={value || ''}
-      required={required}
-      inputProps={{
-        ['aria-describedby']: `question_number_${id}`,
-        ['aria-invalid']: invalid,
-      }}
-    />
+    >
+      {/**replace non-breaking spaces that are returned with the label with normal spaces to prevent unwanted wrapping **/}
+      <FormLabel component="legend">{label?.replace(/\xA0/g, ' ')}</FormLabel>
+      {options?.map(({ label, value, color }, i) => (
+        <RadioItem
+          $color={color}
+          value={value}
+          control={
+            <RadioButton
+              $color={color}
+              required={required && i === 0}
+              icon={<RadioIcon />}
+              checkedIcon={<RadioIcon checked optionColor={color} />}
+            />
+          } // only the first radio button is required, as this is enough to make the whole group required
+          label={label}
+        />
+      ))}
+    </StyledRadioGroup>
   );
 };

--- a/packages/datatrak-web/src/features/Questions/RadioQuestion.tsx
+++ b/packages/datatrak-web/src/features/Questions/RadioQuestion.tsx
@@ -8,23 +8,13 @@ import styled from 'styled-components';
 import { FormControlLabel, FormLabel, Radio, RadioGroup, lighten } from '@material-ui/core';
 import { SurveyQuestionInputProps } from '../../types';
 import { RadioIcon } from '../../components';
+import { QuestionHelperText } from './QuestionHelperText';
 
 const StyledRadioGroup = styled(RadioGroup)`
   width: 100%;
   margin-bottom: 0;
   display: flex;
   flex-direction: column;
-  legend {
-    color: ${({ theme }) => theme.palette.text.primary};
-    margin-bottom: 1rem;
-    font-weight: ${({ theme }) => theme.typography.fontWeightMedium};
-    font-size: 0.875rem;
-    line-height: 1.2;
-    ${({ theme }) => theme.breakpoints.up('md')} {
-      font-size: 1rem;
-      font-weight: ${({ theme }) => theme.typography.fontWeightRegular};
-    }
-  }
 `;
 
 const RadioItem = styled(FormControlLabel)<{
@@ -71,12 +61,27 @@ const RadioButton = styled(Radio)<{
   }
 `;
 
+const LegendWrapper = styled.div`
+  margin-bottom: 1rem;
+  legend {
+    color: ${({ theme }) => theme.palette.text.primary};
+    font-weight: ${({ theme }) => theme.typography.fontWeightMedium};
+    font-size: 0.875rem;
+    line-height: 1.2;
+    ${({ theme }) => theme.breakpoints.up('md')} {
+      font-size: 1rem;
+      font-weight: ${({ theme }) => theme.typography.fontWeightRegular};
+    }
+  }
+`;
+
 export const RadioQuestion = ({
   id,
   label,
   name,
   options,
   required,
+  detailLabel,
   controllerProps: { onChange, value, ref, invalid },
 }: SurveyQuestionInputProps) => {
   // This is a controlled component because value and onChange are required props
@@ -91,7 +96,10 @@ export const RadioQuestion = ({
       value={value || ''}
     >
       {/**replace non-breaking spaces that are returned with the label with normal spaces to prevent unwanted wrapping **/}
-      <FormLabel component="legend">{label?.replace(/\xA0/g, ' ')}</FormLabel>
+      <LegendWrapper>
+        <FormLabel component="legend">{label?.replace(/\xA0/g, ' ')}</FormLabel>
+        {detailLabel && <QuestionHelperText>{detailLabel}</QuestionHelperText>}
+      </LegendWrapper>
       {options?.map(({ label, value, color }, i) => (
         <RadioItem
           $color={color}

--- a/packages/datatrak-web/src/features/Questions/ReadOnlyQuestion.tsx
+++ b/packages/datatrak-web/src/features/Questions/ReadOnlyQuestion.tsx
@@ -11,6 +11,7 @@ import { Tooltip } from '@tupaia/ui-components';
 import { QuestionType } from '@tupaia/types';
 import { useSurveyForm } from '..';
 import { getArithmeticDisplayAnswer } from '../Survey';
+import { QuestionHelperText } from './QuestionHelperText';
 
 const Wrapper = styled.div`
   width: 100%;
@@ -29,12 +30,6 @@ const Label = styled(Typography).attrs({
 })`
   font-size: 1rem;
   cursor: pointer;
-`;
-
-const HelperText = styled(Typography)`
-  font-size: 0.875rem;
-  margin-top: 0.5rem;
-  color: ${({ theme }) => theme.palette.text.secondary};
 `;
 
 const ValueWrapper = styled.div`
@@ -61,7 +56,7 @@ export const ReadOnlyQuestion = ({
       <Tooltip title="Complete questions above to calculate" enterDelay={1000}>
         <Label>{label}</Label>
       </Tooltip>
-      {detailLabel && <HelperText>{detailLabel}</HelperText>}
+      {detailLabel && <QuestionHelperText>{detailLabel}</QuestionHelperText>}
       <ValueWrapper>
         <Value>{displayValue}</Value>
       </ValueWrapper>

--- a/packages/datatrak-web/src/features/Questions/TextQuestion.tsx
+++ b/packages/datatrak-web/src/features/Questions/TextQuestion.tsx
@@ -9,6 +9,7 @@ import styled from 'styled-components';
 import { TextInput } from '../../components';
 import { MOBILE_BREAKPOINT } from '../../constants';
 import { useSurveyForm } from '..';
+import { QuestionHelperText } from './QuestionHelperText';
 
 const Wrapper = styled.div<{
   $type?: string;
@@ -19,6 +20,8 @@ const Wrapper = styled.div<{
   }
   .MuiFormControl-root {
     max-width: ${({ $type }) => ($type === 'Number' ? '25rem' : 'none')};
+    display: flex;
+    flex-direction: column-reverse; // make the helper text appear above the input
   }
   .MuiFormControlLabel-label {
     font-weight: ${({ theme }) => theme.typography.fontWeightMedium};
@@ -40,6 +43,7 @@ export const TextQuestion = ({
   type,
   required,
   min,
+  detailLabel,
   max,
   controllerProps: { onChange, value = '', ref, invalid },
 }: SurveyQuestionInputProps) => {
@@ -62,6 +66,10 @@ export const TextQuestion = ({
           min,
           max,
           multiline: type === 'FreeText',
+          helperText: detailLabel,
+          FormHelperTextProps: {
+            component: QuestionHelperText,
+          },
         }}
       />
     </Wrapper>

--- a/packages/datatrak-web/src/features/Survey/Components/SurveyQuestionGroup.tsx
+++ b/packages/datatrak-web/src/features/Survey/Components/SurveyQuestionGroup.tsx
@@ -83,12 +83,12 @@ export const SurveyQuestionGroup = ({ questions }: { questions: SurveyScreenComp
                 </QuestionNumber>
               )}
               <SurveyQuestion
-                detailLabel={detailLabel}
+                detailLabel={'test'}
                 id={questionId}
                 code={code}
                 name={questionId}
                 type={type}
-                text={detailLabel || text}
+                text={text}
                 options={options}
                 config={config}
                 label={label || text}

--- a/packages/datatrak-web/src/features/Survey/Components/SurveyQuestionGroup.tsx
+++ b/packages/datatrak-web/src/features/Survey/Components/SurveyQuestionGroup.tsx
@@ -83,7 +83,7 @@ export const SurveyQuestionGroup = ({ questions }: { questions: SurveyScreenComp
                 </QuestionNumber>
               )}
               <SurveyQuestion
-                detailLabel={'test'}
+                detailLabel={detailLabel}
                 id={questionId}
                 code={code}
                 name={questionId}

--- a/packages/datatrak-web/src/features/Survey/Screens/SurveyScreen.tsx
+++ b/packages/datatrak-web/src/features/Survey/Screens/SurveyScreen.tsx
@@ -8,6 +8,7 @@ import { Typography } from '@material-ui/core';
 import { useSurveyForm } from '../SurveyContext';
 import { SurveyQuestionGroup } from '../Components';
 import { ScrollableBody } from '../../../layout';
+import { QuestionType } from '@tupaia/types';
 
 const ScreenHeading = styled(Typography)<{
   $centered?: boolean;
@@ -29,11 +30,14 @@ const ScreenHeading = styled(Typography)<{
  * This is the component that renders survey questions.
  */
 export const SurveyScreen = () => {
-  const { displayQuestions, screenHeader } = useSurveyForm();
+  const { displayQuestions, screenHeader, activeScreen } = useSurveyForm();
 
   return (
     <ScrollableBody $hasSidebar>
-      <ScreenHeading variant="h2" $centered={displayQuestions.length === 0}>
+      <ScreenHeading
+        variant="h2"
+        $centered={activeScreen.every(question => question.type === QuestionType.Instruction)}
+      >
         {screenHeader}
       </ScreenHeading>
       <SurveyQuestionGroup questions={displayQuestions} />

--- a/packages/datatrak-web/src/features/Survey/utils.ts
+++ b/packages/datatrak-web/src/features/Survey/utils.ts
@@ -15,18 +15,16 @@ export const convertNumberToLetter = (number: number) => {
 export const getSurveyScreenNumber = (screens, screen) => {
   if (!screen) return null;
   const { surveyScreenComponents, id } = screen;
-  const { type } = surveyScreenComponents[0];
   const nonInstructionScreens =
-    screens?.filter(
-      screen =>
-        screen.surveyScreenComponents.length > 1 ||
-        screen.surveyScreenComponents[0].type !== QuestionType.Instruction,
+    screens?.filter(screen =>
+      screen.surveyScreenComponents.some(component => component.type !== QuestionType.Instruction),
     ) ?? [];
 
-  const screenNumber =
-    surveyScreenComponents?.length > 1 || type !== QuestionType.Instruction
-      ? nonInstructionScreens.findIndex(nonInstructionScreen => nonInstructionScreen.id === id) + 1
-      : null;
+  const screenNumber = surveyScreenComponents.some(
+    component => component.type !== QuestionType.Instruction,
+  )
+    ? nonInstructionScreens.findIndex(nonInstructionScreen => nonInstructionScreen.id === id) + 1
+    : null;
 
   return screenNumber;
 };

--- a/packages/datatrak-web/src/types/mui.d.ts
+++ b/packages/datatrak-web/src/types/mui.d.ts
@@ -4,12 +4,26 @@ import {
   TextFieldProps as MuiTextFieldProps,
 } from '@material-ui/core';
 
+import {
+  KeyboardDatePickerProps as MuiKeyboardDatePickerProps,
+  KeyboardDateTimePickerProps as MuiKeyboardDateTimePickerProps,
+} from '@material-ui/pickers';
+
 declare module '@material-ui/core' {
   export type ListItemProps = Omit<MuiListItemProps, 'button'> & {
     button?: boolean; // override this to make it optional, due to issue with 'button' prop in MuiListItemProps throwing an error when it is undefined
   };
 
   export type TextFieldProps = MuiTextFieldProps & {
+    FormHelperTextProps?: FormHelperTextProps; // override this to handle the issue with 'component' prop in MuiFormHelperTextProps not being recognized in TextFieldProps
+  };
+}
+
+declare module '@material-ui/pickers' {
+  export type KeyboardDatePickerProps = MuiKeyboardDatePickerProps & {
+    FormHelperTextProps?: FormHelperTextProps; // override this to handle the issue with 'component' prop in MuiFormHelperTextProps not being recognized in TextFieldProps
+  };
+  export type KeyboardDateTimePickerProps = MuiKeyboardDateTimePickerProps & {
     FormHelperTextProps?: FormHelperTextProps; // override this to handle the issue with 'component' prop in MuiFormHelperTextProps not being recognized in TextFieldProps
   };
 }

--- a/packages/datatrak-web/src/types/mui.d.ts
+++ b/packages/datatrak-web/src/types/mui.d.ts
@@ -1,7 +1,15 @@
-import { ListItemProps as MuiListItemProps } from '@material-ui/core';
+import {
+  ListItemProps as MuiListItemProps,
+  FormHelperTextProps,
+  TextFieldProps as MuiTextFieldProps,
+} from '@material-ui/core';
 
 declare module '@material-ui/core' {
   export type ListItemProps = Omit<MuiListItemProps, 'button'> & {
     button?: boolean; // override this to make it optional, due to issue with 'button' prop in MuiListItemProps throwing an error when it is undefined
+  };
+
+  export type TextFieldProps = MuiTextFieldProps & {
+    FormHelperTextProps?: FormHelperTextProps; // override this to handle the issue with 'component' prop in MuiFormHelperTextProps not being recognized in TextFieldProps
   };
 }

--- a/packages/types/src/types/requests/datatrak-web-server/SurveyRequest.ts
+++ b/packages/types/src/types/requests/datatrak-web-server/SurveyRequest.ts
@@ -8,6 +8,7 @@ import {
   Survey,
   SurveyScreen as BaseSurveyScreen,
   SurveyScreenComponent as BaseSurveyScreenComponent,
+  Option as BaseOption,
 } from '../../models';
 import { KeysToCamelCase } from '../../../utils/casing';
 
@@ -99,6 +100,10 @@ export type SurveyScreenComponentConfig = {
   arithmetic?: ArithmeticConfig;
 };
 
+export type Option = Pick<BaseOption, 'value' | 'label'> & {
+  color?: string;
+};
+
 export type SurveyScreenComponent = CamelCasedComponent &
   CamelCasedQuestion & {
     visibilityCriteria?: VisibilityCriteria;
@@ -106,7 +111,7 @@ export type SurveyScreenComponent = CamelCasedComponent &
     config?: SurveyScreenComponentConfig | null;
     componentId?: BaseSurveyScreenComponent['id'];
     label?: BaseSurveyScreenComponent['question_label'];
-    options?: Record<string, unknown>[] | null;
+    options?: Option[] | null;
     screenId?: string;
   };
 

--- a/packages/ui-components/src/components/Inputs/Autocomplete.tsx
+++ b/packages/ui-components/src/components/Inputs/Autocomplete.tsx
@@ -10,6 +10,7 @@ import MuiKeyboardArrowDown from '@material-ui/icons/KeyboardArrowDown';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import styled from 'styled-components';
 import { TextField } from './TextField';
+import { TextFieldProps } from '@material-ui/core';
 
 const KeyboardArrowDown = styled(MuiKeyboardArrowDown)`
   color: ${props => props.theme.palette.text.tertiary};
@@ -73,6 +74,7 @@ interface AutocompleteProps extends BaseAutocompleteProps {
   name?: string;
   defaultValue?: any;
   tooltip?: string;
+  textFieldProps?: TextFieldProps;
 }
 
 export const Autocomplete = ({
@@ -97,6 +99,7 @@ export const Autocomplete = ({
   name,
   defaultValue,
   tooltip,
+  textFieldProps,
 }: AutocompleteProps) => (
   <StyledAutocomplete
     id={id}
@@ -117,6 +120,7 @@ export const Autocomplete = ({
     renderInput={params => (
       <TextField
         {...(params as any)}
+        {...textFieldProps}
         label={label}
         tooltip={tooltip}
         name={name}


### PR DESCRIPTION
### Issue WAITP-1345:Core question updates

### Changes:
- Added support for option colours on radio inputs
- Added support and styling for question helper text

---

### Screenshots:

Helper texts
![Screenshot 2023-10-12 at 9 52 26 am](https://github.com/beyondessential/tupaia/assets/129009580/9f7b8b10-6228-4170-8262-0a905780ed2e)
![Screenshot 2023-10-12 at 9 48 14 am](https://github.com/beyondessential/tupaia/assets/129009580/dbec6b6c-5819-4ce0-8058-3f2e72586489)
![Screenshot 2023-10-12 at 9 43 32 am](https://github.com/beyondessential/tupaia/assets/129009580/8c098fe7-41ec-4221-a5be-5a64f3538132)
![Screenshot 2023-10-12 at 9 41 05 am](https://github.com/beyondessential/tupaia/assets/129009580/21282d4c-4a46-4460-a063-bb80f3aecee2)
![Screenshot 2023-10-12 at 9 37 35 am](https://github.com/beyondessential/tupaia/assets/129009580/ff082655-06d2-4d5e-893d-25523b37b47c)
![Screenshot 2023-10-12 at 9 35 55 am](https://github.com/beyondessential/tupaia/assets/129009580/f247f35b-f74c-40af-b31d-5077c73f9ab2)
![Screenshot 2023-10-12 at 9 32 31 am](https://github.com/beyondessential/tupaia/assets/129009580/f78f7d2d-837d-4848-8e14-9b6974fe5322)


Radio input option colours
![Screenshot 2023-10-12 at 9 00 34 am](https://github.com/beyondessential/tupaia/assets/129009580/955741b5-6b09-4af8-9e14-212f59758721)
![Screenshot 2023-10-12 at 9 00 40 am](https://github.com/beyondessential/tupaia/assets/129009580/6ca58b29-f2c3-41e5-9ae7-6867daa6ac3c)
