### PR TITLE
WAITP-1349: Fix DataTrak survey submit

### DIFF
--- a/packages/central-server/src/apiV2/surveyResponse.js
+++ b/packages/central-server/src/apiV2/surveyResponse.js
@@ -13,6 +13,7 @@ import {
   constructRecordExistsWithCode,
   constructIsEmptyOr,
   takesIdForm,
+  constructIsNotPresentOr,
   takesDateForm,
 } from '@tupaia/utils';
 import { constructAnswerValidator } from './utilities/constructAnswerValidator';
@@ -146,6 +147,7 @@ export async function surveyResponse(req, res) {
 }
 
 const constructAnswerValidators = models => ({
+  id: [constructIsNotPresentOr(takesIdForm)],
   type: [hasContent],
   question_id: [hasContent, takesIdForm, constructRecordExistsWithId(models.question)],
   body: [hasContent],

--- a/packages/central-server/src/apiV2/surveyResponse.js
+++ b/packages/central-server/src/apiV2/surveyResponse.js
@@ -146,7 +146,6 @@ export async function surveyResponse(req, res) {
 }
 
 const constructAnswerValidators = models => ({
-  id: [hasContent, takesIdForm],
   type: [hasContent],
   question_id: [hasContent, takesIdForm, constructRecordExistsWithId(models.question)],
   body: [hasContent],


### PR DESCRIPTION
### Issue #: WAITP-1349: Fix DataTrak survey submit

### Changes:

- Make **id** an optional field in the answers of survey questions in the central-server `surveyResponses` endpoint

In the saving of the survey response, it already handles the id being undefined but we are validating for an id in the surveyResponse questions.

This is the line where it handles the id not being set buildResponseRecord:

```
saveResponsestoDatabase.js line 73

...
  return {
    id: id || generateId(),
    survey_id: surveyId,
    user_id: user.id,
    entity_id: entityId || entitiesByCode[entityCode].id,
    data_time: dataTime,
    start_time: startTime,
    end_time: endTime,
    timezone: timezone || getTimezoneNameFromTimestamp(timestamp),
    assessor_name: user.fullName,
    approval_status: approvalStatus,
  };


