### PR TITLE
WAITP-1241: Photo gallery

### DIFF
--- a/packages/tupaia-web/src/features/Visuals/View/DownloadFiles.tsx
+++ b/packages/tupaia-web/src/features/Visuals/View/DownloadFiles.tsx
@@ -19,6 +19,23 @@ const StyledDownloadFilesVisual = styled(DownloadFilesVisual)`
   .checkbox-icon {
     color: ${({ theme }) => darken(theme.palette.common.white, 0.1)};
   }
+  button {
+    text-transform: none;
+    font-size: 1rem;
+    padding: 0.5rem 1rem;
+  }
+  // override button styles from @tupaia/ui-components to match the theme of the app
+  .MuiButton-text {
+    border: 1px solid ${({ theme }) => theme.palette.primary.main};
+    color: ${({ theme }) => theme.palette.primary.main};
+  }
+  .MuiButton-containedPrimary {
+    box-shadow: none;
+    border: 1px solid ${({ theme }) => theme.palette.primary.main};
+    &:hover {
+      border-color: ${({ theme }) => darken(theme.palette.primary.main, 0.3)};
+    }
+  }
 `;
 
 interface DownloadFilesVisualProps {

--- a/packages/tupaia-web/src/features/Visuals/View/MultiPhotograph/Carousel.tsx
+++ b/packages/tupaia-web/src/features/Visuals/View/MultiPhotograph/Carousel.tsx
@@ -1,0 +1,103 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { ViewReport } from '@tupaia/types';
+import { Modal } from '../../../../components';
+import { IconButton, Slide } from '@material-ui/core';
+import { KeyboardArrowLeft, KeyboardArrowRight } from '@material-ui/icons';
+
+const Wrapper = styled.div`
+  position: relative;
+  overflow: hidden;
+  max-width: 38rem;
+  padding: 0 1rem;
+  flex: 1;
+  display: flex;
+  align-items: center;
+`;
+
+const ImageWrapper = styled.div`
+  overflow-y: auto;
+  overflow-x: hidden;
+  width: 100%;
+  min-height: 30rem;
+`;
+const Image = styled.img<{
+  $isActive: boolean;
+}>`
+  max-width: 100%;
+  height: auto;
+  max-height: 100%;
+  display: ${({ $isActive }) => ($isActive ? 'block' : 'none')};
+  margin: 0 auto;
+`;
+
+const ArrowButton = styled(IconButton)`
+  position: absolute;
+  top: 45%;
+  z-index: 1;
+  &:first-child {
+    left: 0.5rem;
+  }
+  &:last-child {
+    right: 0.5rem;
+  }
+  svg {
+    width: 3rem;
+    height: 3rem;
+  }
+`;
+
+interface CarouselProps {
+  report: ViewReport;
+  onClose: () => void;
+}
+
+export const Carousel = ({ report: { data = [] }, onClose }: CarouselProps) => {
+  const [activeImageIndex, setActiveImageIndex] = useState(0);
+  const [slideDirection, setSlideDirection] = useState<'left' | 'right'>('right');
+
+  const handleNext = () => {
+    if (activeImageIndex === data.length - 1) return;
+    setSlideDirection('right');
+    setActiveImageIndex(activeImageIndex + 1);
+  };
+  const handlePrevious = () => {
+    if (activeImageIndex === 0) return;
+    setSlideDirection('left');
+    setActiveImageIndex(activeImageIndex - 1);
+  };
+
+  if (!data[activeImageIndex]) return null;
+  return (
+    <Modal isOpen onClose={onClose}>
+      <Wrapper>
+        <ImageWrapper>
+          {data.map((image, index) => (
+            <Slide
+              direction={slideDirection}
+              in={activeImageIndex === index}
+              key={index}
+              timeout={500}
+            >
+              <Image src={image.value} key={index} $isActive={activeImageIndex === index} />
+            </Slide>
+          ))}
+        </ImageWrapper>
+        {data.length > 1 && (
+          <>
+            <ArrowButton onClick={handlePrevious} disabled={activeImageIndex === 0}>
+              <KeyboardArrowLeft />
+            </ArrowButton>
+            <ArrowButton onClick={handleNext} disabled={activeImageIndex === data.length - 1}>
+              <KeyboardArrowRight />
+            </ArrowButton>
+          </>
+        )}
+      </Wrapper>
+    </Modal>
+  );
+};

--- a/packages/tupaia-web/src/features/Visuals/View/MultiPhotograph/MultiPhotograph.tsx
+++ b/packages/tupaia-web/src/features/Visuals/View/MultiPhotograph/MultiPhotograph.tsx
@@ -1,0 +1,19 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+import React from 'react';
+import { ViewConfig, ViewReport } from '@tupaia/types';
+import { MultiPhotographPreview } from './MultiPhotographPreview';
+import { MultiPhotographEnlarged } from './MultiPhotographEnlarged';
+
+interface MultiPhotographProps {
+  report: ViewReport;
+  config: ViewConfig;
+  isEnlarged?: boolean;
+}
+
+export const MultiPhotograph = ({ report, config, isEnlarged }: MultiPhotographProps) => {
+  if (!isEnlarged) return <MultiPhotographPreview report={report} config={config} />;
+  return <MultiPhotographEnlarged report={report} config={config} />;
+};

--- a/packages/tupaia-web/src/features/Visuals/View/MultiPhotograph/MultiPhotographEnlarged.tsx
+++ b/packages/tupaia-web/src/features/Visuals/View/MultiPhotograph/MultiPhotographEnlarged.tsx
@@ -1,0 +1,54 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { ViewConfig, ViewReport } from '@tupaia/types';
+import { MultiPhotographPreview } from './MultiPhotographPreview';
+import { ZoomIn as MuiZoomIn } from '@material-ui/icons';
+import { Carousel } from './Carousel';
+
+const Wrapper = styled.div`
+  position: relative;
+`;
+
+const ExpandButton = styled.button`
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  border: none;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  background-color: rgba(32, 33, 36, 0.6);
+  color: ${({ theme }) => theme.palette.common.white};
+  &:hover,
+  &:focus-visible {
+    opacity: 1;
+  }
+`;
+
+const ZoomIn = styled(MuiZoomIn)`
+  width: 4rem;
+  height: 4rem;
+`;
+
+interface MultiPhotographEnlargedProps {
+  report: ViewReport;
+  config: ViewConfig;
+}
+
+export const MultiPhotographEnlarged = ({ report, config }: MultiPhotographEnlargedProps) => {
+  const [carouselOpen, setCarouselOpen] = useState(false);
+  return (
+    <Wrapper>
+      <MultiPhotographPreview report={report} config={config} />
+      <ExpandButton onClick={() => setCarouselOpen(true)}>
+        <ZoomIn />
+      </ExpandButton>
+      {carouselOpen && <Carousel report={report} onClose={() => setCarouselOpen(false)} />}
+    </Wrapper>
+  );
+};

--- a/packages/tupaia-web/src/features/Visuals/View/MultiPhotograph/MultiPhotographPreview.tsx
+++ b/packages/tupaia-web/src/features/Visuals/View/MultiPhotograph/MultiPhotographPreview.tsx
@@ -1,0 +1,56 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+import React from 'react';
+import styled from 'styled-components';
+import { ViewConfig, ViewReport } from '@tupaia/types';
+
+const MAX_THUMBNAILS = 3;
+
+const Wrapper = styled.div`
+  display: flex;
+  height: 16rem;
+`;
+
+const Thumbnail = styled.div<{
+  thumbCount: number;
+  src: string;
+}>`
+  max-height: 100%;
+  background-image: url(${({ src }) => src});
+  background-size: cover;
+  background-repeat: no-repeat;
+  width: ${({ thumbCount }) => {
+    if (thumbCount === 1) return '100%';
+    if (thumbCount === 2) return '50%';
+    return '25%';
+  }};
+  &:nth-child(2) {
+    width: 50%;
+  }
+`;
+
+interface MultiPhotographPreviewProps {
+  report: ViewReport;
+  config: ViewConfig;
+}
+
+export const MultiPhotographPreview = ({
+  report: { data = [] },
+  config,
+}: MultiPhotographPreviewProps) => {
+  const thumbnails = data.slice(0, MAX_THUMBNAILS).map(({ value }) => value);
+  return (
+    <Wrapper>
+      {thumbnails.map((thumbnail, i) => (
+        <Thumbnail
+          src={thumbnail}
+          key={thumbnail}
+          aria-label={`Thumbnail ${i + 1} for visualisation ${config?.name}`}
+          thumbCount={thumbnails.length}
+        />
+      ))}
+    </Wrapper>
+  );
+};

--- a/packages/tupaia-web/src/features/Visuals/View/MultiPhotograph/index.ts
+++ b/packages/tupaia-web/src/features/Visuals/View/MultiPhotograph/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+export { MultiPhotograph } from './MultiPhotograph';

--- a/packages/tupaia-web/src/features/Visuals/View/View.tsx
+++ b/packages/tupaia-web/src/features/Visuals/View/View.tsx
@@ -17,6 +17,7 @@ import { DownloadFiles } from './DownloadFiles';
 import { QRCode } from './QRCode';
 import { DashboardItemContext } from '../../DashboardItem';
 import { DashboardInfoHover } from '../../DashboardItem';
+import { MultiPhotograph } from './MultiPhotograph';
 
 const MultiSingleValueWrapper = styled.div`
   & + & {
@@ -38,6 +39,7 @@ const VIEWS = {
   dataDownload: DataDownload,
   filesDownload: DownloadFiles,
   qrCodeVisual: QRCode,
+  multiPhotograph: MultiPhotograph,
 };
 
 const formatData = (data: ViewReport['data'], config: ViewConfig) => {


### PR DESCRIPTION
### Issue WAITP-1241: Photo gallery visualisations

### Changes:
- Added support `multiPhotograph` viz type in `tupaia-web`
- Fixed download files viz button styling to match the rest of the app

Note: I have just made it match in design to the current front-end, so there may be some design changes later, which is out of scope for this ticket

---

### Screenshots:
Carousel
![Screenshot 2023-10-18 at 4 14 12 pm](https://github.com/beyondessential/tupaia/assets/129009580/0b9ec33e-02e4-4392-a6af-f72db3516f53)

Modal
![Screenshot 2023-10-18 at 4 14 17 pm](https://github.com/beyondessential/tupaia/assets/129009580/3b34daaf-7b85-4e7d-84d9-8f938c1ab940)

Preview
![Screenshot 2023-10-18 at 4 14 23 pm](https://github.com/beyondessential/tupaia/assets/129009580/94881243-a772-4493-8744-529bb0b805c8)
