### PR TITLE
MDEV-199: Hide parent entity config option

### DIFF
--- a/packages/meditrak-app/app/entityMenu/EntityItem.js
+++ b/packages/meditrak-app/app/entityMenu/EntityItem.js
@@ -33,7 +33,7 @@ export class EntityItem extends Component {
   };
 
   render() {
-    const { isSelected, entity, onPress, onDeselect } = this.props;
+    const { isSelected, entity, onPress, onDeselect, hideParentName } = this.props;
     const Container = onPress && !isSelected ? TouchableOpacity : View;
 
     return (
@@ -49,7 +49,9 @@ export class EntityItem extends Component {
         />
         <View style={localStyles.rowContent}>
           <Text style={localStyles.entityCellText}>{entity.name}</Text>
-          <Text style={localStyles.entityCellSubText}>{entity.parent?.name}</Text>
+          {!hideParentName && (
+            <Text style={localStyles.entityCellSubText}>{entity.parent?.name}</Text>
+          )}
         </View>
         {onDeselect && (
           <TouchableOpacity analyticsLabel="Selected Entity: Clear" onPress={onDeselect}>
@@ -66,11 +68,13 @@ EntityItem.propTypes = {
   entity: PropTypes.shape({}).isRequired,
   isSelected: PropTypes.bool,
   onDeselect: PropTypes.func,
+  hideParentName: PropTypes.bool,
 };
 
 EntityItem.defaultProps = {
   isSelected: false,
   onDeselect: null,
+  hideParentName: false,
 };
 
 const localStyles = StyleSheet.create({

--- a/packages/meditrak-app/app/entityMenu/EntityList.js
+++ b/packages/meditrak-app/app/entityMenu/EntityList.js
@@ -163,11 +163,12 @@ export class EntityList extends PureComponent {
   };
 
   renderEntityCell = ({ item, onDeselect }) => {
-    const { selectedEntityId } = this.props;
+    const { selectedEntityId, config } = this.props;
     const isSelected = item.id === selectedEntityId;
     return (
       <EntityItem
         entity={item}
+        hideParentName={config?.entity?.hideParentName}
         onPress={this.selectRow}
         isSelected={isSelected}
         onDeselect={onDeselect}
@@ -283,10 +284,12 @@ EntityList.propTypes = {
   takeScrollControl: PropTypes.func.isRequired,
   releaseScrollControl: PropTypes.func.isRequired,
   scrollIntoFocus: PropTypes.func.isRequired,
+  config: PropTypes.object,
 };
 
 EntityList.defaultProps = {
   selectedEntityId: '',
+  config: null,
 };
 
 const localStyles = StyleSheet.create({


### PR DESCRIPTION
### Issue MDEV-199: Hide parent entity config option

### Changes:
- Allow setting of config option `hideParentName` for entity questions (as a workaround until projects are linked to surveys and the correct hierarchy can be applied)

---

### Screenshots:
![Screenshot 2023-10-17 at 3 34 20 pm](https://github.com/beyondessential/tupaia/assets/129009580/ec0d1792-7381-4056-aca3-8caa8e4ea3d7)

