### PR TITLE
Fix DeleteAfter

### DIFF
--- a/packages/devops/scripts/lambda/actions/delete_old_servers.py
+++ b/packages/devops/scripts/lambda/actions/delete_old_servers.py
@@ -10,7 +10,7 @@ def delete_old_servers(event):
     current_date = time.strftime("%Y-%m-%d")
     filters = [
         {'Name': 'instance-state-name', 'Values': ['running', 'stopped']}, # ignore terminated instances
-        {'Name': 'tag:DeleteAfter', 'Values': [current_date + '*']} # get any due to be deleted this hour
+        {'Name': 'tag:DeleteAfter', 'Values': ['*'] }
     ]
     instances = find_instances(filters)
 


### PR DESCRIPTION
### Issue #: No Issue

Currently the DeleteAfter logic requires the check to run the same day as the DeleteAfter value.

If an instance is shut down overnight it can be missed by the deleter completely. This change just makes it consider all instances with DeleteAfter, not just those with a value of today.

Tested in `igor-test-deployment` lambda function.