### PR TITLE
WAITP-1418 Permission revoking fixup

### DIFF
--- a/packages/central-server/src/database/models/User.js
+++ b/packages/central-server/src/database/models/User.js
@@ -1,0 +1,32 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+import { UserType as CommonUserType, UserModel as CommonUserModel } from '@tupaia/database';
+
+const SERVICES = {
+  // admin_panel: 'admin_panel_session',
+  // datatrak_web: 'datatrak_web_session',
+  tupaia_web: 'tupaia_web_session',
+};
+
+class UserType extends CommonUserType {
+  async expireSessionToken(service) {
+    if (!SERVICES[service]) {
+      throw new Error(`${service} is not a support service for session expiry`);
+    }
+    await this.database.executeSql(
+      `
+        UPDATE ?? SET access_token_expiry = 0 WHERE email = ?
+      `,
+      [SERVICES[service], this.email],
+    );
+  }
+}
+
+export class UserModel extends CommonUserModel {
+  get DatabaseTypeClass() {
+    return UserType;
+  }
+}

--- a/packages/central-server/src/database/models/User.js
+++ b/packages/central-server/src/database/models/User.js
@@ -5,6 +5,10 @@
 
 import { UserType as CommonUserType, UserModel as CommonUserModel } from '@tupaia/database';
 
+// Currently our pattern is that session tables don't have models
+// in the generic database package, this is a quick and dirty way to get
+// context for them into central-server
+// TODO: Move sessions into database and clean this up
 const SERVICES = {
   // admin_panel: 'admin_panel_session',
   // datatrak_web: 'datatrak_web_session',

--- a/packages/central-server/src/database/models/UserEntityPermission.js
+++ b/packages/central-server/src/database/models/UserEntityPermission.js
@@ -64,7 +64,7 @@ async function onUpsertSendPermissionGrantEmail(
 }
 
 /**
- * This sets the expiry on the users session information to cause a logout. We do this to
+ * This sets the expiry on the users session information to cause a permission refresh. We do this to
  * ensure we don't use a cached version of the accessPolicy after changing a users access
  */
 async function expireAccess({ new_record: newRecord, old_record: oldRecord }, models) {

--- a/packages/central-server/src/database/models/UserEntityPermission.js
+++ b/packages/central-server/src/database/models/UserEntityPermission.js
@@ -8,7 +8,7 @@ import { UserEntityPermissionModel as CommonUserEntityPermissionModel } from '@t
 import { sendEmail } from '../../utilities';
 
 export class UserEntityPermissionModel extends CommonUserEntityPermissionModel {
-  notifiers = [onUpsertSendPermissionGrantEmail];
+  notifiers = [onUpsertSendPermissionGrantEmail, expireAccess];
 }
 
 const EMAILS = {
@@ -61,4 +61,14 @@ async function onUpsertSendPermissionGrantEmail(
     null,
     signOff,
   );
+}
+
+/**
+ * This sets the expiry on the users session information to cause a logout. We do this to
+ * ensure we don't use a cached version of the accessPolicy after changing a users access
+ */
+async function expireAccess({ new_record: newRecord, old_record: oldRecord }, models) {
+  const userId = newRecord?.user_id || oldRecord.user_id;
+  const user = await models.user.findById(userId);
+  await user.expireSessionToken('tupaia_web');
 }

--- a/packages/central-server/src/database/models/index.js
+++ b/packages/central-server/src/database/models/index.js
@@ -25,4 +25,5 @@ export { SurveyGroupModel as SurveyGroup } from './SurveyGroup';
 export { SurveyResponseModel as SurveyResponse } from './SurveyResponse';
 export { SurveyScreenComponentModel as SurveyScreenComponent } from './SurveyScreenComponent';
 export { SurveyScreenModel as SurveyScreen } from './SurveyScreen';
+export { UserModel as User } from './User';
 export { UserEntityPermissionModel as UserEntityPermission } from './UserEntityPermission';


### PR DESCRIPTION
### Issue #: WAITP-1418

### Changes:

- Add ability to expire sessions for a user from `central-server`
- Trigger an expiry after a `user_entity_permission` change

This should only expire your access token for `tupaia_web`, once the `access_token` expires, the web session will automatically refresh using the `refresh_token` which means you get the updated `access_policy`