### PR TITLE
no-issue: Added <Model>Create and <Model>Update types

### DIFF
--- a/packages/types/generate-models.ts
+++ b/packages/types/generate-models.ts
@@ -5,7 +5,7 @@
 
 // See https://rmp135.github.io/sql-ts/#/?id=totypescript
 
-import sqlts from '@rmp135/sql-ts';
+import sqlts, { Table } from '@rmp135/sql-ts';
 
 import Knex from 'knex';
 // @ts-ignore
@@ -26,17 +26,52 @@ const db = Knex({
   },
 });
 
+const renameTables = (tables: Table[], suffix: string) =>
+  tables.map(table => ({
+    ...table,
+    interfaceName: `${table.interfaceName}${suffix}`,
+  }));
+
+const combineTables = (baseTables: Table[], createTables: Table[], updateTables: Table[]) => {
+  const combinedTables: Table[] = [];
+  for (let i = 0; i < baseTables.length; i++) {
+    combinedTables.push(baseTables[i], createTables[i], updateTables[i]);
+  }
+  return combinedTables;
+};
+
+const removeIdColumn = (tables: Table[]) =>
+  tables.map(({ columns, ...restOfTable }) => ({
+    ...restOfTable,
+    columns: columns.filter(({ name }) => name !== 'id'),
+  }));
+
 const run = async () => {
   const failOnChanges = process.argv[2] === '--failOnChanges';
 
+  // Base tables have all fields present
   // @ts-ignore
-  const tsString = await sqlts.toTypeScript(config, db);
+  const definitions = await sqlts.toObject({ ...config, globalOptionality: 'required' }, db);
+
+  // Create tables allow for optional and nullable fields to be missing
+  // @ts-ignore
+  const createDefinitions = await sqlts.toObject(config, db);
+
+  // Update tables allow for all fields to be optional since just updating an existing table
+  // @ts-ignore
+  const upsertDefinitions = await sqlts.toObject({ ...config, globalOptionality: 'optional' }, db);
+  const createTables = removeIdColumn(renameTables(createDefinitions.tables, 'Create'));
+  const updateTables = renameTables(upsertDefinitions.tables, 'Update');
+  const allTables = combineTables(definitions.tables, createTables, updateTables);
+  const tsString = sqlts.fromObject({ ...definitions, tables: allTables }, config);
 
   if (failOnChanges) {
     const currentTsString = fs.readFileSync(config.filename, { encoding: 'utf8' });
     if (currentTsString !== tsString) {
-      console.log("❌ There are changes in the db schema which are not reflected in @tupaia/types.")
-      console.log("Run 'yarn workspace @tupaia/types generate' to fix")
+      console.log(
+        '❌ There are changes in the db schema which are not reflected in @tupaia/types.',
+      );
+      console.log("Run 'yarn workspace @tupaia/types generate' to fix");
       process.exit(1);
     }
   }

--- a/packages/types/src/schemas/schemas.ts
+++ b/packages/types/src/schemas/schemas.ts
@@ -26558,17 +26558,7 @@ export const AccessRequestSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
-		"approved",
-		"created_time",
-		"entity_id",
-		"id",
-		"message",
-		"note",
-		"permission_group_id",
-		"processed_by",
-		"processed_date",
-		"project_id",
-		"user_id"
+		"id"
 	]
 } 
 
@@ -26775,21 +26765,7 @@ export const AnalyticsSchema = {
 			"type": "string"
 		}
 	},
-	"additionalProperties": false,
-	"required": [
-		"data_element_code",
-		"data_group_code",
-		"date",
-		"day_period",
-		"entity_code",
-		"entity_name",
-		"event_id",
-		"month_period",
-		"type",
-		"value",
-		"week_period",
-		"year_period"
-	]
+	"additionalProperties": false
 } 
 
 export const AnalyticsCreateSchema = {
@@ -26980,7 +26956,6 @@ export const AnswerSchema = {
 		"id",
 		"question_id",
 		"survey_response_id",
-		"text",
 		"type"
 	]
 } 
@@ -27051,7 +27026,6 @@ export const ApiClientSchema = {
 	"required": [
 		"id",
 		"secret_key_hash",
-		"user_account_id",
 		"username"
 	]
 } 
@@ -27131,12 +27105,6 @@ export const ApiRequestLogSchema = {
 		"api",
 		"endpoint",
 		"id",
-		"metadata",
-		"method",
-		"query",
-		"refresh_token",
-		"request_time",
-		"user_id",
 		"version"
 	]
 } 
@@ -27241,14 +27209,11 @@ export const ClinicSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
-		"category_code",
 		"code",
 		"country_id",
 		"geographical_area_id",
 		"id",
-		"name",
-		"type",
-		"type_name"
+		"name"
 	]
 } 
 
@@ -27443,8 +27408,7 @@ export const DashboardSchema = {
 		"code",
 		"id",
 		"name",
-		"root_entity_code",
-		"sort_order"
+		"root_entity_code"
 	]
 } 
 
@@ -35501,11 +35465,7 @@ export const DashboardItemSchema = {
 	"additionalProperties": false,
 	"required": [
 		"code",
-		"config",
-		"id",
-		"legacy",
-		"permission_group_ids",
-		"report_code"
+		"id"
 	]
 } 
 
@@ -51559,8 +51519,7 @@ export const DashboardRelationSchema = {
 		"entity_types",
 		"id",
 		"permission_groups",
-		"project_codes",
-		"sort_order"
+		"project_codes"
 	]
 } 
 
@@ -51664,9 +51623,7 @@ export const DataElementSchema = {
 	"additionalProperties": false,
 	"required": [
 		"code",
-		"config",
 		"id",
-		"permission_groups",
 		"service_type"
 	]
 } 
@@ -51821,7 +51778,6 @@ export const DataElementDataServiceSchema = {
 		"country_code",
 		"data_element_code",
 		"id",
-		"service_config",
 		"service_type"
 	]
 } 
@@ -51912,7 +51868,6 @@ export const DataGroupSchema = {
 	"additionalProperties": false,
 	"required": [
 		"code",
-		"config",
 		"id",
 		"service_type"
 	]
@@ -52062,9 +52017,7 @@ export const DataServiceSyncGroupSchema = {
 		"config",
 		"data_group_code",
 		"id",
-		"service_type",
-		"sync_cursor",
-		"sync_status"
+		"service_type"
 	]
 } 
 
@@ -52187,8 +52140,6 @@ export const DataTableSchema = {
 	"additionalProperties": false,
 	"required": [
 		"code",
-		"config",
-		"description",
 		"id",
 		"permission_groups",
 		"type"
@@ -52445,16 +52396,9 @@ export const DhisSyncLogSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
-		"data",
-		"deleted",
-		"dhis_reference",
-		"error_list",
 		"id",
-		"ignored",
-		"imported",
 		"record_id",
-		"record_type",
-		"updated"
+		"record_type"
 	]
 } 
 
@@ -52569,13 +52513,7 @@ export const DhisSyncQueueSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
-		"bad_request_count",
-		"change_time",
-		"details",
 		"id",
-		"is_dead_letter",
-		"is_deleted",
-		"priority",
 		"record_id",
 		"record_type",
 		"type"
@@ -52687,7 +52625,6 @@ export const DisasterSchema = {
 	"additionalProperties": false,
 	"required": [
 		"countryCode",
-		"description",
 		"id",
 		"name",
 		"type"
@@ -52918,18 +52855,9 @@ export const EntitySchema = {
 	},
 	"additionalProperties": false,
 	"required": [
-		"attributes",
-		"bounds",
 		"code",
-		"country_code",
 		"id",
-		"image_url",
-		"metadata",
-		"name",
-		"parent_id",
-		"point",
-		"region",
-		"type"
+		"name"
 	]
 } 
 
@@ -53094,7 +53022,6 @@ export const EntityHierarchySchema = {
 	},
 	"additionalProperties": false,
 	"required": [
-		"canonical_types",
 		"id",
 		"name"
 	]
@@ -53225,11 +53152,7 @@ export const ErrorLogSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
-		"api_request_log_id",
-		"error_time",
-		"id",
-		"message",
-		"type"
+		"id"
 	]
 } 
 
@@ -53301,10 +53224,8 @@ export const ExternalDatabaseConnectionSchema = {
 	"additionalProperties": false,
 	"required": [
 		"code",
-		"description",
 		"id",
-		"name",
-		"permission_groups"
+		"name"
 	]
 } 
 
@@ -53402,15 +53323,7 @@ export const FeedItemSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
-		"country_id",
-		"creation_date",
-		"geographical_area_id",
-		"id",
-		"permission_group_id",
-		"record_id",
-		"template_variables",
-		"type",
-		"user_id"
+		"id"
 	]
 } 
 
@@ -53526,13 +53439,11 @@ export const GeographicalAreaSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
-		"code",
 		"country_id",
 		"id",
 		"level_code",
 		"level_name",
-		"name",
-		"parent_id"
+		"name"
 	]
 } 
 
@@ -53613,7 +53524,6 @@ export const IndicatorSchema = {
 	"required": [
 		"builder",
 		"code",
-		"config",
 		"id"
 	]
 } 
@@ -53707,21 +53617,9 @@ export const LandingPageSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
-		"contact_us",
-		"extended_title",
-		"external_link",
 		"id",
-		"image_url",
-		"include_name_in_header",
-		"logo_url",
-		"long_bio",
 		"name",
-		"phone_number",
-		"primary_hexcode",
-		"project_codes",
-		"secondary_hexcode",
-		"url_segment",
-		"website_url"
+		"url_segment"
 	]
 } 
 
@@ -53854,9 +53752,6 @@ export const LegacyReportSchema = {
 	"additionalProperties": false,
 	"required": [
 		"code",
-		"data_builder",
-		"data_builder_config",
-		"data_services",
 		"id"
 	]
 } 
@@ -54478,16 +54373,8 @@ export const MapOverlaySchema = {
 	"additionalProperties": false,
 	"required": [
 		"code",
-		"config",
-		"country_codes",
-		"data_services",
-		"id",
-		"legacy",
-		"linked_measures",
 		"name",
-		"permission_group",
-		"project_codes",
-		"report_code"
+		"permission_group"
 	]
 } 
 
@@ -55571,8 +55458,7 @@ export const MapOverlayGroupRelationSchema = {
 		"child_id",
 		"child_type",
 		"id",
-		"map_overlay_group_id",
-		"sort_order"
+		"map_overlay_group_id"
 	]
 } 
 
@@ -55644,11 +55530,8 @@ export const MeditrakDeviceSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
-		"app_version",
-		"config",
 		"id",
 		"install_id",
-		"platform",
 		"user_id"
 	]
 } 
@@ -55721,7 +55604,6 @@ export const MeditrakSyncQueueSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
-		"change_time",
 		"id",
 		"record_id",
 		"record_type",
@@ -55802,10 +55684,6 @@ export const Ms1SyncLogSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
-		"count",
-		"data",
-		"endpoint",
-		"error_list",
 		"id",
 		"record_id",
 		"record_type"
@@ -55905,13 +55783,7 @@ export const Ms1SyncQueueSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
-		"bad_request_count",
-		"change_time",
-		"details",
 		"id",
-		"is_dead_letter",
-		"is_deleted",
-		"priority",
 		"record_id",
 		"record_type",
 		"type"
@@ -56017,10 +55889,8 @@ export const OneTimeLoginSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
-		"creation_date",
 		"id",
 		"token",
-		"use_date",
 		"user_id"
 	]
 } 
@@ -56096,11 +55966,8 @@ export const OptionSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
-		"attributes",
 		"id",
-		"label",
 		"option_set_id",
-		"sort_order",
 		"value"
 	]
 } 
@@ -56211,8 +56078,7 @@ export const PermissionGroupSchema = {
 	"additionalProperties": false,
 	"required": [
 		"id",
-		"name",
-		"parent_id"
+		"name"
 	]
 } 
 
@@ -56320,17 +56186,7 @@ export const PermissionsBasedMeditrakSyncQueueSchema = {
 			"type": "string"
 		}
 	},
-	"additionalProperties": false,
-	"required": [
-		"change_time",
-		"country_ids",
-		"entity_type",
-		"id",
-		"permission_groups",
-		"record_id",
-		"record_type",
-		"type"
-	]
+	"additionalProperties": false
 } 
 
 export const PermissionsBasedMeditrakSyncQueueCreateSchema = {
@@ -56524,17 +56380,7 @@ export const ProjectSchema = {
 	"additionalProperties": false,
 	"required": [
 		"code",
-		"config",
-		"dashboard_group_name",
-		"default_measure",
-		"description",
-		"entity_hierarchy_id",
-		"entity_id",
-		"id",
-		"image_url",
-		"logo_url",
-		"permission_groups",
-		"sort_order"
+		"id"
 	]
 } 
 
@@ -56767,14 +56613,7 @@ export const QuestionSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
-		"code",
-		"data_element_id",
-		"detail",
-		"hook",
 		"id",
-		"name",
-		"option_set_id",
-		"options",
 		"text",
 		"type"
 	]
@@ -56927,10 +56766,7 @@ export const RefreshTokenSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
-		"device",
-		"expiry",
 		"id",
-		"meditrak_device_id",
 		"token",
 		"user_id"
 	]
@@ -57188,8 +57024,7 @@ export const SettingSchema = {
 	"additionalProperties": false,
 	"required": [
 		"id",
-		"key",
-		"value"
+		"key"
 	]
 } 
 
@@ -57320,17 +57155,9 @@ export const SurveySchema = {
 	},
 	"additionalProperties": false,
 	"required": [
-		"can_repeat",
 		"code",
-		"country_ids",
-		"data_group_id",
 		"id",
-		"integration_metadata",
-		"name",
-		"period_granularity",
-		"permission_group_id",
-		"requires_approval",
-		"survey_group_id"
+		"name"
 	]
 } 
 
@@ -57525,17 +57352,12 @@ export const SurveyResponseSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
-		"approval_status",
 		"assessor_name",
-		"data_time",
 		"end_time",
 		"entity_id",
 		"id",
-		"metadata",
-		"outdated",
 		"start_time",
 		"survey_id",
-		"timezone",
 		"user_id"
 	]
 } 
@@ -57799,17 +57621,10 @@ export const SurveyScreenComponentSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
-		"answers_enabling_follow_up",
 		"component_number",
-		"config",
-		"detail_label",
 		"id",
-		"is_follow_up",
 		"question_id",
-		"question_label",
-		"screen_id",
-		"validation_criteria",
-		"visibility_criteria"
+		"screen_id"
 	]
 } 
 
@@ -57935,8 +57750,7 @@ export const SyncGroupLogSchema = {
 		"id",
 		"log_message",
 		"service_type",
-		"sync_group_code",
-		"timestamp"
+		"sync_group_code"
 	]
 } 
 
@@ -58146,21 +57960,10 @@ export const UserAccountSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
-		"creation_date",
 		"email",
-		"employer",
-		"first_name",
-		"gender",
 		"id",
-		"last_name",
-		"mobile_number",
 		"password_hash",
-		"password_salt",
-		"position",
-		"preferences",
-		"primary_platform",
-		"profile_image",
-		"verified_email"
+		"password_salt"
 	]
 } 
 
@@ -58304,10 +58107,7 @@ export const UserEntityPermissionSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
-		"entity_id",
-		"id",
-		"permission_group_id",
-		"user_id"
+		"id"
 	]
 } 
 
@@ -58422,9 +58222,6 @@ export const UserSessionSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
-		"accessPolicy",
-		"accessToken",
-		"access_token_expiry",
 		"id",
 		"refreshToken",
 		"userName"
@@ -58813,18 +58610,9 @@ export const MeditrakSurveyResponseRequestSchema = {
 				},
 				"additionalProperties": false,
 				"required": [
-					"attributes",
-					"bounds",
 					"code",
-					"country_code",
 					"id",
-					"image_url",
-					"metadata",
-					"name",
-					"parent_id",
-					"point",
-					"region",
-					"type"
+					"name"
 				]
 			}
 		},
@@ -58849,10 +58637,7 @@ export const MeditrakSurveyResponseRequestSchema = {
 				},
 				"additionalProperties": false,
 				"required": [
-					"attributes",
-					"label",
 					"option_set_id",
-					"sort_order",
 					"value"
 				]
 			}
@@ -58909,8 +58694,6 @@ export const DataTablePreviewRequestSchema = {
 	"additionalProperties": false,
 	"required": [
 		"code",
-		"config",
-		"description",
 		"permission_groups",
 		"type"
 	]
@@ -59083,18 +58866,9 @@ export const ResBodySchema = {
 		},
 		"additionalProperties": false,
 		"required": [
-			"attributes",
-			"bounds",
 			"code",
-			"countryCode",
 			"id",
-			"imageUrl",
-			"metadata",
-			"name",
-			"parentId",
-			"point",
-			"region",
-			"type"
+			"name"
 		]
 	}
 } 
@@ -59176,20 +58950,10 @@ export const ProjectResponseSchema = {
 	},
 	"required": [
 		"code",
-		"config",
-		"dashboardGroupName",
-		"defaultMeasure",
-		"description",
-		"entityHierarchyId",
-		"entityId",
 		"hasAccess",
 		"hasPendingAccess",
 		"id",
-		"imageUrl",
-		"logoUrl",
-		"name",
-		"permissionGroups",
-		"sortOrder"
+		"name"
 	]
 } 
 
@@ -59270,12 +59034,6 @@ export const CamelCasedQuestionSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
-		"code",
-		"dataElementId",
-		"detail",
-		"hook",
-		"name",
-		"optionSetId",
 		"text",
 		"type"
 	]
@@ -59305,10 +59063,7 @@ export const CamelCasedComponentSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
-		"answersEnablingFollowUp",
 		"componentNumber",
-		"detailLabel",
-		"isFollowUp",
 		"questionId"
 	]
 } 
@@ -67759,11 +67514,7 @@ export const DashboardWithItemsSchema = {
 				"additionalProperties": false,
 				"required": [
 					"code",
-					"config",
-					"id",
-					"legacy",
-					"permission_group_ids",
-					"report_code"
+					"id"
 				]
 			}
 		},
@@ -67789,8 +67540,7 @@ export const DashboardWithItemsSchema = {
 		"id",
 		"items",
 		"name",
-		"root_entity_code",
-		"sort_order"
+		"root_entity_code"
 	]
 } 
 
@@ -68261,9 +68011,7 @@ export const TranslatedMapOverlaySchema = {
 	"required": [
 		"code",
 		"displayType",
-		"legacy",
-		"name",
-		"reportCode"
+		"name"
 	]
 } 
 

--- a/packages/types/src/schemas/schemas.ts
+++ b/packages/types/src/schemas/schemas.ts
@@ -26558,8 +26558,99 @@ export const AccessRequestSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
-		"id"
+		"approved",
+		"created_time",
+		"entity_id",
+		"id",
+		"message",
+		"note",
+		"permission_group_id",
+		"processed_by",
+		"processed_date",
+		"project_id",
+		"user_id"
 	]
+} 
+
+export const AccessRequestCreateSchema = {
+	"type": "object",
+	"properties": {
+		"approved": {
+			"type": "boolean"
+		},
+		"created_time": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"entity_id": {
+			"type": "string"
+		},
+		"message": {
+			"type": "string"
+		},
+		"note": {
+			"type": "string"
+		},
+		"permission_group_id": {
+			"type": "string"
+		},
+		"processed_by": {
+			"type": "string"
+		},
+		"processed_date": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"project_id": {
+			"type": "string"
+		},
+		"user_id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
+} 
+
+export const AccessRequestUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"approved": {
+			"type": "boolean"
+		},
+		"created_time": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"entity_id": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"message": {
+			"type": "string"
+		},
+		"note": {
+			"type": "string"
+		},
+		"permission_group_id": {
+			"type": "string"
+		},
+		"processed_by": {
+			"type": "string"
+		},
+		"processed_date": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"project_id": {
+			"type": "string"
+		},
+		"user_id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const AdminPanelSessionSchema = {
@@ -26593,7 +26684,208 @@ export const AdminPanelSessionSchema = {
 	]
 } 
 
+export const AdminPanelSessionCreateSchema = {
+	"type": "object",
+	"properties": {
+		"access_policy": {},
+		"access_token": {
+			"type": "string"
+		},
+		"access_token_expiry": {
+			"type": "string"
+		},
+		"email": {
+			"type": "string"
+		},
+		"refresh_token": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"access_policy",
+		"access_token",
+		"access_token_expiry",
+		"email",
+		"refresh_token"
+	]
+} 
+
+export const AdminPanelSessionUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"access_policy": {},
+		"access_token": {
+			"type": "string"
+		},
+		"access_token_expiry": {
+			"type": "string"
+		},
+		"email": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"refresh_token": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
+} 
+
 export const AnalyticsSchema = {
+	"type": "object",
+	"properties": {
+		"answer_entity_m_row$": {
+			"type": "string"
+		},
+		"answer_m_row$": {
+			"type": "string"
+		},
+		"data_element_code": {
+			"type": "string"
+		},
+		"data_element_m_row$": {
+			"type": "string"
+		},
+		"data_group_code": {
+			"type": "string"
+		},
+		"date": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"day_period": {
+			"type": "string"
+		},
+		"entity_code": {
+			"type": "string"
+		},
+		"entity_m_row$": {
+			"type": "string"
+		},
+		"entity_name": {
+			"type": "string"
+		},
+		"event_id": {
+			"type": "string"
+		},
+		"month_period": {
+			"type": "string"
+		},
+		"question_m_row$": {
+			"type": "string"
+		},
+		"survey_m_row$": {
+			"type": "string"
+		},
+		"survey_response_m_row$": {
+			"type": "string"
+		},
+		"type": {
+			"type": "string"
+		},
+		"value": {
+			"type": "string"
+		},
+		"week_period": {
+			"type": "string"
+		},
+		"year_period": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"answer_entity_m_row$",
+		"answer_m_row$",
+		"data_element_code",
+		"data_element_m_row$",
+		"data_group_code",
+		"date",
+		"day_period",
+		"entity_code",
+		"entity_m_row$",
+		"entity_name",
+		"event_id",
+		"month_period",
+		"question_m_row$",
+		"survey_m_row$",
+		"survey_response_m_row$",
+		"type",
+		"value",
+		"week_period",
+		"year_period"
+	]
+} 
+
+export const AnalyticsCreateSchema = {
+	"type": "object",
+	"properties": {
+		"answer_entity_m_row$": {
+			"type": "string"
+		},
+		"answer_m_row$": {
+			"type": "string"
+		},
+		"data_element_code": {
+			"type": "string"
+		},
+		"data_element_m_row$": {
+			"type": "string"
+		},
+		"data_group_code": {
+			"type": "string"
+		},
+		"date": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"day_period": {
+			"type": "string"
+		},
+		"entity_code": {
+			"type": "string"
+		},
+		"entity_m_row$": {
+			"type": "string"
+		},
+		"entity_name": {
+			"type": "string"
+		},
+		"event_id": {
+			"type": "string"
+		},
+		"month_period": {
+			"type": "string"
+		},
+		"question_m_row$": {
+			"type": "string"
+		},
+		"survey_m_row$": {
+			"type": "string"
+		},
+		"survey_response_m_row$": {
+			"type": "string"
+		},
+		"type": {
+			"type": "string"
+		},
+		"value": {
+			"type": "string"
+		},
+		"week_period": {
+			"type": "string"
+		},
+		"year_period": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
+} 
+
+export const AnalyticsUpdateSchema = {
 	"type": "object",
 	"properties": {
 		"answer_entity_m_row$": {
@@ -26687,6 +26979,53 @@ export const AncestorDescendantRelationSchema = {
 	]
 } 
 
+export const AncestorDescendantRelationCreateSchema = {
+	"type": "object",
+	"properties": {
+		"ancestor_id": {
+			"type": "string"
+		},
+		"descendant_id": {
+			"type": "string"
+		},
+		"entity_hierarchy_id": {
+			"type": "string"
+		},
+		"generational_distance": {
+			"type": "number"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"ancestor_id",
+		"descendant_id",
+		"entity_hierarchy_id",
+		"generational_distance"
+	]
+} 
+
+export const AncestorDescendantRelationUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"ancestor_id": {
+			"type": "string"
+		},
+		"descendant_id": {
+			"type": "string"
+		},
+		"entity_hierarchy_id": {
+			"type": "string"
+		},
+		"generational_distance": {
+			"type": "number"
+		},
+		"id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
+} 
+
 export const AnswerSchema = {
 	"type": "object",
 	"properties": {
@@ -26712,10 +27051,64 @@ export const AnswerSchema = {
 	"additionalProperties": false,
 	"required": [
 		"id",
+		"m_row$",
+		"question_id",
+		"survey_response_id",
+		"text",
+		"type"
+	]
+} 
+
+export const AnswerCreateSchema = {
+	"type": "object",
+	"properties": {
+		"m_row$": {
+			"type": "string"
+		},
+		"question_id": {
+			"type": "string"
+		},
+		"survey_response_id": {
+			"type": "string"
+		},
+		"text": {
+			"type": "string"
+		},
+		"type": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
 		"question_id",
 		"survey_response_id",
 		"type"
 	]
+} 
+
+export const AnswerUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"id": {
+			"type": "string"
+		},
+		"m_row$": {
+			"type": "string"
+		},
+		"question_id": {
+			"type": "string"
+		},
+		"survey_response_id": {
+			"type": "string"
+		},
+		"text": {
+			"type": "string"
+		},
+		"type": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const ApiClientSchema = {
@@ -26738,8 +27131,48 @@ export const ApiClientSchema = {
 	"required": [
 		"id",
 		"secret_key_hash",
+		"user_account_id",
 		"username"
 	]
+} 
+
+export const ApiClientCreateSchema = {
+	"type": "object",
+	"properties": {
+		"secret_key_hash": {
+			"type": "string"
+		},
+		"user_account_id": {
+			"type": "string"
+		},
+		"username": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"secret_key_hash",
+		"username"
+	]
+} 
+
+export const ApiClientUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"id": {
+			"type": "string"
+		},
+		"secret_key_hash": {
+			"type": "string"
+		},
+		"user_account_id": {
+			"type": "string"
+		},
+		"username": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const ApiRequestLogSchema = {
@@ -26778,8 +27211,84 @@ export const ApiRequestLogSchema = {
 		"api",
 		"endpoint",
 		"id",
+		"metadata",
+		"method",
+		"query",
+		"refresh_token",
+		"request_time",
+		"user_id",
 		"version"
 	]
+} 
+
+export const ApiRequestLogCreateSchema = {
+	"type": "object",
+	"properties": {
+		"api": {
+			"type": "string"
+		},
+		"endpoint": {
+			"type": "string"
+		},
+		"metadata": {},
+		"method": {
+			"type": "string"
+		},
+		"query": {},
+		"refresh_token": {
+			"type": "string"
+		},
+		"request_time": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"user_id": {
+			"type": "string"
+		},
+		"version": {
+			"type": "number"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"api",
+		"endpoint",
+		"version"
+	]
+} 
+
+export const ApiRequestLogUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"api": {
+			"type": "string"
+		},
+		"endpoint": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"metadata": {},
+		"method": {
+			"type": "string"
+		},
+		"query": {},
+		"refresh_token": {
+			"type": "string"
+		},
+		"request_time": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"user_id": {
+			"type": "string"
+		},
+		"version": {
+			"type": "number"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const ClinicSchema = {
@@ -26812,12 +27321,128 @@ export const ClinicSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
+		"category_code",
 		"code",
 		"country_id",
 		"geographical_area_id",
 		"id",
+		"name",
+		"type",
+		"type_name"
+	]
+} 
+
+export const ClinicCreateSchema = {
+	"type": "object",
+	"properties": {
+		"category_code": {
+			"type": "string"
+		},
+		"code": {
+			"type": "string"
+		},
+		"country_id": {
+			"type": "string"
+		},
+		"geographical_area_id": {
+			"type": "string"
+		},
+		"name": {
+			"type": "string"
+		},
+		"type": {
+			"type": "string"
+		},
+		"type_name": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"code",
+		"country_id",
+		"geographical_area_id",
 		"name"
 	]
+} 
+
+export const ClinicUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"category_code": {
+			"type": "string"
+		},
+		"code": {
+			"type": "string"
+		},
+		"country_id": {
+			"type": "string"
+		},
+		"geographical_area_id": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"name": {
+			"type": "string"
+		},
+		"type": {
+			"type": "string"
+		},
+		"type_name": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
+} 
+
+export const CommentCreateSchema = {
+	"type": "object",
+	"properties": {
+		"created_time": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"last_modified_time": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"text": {
+			"type": "string"
+		},
+		"user_id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"text"
+	]
+} 
+
+export const CommentUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"created_time": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"id": {
+			"type": "string"
+		},
+		"last_modified_time": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"text": {
+			"type": "string"
+		},
+		"user_id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const CountrySchema = {
@@ -26839,6 +27464,39 @@ export const CountrySchema = {
 		"id",
 		"name"
 	]
+} 
+
+export const CountryCreateSchema = {
+	"type": "object",
+	"properties": {
+		"code": {
+			"type": "string"
+		},
+		"name": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"code",
+		"name"
+	]
+} 
+
+export const CountryUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"code": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"name": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const DashboardSchema = {
@@ -26865,8 +27523,55 @@ export const DashboardSchema = {
 		"code",
 		"id",
 		"name",
+		"root_entity_code",
+		"sort_order"
+	]
+} 
+
+export const DashboardCreateSchema = {
+	"type": "object",
+	"properties": {
+		"code": {
+			"type": "string"
+		},
+		"name": {
+			"type": "string"
+		},
+		"root_entity_code": {
+			"type": "string"
+		},
+		"sort_order": {
+			"type": "number"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"code",
+		"name",
 		"root_entity_code"
 	]
+} 
+
+export const DashboardUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"code": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"name": {
+			"type": "string"
+		},
+		"root_entity_code": {
+			"type": "string"
+		},
+		"sort_order": {
+			"type": "number"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const DashboardItemSchema = {
@@ -34876,8 +35581,16026 @@ export const DashboardItemSchema = {
 	"additionalProperties": false,
 	"required": [
 		"code",
-		"id"
+		"config",
+		"id",
+		"legacy",
+		"permission_group_ids",
+		"report_code"
 	]
+} 
+
+export const DashboardItemCreateSchema = {
+	"type": "object",
+	"properties": {
+		"code": {
+			"type": "string"
+		},
+		"config": {
+			"description": "The master list of viz types.\nPlease also keep ../../utils/vizTypes up to date when making changes",
+			"anyOf": [
+				{
+					"description": "Matrix viz type",
+					"additionalProperties": false,
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						},
+						"description": {
+							"description": "A short description that appears above a viz",
+							"type": "string"
+						},
+						"placeholder": {
+							"description": "A url to an image to be used when a viz is collapsed. Some vizes display small, others display a placeholder.",
+							"type": "string"
+						},
+						"periodGranularity": {
+							"enum": [
+								"day",
+								"month",
+								"one_day_at_a_time",
+								"one_month_at_a_time",
+								"one_quarter_at_a_time",
+								"one_week_at_a_time",
+								"one_year_at_a_time",
+								"quarter",
+								"week",
+								"year"
+							],
+							"type": "string"
+						},
+						"defaultTimePeriod": {
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"offset": {
+											"type": "number"
+										},
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										},
+										"end": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"end",
+										"start"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"description": "ISO Date Time",
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"start"
+									]
+								}
+							]
+						},
+						"datePickerLimits": {
+							"type": "object",
+							"properties": {
+								"start": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								"end": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								}
+							},
+							"additionalProperties": false
+						},
+						"exportConfig": {
+							"description": "Extra config options for exporting"
+						},
+						"noDataMessage": {
+							"description": "Message which shows if no data is found",
+							"type": "string"
+						},
+						"noDataFetch": {
+							"description": "If true, Tupaia will not fetch any data for this viz. Usually used with custom vizes of type: component, e.g. ProjectDescription.",
+							"default": false,
+							"type": "boolean"
+						},
+						"drillDown": {
+							"type": "object",
+							"properties": {
+								"keyLink": {
+									"type": "string"
+								},
+								"itemCode": {
+									"type": "string"
+								},
+								"parameterLink": {
+									"type": "string"
+								},
+								"itemCodeByEntry": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "string"
+									}
+								}
+							},
+							"additionalProperties": false
+						},
+						"entityHeader": {
+							"description": "",
+							"type": "string"
+						},
+						"reference": {
+							"description": "If provided shows an (i) icon next to the viz title, which allows linking to the source data",
+							"type": "object",
+							"properties": {
+								"link": {
+									"description": "url",
+									"type": "string"
+								},
+								"name": {
+									"description": "label",
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"link",
+								"name"
+							]
+						},
+						"source": {
+							"description": "If specified allows the frontend to know where the data is coming from, so if there is no data it can show a custom no-data message e.g. \"Requires mSupply\".",
+							"type": "string"
+						},
+						"displayOnEntityConditions": {
+							"description": "If specified will only show this viz if the conditions are met against the current Entity.",
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"attributes": {
+											"type": "object",
+											"additionalProperties": {
+												"type": [
+													"string",
+													"number",
+													"boolean"
+												]
+											}
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"attributes"
+									]
+								},
+								{
+									"type": "object",
+									"additionalProperties": {
+										"type": [
+											"string",
+											"number",
+											"boolean"
+										]
+									}
+								}
+							]
+						},
+						"weekDisplayFormat": {
+							"description": "Allows customising how weeks are displayed, e.g. 'W/C 6 Jan 2020' or 'ISO Week 2 2020'",
+							"default": "'WEEK_COMMENCING_ABBR'",
+							"enum": [
+								"ISO_WEEK_NUMBER",
+								"WEEK_COMMENCING",
+								"WEEK_COMMENCING_ABBR",
+								"WEEK_ENDING",
+								"WEEK_ENDING_ABBR"
+							],
+							"type": "string"
+						},
+						"type": {
+							"type": "string",
+							"enum": [
+								"matrix"
+							]
+						},
+						"dataElementColumnTitle": {
+							"description": "Matrix viz type can specify a column as the data element column.",
+							"type": "string"
+						},
+						"hideColumnTitles": {
+							"description": "Like it sounds",
+							"type": "boolean"
+						},
+						"presentationOptions": {
+							"description": "Allows for conditional styling",
+							"anyOf": [
+								{
+									"additionalProperties": false,
+									"type": "object",
+									"properties": {
+										"exportWithLabels": {
+											"type": "boolean"
+										},
+										"exportWithTable": {
+											"type": "boolean"
+										},
+										"exportWithTableDisabled": {
+											"type": "boolean"
+										},
+										"type": {
+											"type": "string",
+											"enum": [
+												"condition"
+											]
+										},
+										"conditions": {
+											"type": "array",
+											"items": {
+												"additionalProperties": false,
+												"type": "object",
+												"properties": {
+													"color": {
+														"description": "Specify the color of the display item",
+														"type": "string"
+													},
+													"description": {
+														"description": "Specify the text for the legend item. Also used in the enlarged cell view",
+														"type": "string"
+													},
+													"label": {
+														"description": "Specify if you want a label to appear above the enlarged",
+														"type": "string"
+													},
+													"key": {
+														"type": "string"
+													},
+													"condition": {
+														"description": "the value to match against exactly, or an object with match criteria e.g. { '>=': 5.5 }",
+														"anyOf": [
+															{
+																"type": "object",
+																"properties": {
+																	"=": {
+																		"type": [
+																			"string",
+																			"number"
+																		]
+																	},
+																	">": {
+																		"type": [
+																			"string",
+																			"number"
+																		]
+																	},
+																	"<": {
+																		"type": [
+																			"string",
+																			"number"
+																		]
+																	},
+																	">=": {
+																		"type": [
+																			"string",
+																			"number"
+																		]
+																	},
+																	"<=": {
+																		"type": [
+																			"string",
+																			"number"
+																		]
+																	}
+																},
+																"additionalProperties": false,
+																"required": [
+																	"<",
+																	"<=",
+																	"=",
+																	">",
+																	">="
+																]
+															},
+															{
+																"type": [
+																	"string",
+																	"number"
+																]
+															}
+														]
+													},
+													"legendLabel": {
+														"type": "string"
+													}
+												},
+												"required": [
+													"condition",
+													"key"
+												]
+											}
+										},
+										"showRawValue": {
+											"default": false,
+											"type": "boolean"
+										},
+										"showNestedRows": {
+											"default": false,
+											"type": "boolean"
+										},
+										"applyLocation": {
+											"description": "Specify if you want to limit where to apply the conditional presentation",
+											"type": "object",
+											"properties": {
+												"columnIndexes": {
+													"type": "array",
+													"items": {
+														"type": "number"
+													}
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"columnIndexes"
+											]
+										}
+									}
+								},
+								{
+									"additionalProperties": false,
+									"type": "object",
+									"properties": {
+										"exportWithLabels": {
+											"type": "boolean"
+										},
+										"exportWithTable": {
+											"type": "boolean"
+										},
+										"exportWithTableDisabled": {
+											"type": "boolean"
+										},
+										"type": {
+											"type": "string",
+											"enum": [
+												"range"
+											]
+										},
+										"showRawValue": {
+											"type": "boolean"
+										}
+									},
+									"required": [
+										"type"
+									]
+								}
+							]
+						},
+						"categoryPresentationOptions": {
+							"description": "Category header rows can have values just like real rows, this is how you style them",
+							"anyOf": [
+								{
+									"additionalProperties": false,
+									"type": "object",
+									"properties": {
+										"exportWithLabels": {
+											"type": "boolean"
+										},
+										"exportWithTable": {
+											"type": "boolean"
+										},
+										"exportWithTableDisabled": {
+											"type": "boolean"
+										},
+										"type": {
+											"type": "string",
+											"enum": [
+												"condition"
+											]
+										},
+										"conditions": {
+											"type": "array",
+											"items": {
+												"additionalProperties": false,
+												"type": "object",
+												"properties": {
+													"color": {
+														"description": "Specify the color of the display item",
+														"type": "string"
+													},
+													"description": {
+														"description": "Specify the text for the legend item. Also used in the enlarged cell view",
+														"type": "string"
+													},
+													"label": {
+														"description": "Specify if you want a label to appear above the enlarged",
+														"type": "string"
+													},
+													"key": {
+														"type": "string"
+													},
+													"condition": {
+														"description": "the value to match against exactly, or an object with match criteria e.g. { '>=': 5.5 }",
+														"anyOf": [
+															{
+																"type": "object",
+																"properties": {
+																	"=": {
+																		"type": [
+																			"string",
+																			"number"
+																		]
+																	},
+																	">": {
+																		"type": [
+																			"string",
+																			"number"
+																		]
+																	},
+																	"<": {
+																		"type": [
+																			"string",
+																			"number"
+																		]
+																	},
+																	">=": {
+																		"type": [
+																			"string",
+																			"number"
+																		]
+																	},
+																	"<=": {
+																		"type": [
+																			"string",
+																			"number"
+																		]
+																	}
+																},
+																"additionalProperties": false,
+																"required": [
+																	"<",
+																	"<=",
+																	"=",
+																	">",
+																	">="
+																]
+															},
+															{
+																"type": [
+																	"string",
+																	"number"
+																]
+															}
+														]
+													},
+													"legendLabel": {
+														"type": "string"
+													}
+												},
+												"required": [
+													"condition",
+													"key"
+												]
+											}
+										},
+										"showRawValue": {
+											"default": false,
+											"type": "boolean"
+										},
+										"showNestedRows": {
+											"default": false,
+											"type": "boolean"
+										},
+										"applyLocation": {
+											"description": "Specify if you want to limit where to apply the conditional presentation",
+											"type": "object",
+											"properties": {
+												"columnIndexes": {
+													"type": "array",
+													"items": {
+														"type": "number"
+													}
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"columnIndexes"
+											]
+										}
+									}
+								},
+								{
+									"additionalProperties": false,
+									"type": "object",
+									"properties": {
+										"exportWithLabels": {
+											"type": "boolean"
+										},
+										"exportWithTable": {
+											"type": "boolean"
+										},
+										"exportWithTableDisabled": {
+											"type": "boolean"
+										},
+										"type": {
+											"type": "string",
+											"enum": [
+												"range"
+											]
+										},
+										"showRawValue": {
+											"type": "boolean"
+										}
+									},
+									"required": [
+										"type"
+									]
+								}
+							]
+						},
+						"valueType": {
+							"description": "Specify the valueType for formatting of the value in the matrix",
+							"enum": [
+								"boolean",
+								"color",
+								"currency",
+								"fraction",
+								"fractionAndPercentage",
+								"number",
+								"oneDecimalPlace",
+								"percentage",
+								"text",
+								"view"
+							],
+							"type": "string"
+						}
+					},
+					"required": [
+						"name",
+						"type"
+					]
+				},
+				{
+					"description": "A Component viz type simply renders a React component as the viz",
+					"additionalProperties": false,
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						},
+						"description": {
+							"description": "A short description that appears above a viz",
+							"type": "string"
+						},
+						"placeholder": {
+							"description": "A url to an image to be used when a viz is collapsed. Some vizes display small, others display a placeholder.",
+							"type": "string"
+						},
+						"periodGranularity": {
+							"enum": [
+								"day",
+								"month",
+								"one_day_at_a_time",
+								"one_month_at_a_time",
+								"one_quarter_at_a_time",
+								"one_week_at_a_time",
+								"one_year_at_a_time",
+								"quarter",
+								"week",
+								"year"
+							],
+							"type": "string"
+						},
+						"defaultTimePeriod": {
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"offset": {
+											"type": "number"
+										},
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										},
+										"end": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"end",
+										"start"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"description": "ISO Date Time",
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"start"
+									]
+								}
+							]
+						},
+						"datePickerLimits": {
+							"type": "object",
+							"properties": {
+								"start": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								"end": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								}
+							},
+							"additionalProperties": false
+						},
+						"exportConfig": {
+							"description": "Extra config options for exporting"
+						},
+						"noDataMessage": {
+							"description": "Message which shows if no data is found",
+							"type": "string"
+						},
+						"noDataFetch": {
+							"description": "If true, Tupaia will not fetch any data for this viz. Usually used with custom vizes of type: component, e.g. ProjectDescription.",
+							"default": false,
+							"type": "boolean"
+						},
+						"drillDown": {
+							"type": "object",
+							"properties": {
+								"keyLink": {
+									"type": "string"
+								},
+								"itemCode": {
+									"type": "string"
+								},
+								"parameterLink": {
+									"type": "string"
+								},
+								"itemCodeByEntry": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "string"
+									}
+								}
+							},
+							"additionalProperties": false
+						},
+						"entityHeader": {
+							"description": "",
+							"type": "string"
+						},
+						"reference": {
+							"description": "If provided shows an (i) icon next to the viz title, which allows linking to the source data",
+							"type": "object",
+							"properties": {
+								"link": {
+									"description": "url",
+									"type": "string"
+								},
+								"name": {
+									"description": "label",
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"link",
+								"name"
+							]
+						},
+						"source": {
+							"description": "If specified allows the frontend to know where the data is coming from, so if there is no data it can show a custom no-data message e.g. \"Requires mSupply\".",
+							"type": "string"
+						},
+						"displayOnEntityConditions": {
+							"description": "If specified will only show this viz if the conditions are met against the current Entity.",
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"attributes": {
+											"type": "object",
+											"additionalProperties": {
+												"type": [
+													"string",
+													"number",
+													"boolean"
+												]
+											}
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"attributes"
+									]
+								},
+								{
+									"type": "object",
+									"additionalProperties": {
+										"type": [
+											"string",
+											"number",
+											"boolean"
+										]
+									}
+								}
+							]
+						},
+						"weekDisplayFormat": {
+							"description": "Allows customising how weeks are displayed, e.g. 'W/C 6 Jan 2020' or 'ISO Week 2 2020'",
+							"default": "'WEEK_COMMENCING_ABBR'",
+							"enum": [
+								"ISO_WEEK_NUMBER",
+								"WEEK_COMMENCING",
+								"WEEK_COMMENCING_ABBR",
+								"WEEK_ENDING",
+								"WEEK_ENDING_ABBR"
+							],
+							"type": "string"
+						},
+						"type": {
+							"type": "string",
+							"enum": [
+								"component"
+							]
+						},
+						"componentName": {
+							"enum": [
+								"ActiveDisasters",
+								"NoAccessDashboard",
+								"NoDataAtLevelDashboard",
+								"ProjectDescription"
+							],
+							"type": "string"
+						}
+					},
+					"required": [
+						"componentName",
+						"name",
+						"type"
+					]
+				},
+				{
+					"description": "Gauge Chart",
+					"additionalProperties": false,
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						},
+						"description": {
+							"description": "A short description that appears above a viz",
+							"type": "string"
+						},
+						"placeholder": {
+							"description": "A url to an image to be used when a viz is collapsed. Some vizes display small, others display a placeholder.",
+							"type": "string"
+						},
+						"periodGranularity": {
+							"enum": [
+								"day",
+								"month",
+								"one_day_at_a_time",
+								"one_month_at_a_time",
+								"one_quarter_at_a_time",
+								"one_week_at_a_time",
+								"one_year_at_a_time",
+								"quarter",
+								"week",
+								"year"
+							],
+							"type": "string"
+						},
+						"defaultTimePeriod": {
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"offset": {
+											"type": "number"
+										},
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										},
+										"end": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"end",
+										"start"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"description": "ISO Date Time",
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"start"
+									]
+								}
+							]
+						},
+						"datePickerLimits": {
+							"type": "object",
+							"properties": {
+								"start": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								"end": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								}
+							},
+							"additionalProperties": false
+						},
+						"exportConfig": {
+							"description": "Extra config options for exporting"
+						},
+						"noDataMessage": {
+							"description": "Message which shows if no data is found",
+							"type": "string"
+						},
+						"noDataFetch": {
+							"description": "If true, Tupaia will not fetch any data for this viz. Usually used with custom vizes of type: component, e.g. ProjectDescription.",
+							"default": false,
+							"type": "boolean"
+						},
+						"drillDown": {
+							"type": "object",
+							"properties": {
+								"keyLink": {
+									"type": "string"
+								},
+								"itemCode": {
+									"type": "string"
+								},
+								"parameterLink": {
+									"type": "string"
+								},
+								"itemCodeByEntry": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "string"
+									}
+								}
+							},
+							"additionalProperties": false
+						},
+						"entityHeader": {
+							"description": "",
+							"type": "string"
+						},
+						"reference": {
+							"description": "If provided shows an (i) icon next to the viz title, which allows linking to the source data",
+							"type": "object",
+							"properties": {
+								"link": {
+									"description": "url",
+									"type": "string"
+								},
+								"name": {
+									"description": "label",
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"link",
+								"name"
+							]
+						},
+						"source": {
+							"description": "If specified allows the frontend to know where the data is coming from, so if there is no data it can show a custom no-data message e.g. \"Requires mSupply\".",
+							"type": "string"
+						},
+						"displayOnEntityConditions": {
+							"description": "If specified will only show this viz if the conditions are met against the current Entity.",
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"attributes": {
+											"type": "object",
+											"additionalProperties": {
+												"type": [
+													"string",
+													"number",
+													"boolean"
+												]
+											}
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"attributes"
+									]
+								},
+								{
+									"type": "object",
+									"additionalProperties": {
+										"type": [
+											"string",
+											"number",
+											"boolean"
+										]
+									}
+								}
+							]
+						},
+						"weekDisplayFormat": {
+							"description": "Allows customising how weeks are displayed, e.g. 'W/C 6 Jan 2020' or 'ISO Week 2 2020'",
+							"default": "'WEEK_COMMENCING_ABBR'",
+							"enum": [
+								"ISO_WEEK_NUMBER",
+								"WEEK_COMMENCING",
+								"WEEK_COMMENCING_ABBR",
+								"WEEK_ENDING",
+								"WEEK_ENDING_ABBR"
+							],
+							"type": "string"
+						},
+						"ticks": {},
+						"startDate": {
+							"type": "string"
+						},
+						"endDate": {
+							"type": "string"
+						},
+						"valueType": {
+							"enum": [
+								"boolean",
+								"color",
+								"currency",
+								"fraction",
+								"fractionAndPercentage",
+								"number",
+								"oneDecimalPlace",
+								"percentage",
+								"text",
+								"view"
+							],
+							"type": "string"
+						},
+						"showPeriodRange": {
+							"type": "string",
+							"enum": [
+								"all"
+							]
+						},
+						"color": {
+							"description": "Some chart types take 'color' as an option",
+							"type": "string"
+						},
+						"displayOnLevel": {},
+						"label": {},
+						"labelType": {
+							"description": "Some charts can have their label customised",
+							"enum": [
+								"fraction",
+								"fractionAndPercentage",
+								"number"
+							],
+							"type": "string"
+						},
+						"measureLevel": {},
+						"renderLegendForOneItem": {
+							"type": "boolean"
+						},
+						"type": {
+							"type": "string",
+							"enum": [
+								"chart"
+							]
+						},
+						"chartType": {
+							"type": "string",
+							"enum": [
+								"gauge"
+							]
+						}
+					},
+					"required": [
+						"chartType",
+						"name",
+						"type"
+					]
+				},
+				{
+					"description": "A Composed chart is a concept from Recharts, e.g. a line chart layered on top of a bar chart",
+					"additionalProperties": false,
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						},
+						"description": {
+							"description": "A short description that appears above a viz",
+							"type": "string"
+						},
+						"placeholder": {
+							"description": "A url to an image to be used when a viz is collapsed. Some vizes display small, others display a placeholder.",
+							"type": "string"
+						},
+						"periodGranularity": {
+							"enum": [
+								"day",
+								"month",
+								"one_day_at_a_time",
+								"one_month_at_a_time",
+								"one_quarter_at_a_time",
+								"one_week_at_a_time",
+								"one_year_at_a_time",
+								"quarter",
+								"week",
+								"year"
+							],
+							"type": "string"
+						},
+						"defaultTimePeriod": {
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"offset": {
+											"type": "number"
+										},
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										},
+										"end": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"end",
+										"start"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"description": "ISO Date Time",
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"start"
+									]
+								}
+							]
+						},
+						"datePickerLimits": {
+							"type": "object",
+							"properties": {
+								"start": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								"end": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								}
+							},
+							"additionalProperties": false
+						},
+						"exportConfig": {
+							"description": "Extra config options for exporting"
+						},
+						"noDataMessage": {
+							"description": "Message which shows if no data is found",
+							"type": "string"
+						},
+						"noDataFetch": {
+							"description": "If true, Tupaia will not fetch any data for this viz. Usually used with custom vizes of type: component, e.g. ProjectDescription.",
+							"default": false,
+							"type": "boolean"
+						},
+						"drillDown": {
+							"type": "object",
+							"properties": {
+								"keyLink": {
+									"type": "string"
+								},
+								"itemCode": {
+									"type": "string"
+								},
+								"parameterLink": {
+									"type": "string"
+								},
+								"itemCodeByEntry": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "string"
+									}
+								}
+							},
+							"additionalProperties": false
+						},
+						"entityHeader": {
+							"description": "",
+							"type": "string"
+						},
+						"reference": {
+							"description": "If provided shows an (i) icon next to the viz title, which allows linking to the source data",
+							"type": "object",
+							"properties": {
+								"link": {
+									"description": "url",
+									"type": "string"
+								},
+								"name": {
+									"description": "label",
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"link",
+								"name"
+							]
+						},
+						"source": {
+							"description": "If specified allows the frontend to know where the data is coming from, so if there is no data it can show a custom no-data message e.g. \"Requires mSupply\".",
+							"type": "string"
+						},
+						"displayOnEntityConditions": {
+							"description": "If specified will only show this viz if the conditions are met against the current Entity.",
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"attributes": {
+											"type": "object",
+											"additionalProperties": {
+												"type": [
+													"string",
+													"number",
+													"boolean"
+												]
+											}
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"attributes"
+									]
+								},
+								{
+									"type": "object",
+									"additionalProperties": {
+										"type": [
+											"string",
+											"number",
+											"boolean"
+										]
+									}
+								}
+							]
+						},
+						"weekDisplayFormat": {
+							"description": "Allows customising how weeks are displayed, e.g. 'W/C 6 Jan 2020' or 'ISO Week 2 2020'",
+							"default": "'WEEK_COMMENCING_ABBR'",
+							"enum": [
+								"ISO_WEEK_NUMBER",
+								"WEEK_COMMENCING",
+								"WEEK_COMMENCING_ABBR",
+								"WEEK_ENDING",
+								"WEEK_ENDING_ABBR"
+							],
+							"type": "string"
+						},
+						"ticks": {},
+						"startDate": {
+							"type": "string"
+						},
+						"endDate": {
+							"type": "string"
+						},
+						"valueType": {
+							"enum": [
+								"boolean",
+								"color",
+								"currency",
+								"fraction",
+								"fractionAndPercentage",
+								"number",
+								"oneDecimalPlace",
+								"percentage",
+								"text",
+								"view"
+							],
+							"type": "string"
+						},
+						"showPeriodRange": {
+							"type": "string",
+							"enum": [
+								"all"
+							]
+						},
+						"color": {
+							"description": "Some chart types take 'color' as an option",
+							"type": "string"
+						},
+						"displayOnLevel": {},
+						"label": {},
+						"labelType": {
+							"description": "Some charts can have their label customised",
+							"enum": [
+								"fraction",
+								"fractionAndPercentage",
+								"number"
+							],
+							"type": "string"
+						},
+						"measureLevel": {},
+						"renderLegendForOneItem": {
+							"type": "boolean"
+						},
+						"xName": {
+							"description": "The label on the x-axis",
+							"type": "string"
+						},
+						"yName": {
+							"description": "The label on the y-axis",
+							"type": "string"
+						},
+						"yAxisDomain": {
+							"description": "Configuration options for the y-axis",
+							"type": "object",
+							"properties": {
+								"max": {
+									"type": "object",
+									"properties": {
+										"type": {
+											"enum": [
+												"clamp",
+												"number",
+												"scale",
+												"string"
+											],
+											"type": "string"
+										},
+										"value": {
+											"type": [
+												"string",
+												"number"
+											]
+										},
+										"min": {
+											"type": "number"
+										},
+										"max": {
+											"type": "number"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"type"
+									]
+								},
+								"min": {
+									"type": "object",
+									"properties": {
+										"type": {
+											"enum": [
+												"clamp",
+												"number",
+												"scale",
+												"string"
+											],
+											"type": "string"
+										},
+										"value": {
+											"type": [
+												"string",
+												"number"
+											]
+										},
+										"min": {
+											"type": "number"
+										},
+										"max": {
+											"type": "number"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"type"
+									]
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"max",
+								"min"
+							]
+						},
+						"presentationOptions": {},
+						"type": {
+							"type": "string",
+							"enum": [
+								"chart"
+							]
+						},
+						"chartType": {
+							"type": "string",
+							"enum": [
+								"composed"
+							]
+						},
+						"chartConfig": {
+							"type": "object",
+							"additionalProperties": {
+								"type": "object",
+								"properties": {
+									"color": {
+										"type": "string"
+									},
+									"label": {
+										"type": "string"
+									},
+									"stackId": {
+										"type": "number"
+									},
+									"legendOrder": {
+										"type": "number"
+									},
+									"yAxisDomain": {},
+									"valueType": {
+										"enum": [
+											"boolean",
+											"color",
+											"currency",
+											"fraction",
+											"fractionAndPercentage",
+											"number",
+											"oneDecimalPlace",
+											"percentage",
+											"text",
+											"view"
+										],
+										"type": "string"
+									}
+								},
+								"additionalProperties": false
+							}
+						}
+					},
+					"required": [
+						"chartType",
+						"name",
+						"type"
+					]
+				},
+				{
+					"description": "Bar Chart",
+					"additionalProperties": false,
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						},
+						"description": {
+							"description": "A short description that appears above a viz",
+							"type": "string"
+						},
+						"placeholder": {
+							"description": "A url to an image to be used when a viz is collapsed. Some vizes display small, others display a placeholder.",
+							"type": "string"
+						},
+						"periodGranularity": {
+							"enum": [
+								"day",
+								"month",
+								"one_day_at_a_time",
+								"one_month_at_a_time",
+								"one_quarter_at_a_time",
+								"one_week_at_a_time",
+								"one_year_at_a_time",
+								"quarter",
+								"week",
+								"year"
+							],
+							"type": "string"
+						},
+						"defaultTimePeriod": {
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"offset": {
+											"type": "number"
+										},
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										},
+										"end": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"end",
+										"start"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"description": "ISO Date Time",
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"start"
+									]
+								}
+							]
+						},
+						"datePickerLimits": {
+							"type": "object",
+							"properties": {
+								"start": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								"end": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								}
+							},
+							"additionalProperties": false
+						},
+						"exportConfig": {
+							"description": "Extra config options for exporting"
+						},
+						"noDataMessage": {
+							"description": "Message which shows if no data is found",
+							"type": "string"
+						},
+						"noDataFetch": {
+							"description": "If true, Tupaia will not fetch any data for this viz. Usually used with custom vizes of type: component, e.g. ProjectDescription.",
+							"default": false,
+							"type": "boolean"
+						},
+						"drillDown": {
+							"type": "object",
+							"properties": {
+								"keyLink": {
+									"type": "string"
+								},
+								"itemCode": {
+									"type": "string"
+								},
+								"parameterLink": {
+									"type": "string"
+								},
+								"itemCodeByEntry": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "string"
+									}
+								}
+							},
+							"additionalProperties": false
+						},
+						"entityHeader": {
+							"description": "",
+							"type": "string"
+						},
+						"reference": {
+							"description": "If provided shows an (i) icon next to the viz title, which allows linking to the source data",
+							"type": "object",
+							"properties": {
+								"link": {
+									"description": "url",
+									"type": "string"
+								},
+								"name": {
+									"description": "label",
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"link",
+								"name"
+							]
+						},
+						"source": {
+							"description": "If specified allows the frontend to know where the data is coming from, so if there is no data it can show a custom no-data message e.g. \"Requires mSupply\".",
+							"type": "string"
+						},
+						"displayOnEntityConditions": {
+							"description": "If specified will only show this viz if the conditions are met against the current Entity.",
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"attributes": {
+											"type": "object",
+											"additionalProperties": {
+												"type": [
+													"string",
+													"number",
+													"boolean"
+												]
+											}
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"attributes"
+									]
+								},
+								{
+									"type": "object",
+									"additionalProperties": {
+										"type": [
+											"string",
+											"number",
+											"boolean"
+										]
+									}
+								}
+							]
+						},
+						"weekDisplayFormat": {
+							"description": "Allows customising how weeks are displayed, e.g. 'W/C 6 Jan 2020' or 'ISO Week 2 2020'",
+							"default": "'WEEK_COMMENCING_ABBR'",
+							"enum": [
+								"ISO_WEEK_NUMBER",
+								"WEEK_COMMENCING",
+								"WEEK_COMMENCING_ABBR",
+								"WEEK_ENDING",
+								"WEEK_ENDING_ABBR"
+							],
+							"type": "string"
+						},
+						"ticks": {},
+						"startDate": {
+							"type": "string"
+						},
+						"endDate": {
+							"type": "string"
+						},
+						"valueType": {
+							"enum": [
+								"boolean",
+								"color",
+								"currency",
+								"fraction",
+								"fractionAndPercentage",
+								"number",
+								"oneDecimalPlace",
+								"percentage",
+								"text",
+								"view"
+							],
+							"type": "string"
+						},
+						"showPeriodRange": {
+							"type": "string",
+							"enum": [
+								"all"
+							]
+						},
+						"color": {
+							"description": "Some chart types take 'color' as an option",
+							"type": "string"
+						},
+						"displayOnLevel": {},
+						"label": {},
+						"labelType": {
+							"description": "Some charts can have their label customised",
+							"enum": [
+								"fraction",
+								"fractionAndPercentage",
+								"number"
+							],
+							"type": "string"
+						},
+						"measureLevel": {},
+						"renderLegendForOneItem": {
+							"type": "boolean"
+						},
+						"xName": {
+							"description": "The label on the x-axis",
+							"type": "string"
+						},
+						"yName": {
+							"description": "The label on the y-axis",
+							"type": "string"
+						},
+						"yAxisDomain": {
+							"description": "Configuration options for the y-axis",
+							"type": "object",
+							"properties": {
+								"max": {
+									"type": "object",
+									"properties": {
+										"type": {
+											"enum": [
+												"clamp",
+												"number",
+												"scale",
+												"string"
+											],
+											"type": "string"
+										},
+										"value": {
+											"type": [
+												"string",
+												"number"
+											]
+										},
+										"min": {
+											"type": "number"
+										},
+										"max": {
+											"type": "number"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"type"
+									]
+								},
+								"min": {
+									"type": "object",
+									"properties": {
+										"type": {
+											"enum": [
+												"clamp",
+												"number",
+												"scale",
+												"string"
+											],
+											"type": "string"
+										},
+										"value": {
+											"type": [
+												"string",
+												"number"
+											]
+										},
+										"min": {
+											"type": "number"
+										},
+										"max": {
+											"type": "number"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"type"
+									]
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"max",
+								"min"
+							]
+						},
+						"presentationOptions": {},
+						"type": {
+							"type": "string",
+							"enum": [
+								"chart"
+							]
+						},
+						"chartType": {
+							"type": "string",
+							"enum": [
+								"bar"
+							]
+						},
+						"chartConfig": {
+							"type": "object",
+							"additionalProperties": {
+								"type": "object",
+								"properties": {
+									"color": {
+										"type": "string"
+									},
+									"label": {
+										"type": "string"
+									},
+									"stackId": {
+										"type": "number"
+									},
+									"legendOrder": {
+										"type": "number"
+									},
+									"yAxisDomain": {},
+									"valueType": {
+										"enum": [
+											"boolean",
+											"color",
+											"currency",
+											"fraction",
+											"fractionAndPercentage",
+											"number",
+											"oneDecimalPlace",
+											"percentage",
+											"text",
+											"view"
+										],
+										"type": "string"
+									}
+								},
+								"additionalProperties": false
+							}
+						}
+					},
+					"required": [
+						"chartType",
+						"name",
+						"type"
+					]
+				},
+				{
+					"description": "Pie Chart",
+					"additionalProperties": false,
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						},
+						"description": {
+							"description": "A short description that appears above a viz",
+							"type": "string"
+						},
+						"placeholder": {
+							"description": "A url to an image to be used when a viz is collapsed. Some vizes display small, others display a placeholder.",
+							"type": "string"
+						},
+						"periodGranularity": {
+							"enum": [
+								"day",
+								"month",
+								"one_day_at_a_time",
+								"one_month_at_a_time",
+								"one_quarter_at_a_time",
+								"one_week_at_a_time",
+								"one_year_at_a_time",
+								"quarter",
+								"week",
+								"year"
+							],
+							"type": "string"
+						},
+						"defaultTimePeriod": {
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"offset": {
+											"type": "number"
+										},
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										},
+										"end": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"end",
+										"start"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"description": "ISO Date Time",
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"start"
+									]
+								}
+							]
+						},
+						"datePickerLimits": {
+							"type": "object",
+							"properties": {
+								"start": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								"end": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								}
+							},
+							"additionalProperties": false
+						},
+						"exportConfig": {
+							"description": "Extra config options for exporting"
+						},
+						"noDataMessage": {
+							"description": "Message which shows if no data is found",
+							"type": "string"
+						},
+						"noDataFetch": {
+							"description": "If true, Tupaia will not fetch any data for this viz. Usually used with custom vizes of type: component, e.g. ProjectDescription.",
+							"default": false,
+							"type": "boolean"
+						},
+						"drillDown": {
+							"type": "object",
+							"properties": {
+								"keyLink": {
+									"type": "string"
+								},
+								"itemCode": {
+									"type": "string"
+								},
+								"parameterLink": {
+									"type": "string"
+								},
+								"itemCodeByEntry": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "string"
+									}
+								}
+							},
+							"additionalProperties": false
+						},
+						"entityHeader": {
+							"description": "",
+							"type": "string"
+						},
+						"reference": {
+							"description": "If provided shows an (i) icon next to the viz title, which allows linking to the source data",
+							"type": "object",
+							"properties": {
+								"link": {
+									"description": "url",
+									"type": "string"
+								},
+								"name": {
+									"description": "label",
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"link",
+								"name"
+							]
+						},
+						"source": {
+							"description": "If specified allows the frontend to know where the data is coming from, so if there is no data it can show a custom no-data message e.g. \"Requires mSupply\".",
+							"type": "string"
+						},
+						"displayOnEntityConditions": {
+							"description": "If specified will only show this viz if the conditions are met against the current Entity.",
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"attributes": {
+											"type": "object",
+											"additionalProperties": {
+												"type": [
+													"string",
+													"number",
+													"boolean"
+												]
+											}
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"attributes"
+									]
+								},
+								{
+									"type": "object",
+									"additionalProperties": {
+										"type": [
+											"string",
+											"number",
+											"boolean"
+										]
+									}
+								}
+							]
+						},
+						"weekDisplayFormat": {
+							"description": "Allows customising how weeks are displayed, e.g. 'W/C 6 Jan 2020' or 'ISO Week 2 2020'",
+							"default": "'WEEK_COMMENCING_ABBR'",
+							"enum": [
+								"ISO_WEEK_NUMBER",
+								"WEEK_COMMENCING",
+								"WEEK_COMMENCING_ABBR",
+								"WEEK_ENDING",
+								"WEEK_ENDING_ABBR"
+							],
+							"type": "string"
+						},
+						"ticks": {},
+						"startDate": {
+							"type": "string"
+						},
+						"endDate": {
+							"type": "string"
+						},
+						"valueType": {
+							"enum": [
+								"boolean",
+								"color",
+								"currency",
+								"fraction",
+								"fractionAndPercentage",
+								"number",
+								"oneDecimalPlace",
+								"percentage",
+								"text",
+								"view"
+							],
+							"type": "string"
+						},
+						"showPeriodRange": {
+							"type": "string",
+							"enum": [
+								"all"
+							]
+						},
+						"color": {
+							"description": "Some chart types take 'color' as an option",
+							"type": "string"
+						},
+						"displayOnLevel": {},
+						"label": {},
+						"labelType": {
+							"description": "Some charts can have their label customised",
+							"enum": [
+								"fraction",
+								"fractionAndPercentage",
+								"number"
+							],
+							"type": "string"
+						},
+						"measureLevel": {},
+						"renderLegendForOneItem": {
+							"type": "boolean"
+						},
+						"type": {
+							"type": "string",
+							"enum": [
+								"chart"
+							]
+						},
+						"chartType": {
+							"type": "string",
+							"enum": [
+								"pie"
+							]
+						},
+						"presentationOptions": {
+							"additionalProperties": false,
+							"type": "object",
+							"properties": {
+								"exportWithLabels": {
+									"type": "boolean"
+								},
+								"exportWithTable": {
+									"type": "boolean"
+								},
+								"exportWithTableDisabled": {
+									"type": "boolean"
+								}
+							}
+						}
+					},
+					"required": [
+						"chartType",
+						"name",
+						"type"
+					]
+				},
+				{
+					"description": "Line Chart",
+					"additionalProperties": false,
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						},
+						"description": {
+							"description": "A short description that appears above a viz",
+							"type": "string"
+						},
+						"placeholder": {
+							"description": "A url to an image to be used when a viz is collapsed. Some vizes display small, others display a placeholder.",
+							"type": "string"
+						},
+						"periodGranularity": {
+							"enum": [
+								"day",
+								"month",
+								"one_day_at_a_time",
+								"one_month_at_a_time",
+								"one_quarter_at_a_time",
+								"one_week_at_a_time",
+								"one_year_at_a_time",
+								"quarter",
+								"week",
+								"year"
+							],
+							"type": "string"
+						},
+						"defaultTimePeriod": {
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"offset": {
+											"type": "number"
+										},
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										},
+										"end": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"end",
+										"start"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"description": "ISO Date Time",
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"start"
+									]
+								}
+							]
+						},
+						"datePickerLimits": {
+							"type": "object",
+							"properties": {
+								"start": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								"end": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								}
+							},
+							"additionalProperties": false
+						},
+						"exportConfig": {
+							"description": "Extra config options for exporting"
+						},
+						"noDataMessage": {
+							"description": "Message which shows if no data is found",
+							"type": "string"
+						},
+						"noDataFetch": {
+							"description": "If true, Tupaia will not fetch any data for this viz. Usually used with custom vizes of type: component, e.g. ProjectDescription.",
+							"default": false,
+							"type": "boolean"
+						},
+						"drillDown": {
+							"type": "object",
+							"properties": {
+								"keyLink": {
+									"type": "string"
+								},
+								"itemCode": {
+									"type": "string"
+								},
+								"parameterLink": {
+									"type": "string"
+								},
+								"itemCodeByEntry": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "string"
+									}
+								}
+							},
+							"additionalProperties": false
+						},
+						"entityHeader": {
+							"description": "",
+							"type": "string"
+						},
+						"reference": {
+							"description": "If provided shows an (i) icon next to the viz title, which allows linking to the source data",
+							"type": "object",
+							"properties": {
+								"link": {
+									"description": "url",
+									"type": "string"
+								},
+								"name": {
+									"description": "label",
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"link",
+								"name"
+							]
+						},
+						"source": {
+							"description": "If specified allows the frontend to know where the data is coming from, so if there is no data it can show a custom no-data message e.g. \"Requires mSupply\".",
+							"type": "string"
+						},
+						"displayOnEntityConditions": {
+							"description": "If specified will only show this viz if the conditions are met against the current Entity.",
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"attributes": {
+											"type": "object",
+											"additionalProperties": {
+												"type": [
+													"string",
+													"number",
+													"boolean"
+												]
+											}
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"attributes"
+									]
+								},
+								{
+									"type": "object",
+									"additionalProperties": {
+										"type": [
+											"string",
+											"number",
+											"boolean"
+										]
+									}
+								}
+							]
+						},
+						"weekDisplayFormat": {
+							"description": "Allows customising how weeks are displayed, e.g. 'W/C 6 Jan 2020' or 'ISO Week 2 2020'",
+							"default": "'WEEK_COMMENCING_ABBR'",
+							"enum": [
+								"ISO_WEEK_NUMBER",
+								"WEEK_COMMENCING",
+								"WEEK_COMMENCING_ABBR",
+								"WEEK_ENDING",
+								"WEEK_ENDING_ABBR"
+							],
+							"type": "string"
+						},
+						"ticks": {},
+						"startDate": {
+							"type": "string"
+						},
+						"endDate": {
+							"type": "string"
+						},
+						"valueType": {
+							"enum": [
+								"boolean",
+								"color",
+								"currency",
+								"fraction",
+								"fractionAndPercentage",
+								"number",
+								"oneDecimalPlace",
+								"percentage",
+								"text",
+								"view"
+							],
+							"type": "string"
+						},
+						"showPeriodRange": {
+							"type": "string",
+							"enum": [
+								"all"
+							]
+						},
+						"color": {
+							"description": "Some chart types take 'color' as an option",
+							"type": "string"
+						},
+						"displayOnLevel": {},
+						"label": {},
+						"labelType": {
+							"description": "Some charts can have their label customised",
+							"enum": [
+								"fraction",
+								"fractionAndPercentage",
+								"number"
+							],
+							"type": "string"
+						},
+						"measureLevel": {},
+						"renderLegendForOneItem": {
+							"type": "boolean"
+						},
+						"xName": {
+							"description": "The label on the x-axis",
+							"type": "string"
+						},
+						"yName": {
+							"description": "The label on the y-axis",
+							"type": "string"
+						},
+						"yAxisDomain": {
+							"description": "Configuration options for the y-axis",
+							"type": "object",
+							"properties": {
+								"max": {
+									"type": "object",
+									"properties": {
+										"type": {
+											"enum": [
+												"clamp",
+												"number",
+												"scale",
+												"string"
+											],
+											"type": "string"
+										},
+										"value": {
+											"type": [
+												"string",
+												"number"
+											]
+										},
+										"min": {
+											"type": "number"
+										},
+										"max": {
+											"type": "number"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"type"
+									]
+								},
+								"min": {
+									"type": "object",
+									"properties": {
+										"type": {
+											"enum": [
+												"clamp",
+												"number",
+												"scale",
+												"string"
+											],
+											"type": "string"
+										},
+										"value": {
+											"type": [
+												"string",
+												"number"
+											]
+										},
+										"min": {
+											"type": "number"
+										},
+										"max": {
+											"type": "number"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"type"
+									]
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"max",
+								"min"
+							]
+						},
+						"presentationOptions": {},
+						"type": {
+							"type": "string",
+							"enum": [
+								"chart"
+							]
+						},
+						"chartType": {
+							"type": "string",
+							"enum": [
+								"line"
+							]
+						},
+						"chartConfig": {
+							"type": "object",
+							"additionalProperties": {
+								"type": "object",
+								"properties": {
+									"color": {
+										"type": "string"
+									},
+									"label": {
+										"type": "string"
+									},
+									"stackId": {
+										"type": "number"
+									},
+									"legendOrder": {
+										"type": "number"
+									},
+									"yAxisDomain": {},
+									"valueType": {
+										"enum": [
+											"boolean",
+											"color",
+											"currency",
+											"fraction",
+											"fractionAndPercentage",
+											"number",
+											"oneDecimalPlace",
+											"percentage",
+											"text",
+											"view"
+										],
+										"type": "string"
+									}
+								},
+								"additionalProperties": false
+							}
+						}
+					},
+					"required": [
+						"chartType",
+						"name",
+						"type"
+					]
+				},
+				{
+					"additionalProperties": false,
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						},
+						"description": {
+							"description": "A short description that appears above a viz",
+							"type": "string"
+						},
+						"placeholder": {
+							"description": "A url to an image to be used when a viz is collapsed. Some vizes display small, others display a placeholder.",
+							"type": "string"
+						},
+						"periodGranularity": {
+							"enum": [
+								"day",
+								"month",
+								"one_day_at_a_time",
+								"one_month_at_a_time",
+								"one_quarter_at_a_time",
+								"one_week_at_a_time",
+								"one_year_at_a_time",
+								"quarter",
+								"week",
+								"year"
+							],
+							"type": "string"
+						},
+						"defaultTimePeriod": {
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"offset": {
+											"type": "number"
+										},
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										},
+										"end": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"end",
+										"start"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"description": "ISO Date Time",
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"start"
+									]
+								}
+							]
+						},
+						"datePickerLimits": {
+							"type": "object",
+							"properties": {
+								"start": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								"end": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								}
+							},
+							"additionalProperties": false
+						},
+						"exportConfig": {
+							"description": "Extra config options for exporting"
+						},
+						"noDataMessage": {
+							"description": "Message which shows if no data is found",
+							"type": "string"
+						},
+						"noDataFetch": {
+							"description": "If true, Tupaia will not fetch any data for this viz. Usually used with custom vizes of type: component, e.g. ProjectDescription.",
+							"default": false,
+							"type": "boolean"
+						},
+						"drillDown": {
+							"type": "object",
+							"properties": {
+								"keyLink": {
+									"type": "string"
+								},
+								"itemCode": {
+									"type": "string"
+								},
+								"parameterLink": {
+									"type": "string"
+								},
+								"itemCodeByEntry": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "string"
+									}
+								}
+							},
+							"additionalProperties": false
+						},
+						"entityHeader": {
+							"description": "",
+							"type": "string"
+						},
+						"reference": {
+							"description": "If provided shows an (i) icon next to the viz title, which allows linking to the source data",
+							"type": "object",
+							"properties": {
+								"link": {
+									"description": "url",
+									"type": "string"
+								},
+								"name": {
+									"description": "label",
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"link",
+								"name"
+							]
+						},
+						"source": {
+							"description": "If specified allows the frontend to know where the data is coming from, so if there is no data it can show a custom no-data message e.g. \"Requires mSupply\".",
+							"type": "string"
+						},
+						"displayOnEntityConditions": {
+							"description": "If specified will only show this viz if the conditions are met against the current Entity.",
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"attributes": {
+											"type": "object",
+											"additionalProperties": {
+												"type": [
+													"string",
+													"number",
+													"boolean"
+												]
+											}
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"attributes"
+									]
+								},
+								{
+									"type": "object",
+									"additionalProperties": {
+										"type": [
+											"string",
+											"number",
+											"boolean"
+										]
+									}
+								}
+							]
+						},
+						"weekDisplayFormat": {
+							"description": "Allows customising how weeks are displayed, e.g. 'W/C 6 Jan 2020' or 'ISO Week 2 2020'",
+							"default": "'WEEK_COMMENCING_ABBR'",
+							"enum": [
+								"ISO_WEEK_NUMBER",
+								"WEEK_COMMENCING",
+								"WEEK_COMMENCING_ABBR",
+								"WEEK_ENDING",
+								"WEEK_ENDING_ABBR"
+							],
+							"type": "string"
+						},
+						"type": {
+							"type": "string",
+							"enum": [
+								"view"
+							]
+						},
+						"valueType": {
+							"enum": [
+								"boolean",
+								"color",
+								"currency",
+								"fraction",
+								"fractionAndPercentage",
+								"number",
+								"oneDecimalPlace",
+								"percentage",
+								"text",
+								"view"
+							],
+							"type": "string"
+						},
+						"value_metadata": {
+							"type": "object",
+							"additionalProperties": false
+						},
+						"viewType": {
+							"type": "string",
+							"enum": [
+								"list"
+							]
+						},
+						"listConfig": {
+							"type": "object",
+							"additionalProperties": {
+								"type": "object",
+								"properties": {
+									"color": {
+										"type": "string"
+									},
+									"label": {
+										"type": "string"
+									}
+								},
+								"additionalProperties": false,
+								"required": [
+									"color",
+									"label"
+								]
+							}
+						},
+						"valueTranslationOptions": {
+							"description": "If provided, performs a find and replace on list item content",
+							"type": "object",
+							"properties": {
+								"match": {
+									"type": "string"
+								},
+								"replace": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"match",
+								"replace"
+							]
+						}
+					},
+					"required": [
+						"listConfig",
+						"name",
+						"type",
+						"viewType"
+					]
+				},
+				{
+					"additionalProperties": false,
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						},
+						"description": {
+							"description": "A short description that appears above a viz",
+							"type": "string"
+						},
+						"placeholder": {
+							"description": "A url to an image to be used when a viz is collapsed. Some vizes display small, others display a placeholder.",
+							"type": "string"
+						},
+						"periodGranularity": {
+							"enum": [
+								"day",
+								"month",
+								"one_day_at_a_time",
+								"one_month_at_a_time",
+								"one_quarter_at_a_time",
+								"one_week_at_a_time",
+								"one_year_at_a_time",
+								"quarter",
+								"week",
+								"year"
+							],
+							"type": "string"
+						},
+						"defaultTimePeriod": {
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"offset": {
+											"type": "number"
+										},
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										},
+										"end": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"end",
+										"start"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"description": "ISO Date Time",
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"start"
+									]
+								}
+							]
+						},
+						"datePickerLimits": {
+							"type": "object",
+							"properties": {
+								"start": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								"end": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								}
+							},
+							"additionalProperties": false
+						},
+						"exportConfig": {
+							"description": "Extra config options for exporting"
+						},
+						"noDataMessage": {
+							"description": "Message which shows if no data is found",
+							"type": "string"
+						},
+						"noDataFetch": {
+							"description": "If true, Tupaia will not fetch any data for this viz. Usually used with custom vizes of type: component, e.g. ProjectDescription.",
+							"default": false,
+							"type": "boolean"
+						},
+						"drillDown": {
+							"type": "object",
+							"properties": {
+								"keyLink": {
+									"type": "string"
+								},
+								"itemCode": {
+									"type": "string"
+								},
+								"parameterLink": {
+									"type": "string"
+								},
+								"itemCodeByEntry": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "string"
+									}
+								}
+							},
+							"additionalProperties": false
+						},
+						"entityHeader": {
+							"description": "",
+							"type": "string"
+						},
+						"reference": {
+							"description": "If provided shows an (i) icon next to the viz title, which allows linking to the source data",
+							"type": "object",
+							"properties": {
+								"link": {
+									"description": "url",
+									"type": "string"
+								},
+								"name": {
+									"description": "label",
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"link",
+								"name"
+							]
+						},
+						"source": {
+							"description": "If specified allows the frontend to know where the data is coming from, so if there is no data it can show a custom no-data message e.g. \"Requires mSupply\".",
+							"type": "string"
+						},
+						"displayOnEntityConditions": {
+							"description": "If specified will only show this viz if the conditions are met against the current Entity.",
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"attributes": {
+											"type": "object",
+											"additionalProperties": {
+												"type": [
+													"string",
+													"number",
+													"boolean"
+												]
+											}
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"attributes"
+									]
+								},
+								{
+									"type": "object",
+									"additionalProperties": {
+										"type": [
+											"string",
+											"number",
+											"boolean"
+										]
+									}
+								}
+							]
+						},
+						"weekDisplayFormat": {
+							"description": "Allows customising how weeks are displayed, e.g. 'W/C 6 Jan 2020' or 'ISO Week 2 2020'",
+							"default": "'WEEK_COMMENCING_ABBR'",
+							"enum": [
+								"ISO_WEEK_NUMBER",
+								"WEEK_COMMENCING",
+								"WEEK_COMMENCING_ABBR",
+								"WEEK_ENDING",
+								"WEEK_ENDING_ABBR"
+							],
+							"type": "string"
+						},
+						"type": {
+							"type": "string",
+							"enum": [
+								"view"
+							]
+						},
+						"valueType": {
+							"enum": [
+								"boolean",
+								"color",
+								"currency",
+								"fraction",
+								"fractionAndPercentage",
+								"number",
+								"oneDecimalPlace",
+								"percentage",
+								"text",
+								"view"
+							],
+							"type": "string"
+						},
+						"value_metadata": {
+							"type": "object",
+							"additionalProperties": false
+						},
+						"viewType": {
+							"type": "string",
+							"enum": [
+								"singleValue"
+							]
+						},
+						"dataColor": {
+							"type": "string"
+						}
+					},
+					"required": [
+						"dataColor",
+						"name",
+						"type",
+						"viewType"
+					]
+				},
+				{
+					"additionalProperties": false,
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						},
+						"description": {
+							"description": "A short description that appears above a viz",
+							"type": "string"
+						},
+						"placeholder": {
+							"description": "A url to an image to be used when a viz is collapsed. Some vizes display small, others display a placeholder.",
+							"type": "string"
+						},
+						"periodGranularity": {
+							"enum": [
+								"day",
+								"month",
+								"one_day_at_a_time",
+								"one_month_at_a_time",
+								"one_quarter_at_a_time",
+								"one_week_at_a_time",
+								"one_year_at_a_time",
+								"quarter",
+								"week",
+								"year"
+							],
+							"type": "string"
+						},
+						"defaultTimePeriod": {
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"offset": {
+											"type": "number"
+										},
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										},
+										"end": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"end",
+										"start"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"description": "ISO Date Time",
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"start"
+									]
+								}
+							]
+						},
+						"datePickerLimits": {
+							"type": "object",
+							"properties": {
+								"start": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								"end": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								}
+							},
+							"additionalProperties": false
+						},
+						"exportConfig": {
+							"description": "Extra config options for exporting"
+						},
+						"noDataMessage": {
+							"description": "Message which shows if no data is found",
+							"type": "string"
+						},
+						"noDataFetch": {
+							"description": "If true, Tupaia will not fetch any data for this viz. Usually used with custom vizes of type: component, e.g. ProjectDescription.",
+							"default": false,
+							"type": "boolean"
+						},
+						"drillDown": {
+							"type": "object",
+							"properties": {
+								"keyLink": {
+									"type": "string"
+								},
+								"itemCode": {
+									"type": "string"
+								},
+								"parameterLink": {
+									"type": "string"
+								},
+								"itemCodeByEntry": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "string"
+									}
+								}
+							},
+							"additionalProperties": false
+						},
+						"entityHeader": {
+							"description": "",
+							"type": "string"
+						},
+						"reference": {
+							"description": "If provided shows an (i) icon next to the viz title, which allows linking to the source data",
+							"type": "object",
+							"properties": {
+								"link": {
+									"description": "url",
+									"type": "string"
+								},
+								"name": {
+									"description": "label",
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"link",
+								"name"
+							]
+						},
+						"source": {
+							"description": "If specified allows the frontend to know where the data is coming from, so if there is no data it can show a custom no-data message e.g. \"Requires mSupply\".",
+							"type": "string"
+						},
+						"displayOnEntityConditions": {
+							"description": "If specified will only show this viz if the conditions are met against the current Entity.",
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"attributes": {
+											"type": "object",
+											"additionalProperties": {
+												"type": [
+													"string",
+													"number",
+													"boolean"
+												]
+											}
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"attributes"
+									]
+								},
+								{
+									"type": "object",
+									"additionalProperties": {
+										"type": [
+											"string",
+											"number",
+											"boolean"
+										]
+									}
+								}
+							]
+						},
+						"weekDisplayFormat": {
+							"description": "Allows customising how weeks are displayed, e.g. 'W/C 6 Jan 2020' or 'ISO Week 2 2020'",
+							"default": "'WEEK_COMMENCING_ABBR'",
+							"enum": [
+								"ISO_WEEK_NUMBER",
+								"WEEK_COMMENCING",
+								"WEEK_COMMENCING_ABBR",
+								"WEEK_ENDING",
+								"WEEK_ENDING_ABBR"
+							],
+							"type": "string"
+						},
+						"type": {
+							"type": "string",
+							"enum": [
+								"view"
+							]
+						},
+						"valueType": {
+							"enum": [
+								"boolean",
+								"color",
+								"currency",
+								"fraction",
+								"fractionAndPercentage",
+								"number",
+								"oneDecimalPlace",
+								"percentage",
+								"text",
+								"view"
+							],
+							"type": "string"
+						},
+						"value_metadata": {
+							"type": "object",
+							"additionalProperties": false
+						},
+						"viewType": {
+							"type": "string",
+							"enum": [
+								"multiPhotograph"
+							]
+						}
+					},
+					"required": [
+						"name",
+						"type",
+						"viewType"
+					]
+				},
+				{
+					"additionalProperties": false,
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						},
+						"description": {
+							"description": "A short description that appears above a viz",
+							"type": "string"
+						},
+						"placeholder": {
+							"description": "A url to an image to be used when a viz is collapsed. Some vizes display small, others display a placeholder.",
+							"type": "string"
+						},
+						"periodGranularity": {
+							"enum": [
+								"day",
+								"month",
+								"one_day_at_a_time",
+								"one_month_at_a_time",
+								"one_quarter_at_a_time",
+								"one_week_at_a_time",
+								"one_year_at_a_time",
+								"quarter",
+								"week",
+								"year"
+							],
+							"type": "string"
+						},
+						"defaultTimePeriod": {
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"offset": {
+											"type": "number"
+										},
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										},
+										"end": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"end",
+										"start"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"description": "ISO Date Time",
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"start"
+									]
+								}
+							]
+						},
+						"datePickerLimits": {
+							"type": "object",
+							"properties": {
+								"start": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								"end": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								}
+							},
+							"additionalProperties": false
+						},
+						"exportConfig": {
+							"description": "Extra config options for exporting"
+						},
+						"noDataMessage": {
+							"description": "Message which shows if no data is found",
+							"type": "string"
+						},
+						"noDataFetch": {
+							"description": "If true, Tupaia will not fetch any data for this viz. Usually used with custom vizes of type: component, e.g. ProjectDescription.",
+							"default": false,
+							"type": "boolean"
+						},
+						"drillDown": {
+							"type": "object",
+							"properties": {
+								"keyLink": {
+									"type": "string"
+								},
+								"itemCode": {
+									"type": "string"
+								},
+								"parameterLink": {
+									"type": "string"
+								},
+								"itemCodeByEntry": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "string"
+									}
+								}
+							},
+							"additionalProperties": false
+						},
+						"entityHeader": {
+							"description": "",
+							"type": "string"
+						},
+						"reference": {
+							"description": "If provided shows an (i) icon next to the viz title, which allows linking to the source data",
+							"type": "object",
+							"properties": {
+								"link": {
+									"description": "url",
+									"type": "string"
+								},
+								"name": {
+									"description": "label",
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"link",
+								"name"
+							]
+						},
+						"source": {
+							"description": "If specified allows the frontend to know where the data is coming from, so if there is no data it can show a custom no-data message e.g. \"Requires mSupply\".",
+							"type": "string"
+						},
+						"displayOnEntityConditions": {
+							"description": "If specified will only show this viz if the conditions are met against the current Entity.",
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"attributes": {
+											"type": "object",
+											"additionalProperties": {
+												"type": [
+													"string",
+													"number",
+													"boolean"
+												]
+											}
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"attributes"
+									]
+								},
+								{
+									"type": "object",
+									"additionalProperties": {
+										"type": [
+											"string",
+											"number",
+											"boolean"
+										]
+									}
+								}
+							]
+						},
+						"weekDisplayFormat": {
+							"description": "Allows customising how weeks are displayed, e.g. 'W/C 6 Jan 2020' or 'ISO Week 2 2020'",
+							"default": "'WEEK_COMMENCING_ABBR'",
+							"enum": [
+								"ISO_WEEK_NUMBER",
+								"WEEK_COMMENCING",
+								"WEEK_COMMENCING_ABBR",
+								"WEEK_ENDING",
+								"WEEK_ENDING_ABBR"
+							],
+							"type": "string"
+						},
+						"type": {
+							"type": "string",
+							"enum": [
+								"view"
+							]
+						},
+						"valueType": {
+							"enum": [
+								"boolean",
+								"color",
+								"currency",
+								"fraction",
+								"fractionAndPercentage",
+								"number",
+								"oneDecimalPlace",
+								"percentage",
+								"text",
+								"view"
+							],
+							"type": "string"
+						},
+						"value_metadata": {
+							"type": "object",
+							"additionalProperties": false
+						},
+						"viewType": {
+							"type": "string",
+							"enum": [
+								"multiSingleValue"
+							]
+						}
+					},
+					"required": [
+						"name",
+						"type",
+						"viewType"
+					]
+				},
+				{
+					"additionalProperties": false,
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						},
+						"description": {
+							"description": "A short description that appears above a viz",
+							"type": "string"
+						},
+						"placeholder": {
+							"description": "A url to an image to be used when a viz is collapsed. Some vizes display small, others display a placeholder.",
+							"type": "string"
+						},
+						"periodGranularity": {
+							"enum": [
+								"day",
+								"month",
+								"one_day_at_a_time",
+								"one_month_at_a_time",
+								"one_quarter_at_a_time",
+								"one_week_at_a_time",
+								"one_year_at_a_time",
+								"quarter",
+								"week",
+								"year"
+							],
+							"type": "string"
+						},
+						"defaultTimePeriod": {
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"offset": {
+											"type": "number"
+										},
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										},
+										"end": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"end",
+										"start"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"description": "ISO Date Time",
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"start"
+									]
+								}
+							]
+						},
+						"datePickerLimits": {
+							"type": "object",
+							"properties": {
+								"start": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								"end": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								}
+							},
+							"additionalProperties": false
+						},
+						"exportConfig": {
+							"description": "Extra config options for exporting"
+						},
+						"noDataMessage": {
+							"description": "Message which shows if no data is found",
+							"type": "string"
+						},
+						"noDataFetch": {
+							"description": "If true, Tupaia will not fetch any data for this viz. Usually used with custom vizes of type: component, e.g. ProjectDescription.",
+							"default": false,
+							"type": "boolean"
+						},
+						"drillDown": {
+							"type": "object",
+							"properties": {
+								"keyLink": {
+									"type": "string"
+								},
+								"itemCode": {
+									"type": "string"
+								},
+								"parameterLink": {
+									"type": "string"
+								},
+								"itemCodeByEntry": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "string"
+									}
+								}
+							},
+							"additionalProperties": false
+						},
+						"entityHeader": {
+							"description": "",
+							"type": "string"
+						},
+						"reference": {
+							"description": "If provided shows an (i) icon next to the viz title, which allows linking to the source data",
+							"type": "object",
+							"properties": {
+								"link": {
+									"description": "url",
+									"type": "string"
+								},
+								"name": {
+									"description": "label",
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"link",
+								"name"
+							]
+						},
+						"source": {
+							"description": "If specified allows the frontend to know where the data is coming from, so if there is no data it can show a custom no-data message e.g. \"Requires mSupply\".",
+							"type": "string"
+						},
+						"displayOnEntityConditions": {
+							"description": "If specified will only show this viz if the conditions are met against the current Entity.",
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"attributes": {
+											"type": "object",
+											"additionalProperties": {
+												"type": [
+													"string",
+													"number",
+													"boolean"
+												]
+											}
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"attributes"
+									]
+								},
+								{
+									"type": "object",
+									"additionalProperties": {
+										"type": [
+											"string",
+											"number",
+											"boolean"
+										]
+									}
+								}
+							]
+						},
+						"weekDisplayFormat": {
+							"description": "Allows customising how weeks are displayed, e.g. 'W/C 6 Jan 2020' or 'ISO Week 2 2020'",
+							"default": "'WEEK_COMMENCING_ABBR'",
+							"enum": [
+								"ISO_WEEK_NUMBER",
+								"WEEK_COMMENCING",
+								"WEEK_COMMENCING_ABBR",
+								"WEEK_ENDING",
+								"WEEK_ENDING_ABBR"
+							],
+							"type": "string"
+						},
+						"type": {
+							"type": "string",
+							"enum": [
+								"view"
+							]
+						},
+						"valueType": {
+							"enum": [
+								"boolean",
+								"color",
+								"currency",
+								"fraction",
+								"fractionAndPercentage",
+								"number",
+								"oneDecimalPlace",
+								"percentage",
+								"text",
+								"view"
+							],
+							"type": "string"
+						},
+						"value_metadata": {
+							"type": "object",
+							"additionalProperties": false
+						},
+						"viewType": {
+							"type": "string",
+							"enum": [
+								"singleDownloadLink"
+							]
+						}
+					},
+					"required": [
+						"name",
+						"type",
+						"viewType"
+					]
+				},
+				{
+					"additionalProperties": false,
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						},
+						"description": {
+							"description": "A short description that appears above a viz",
+							"type": "string"
+						},
+						"placeholder": {
+							"description": "A url to an image to be used when a viz is collapsed. Some vizes display small, others display a placeholder.",
+							"type": "string"
+						},
+						"periodGranularity": {
+							"enum": [
+								"day",
+								"month",
+								"one_day_at_a_time",
+								"one_month_at_a_time",
+								"one_quarter_at_a_time",
+								"one_week_at_a_time",
+								"one_year_at_a_time",
+								"quarter",
+								"week",
+								"year"
+							],
+							"type": "string"
+						},
+						"defaultTimePeriod": {
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"offset": {
+											"type": "number"
+										},
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										},
+										"end": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"end",
+										"start"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"description": "ISO Date Time",
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"start"
+									]
+								}
+							]
+						},
+						"datePickerLimits": {
+							"type": "object",
+							"properties": {
+								"start": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								"end": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								}
+							},
+							"additionalProperties": false
+						},
+						"exportConfig": {
+							"description": "Extra config options for exporting"
+						},
+						"noDataMessage": {
+							"description": "Message which shows if no data is found",
+							"type": "string"
+						},
+						"noDataFetch": {
+							"description": "If true, Tupaia will not fetch any data for this viz. Usually used with custom vizes of type: component, e.g. ProjectDescription.",
+							"default": false,
+							"type": "boolean"
+						},
+						"drillDown": {
+							"type": "object",
+							"properties": {
+								"keyLink": {
+									"type": "string"
+								},
+								"itemCode": {
+									"type": "string"
+								},
+								"parameterLink": {
+									"type": "string"
+								},
+								"itemCodeByEntry": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "string"
+									}
+								}
+							},
+							"additionalProperties": false
+						},
+						"entityHeader": {
+							"description": "",
+							"type": "string"
+						},
+						"reference": {
+							"description": "If provided shows an (i) icon next to the viz title, which allows linking to the source data",
+							"type": "object",
+							"properties": {
+								"link": {
+									"description": "url",
+									"type": "string"
+								},
+								"name": {
+									"description": "label",
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"link",
+								"name"
+							]
+						},
+						"source": {
+							"description": "If specified allows the frontend to know where the data is coming from, so if there is no data it can show a custom no-data message e.g. \"Requires mSupply\".",
+							"type": "string"
+						},
+						"displayOnEntityConditions": {
+							"description": "If specified will only show this viz if the conditions are met against the current Entity.",
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"attributes": {
+											"type": "object",
+											"additionalProperties": {
+												"type": [
+													"string",
+													"number",
+													"boolean"
+												]
+											}
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"attributes"
+									]
+								},
+								{
+									"type": "object",
+									"additionalProperties": {
+										"type": [
+											"string",
+											"number",
+											"boolean"
+										]
+									}
+								}
+							]
+						},
+						"weekDisplayFormat": {
+							"description": "Allows customising how weeks are displayed, e.g. 'W/C 6 Jan 2020' or 'ISO Week 2 2020'",
+							"default": "'WEEK_COMMENCING_ABBR'",
+							"enum": [
+								"ISO_WEEK_NUMBER",
+								"WEEK_COMMENCING",
+								"WEEK_COMMENCING_ABBR",
+								"WEEK_ENDING",
+								"WEEK_ENDING_ABBR"
+							],
+							"type": "string"
+						},
+						"type": {
+							"type": "string",
+							"enum": [
+								"view"
+							]
+						},
+						"valueType": {
+							"enum": [
+								"boolean",
+								"color",
+								"currency",
+								"fraction",
+								"fractionAndPercentage",
+								"number",
+								"oneDecimalPlace",
+								"percentage",
+								"text",
+								"view"
+							],
+							"type": "string"
+						},
+						"value_metadata": {
+							"type": "object",
+							"additionalProperties": false
+						},
+						"viewType": {
+							"type": "string",
+							"enum": [
+								"multiValueRow"
+							]
+						},
+						"presentationOptions": {
+							"additionalProperties": false,
+							"type": "object",
+							"properties": {
+								"color": {
+									"type": "string"
+								},
+								"header": {
+									"type": "string"
+								},
+								"dataPairNames": {
+									"type": "array",
+									"items": {
+										"type": "string"
+									}
+								},
+								"rowHeader": {
+									"additionalProperties": false,
+									"type": "object",
+									"properties": {
+										"color": {
+											"type": "string"
+										},
+										"name": {
+											"type": "string"
+										}
+									},
+									"required": [
+										"color"
+									]
+								},
+								"leftColumn": {
+									"additionalProperties": false,
+									"type": "object",
+									"properties": {
+										"color": {
+											"type": "string"
+										},
+										"header": {
+											"type": "string"
+										}
+									},
+									"required": [
+										"color",
+										"header"
+									]
+								},
+								"rightColumn": {
+									"additionalProperties": false,
+									"type": "object",
+									"properties": {
+										"color": {
+											"type": "string"
+										},
+										"header": {
+											"type": "string"
+										}
+									},
+									"required": [
+										"color",
+										"header"
+									]
+								},
+								"middleColumn": {
+									"additionalProperties": false,
+									"type": "object",
+									"properties": {
+										"color": {
+											"type": "string"
+										},
+										"header": {
+											"type": "string"
+										}
+									},
+									"required": [
+										"color",
+										"header"
+									]
+								}
+							},
+							"required": [
+								"color",
+								"header"
+							]
+						}
+					},
+					"required": [
+						"name",
+						"type",
+						"viewType"
+					]
+				},
+				{
+					"additionalProperties": false,
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						},
+						"description": {
+							"description": "A short description that appears above a viz",
+							"type": "string"
+						},
+						"placeholder": {
+							"description": "A url to an image to be used when a viz is collapsed. Some vizes display small, others display a placeholder.",
+							"type": "string"
+						},
+						"periodGranularity": {
+							"enum": [
+								"day",
+								"month",
+								"one_day_at_a_time",
+								"one_month_at_a_time",
+								"one_quarter_at_a_time",
+								"one_week_at_a_time",
+								"one_year_at_a_time",
+								"quarter",
+								"week",
+								"year"
+							],
+							"type": "string"
+						},
+						"defaultTimePeriod": {
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"offset": {
+											"type": "number"
+										},
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										},
+										"end": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"end",
+										"start"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"description": "ISO Date Time",
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"start"
+									]
+								}
+							]
+						},
+						"datePickerLimits": {
+							"type": "object",
+							"properties": {
+								"start": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								"end": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								}
+							},
+							"additionalProperties": false
+						},
+						"exportConfig": {
+							"description": "Extra config options for exporting"
+						},
+						"noDataMessage": {
+							"description": "Message which shows if no data is found",
+							"type": "string"
+						},
+						"noDataFetch": {
+							"description": "If true, Tupaia will not fetch any data for this viz. Usually used with custom vizes of type: component, e.g. ProjectDescription.",
+							"default": false,
+							"type": "boolean"
+						},
+						"drillDown": {
+							"type": "object",
+							"properties": {
+								"keyLink": {
+									"type": "string"
+								},
+								"itemCode": {
+									"type": "string"
+								},
+								"parameterLink": {
+									"type": "string"
+								},
+								"itemCodeByEntry": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "string"
+									}
+								}
+							},
+							"additionalProperties": false
+						},
+						"entityHeader": {
+							"description": "",
+							"type": "string"
+						},
+						"reference": {
+							"description": "If provided shows an (i) icon next to the viz title, which allows linking to the source data",
+							"type": "object",
+							"properties": {
+								"link": {
+									"description": "url",
+									"type": "string"
+								},
+								"name": {
+									"description": "label",
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"link",
+								"name"
+							]
+						},
+						"source": {
+							"description": "If specified allows the frontend to know where the data is coming from, so if there is no data it can show a custom no-data message e.g. \"Requires mSupply\".",
+							"type": "string"
+						},
+						"displayOnEntityConditions": {
+							"description": "If specified will only show this viz if the conditions are met against the current Entity.",
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"attributes": {
+											"type": "object",
+											"additionalProperties": {
+												"type": [
+													"string",
+													"number",
+													"boolean"
+												]
+											}
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"attributes"
+									]
+								},
+								{
+									"type": "object",
+									"additionalProperties": {
+										"type": [
+											"string",
+											"number",
+											"boolean"
+										]
+									}
+								}
+							]
+						},
+						"weekDisplayFormat": {
+							"description": "Allows customising how weeks are displayed, e.g. 'W/C 6 Jan 2020' or 'ISO Week 2 2020'",
+							"default": "'WEEK_COMMENCING_ABBR'",
+							"enum": [
+								"ISO_WEEK_NUMBER",
+								"WEEK_COMMENCING",
+								"WEEK_COMMENCING_ABBR",
+								"WEEK_ENDING",
+								"WEEK_ENDING_ABBR"
+							],
+							"type": "string"
+						},
+						"type": {
+							"type": "string",
+							"enum": [
+								"view"
+							]
+						},
+						"valueType": {
+							"enum": [
+								"boolean",
+								"color",
+								"currency",
+								"fraction",
+								"fractionAndPercentage",
+								"number",
+								"oneDecimalPlace",
+								"percentage",
+								"text",
+								"view"
+							],
+							"type": "string"
+						},
+						"value_metadata": {
+							"type": "object",
+							"additionalProperties": false
+						},
+						"viewType": {
+							"type": "string",
+							"enum": [
+								"dataDownload"
+							]
+						}
+					},
+					"required": [
+						"name",
+						"type",
+						"viewType"
+					]
+				},
+				{
+					"additionalProperties": false,
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						},
+						"description": {
+							"description": "A short description that appears above a viz",
+							"type": "string"
+						},
+						"placeholder": {
+							"description": "A url to an image to be used when a viz is collapsed. Some vizes display small, others display a placeholder.",
+							"type": "string"
+						},
+						"periodGranularity": {
+							"enum": [
+								"day",
+								"month",
+								"one_day_at_a_time",
+								"one_month_at_a_time",
+								"one_quarter_at_a_time",
+								"one_week_at_a_time",
+								"one_year_at_a_time",
+								"quarter",
+								"week",
+								"year"
+							],
+							"type": "string"
+						},
+						"defaultTimePeriod": {
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"offset": {
+											"type": "number"
+										},
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										},
+										"end": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"end",
+										"start"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"description": "ISO Date Time",
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"start"
+									]
+								}
+							]
+						},
+						"datePickerLimits": {
+							"type": "object",
+							"properties": {
+								"start": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								"end": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								}
+							},
+							"additionalProperties": false
+						},
+						"exportConfig": {
+							"description": "Extra config options for exporting"
+						},
+						"noDataMessage": {
+							"description": "Message which shows if no data is found",
+							"type": "string"
+						},
+						"noDataFetch": {
+							"description": "If true, Tupaia will not fetch any data for this viz. Usually used with custom vizes of type: component, e.g. ProjectDescription.",
+							"default": false,
+							"type": "boolean"
+						},
+						"drillDown": {
+							"type": "object",
+							"properties": {
+								"keyLink": {
+									"type": "string"
+								},
+								"itemCode": {
+									"type": "string"
+								},
+								"parameterLink": {
+									"type": "string"
+								},
+								"itemCodeByEntry": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "string"
+									}
+								}
+							},
+							"additionalProperties": false
+						},
+						"entityHeader": {
+							"description": "",
+							"type": "string"
+						},
+						"reference": {
+							"description": "If provided shows an (i) icon next to the viz title, which allows linking to the source data",
+							"type": "object",
+							"properties": {
+								"link": {
+									"description": "url",
+									"type": "string"
+								},
+								"name": {
+									"description": "label",
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"link",
+								"name"
+							]
+						},
+						"source": {
+							"description": "If specified allows the frontend to know where the data is coming from, so if there is no data it can show a custom no-data message e.g. \"Requires mSupply\".",
+							"type": "string"
+						},
+						"displayOnEntityConditions": {
+							"description": "If specified will only show this viz if the conditions are met against the current Entity.",
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"attributes": {
+											"type": "object",
+											"additionalProperties": {
+												"type": [
+													"string",
+													"number",
+													"boolean"
+												]
+											}
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"attributes"
+									]
+								},
+								{
+									"type": "object",
+									"additionalProperties": {
+										"type": [
+											"string",
+											"number",
+											"boolean"
+										]
+									}
+								}
+							]
+						},
+						"weekDisplayFormat": {
+							"description": "Allows customising how weeks are displayed, e.g. 'W/C 6 Jan 2020' or 'ISO Week 2 2020'",
+							"default": "'WEEK_COMMENCING_ABBR'",
+							"enum": [
+								"ISO_WEEK_NUMBER",
+								"WEEK_COMMENCING",
+								"WEEK_COMMENCING_ABBR",
+								"WEEK_ENDING",
+								"WEEK_ENDING_ABBR"
+							],
+							"type": "string"
+						},
+						"type": {
+							"type": "string",
+							"enum": [
+								"view"
+							]
+						},
+						"valueType": {
+							"enum": [
+								"boolean",
+								"color",
+								"currency",
+								"fraction",
+								"fractionAndPercentage",
+								"number",
+								"oneDecimalPlace",
+								"percentage",
+								"text",
+								"view"
+							],
+							"type": "string"
+						},
+						"value_metadata": {
+							"type": "object",
+							"additionalProperties": false
+						},
+						"viewType": {
+							"type": "string",
+							"enum": [
+								"singleDate"
+							]
+						}
+					},
+					"required": [
+						"name",
+						"type",
+						"viewType"
+					]
+				},
+				{
+					"additionalProperties": false,
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						},
+						"description": {
+							"description": "A short description that appears above a viz",
+							"type": "string"
+						},
+						"placeholder": {
+							"description": "A url to an image to be used when a viz is collapsed. Some vizes display small, others display a placeholder.",
+							"type": "string"
+						},
+						"periodGranularity": {
+							"enum": [
+								"day",
+								"month",
+								"one_day_at_a_time",
+								"one_month_at_a_time",
+								"one_quarter_at_a_time",
+								"one_week_at_a_time",
+								"one_year_at_a_time",
+								"quarter",
+								"week",
+								"year"
+							],
+							"type": "string"
+						},
+						"defaultTimePeriod": {
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"offset": {
+											"type": "number"
+										},
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										},
+										"end": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"end",
+										"start"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"description": "ISO Date Time",
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"start"
+									]
+								}
+							]
+						},
+						"datePickerLimits": {
+							"type": "object",
+							"properties": {
+								"start": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								"end": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								}
+							},
+							"additionalProperties": false
+						},
+						"exportConfig": {
+							"description": "Extra config options for exporting"
+						},
+						"noDataMessage": {
+							"description": "Message which shows if no data is found",
+							"type": "string"
+						},
+						"noDataFetch": {
+							"description": "If true, Tupaia will not fetch any data for this viz. Usually used with custom vizes of type: component, e.g. ProjectDescription.",
+							"default": false,
+							"type": "boolean"
+						},
+						"drillDown": {
+							"type": "object",
+							"properties": {
+								"keyLink": {
+									"type": "string"
+								},
+								"itemCode": {
+									"type": "string"
+								},
+								"parameterLink": {
+									"type": "string"
+								},
+								"itemCodeByEntry": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "string"
+									}
+								}
+							},
+							"additionalProperties": false
+						},
+						"entityHeader": {
+							"description": "",
+							"type": "string"
+						},
+						"reference": {
+							"description": "If provided shows an (i) icon next to the viz title, which allows linking to the source data",
+							"type": "object",
+							"properties": {
+								"link": {
+									"description": "url",
+									"type": "string"
+								},
+								"name": {
+									"description": "label",
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"link",
+								"name"
+							]
+						},
+						"source": {
+							"description": "If specified allows the frontend to know where the data is coming from, so if there is no data it can show a custom no-data message e.g. \"Requires mSupply\".",
+							"type": "string"
+						},
+						"displayOnEntityConditions": {
+							"description": "If specified will only show this viz if the conditions are met against the current Entity.",
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"attributes": {
+											"type": "object",
+											"additionalProperties": {
+												"type": [
+													"string",
+													"number",
+													"boolean"
+												]
+											}
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"attributes"
+									]
+								},
+								{
+									"type": "object",
+									"additionalProperties": {
+										"type": [
+											"string",
+											"number",
+											"boolean"
+										]
+									}
+								}
+							]
+						},
+						"weekDisplayFormat": {
+							"description": "Allows customising how weeks are displayed, e.g. 'W/C 6 Jan 2020' or 'ISO Week 2 2020'",
+							"default": "'WEEK_COMMENCING_ABBR'",
+							"enum": [
+								"ISO_WEEK_NUMBER",
+								"WEEK_COMMENCING",
+								"WEEK_COMMENCING_ABBR",
+								"WEEK_ENDING",
+								"WEEK_ENDING_ABBR"
+							],
+							"type": "string"
+						},
+						"type": {
+							"type": "string",
+							"enum": [
+								"view"
+							]
+						},
+						"valueType": {
+							"enum": [
+								"boolean",
+								"color",
+								"currency",
+								"fraction",
+								"fractionAndPercentage",
+								"number",
+								"oneDecimalPlace",
+								"percentage",
+								"text",
+								"view"
+							],
+							"type": "string"
+						},
+						"value_metadata": {
+							"type": "object",
+							"additionalProperties": false
+						},
+						"viewType": {
+							"type": "string",
+							"enum": [
+								"filesDownload"
+							]
+						}
+					},
+					"required": [
+						"name",
+						"type",
+						"viewType"
+					]
+				},
+				{
+					"additionalProperties": false,
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						},
+						"description": {
+							"description": "A short description that appears above a viz",
+							"type": "string"
+						},
+						"placeholder": {
+							"description": "A url to an image to be used when a viz is collapsed. Some vizes display small, others display a placeholder.",
+							"type": "string"
+						},
+						"periodGranularity": {
+							"enum": [
+								"day",
+								"month",
+								"one_day_at_a_time",
+								"one_month_at_a_time",
+								"one_quarter_at_a_time",
+								"one_week_at_a_time",
+								"one_year_at_a_time",
+								"quarter",
+								"week",
+								"year"
+							],
+							"type": "string"
+						},
+						"defaultTimePeriod": {
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"offset": {
+											"type": "number"
+										},
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										},
+										"end": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"end",
+										"start"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"description": "ISO Date Time",
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"start"
+									]
+								}
+							]
+						},
+						"datePickerLimits": {
+							"type": "object",
+							"properties": {
+								"start": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								"end": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								}
+							},
+							"additionalProperties": false
+						},
+						"exportConfig": {
+							"description": "Extra config options for exporting"
+						},
+						"noDataMessage": {
+							"description": "Message which shows if no data is found",
+							"type": "string"
+						},
+						"noDataFetch": {
+							"description": "If true, Tupaia will not fetch any data for this viz. Usually used with custom vizes of type: component, e.g. ProjectDescription.",
+							"default": false,
+							"type": "boolean"
+						},
+						"drillDown": {
+							"type": "object",
+							"properties": {
+								"keyLink": {
+									"type": "string"
+								},
+								"itemCode": {
+									"type": "string"
+								},
+								"parameterLink": {
+									"type": "string"
+								},
+								"itemCodeByEntry": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "string"
+									}
+								}
+							},
+							"additionalProperties": false
+						},
+						"entityHeader": {
+							"description": "",
+							"type": "string"
+						},
+						"reference": {
+							"description": "If provided shows an (i) icon next to the viz title, which allows linking to the source data",
+							"type": "object",
+							"properties": {
+								"link": {
+									"description": "url",
+									"type": "string"
+								},
+								"name": {
+									"description": "label",
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"link",
+								"name"
+							]
+						},
+						"source": {
+							"description": "If specified allows the frontend to know where the data is coming from, so if there is no data it can show a custom no-data message e.g. \"Requires mSupply\".",
+							"type": "string"
+						},
+						"displayOnEntityConditions": {
+							"description": "If specified will only show this viz if the conditions are met against the current Entity.",
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"attributes": {
+											"type": "object",
+											"additionalProperties": {
+												"type": [
+													"string",
+													"number",
+													"boolean"
+												]
+											}
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"attributes"
+									]
+								},
+								{
+									"type": "object",
+									"additionalProperties": {
+										"type": [
+											"string",
+											"number",
+											"boolean"
+										]
+									}
+								}
+							]
+						},
+						"weekDisplayFormat": {
+							"description": "Allows customising how weeks are displayed, e.g. 'W/C 6 Jan 2020' or 'ISO Week 2 2020'",
+							"default": "'WEEK_COMMENCING_ABBR'",
+							"enum": [
+								"ISO_WEEK_NUMBER",
+								"WEEK_COMMENCING",
+								"WEEK_COMMENCING_ABBR",
+								"WEEK_ENDING",
+								"WEEK_ENDING_ABBR"
+							],
+							"type": "string"
+						},
+						"type": {
+							"type": "string",
+							"enum": [
+								"view"
+							]
+						},
+						"valueType": {
+							"enum": [
+								"boolean",
+								"color",
+								"currency",
+								"fraction",
+								"fractionAndPercentage",
+								"number",
+								"oneDecimalPlace",
+								"percentage",
+								"text",
+								"view"
+							],
+							"type": "string"
+						},
+						"value_metadata": {
+							"type": "object",
+							"additionalProperties": false
+						},
+						"viewType": {
+							"type": "string",
+							"enum": [
+								"multiValue"
+							]
+						},
+						"presentationOptions": {
+							"additionalProperties": false,
+							"type": "object",
+							"properties": {
+								"isTitleVisible": {
+									"type": "boolean"
+								},
+								"valueFormat": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"required": [
+						"name",
+						"type",
+						"viewType"
+					]
+				},
+				{
+					"additionalProperties": false,
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						},
+						"description": {
+							"description": "A short description that appears above a viz",
+							"type": "string"
+						},
+						"placeholder": {
+							"description": "A url to an image to be used when a viz is collapsed. Some vizes display small, others display a placeholder.",
+							"type": "string"
+						},
+						"periodGranularity": {
+							"enum": [
+								"day",
+								"month",
+								"one_day_at_a_time",
+								"one_month_at_a_time",
+								"one_quarter_at_a_time",
+								"one_week_at_a_time",
+								"one_year_at_a_time",
+								"quarter",
+								"week",
+								"year"
+							],
+							"type": "string"
+						},
+						"defaultTimePeriod": {
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"offset": {
+											"type": "number"
+										},
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										},
+										"end": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"end",
+										"start"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"description": "ISO Date Time",
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"start"
+									]
+								}
+							]
+						},
+						"datePickerLimits": {
+							"type": "object",
+							"properties": {
+								"start": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								"end": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								}
+							},
+							"additionalProperties": false
+						},
+						"exportConfig": {
+							"description": "Extra config options for exporting"
+						},
+						"noDataMessage": {
+							"description": "Message which shows if no data is found",
+							"type": "string"
+						},
+						"noDataFetch": {
+							"description": "If true, Tupaia will not fetch any data for this viz. Usually used with custom vizes of type: component, e.g. ProjectDescription.",
+							"default": false,
+							"type": "boolean"
+						},
+						"drillDown": {
+							"type": "object",
+							"properties": {
+								"keyLink": {
+									"type": "string"
+								},
+								"itemCode": {
+									"type": "string"
+								},
+								"parameterLink": {
+									"type": "string"
+								},
+								"itemCodeByEntry": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "string"
+									}
+								}
+							},
+							"additionalProperties": false
+						},
+						"entityHeader": {
+							"description": "",
+							"type": "string"
+						},
+						"reference": {
+							"description": "If provided shows an (i) icon next to the viz title, which allows linking to the source data",
+							"type": "object",
+							"properties": {
+								"link": {
+									"description": "url",
+									"type": "string"
+								},
+								"name": {
+									"description": "label",
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"link",
+								"name"
+							]
+						},
+						"source": {
+							"description": "If specified allows the frontend to know where the data is coming from, so if there is no data it can show a custom no-data message e.g. \"Requires mSupply\".",
+							"type": "string"
+						},
+						"displayOnEntityConditions": {
+							"description": "If specified will only show this viz if the conditions are met against the current Entity.",
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"attributes": {
+											"type": "object",
+											"additionalProperties": {
+												"type": [
+													"string",
+													"number",
+													"boolean"
+												]
+											}
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"attributes"
+									]
+								},
+								{
+									"type": "object",
+									"additionalProperties": {
+										"type": [
+											"string",
+											"number",
+											"boolean"
+										]
+									}
+								}
+							]
+						},
+						"weekDisplayFormat": {
+							"description": "Allows customising how weeks are displayed, e.g. 'W/C 6 Jan 2020' or 'ISO Week 2 2020'",
+							"default": "'WEEK_COMMENCING_ABBR'",
+							"enum": [
+								"ISO_WEEK_NUMBER",
+								"WEEK_COMMENCING",
+								"WEEK_COMMENCING_ABBR",
+								"WEEK_ENDING",
+								"WEEK_ENDING_ABBR"
+							],
+							"type": "string"
+						},
+						"type": {
+							"type": "string",
+							"enum": [
+								"view"
+							]
+						},
+						"valueType": {
+							"enum": [
+								"boolean",
+								"color",
+								"currency",
+								"fraction",
+								"fractionAndPercentage",
+								"number",
+								"oneDecimalPlace",
+								"percentage",
+								"text",
+								"view"
+							],
+							"type": "string"
+						},
+						"value_metadata": {
+							"type": "object",
+							"additionalProperties": false
+						},
+						"viewType": {
+							"type": "string",
+							"enum": [
+								"qrCodeVisual"
+							]
+						}
+					},
+					"required": [
+						"name",
+						"type",
+						"viewType"
+					]
+				}
+			]
+		},
+		"legacy": {
+			"type": "boolean"
+		},
+		"permission_group_ids": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"report_code": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"code"
+	]
+} 
+
+export const DashboardItemUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"code": {
+			"type": "string"
+		},
+		"config": {
+			"description": "The master list of viz types.\nPlease also keep ../../utils/vizTypes up to date when making changes",
+			"anyOf": [
+				{
+					"description": "Matrix viz type",
+					"additionalProperties": false,
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						},
+						"description": {
+							"description": "A short description that appears above a viz",
+							"type": "string"
+						},
+						"placeholder": {
+							"description": "A url to an image to be used when a viz is collapsed. Some vizes display small, others display a placeholder.",
+							"type": "string"
+						},
+						"periodGranularity": {
+							"enum": [
+								"day",
+								"month",
+								"one_day_at_a_time",
+								"one_month_at_a_time",
+								"one_quarter_at_a_time",
+								"one_week_at_a_time",
+								"one_year_at_a_time",
+								"quarter",
+								"week",
+								"year"
+							],
+							"type": "string"
+						},
+						"defaultTimePeriod": {
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"offset": {
+											"type": "number"
+										},
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										},
+										"end": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"end",
+										"start"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"description": "ISO Date Time",
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"start"
+									]
+								}
+							]
+						},
+						"datePickerLimits": {
+							"type": "object",
+							"properties": {
+								"start": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								"end": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								}
+							},
+							"additionalProperties": false
+						},
+						"exportConfig": {
+							"description": "Extra config options for exporting"
+						},
+						"noDataMessage": {
+							"description": "Message which shows if no data is found",
+							"type": "string"
+						},
+						"noDataFetch": {
+							"description": "If true, Tupaia will not fetch any data for this viz. Usually used with custom vizes of type: component, e.g. ProjectDescription.",
+							"default": false,
+							"type": "boolean"
+						},
+						"drillDown": {
+							"type": "object",
+							"properties": {
+								"keyLink": {
+									"type": "string"
+								},
+								"itemCode": {
+									"type": "string"
+								},
+								"parameterLink": {
+									"type": "string"
+								},
+								"itemCodeByEntry": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "string"
+									}
+								}
+							},
+							"additionalProperties": false
+						},
+						"entityHeader": {
+							"description": "",
+							"type": "string"
+						},
+						"reference": {
+							"description": "If provided shows an (i) icon next to the viz title, which allows linking to the source data",
+							"type": "object",
+							"properties": {
+								"link": {
+									"description": "url",
+									"type": "string"
+								},
+								"name": {
+									"description": "label",
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"link",
+								"name"
+							]
+						},
+						"source": {
+							"description": "If specified allows the frontend to know where the data is coming from, so if there is no data it can show a custom no-data message e.g. \"Requires mSupply\".",
+							"type": "string"
+						},
+						"displayOnEntityConditions": {
+							"description": "If specified will only show this viz if the conditions are met against the current Entity.",
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"attributes": {
+											"type": "object",
+											"additionalProperties": {
+												"type": [
+													"string",
+													"number",
+													"boolean"
+												]
+											}
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"attributes"
+									]
+								},
+								{
+									"type": "object",
+									"additionalProperties": {
+										"type": [
+											"string",
+											"number",
+											"boolean"
+										]
+									}
+								}
+							]
+						},
+						"weekDisplayFormat": {
+							"description": "Allows customising how weeks are displayed, e.g. 'W/C 6 Jan 2020' or 'ISO Week 2 2020'",
+							"default": "'WEEK_COMMENCING_ABBR'",
+							"enum": [
+								"ISO_WEEK_NUMBER",
+								"WEEK_COMMENCING",
+								"WEEK_COMMENCING_ABBR",
+								"WEEK_ENDING",
+								"WEEK_ENDING_ABBR"
+							],
+							"type": "string"
+						},
+						"type": {
+							"type": "string",
+							"enum": [
+								"matrix"
+							]
+						},
+						"dataElementColumnTitle": {
+							"description": "Matrix viz type can specify a column as the data element column.",
+							"type": "string"
+						},
+						"hideColumnTitles": {
+							"description": "Like it sounds",
+							"type": "boolean"
+						},
+						"presentationOptions": {
+							"description": "Allows for conditional styling",
+							"anyOf": [
+								{
+									"additionalProperties": false,
+									"type": "object",
+									"properties": {
+										"exportWithLabels": {
+											"type": "boolean"
+										},
+										"exportWithTable": {
+											"type": "boolean"
+										},
+										"exportWithTableDisabled": {
+											"type": "boolean"
+										},
+										"type": {
+											"type": "string",
+											"enum": [
+												"condition"
+											]
+										},
+										"conditions": {
+											"type": "array",
+											"items": {
+												"additionalProperties": false,
+												"type": "object",
+												"properties": {
+													"color": {
+														"description": "Specify the color of the display item",
+														"type": "string"
+													},
+													"description": {
+														"description": "Specify the text for the legend item. Also used in the enlarged cell view",
+														"type": "string"
+													},
+													"label": {
+														"description": "Specify if you want a label to appear above the enlarged",
+														"type": "string"
+													},
+													"key": {
+														"type": "string"
+													},
+													"condition": {
+														"description": "the value to match against exactly, or an object with match criteria e.g. { '>=': 5.5 }",
+														"anyOf": [
+															{
+																"type": "object",
+																"properties": {
+																	"=": {
+																		"type": [
+																			"string",
+																			"number"
+																		]
+																	},
+																	">": {
+																		"type": [
+																			"string",
+																			"number"
+																		]
+																	},
+																	"<": {
+																		"type": [
+																			"string",
+																			"number"
+																		]
+																	},
+																	">=": {
+																		"type": [
+																			"string",
+																			"number"
+																		]
+																	},
+																	"<=": {
+																		"type": [
+																			"string",
+																			"number"
+																		]
+																	}
+																},
+																"additionalProperties": false,
+																"required": [
+																	"<",
+																	"<=",
+																	"=",
+																	">",
+																	">="
+																]
+															},
+															{
+																"type": [
+																	"string",
+																	"number"
+																]
+															}
+														]
+													},
+													"legendLabel": {
+														"type": "string"
+													}
+												},
+												"required": [
+													"condition",
+													"key"
+												]
+											}
+										},
+										"showRawValue": {
+											"default": false,
+											"type": "boolean"
+										},
+										"showNestedRows": {
+											"default": false,
+											"type": "boolean"
+										},
+										"applyLocation": {
+											"description": "Specify if you want to limit where to apply the conditional presentation",
+											"type": "object",
+											"properties": {
+												"columnIndexes": {
+													"type": "array",
+													"items": {
+														"type": "number"
+													}
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"columnIndexes"
+											]
+										}
+									}
+								},
+								{
+									"additionalProperties": false,
+									"type": "object",
+									"properties": {
+										"exportWithLabels": {
+											"type": "boolean"
+										},
+										"exportWithTable": {
+											"type": "boolean"
+										},
+										"exportWithTableDisabled": {
+											"type": "boolean"
+										},
+										"type": {
+											"type": "string",
+											"enum": [
+												"range"
+											]
+										},
+										"showRawValue": {
+											"type": "boolean"
+										}
+									},
+									"required": [
+										"type"
+									]
+								}
+							]
+						},
+						"categoryPresentationOptions": {
+							"description": "Category header rows can have values just like real rows, this is how you style them",
+							"anyOf": [
+								{
+									"additionalProperties": false,
+									"type": "object",
+									"properties": {
+										"exportWithLabels": {
+											"type": "boolean"
+										},
+										"exportWithTable": {
+											"type": "boolean"
+										},
+										"exportWithTableDisabled": {
+											"type": "boolean"
+										},
+										"type": {
+											"type": "string",
+											"enum": [
+												"condition"
+											]
+										},
+										"conditions": {
+											"type": "array",
+											"items": {
+												"additionalProperties": false,
+												"type": "object",
+												"properties": {
+													"color": {
+														"description": "Specify the color of the display item",
+														"type": "string"
+													},
+													"description": {
+														"description": "Specify the text for the legend item. Also used in the enlarged cell view",
+														"type": "string"
+													},
+													"label": {
+														"description": "Specify if you want a label to appear above the enlarged",
+														"type": "string"
+													},
+													"key": {
+														"type": "string"
+													},
+													"condition": {
+														"description": "the value to match against exactly, or an object with match criteria e.g. { '>=': 5.5 }",
+														"anyOf": [
+															{
+																"type": "object",
+																"properties": {
+																	"=": {
+																		"type": [
+																			"string",
+																			"number"
+																		]
+																	},
+																	">": {
+																		"type": [
+																			"string",
+																			"number"
+																		]
+																	},
+																	"<": {
+																		"type": [
+																			"string",
+																			"number"
+																		]
+																	},
+																	">=": {
+																		"type": [
+																			"string",
+																			"number"
+																		]
+																	},
+																	"<=": {
+																		"type": [
+																			"string",
+																			"number"
+																		]
+																	}
+																},
+																"additionalProperties": false,
+																"required": [
+																	"<",
+																	"<=",
+																	"=",
+																	">",
+																	">="
+																]
+															},
+															{
+																"type": [
+																	"string",
+																	"number"
+																]
+															}
+														]
+													},
+													"legendLabel": {
+														"type": "string"
+													}
+												},
+												"required": [
+													"condition",
+													"key"
+												]
+											}
+										},
+										"showRawValue": {
+											"default": false,
+											"type": "boolean"
+										},
+										"showNestedRows": {
+											"default": false,
+											"type": "boolean"
+										},
+										"applyLocation": {
+											"description": "Specify if you want to limit where to apply the conditional presentation",
+											"type": "object",
+											"properties": {
+												"columnIndexes": {
+													"type": "array",
+													"items": {
+														"type": "number"
+													}
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"columnIndexes"
+											]
+										}
+									}
+								},
+								{
+									"additionalProperties": false,
+									"type": "object",
+									"properties": {
+										"exportWithLabels": {
+											"type": "boolean"
+										},
+										"exportWithTable": {
+											"type": "boolean"
+										},
+										"exportWithTableDisabled": {
+											"type": "boolean"
+										},
+										"type": {
+											"type": "string",
+											"enum": [
+												"range"
+											]
+										},
+										"showRawValue": {
+											"type": "boolean"
+										}
+									},
+									"required": [
+										"type"
+									]
+								}
+							]
+						},
+						"valueType": {
+							"description": "Specify the valueType for formatting of the value in the matrix",
+							"enum": [
+								"boolean",
+								"color",
+								"currency",
+								"fraction",
+								"fractionAndPercentage",
+								"number",
+								"oneDecimalPlace",
+								"percentage",
+								"text",
+								"view"
+							],
+							"type": "string"
+						}
+					},
+					"required": [
+						"name",
+						"type"
+					]
+				},
+				{
+					"description": "A Component viz type simply renders a React component as the viz",
+					"additionalProperties": false,
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						},
+						"description": {
+							"description": "A short description that appears above a viz",
+							"type": "string"
+						},
+						"placeholder": {
+							"description": "A url to an image to be used when a viz is collapsed. Some vizes display small, others display a placeholder.",
+							"type": "string"
+						},
+						"periodGranularity": {
+							"enum": [
+								"day",
+								"month",
+								"one_day_at_a_time",
+								"one_month_at_a_time",
+								"one_quarter_at_a_time",
+								"one_week_at_a_time",
+								"one_year_at_a_time",
+								"quarter",
+								"week",
+								"year"
+							],
+							"type": "string"
+						},
+						"defaultTimePeriod": {
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"offset": {
+											"type": "number"
+										},
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										},
+										"end": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"end",
+										"start"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"description": "ISO Date Time",
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"start"
+									]
+								}
+							]
+						},
+						"datePickerLimits": {
+							"type": "object",
+							"properties": {
+								"start": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								"end": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								}
+							},
+							"additionalProperties": false
+						},
+						"exportConfig": {
+							"description": "Extra config options for exporting"
+						},
+						"noDataMessage": {
+							"description": "Message which shows if no data is found",
+							"type": "string"
+						},
+						"noDataFetch": {
+							"description": "If true, Tupaia will not fetch any data for this viz. Usually used with custom vizes of type: component, e.g. ProjectDescription.",
+							"default": false,
+							"type": "boolean"
+						},
+						"drillDown": {
+							"type": "object",
+							"properties": {
+								"keyLink": {
+									"type": "string"
+								},
+								"itemCode": {
+									"type": "string"
+								},
+								"parameterLink": {
+									"type": "string"
+								},
+								"itemCodeByEntry": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "string"
+									}
+								}
+							},
+							"additionalProperties": false
+						},
+						"entityHeader": {
+							"description": "",
+							"type": "string"
+						},
+						"reference": {
+							"description": "If provided shows an (i) icon next to the viz title, which allows linking to the source data",
+							"type": "object",
+							"properties": {
+								"link": {
+									"description": "url",
+									"type": "string"
+								},
+								"name": {
+									"description": "label",
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"link",
+								"name"
+							]
+						},
+						"source": {
+							"description": "If specified allows the frontend to know where the data is coming from, so if there is no data it can show a custom no-data message e.g. \"Requires mSupply\".",
+							"type": "string"
+						},
+						"displayOnEntityConditions": {
+							"description": "If specified will only show this viz if the conditions are met against the current Entity.",
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"attributes": {
+											"type": "object",
+											"additionalProperties": {
+												"type": [
+													"string",
+													"number",
+													"boolean"
+												]
+											}
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"attributes"
+									]
+								},
+								{
+									"type": "object",
+									"additionalProperties": {
+										"type": [
+											"string",
+											"number",
+											"boolean"
+										]
+									}
+								}
+							]
+						},
+						"weekDisplayFormat": {
+							"description": "Allows customising how weeks are displayed, e.g. 'W/C 6 Jan 2020' or 'ISO Week 2 2020'",
+							"default": "'WEEK_COMMENCING_ABBR'",
+							"enum": [
+								"ISO_WEEK_NUMBER",
+								"WEEK_COMMENCING",
+								"WEEK_COMMENCING_ABBR",
+								"WEEK_ENDING",
+								"WEEK_ENDING_ABBR"
+							],
+							"type": "string"
+						},
+						"type": {
+							"type": "string",
+							"enum": [
+								"component"
+							]
+						},
+						"componentName": {
+							"enum": [
+								"ActiveDisasters",
+								"NoAccessDashboard",
+								"NoDataAtLevelDashboard",
+								"ProjectDescription"
+							],
+							"type": "string"
+						}
+					},
+					"required": [
+						"componentName",
+						"name",
+						"type"
+					]
+				},
+				{
+					"description": "Gauge Chart",
+					"additionalProperties": false,
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						},
+						"description": {
+							"description": "A short description that appears above a viz",
+							"type": "string"
+						},
+						"placeholder": {
+							"description": "A url to an image to be used when a viz is collapsed. Some vizes display small, others display a placeholder.",
+							"type": "string"
+						},
+						"periodGranularity": {
+							"enum": [
+								"day",
+								"month",
+								"one_day_at_a_time",
+								"one_month_at_a_time",
+								"one_quarter_at_a_time",
+								"one_week_at_a_time",
+								"one_year_at_a_time",
+								"quarter",
+								"week",
+								"year"
+							],
+							"type": "string"
+						},
+						"defaultTimePeriod": {
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"offset": {
+											"type": "number"
+										},
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										},
+										"end": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"end",
+										"start"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"description": "ISO Date Time",
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"start"
+									]
+								}
+							]
+						},
+						"datePickerLimits": {
+							"type": "object",
+							"properties": {
+								"start": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								"end": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								}
+							},
+							"additionalProperties": false
+						},
+						"exportConfig": {
+							"description": "Extra config options for exporting"
+						},
+						"noDataMessage": {
+							"description": "Message which shows if no data is found",
+							"type": "string"
+						},
+						"noDataFetch": {
+							"description": "If true, Tupaia will not fetch any data for this viz. Usually used with custom vizes of type: component, e.g. ProjectDescription.",
+							"default": false,
+							"type": "boolean"
+						},
+						"drillDown": {
+							"type": "object",
+							"properties": {
+								"keyLink": {
+									"type": "string"
+								},
+								"itemCode": {
+									"type": "string"
+								},
+								"parameterLink": {
+									"type": "string"
+								},
+								"itemCodeByEntry": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "string"
+									}
+								}
+							},
+							"additionalProperties": false
+						},
+						"entityHeader": {
+							"description": "",
+							"type": "string"
+						},
+						"reference": {
+							"description": "If provided shows an (i) icon next to the viz title, which allows linking to the source data",
+							"type": "object",
+							"properties": {
+								"link": {
+									"description": "url",
+									"type": "string"
+								},
+								"name": {
+									"description": "label",
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"link",
+								"name"
+							]
+						},
+						"source": {
+							"description": "If specified allows the frontend to know where the data is coming from, so if there is no data it can show a custom no-data message e.g. \"Requires mSupply\".",
+							"type": "string"
+						},
+						"displayOnEntityConditions": {
+							"description": "If specified will only show this viz if the conditions are met against the current Entity.",
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"attributes": {
+											"type": "object",
+											"additionalProperties": {
+												"type": [
+													"string",
+													"number",
+													"boolean"
+												]
+											}
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"attributes"
+									]
+								},
+								{
+									"type": "object",
+									"additionalProperties": {
+										"type": [
+											"string",
+											"number",
+											"boolean"
+										]
+									}
+								}
+							]
+						},
+						"weekDisplayFormat": {
+							"description": "Allows customising how weeks are displayed, e.g. 'W/C 6 Jan 2020' or 'ISO Week 2 2020'",
+							"default": "'WEEK_COMMENCING_ABBR'",
+							"enum": [
+								"ISO_WEEK_NUMBER",
+								"WEEK_COMMENCING",
+								"WEEK_COMMENCING_ABBR",
+								"WEEK_ENDING",
+								"WEEK_ENDING_ABBR"
+							],
+							"type": "string"
+						},
+						"ticks": {},
+						"startDate": {
+							"type": "string"
+						},
+						"endDate": {
+							"type": "string"
+						},
+						"valueType": {
+							"enum": [
+								"boolean",
+								"color",
+								"currency",
+								"fraction",
+								"fractionAndPercentage",
+								"number",
+								"oneDecimalPlace",
+								"percentage",
+								"text",
+								"view"
+							],
+							"type": "string"
+						},
+						"showPeriodRange": {
+							"type": "string",
+							"enum": [
+								"all"
+							]
+						},
+						"color": {
+							"description": "Some chart types take 'color' as an option",
+							"type": "string"
+						},
+						"displayOnLevel": {},
+						"label": {},
+						"labelType": {
+							"description": "Some charts can have their label customised",
+							"enum": [
+								"fraction",
+								"fractionAndPercentage",
+								"number"
+							],
+							"type": "string"
+						},
+						"measureLevel": {},
+						"renderLegendForOneItem": {
+							"type": "boolean"
+						},
+						"type": {
+							"type": "string",
+							"enum": [
+								"chart"
+							]
+						},
+						"chartType": {
+							"type": "string",
+							"enum": [
+								"gauge"
+							]
+						}
+					},
+					"required": [
+						"chartType",
+						"name",
+						"type"
+					]
+				},
+				{
+					"description": "A Composed chart is a concept from Recharts, e.g. a line chart layered on top of a bar chart",
+					"additionalProperties": false,
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						},
+						"description": {
+							"description": "A short description that appears above a viz",
+							"type": "string"
+						},
+						"placeholder": {
+							"description": "A url to an image to be used when a viz is collapsed. Some vizes display small, others display a placeholder.",
+							"type": "string"
+						},
+						"periodGranularity": {
+							"enum": [
+								"day",
+								"month",
+								"one_day_at_a_time",
+								"one_month_at_a_time",
+								"one_quarter_at_a_time",
+								"one_week_at_a_time",
+								"one_year_at_a_time",
+								"quarter",
+								"week",
+								"year"
+							],
+							"type": "string"
+						},
+						"defaultTimePeriod": {
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"offset": {
+											"type": "number"
+										},
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										},
+										"end": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"end",
+										"start"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"description": "ISO Date Time",
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"start"
+									]
+								}
+							]
+						},
+						"datePickerLimits": {
+							"type": "object",
+							"properties": {
+								"start": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								"end": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								}
+							},
+							"additionalProperties": false
+						},
+						"exportConfig": {
+							"description": "Extra config options for exporting"
+						},
+						"noDataMessage": {
+							"description": "Message which shows if no data is found",
+							"type": "string"
+						},
+						"noDataFetch": {
+							"description": "If true, Tupaia will not fetch any data for this viz. Usually used with custom vizes of type: component, e.g. ProjectDescription.",
+							"default": false,
+							"type": "boolean"
+						},
+						"drillDown": {
+							"type": "object",
+							"properties": {
+								"keyLink": {
+									"type": "string"
+								},
+								"itemCode": {
+									"type": "string"
+								},
+								"parameterLink": {
+									"type": "string"
+								},
+								"itemCodeByEntry": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "string"
+									}
+								}
+							},
+							"additionalProperties": false
+						},
+						"entityHeader": {
+							"description": "",
+							"type": "string"
+						},
+						"reference": {
+							"description": "If provided shows an (i) icon next to the viz title, which allows linking to the source data",
+							"type": "object",
+							"properties": {
+								"link": {
+									"description": "url",
+									"type": "string"
+								},
+								"name": {
+									"description": "label",
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"link",
+								"name"
+							]
+						},
+						"source": {
+							"description": "If specified allows the frontend to know where the data is coming from, so if there is no data it can show a custom no-data message e.g. \"Requires mSupply\".",
+							"type": "string"
+						},
+						"displayOnEntityConditions": {
+							"description": "If specified will only show this viz if the conditions are met against the current Entity.",
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"attributes": {
+											"type": "object",
+											"additionalProperties": {
+												"type": [
+													"string",
+													"number",
+													"boolean"
+												]
+											}
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"attributes"
+									]
+								},
+								{
+									"type": "object",
+									"additionalProperties": {
+										"type": [
+											"string",
+											"number",
+											"boolean"
+										]
+									}
+								}
+							]
+						},
+						"weekDisplayFormat": {
+							"description": "Allows customising how weeks are displayed, e.g. 'W/C 6 Jan 2020' or 'ISO Week 2 2020'",
+							"default": "'WEEK_COMMENCING_ABBR'",
+							"enum": [
+								"ISO_WEEK_NUMBER",
+								"WEEK_COMMENCING",
+								"WEEK_COMMENCING_ABBR",
+								"WEEK_ENDING",
+								"WEEK_ENDING_ABBR"
+							],
+							"type": "string"
+						},
+						"ticks": {},
+						"startDate": {
+							"type": "string"
+						},
+						"endDate": {
+							"type": "string"
+						},
+						"valueType": {
+							"enum": [
+								"boolean",
+								"color",
+								"currency",
+								"fraction",
+								"fractionAndPercentage",
+								"number",
+								"oneDecimalPlace",
+								"percentage",
+								"text",
+								"view"
+							],
+							"type": "string"
+						},
+						"showPeriodRange": {
+							"type": "string",
+							"enum": [
+								"all"
+							]
+						},
+						"color": {
+							"description": "Some chart types take 'color' as an option",
+							"type": "string"
+						},
+						"displayOnLevel": {},
+						"label": {},
+						"labelType": {
+							"description": "Some charts can have their label customised",
+							"enum": [
+								"fraction",
+								"fractionAndPercentage",
+								"number"
+							],
+							"type": "string"
+						},
+						"measureLevel": {},
+						"renderLegendForOneItem": {
+							"type": "boolean"
+						},
+						"xName": {
+							"description": "The label on the x-axis",
+							"type": "string"
+						},
+						"yName": {
+							"description": "The label on the y-axis",
+							"type": "string"
+						},
+						"yAxisDomain": {
+							"description": "Configuration options for the y-axis",
+							"type": "object",
+							"properties": {
+								"max": {
+									"type": "object",
+									"properties": {
+										"type": {
+											"enum": [
+												"clamp",
+												"number",
+												"scale",
+												"string"
+											],
+											"type": "string"
+										},
+										"value": {
+											"type": [
+												"string",
+												"number"
+											]
+										},
+										"min": {
+											"type": "number"
+										},
+										"max": {
+											"type": "number"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"type"
+									]
+								},
+								"min": {
+									"type": "object",
+									"properties": {
+										"type": {
+											"enum": [
+												"clamp",
+												"number",
+												"scale",
+												"string"
+											],
+											"type": "string"
+										},
+										"value": {
+											"type": [
+												"string",
+												"number"
+											]
+										},
+										"min": {
+											"type": "number"
+										},
+										"max": {
+											"type": "number"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"type"
+									]
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"max",
+								"min"
+							]
+						},
+						"presentationOptions": {},
+						"type": {
+							"type": "string",
+							"enum": [
+								"chart"
+							]
+						},
+						"chartType": {
+							"type": "string",
+							"enum": [
+								"composed"
+							]
+						},
+						"chartConfig": {
+							"type": "object",
+							"additionalProperties": {
+								"type": "object",
+								"properties": {
+									"color": {
+										"type": "string"
+									},
+									"label": {
+										"type": "string"
+									},
+									"stackId": {
+										"type": "number"
+									},
+									"legendOrder": {
+										"type": "number"
+									},
+									"yAxisDomain": {},
+									"valueType": {
+										"enum": [
+											"boolean",
+											"color",
+											"currency",
+											"fraction",
+											"fractionAndPercentage",
+											"number",
+											"oneDecimalPlace",
+											"percentage",
+											"text",
+											"view"
+										],
+										"type": "string"
+									}
+								},
+								"additionalProperties": false
+							}
+						}
+					},
+					"required": [
+						"chartType",
+						"name",
+						"type"
+					]
+				},
+				{
+					"description": "Bar Chart",
+					"additionalProperties": false,
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						},
+						"description": {
+							"description": "A short description that appears above a viz",
+							"type": "string"
+						},
+						"placeholder": {
+							"description": "A url to an image to be used when a viz is collapsed. Some vizes display small, others display a placeholder.",
+							"type": "string"
+						},
+						"periodGranularity": {
+							"enum": [
+								"day",
+								"month",
+								"one_day_at_a_time",
+								"one_month_at_a_time",
+								"one_quarter_at_a_time",
+								"one_week_at_a_time",
+								"one_year_at_a_time",
+								"quarter",
+								"week",
+								"year"
+							],
+							"type": "string"
+						},
+						"defaultTimePeriod": {
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"offset": {
+											"type": "number"
+										},
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										},
+										"end": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"end",
+										"start"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"description": "ISO Date Time",
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"start"
+									]
+								}
+							]
+						},
+						"datePickerLimits": {
+							"type": "object",
+							"properties": {
+								"start": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								"end": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								}
+							},
+							"additionalProperties": false
+						},
+						"exportConfig": {
+							"description": "Extra config options for exporting"
+						},
+						"noDataMessage": {
+							"description": "Message which shows if no data is found",
+							"type": "string"
+						},
+						"noDataFetch": {
+							"description": "If true, Tupaia will not fetch any data for this viz. Usually used with custom vizes of type: component, e.g. ProjectDescription.",
+							"default": false,
+							"type": "boolean"
+						},
+						"drillDown": {
+							"type": "object",
+							"properties": {
+								"keyLink": {
+									"type": "string"
+								},
+								"itemCode": {
+									"type": "string"
+								},
+								"parameterLink": {
+									"type": "string"
+								},
+								"itemCodeByEntry": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "string"
+									}
+								}
+							},
+							"additionalProperties": false
+						},
+						"entityHeader": {
+							"description": "",
+							"type": "string"
+						},
+						"reference": {
+							"description": "If provided shows an (i) icon next to the viz title, which allows linking to the source data",
+							"type": "object",
+							"properties": {
+								"link": {
+									"description": "url",
+									"type": "string"
+								},
+								"name": {
+									"description": "label",
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"link",
+								"name"
+							]
+						},
+						"source": {
+							"description": "If specified allows the frontend to know where the data is coming from, so if there is no data it can show a custom no-data message e.g. \"Requires mSupply\".",
+							"type": "string"
+						},
+						"displayOnEntityConditions": {
+							"description": "If specified will only show this viz if the conditions are met against the current Entity.",
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"attributes": {
+											"type": "object",
+											"additionalProperties": {
+												"type": [
+													"string",
+													"number",
+													"boolean"
+												]
+											}
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"attributes"
+									]
+								},
+								{
+									"type": "object",
+									"additionalProperties": {
+										"type": [
+											"string",
+											"number",
+											"boolean"
+										]
+									}
+								}
+							]
+						},
+						"weekDisplayFormat": {
+							"description": "Allows customising how weeks are displayed, e.g. 'W/C 6 Jan 2020' or 'ISO Week 2 2020'",
+							"default": "'WEEK_COMMENCING_ABBR'",
+							"enum": [
+								"ISO_WEEK_NUMBER",
+								"WEEK_COMMENCING",
+								"WEEK_COMMENCING_ABBR",
+								"WEEK_ENDING",
+								"WEEK_ENDING_ABBR"
+							],
+							"type": "string"
+						},
+						"ticks": {},
+						"startDate": {
+							"type": "string"
+						},
+						"endDate": {
+							"type": "string"
+						},
+						"valueType": {
+							"enum": [
+								"boolean",
+								"color",
+								"currency",
+								"fraction",
+								"fractionAndPercentage",
+								"number",
+								"oneDecimalPlace",
+								"percentage",
+								"text",
+								"view"
+							],
+							"type": "string"
+						},
+						"showPeriodRange": {
+							"type": "string",
+							"enum": [
+								"all"
+							]
+						},
+						"color": {
+							"description": "Some chart types take 'color' as an option",
+							"type": "string"
+						},
+						"displayOnLevel": {},
+						"label": {},
+						"labelType": {
+							"description": "Some charts can have their label customised",
+							"enum": [
+								"fraction",
+								"fractionAndPercentage",
+								"number"
+							],
+							"type": "string"
+						},
+						"measureLevel": {},
+						"renderLegendForOneItem": {
+							"type": "boolean"
+						},
+						"xName": {
+							"description": "The label on the x-axis",
+							"type": "string"
+						},
+						"yName": {
+							"description": "The label on the y-axis",
+							"type": "string"
+						},
+						"yAxisDomain": {
+							"description": "Configuration options for the y-axis",
+							"type": "object",
+							"properties": {
+								"max": {
+									"type": "object",
+									"properties": {
+										"type": {
+											"enum": [
+												"clamp",
+												"number",
+												"scale",
+												"string"
+											],
+											"type": "string"
+										},
+										"value": {
+											"type": [
+												"string",
+												"number"
+											]
+										},
+										"min": {
+											"type": "number"
+										},
+										"max": {
+											"type": "number"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"type"
+									]
+								},
+								"min": {
+									"type": "object",
+									"properties": {
+										"type": {
+											"enum": [
+												"clamp",
+												"number",
+												"scale",
+												"string"
+											],
+											"type": "string"
+										},
+										"value": {
+											"type": [
+												"string",
+												"number"
+											]
+										},
+										"min": {
+											"type": "number"
+										},
+										"max": {
+											"type": "number"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"type"
+									]
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"max",
+								"min"
+							]
+						},
+						"presentationOptions": {},
+						"type": {
+							"type": "string",
+							"enum": [
+								"chart"
+							]
+						},
+						"chartType": {
+							"type": "string",
+							"enum": [
+								"bar"
+							]
+						},
+						"chartConfig": {
+							"type": "object",
+							"additionalProperties": {
+								"type": "object",
+								"properties": {
+									"color": {
+										"type": "string"
+									},
+									"label": {
+										"type": "string"
+									},
+									"stackId": {
+										"type": "number"
+									},
+									"legendOrder": {
+										"type": "number"
+									},
+									"yAxisDomain": {},
+									"valueType": {
+										"enum": [
+											"boolean",
+											"color",
+											"currency",
+											"fraction",
+											"fractionAndPercentage",
+											"number",
+											"oneDecimalPlace",
+											"percentage",
+											"text",
+											"view"
+										],
+										"type": "string"
+									}
+								},
+								"additionalProperties": false
+							}
+						}
+					},
+					"required": [
+						"chartType",
+						"name",
+						"type"
+					]
+				},
+				{
+					"description": "Pie Chart",
+					"additionalProperties": false,
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						},
+						"description": {
+							"description": "A short description that appears above a viz",
+							"type": "string"
+						},
+						"placeholder": {
+							"description": "A url to an image to be used when a viz is collapsed. Some vizes display small, others display a placeholder.",
+							"type": "string"
+						},
+						"periodGranularity": {
+							"enum": [
+								"day",
+								"month",
+								"one_day_at_a_time",
+								"one_month_at_a_time",
+								"one_quarter_at_a_time",
+								"one_week_at_a_time",
+								"one_year_at_a_time",
+								"quarter",
+								"week",
+								"year"
+							],
+							"type": "string"
+						},
+						"defaultTimePeriod": {
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"offset": {
+											"type": "number"
+										},
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										},
+										"end": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"end",
+										"start"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"description": "ISO Date Time",
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"start"
+									]
+								}
+							]
+						},
+						"datePickerLimits": {
+							"type": "object",
+							"properties": {
+								"start": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								"end": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								}
+							},
+							"additionalProperties": false
+						},
+						"exportConfig": {
+							"description": "Extra config options for exporting"
+						},
+						"noDataMessage": {
+							"description": "Message which shows if no data is found",
+							"type": "string"
+						},
+						"noDataFetch": {
+							"description": "If true, Tupaia will not fetch any data for this viz. Usually used with custom vizes of type: component, e.g. ProjectDescription.",
+							"default": false,
+							"type": "boolean"
+						},
+						"drillDown": {
+							"type": "object",
+							"properties": {
+								"keyLink": {
+									"type": "string"
+								},
+								"itemCode": {
+									"type": "string"
+								},
+								"parameterLink": {
+									"type": "string"
+								},
+								"itemCodeByEntry": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "string"
+									}
+								}
+							},
+							"additionalProperties": false
+						},
+						"entityHeader": {
+							"description": "",
+							"type": "string"
+						},
+						"reference": {
+							"description": "If provided shows an (i) icon next to the viz title, which allows linking to the source data",
+							"type": "object",
+							"properties": {
+								"link": {
+									"description": "url",
+									"type": "string"
+								},
+								"name": {
+									"description": "label",
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"link",
+								"name"
+							]
+						},
+						"source": {
+							"description": "If specified allows the frontend to know where the data is coming from, so if there is no data it can show a custom no-data message e.g. \"Requires mSupply\".",
+							"type": "string"
+						},
+						"displayOnEntityConditions": {
+							"description": "If specified will only show this viz if the conditions are met against the current Entity.",
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"attributes": {
+											"type": "object",
+											"additionalProperties": {
+												"type": [
+													"string",
+													"number",
+													"boolean"
+												]
+											}
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"attributes"
+									]
+								},
+								{
+									"type": "object",
+									"additionalProperties": {
+										"type": [
+											"string",
+											"number",
+											"boolean"
+										]
+									}
+								}
+							]
+						},
+						"weekDisplayFormat": {
+							"description": "Allows customising how weeks are displayed, e.g. 'W/C 6 Jan 2020' or 'ISO Week 2 2020'",
+							"default": "'WEEK_COMMENCING_ABBR'",
+							"enum": [
+								"ISO_WEEK_NUMBER",
+								"WEEK_COMMENCING",
+								"WEEK_COMMENCING_ABBR",
+								"WEEK_ENDING",
+								"WEEK_ENDING_ABBR"
+							],
+							"type": "string"
+						},
+						"ticks": {},
+						"startDate": {
+							"type": "string"
+						},
+						"endDate": {
+							"type": "string"
+						},
+						"valueType": {
+							"enum": [
+								"boolean",
+								"color",
+								"currency",
+								"fraction",
+								"fractionAndPercentage",
+								"number",
+								"oneDecimalPlace",
+								"percentage",
+								"text",
+								"view"
+							],
+							"type": "string"
+						},
+						"showPeriodRange": {
+							"type": "string",
+							"enum": [
+								"all"
+							]
+						},
+						"color": {
+							"description": "Some chart types take 'color' as an option",
+							"type": "string"
+						},
+						"displayOnLevel": {},
+						"label": {},
+						"labelType": {
+							"description": "Some charts can have their label customised",
+							"enum": [
+								"fraction",
+								"fractionAndPercentage",
+								"number"
+							],
+							"type": "string"
+						},
+						"measureLevel": {},
+						"renderLegendForOneItem": {
+							"type": "boolean"
+						},
+						"type": {
+							"type": "string",
+							"enum": [
+								"chart"
+							]
+						},
+						"chartType": {
+							"type": "string",
+							"enum": [
+								"pie"
+							]
+						},
+						"presentationOptions": {
+							"additionalProperties": false,
+							"type": "object",
+							"properties": {
+								"exportWithLabels": {
+									"type": "boolean"
+								},
+								"exportWithTable": {
+									"type": "boolean"
+								},
+								"exportWithTableDisabled": {
+									"type": "boolean"
+								}
+							}
+						}
+					},
+					"required": [
+						"chartType",
+						"name",
+						"type"
+					]
+				},
+				{
+					"description": "Line Chart",
+					"additionalProperties": false,
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						},
+						"description": {
+							"description": "A short description that appears above a viz",
+							"type": "string"
+						},
+						"placeholder": {
+							"description": "A url to an image to be used when a viz is collapsed. Some vizes display small, others display a placeholder.",
+							"type": "string"
+						},
+						"periodGranularity": {
+							"enum": [
+								"day",
+								"month",
+								"one_day_at_a_time",
+								"one_month_at_a_time",
+								"one_quarter_at_a_time",
+								"one_week_at_a_time",
+								"one_year_at_a_time",
+								"quarter",
+								"week",
+								"year"
+							],
+							"type": "string"
+						},
+						"defaultTimePeriod": {
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"offset": {
+											"type": "number"
+										},
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										},
+										"end": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"end",
+										"start"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"description": "ISO Date Time",
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"start"
+									]
+								}
+							]
+						},
+						"datePickerLimits": {
+							"type": "object",
+							"properties": {
+								"start": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								"end": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								}
+							},
+							"additionalProperties": false
+						},
+						"exportConfig": {
+							"description": "Extra config options for exporting"
+						},
+						"noDataMessage": {
+							"description": "Message which shows if no data is found",
+							"type": "string"
+						},
+						"noDataFetch": {
+							"description": "If true, Tupaia will not fetch any data for this viz. Usually used with custom vizes of type: component, e.g. ProjectDescription.",
+							"default": false,
+							"type": "boolean"
+						},
+						"drillDown": {
+							"type": "object",
+							"properties": {
+								"keyLink": {
+									"type": "string"
+								},
+								"itemCode": {
+									"type": "string"
+								},
+								"parameterLink": {
+									"type": "string"
+								},
+								"itemCodeByEntry": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "string"
+									}
+								}
+							},
+							"additionalProperties": false
+						},
+						"entityHeader": {
+							"description": "",
+							"type": "string"
+						},
+						"reference": {
+							"description": "If provided shows an (i) icon next to the viz title, which allows linking to the source data",
+							"type": "object",
+							"properties": {
+								"link": {
+									"description": "url",
+									"type": "string"
+								},
+								"name": {
+									"description": "label",
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"link",
+								"name"
+							]
+						},
+						"source": {
+							"description": "If specified allows the frontend to know where the data is coming from, so if there is no data it can show a custom no-data message e.g. \"Requires mSupply\".",
+							"type": "string"
+						},
+						"displayOnEntityConditions": {
+							"description": "If specified will only show this viz if the conditions are met against the current Entity.",
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"attributes": {
+											"type": "object",
+											"additionalProperties": {
+												"type": [
+													"string",
+													"number",
+													"boolean"
+												]
+											}
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"attributes"
+									]
+								},
+								{
+									"type": "object",
+									"additionalProperties": {
+										"type": [
+											"string",
+											"number",
+											"boolean"
+										]
+									}
+								}
+							]
+						},
+						"weekDisplayFormat": {
+							"description": "Allows customising how weeks are displayed, e.g. 'W/C 6 Jan 2020' or 'ISO Week 2 2020'",
+							"default": "'WEEK_COMMENCING_ABBR'",
+							"enum": [
+								"ISO_WEEK_NUMBER",
+								"WEEK_COMMENCING",
+								"WEEK_COMMENCING_ABBR",
+								"WEEK_ENDING",
+								"WEEK_ENDING_ABBR"
+							],
+							"type": "string"
+						},
+						"ticks": {},
+						"startDate": {
+							"type": "string"
+						},
+						"endDate": {
+							"type": "string"
+						},
+						"valueType": {
+							"enum": [
+								"boolean",
+								"color",
+								"currency",
+								"fraction",
+								"fractionAndPercentage",
+								"number",
+								"oneDecimalPlace",
+								"percentage",
+								"text",
+								"view"
+							],
+							"type": "string"
+						},
+						"showPeriodRange": {
+							"type": "string",
+							"enum": [
+								"all"
+							]
+						},
+						"color": {
+							"description": "Some chart types take 'color' as an option",
+							"type": "string"
+						},
+						"displayOnLevel": {},
+						"label": {},
+						"labelType": {
+							"description": "Some charts can have their label customised",
+							"enum": [
+								"fraction",
+								"fractionAndPercentage",
+								"number"
+							],
+							"type": "string"
+						},
+						"measureLevel": {},
+						"renderLegendForOneItem": {
+							"type": "boolean"
+						},
+						"xName": {
+							"description": "The label on the x-axis",
+							"type": "string"
+						},
+						"yName": {
+							"description": "The label on the y-axis",
+							"type": "string"
+						},
+						"yAxisDomain": {
+							"description": "Configuration options for the y-axis",
+							"type": "object",
+							"properties": {
+								"max": {
+									"type": "object",
+									"properties": {
+										"type": {
+											"enum": [
+												"clamp",
+												"number",
+												"scale",
+												"string"
+											],
+											"type": "string"
+										},
+										"value": {
+											"type": [
+												"string",
+												"number"
+											]
+										},
+										"min": {
+											"type": "number"
+										},
+										"max": {
+											"type": "number"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"type"
+									]
+								},
+								"min": {
+									"type": "object",
+									"properties": {
+										"type": {
+											"enum": [
+												"clamp",
+												"number",
+												"scale",
+												"string"
+											],
+											"type": "string"
+										},
+										"value": {
+											"type": [
+												"string",
+												"number"
+											]
+										},
+										"min": {
+											"type": "number"
+										},
+										"max": {
+											"type": "number"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"type"
+									]
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"max",
+								"min"
+							]
+						},
+						"presentationOptions": {},
+						"type": {
+							"type": "string",
+							"enum": [
+								"chart"
+							]
+						},
+						"chartType": {
+							"type": "string",
+							"enum": [
+								"line"
+							]
+						},
+						"chartConfig": {
+							"type": "object",
+							"additionalProperties": {
+								"type": "object",
+								"properties": {
+									"color": {
+										"type": "string"
+									},
+									"label": {
+										"type": "string"
+									},
+									"stackId": {
+										"type": "number"
+									},
+									"legendOrder": {
+										"type": "number"
+									},
+									"yAxisDomain": {},
+									"valueType": {
+										"enum": [
+											"boolean",
+											"color",
+											"currency",
+											"fraction",
+											"fractionAndPercentage",
+											"number",
+											"oneDecimalPlace",
+											"percentage",
+											"text",
+											"view"
+										],
+										"type": "string"
+									}
+								},
+								"additionalProperties": false
+							}
+						}
+					},
+					"required": [
+						"chartType",
+						"name",
+						"type"
+					]
+				},
+				{
+					"additionalProperties": false,
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						},
+						"description": {
+							"description": "A short description that appears above a viz",
+							"type": "string"
+						},
+						"placeholder": {
+							"description": "A url to an image to be used when a viz is collapsed. Some vizes display small, others display a placeholder.",
+							"type": "string"
+						},
+						"periodGranularity": {
+							"enum": [
+								"day",
+								"month",
+								"one_day_at_a_time",
+								"one_month_at_a_time",
+								"one_quarter_at_a_time",
+								"one_week_at_a_time",
+								"one_year_at_a_time",
+								"quarter",
+								"week",
+								"year"
+							],
+							"type": "string"
+						},
+						"defaultTimePeriod": {
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"offset": {
+											"type": "number"
+										},
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										},
+										"end": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"end",
+										"start"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"description": "ISO Date Time",
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"start"
+									]
+								}
+							]
+						},
+						"datePickerLimits": {
+							"type": "object",
+							"properties": {
+								"start": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								"end": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								}
+							},
+							"additionalProperties": false
+						},
+						"exportConfig": {
+							"description": "Extra config options for exporting"
+						},
+						"noDataMessage": {
+							"description": "Message which shows if no data is found",
+							"type": "string"
+						},
+						"noDataFetch": {
+							"description": "If true, Tupaia will not fetch any data for this viz. Usually used with custom vizes of type: component, e.g. ProjectDescription.",
+							"default": false,
+							"type": "boolean"
+						},
+						"drillDown": {
+							"type": "object",
+							"properties": {
+								"keyLink": {
+									"type": "string"
+								},
+								"itemCode": {
+									"type": "string"
+								},
+								"parameterLink": {
+									"type": "string"
+								},
+								"itemCodeByEntry": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "string"
+									}
+								}
+							},
+							"additionalProperties": false
+						},
+						"entityHeader": {
+							"description": "",
+							"type": "string"
+						},
+						"reference": {
+							"description": "If provided shows an (i) icon next to the viz title, which allows linking to the source data",
+							"type": "object",
+							"properties": {
+								"link": {
+									"description": "url",
+									"type": "string"
+								},
+								"name": {
+									"description": "label",
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"link",
+								"name"
+							]
+						},
+						"source": {
+							"description": "If specified allows the frontend to know where the data is coming from, so if there is no data it can show a custom no-data message e.g. \"Requires mSupply\".",
+							"type": "string"
+						},
+						"displayOnEntityConditions": {
+							"description": "If specified will only show this viz if the conditions are met against the current Entity.",
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"attributes": {
+											"type": "object",
+											"additionalProperties": {
+												"type": [
+													"string",
+													"number",
+													"boolean"
+												]
+											}
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"attributes"
+									]
+								},
+								{
+									"type": "object",
+									"additionalProperties": {
+										"type": [
+											"string",
+											"number",
+											"boolean"
+										]
+									}
+								}
+							]
+						},
+						"weekDisplayFormat": {
+							"description": "Allows customising how weeks are displayed, e.g. 'W/C 6 Jan 2020' or 'ISO Week 2 2020'",
+							"default": "'WEEK_COMMENCING_ABBR'",
+							"enum": [
+								"ISO_WEEK_NUMBER",
+								"WEEK_COMMENCING",
+								"WEEK_COMMENCING_ABBR",
+								"WEEK_ENDING",
+								"WEEK_ENDING_ABBR"
+							],
+							"type": "string"
+						},
+						"type": {
+							"type": "string",
+							"enum": [
+								"view"
+							]
+						},
+						"valueType": {
+							"enum": [
+								"boolean",
+								"color",
+								"currency",
+								"fraction",
+								"fractionAndPercentage",
+								"number",
+								"oneDecimalPlace",
+								"percentage",
+								"text",
+								"view"
+							],
+							"type": "string"
+						},
+						"value_metadata": {
+							"type": "object",
+							"additionalProperties": false
+						},
+						"viewType": {
+							"type": "string",
+							"enum": [
+								"list"
+							]
+						},
+						"listConfig": {
+							"type": "object",
+							"additionalProperties": {
+								"type": "object",
+								"properties": {
+									"color": {
+										"type": "string"
+									},
+									"label": {
+										"type": "string"
+									}
+								},
+								"additionalProperties": false,
+								"required": [
+									"color",
+									"label"
+								]
+							}
+						},
+						"valueTranslationOptions": {
+							"description": "If provided, performs a find and replace on list item content",
+							"type": "object",
+							"properties": {
+								"match": {
+									"type": "string"
+								},
+								"replace": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"match",
+								"replace"
+							]
+						}
+					},
+					"required": [
+						"listConfig",
+						"name",
+						"type",
+						"viewType"
+					]
+				},
+				{
+					"additionalProperties": false,
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						},
+						"description": {
+							"description": "A short description that appears above a viz",
+							"type": "string"
+						},
+						"placeholder": {
+							"description": "A url to an image to be used when a viz is collapsed. Some vizes display small, others display a placeholder.",
+							"type": "string"
+						},
+						"periodGranularity": {
+							"enum": [
+								"day",
+								"month",
+								"one_day_at_a_time",
+								"one_month_at_a_time",
+								"one_quarter_at_a_time",
+								"one_week_at_a_time",
+								"one_year_at_a_time",
+								"quarter",
+								"week",
+								"year"
+							],
+							"type": "string"
+						},
+						"defaultTimePeriod": {
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"offset": {
+											"type": "number"
+										},
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										},
+										"end": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"end",
+										"start"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"description": "ISO Date Time",
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"start"
+									]
+								}
+							]
+						},
+						"datePickerLimits": {
+							"type": "object",
+							"properties": {
+								"start": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								"end": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								}
+							},
+							"additionalProperties": false
+						},
+						"exportConfig": {
+							"description": "Extra config options for exporting"
+						},
+						"noDataMessage": {
+							"description": "Message which shows if no data is found",
+							"type": "string"
+						},
+						"noDataFetch": {
+							"description": "If true, Tupaia will not fetch any data for this viz. Usually used with custom vizes of type: component, e.g. ProjectDescription.",
+							"default": false,
+							"type": "boolean"
+						},
+						"drillDown": {
+							"type": "object",
+							"properties": {
+								"keyLink": {
+									"type": "string"
+								},
+								"itemCode": {
+									"type": "string"
+								},
+								"parameterLink": {
+									"type": "string"
+								},
+								"itemCodeByEntry": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "string"
+									}
+								}
+							},
+							"additionalProperties": false
+						},
+						"entityHeader": {
+							"description": "",
+							"type": "string"
+						},
+						"reference": {
+							"description": "If provided shows an (i) icon next to the viz title, which allows linking to the source data",
+							"type": "object",
+							"properties": {
+								"link": {
+									"description": "url",
+									"type": "string"
+								},
+								"name": {
+									"description": "label",
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"link",
+								"name"
+							]
+						},
+						"source": {
+							"description": "If specified allows the frontend to know where the data is coming from, so if there is no data it can show a custom no-data message e.g. \"Requires mSupply\".",
+							"type": "string"
+						},
+						"displayOnEntityConditions": {
+							"description": "If specified will only show this viz if the conditions are met against the current Entity.",
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"attributes": {
+											"type": "object",
+											"additionalProperties": {
+												"type": [
+													"string",
+													"number",
+													"boolean"
+												]
+											}
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"attributes"
+									]
+								},
+								{
+									"type": "object",
+									"additionalProperties": {
+										"type": [
+											"string",
+											"number",
+											"boolean"
+										]
+									}
+								}
+							]
+						},
+						"weekDisplayFormat": {
+							"description": "Allows customising how weeks are displayed, e.g. 'W/C 6 Jan 2020' or 'ISO Week 2 2020'",
+							"default": "'WEEK_COMMENCING_ABBR'",
+							"enum": [
+								"ISO_WEEK_NUMBER",
+								"WEEK_COMMENCING",
+								"WEEK_COMMENCING_ABBR",
+								"WEEK_ENDING",
+								"WEEK_ENDING_ABBR"
+							],
+							"type": "string"
+						},
+						"type": {
+							"type": "string",
+							"enum": [
+								"view"
+							]
+						},
+						"valueType": {
+							"enum": [
+								"boolean",
+								"color",
+								"currency",
+								"fraction",
+								"fractionAndPercentage",
+								"number",
+								"oneDecimalPlace",
+								"percentage",
+								"text",
+								"view"
+							],
+							"type": "string"
+						},
+						"value_metadata": {
+							"type": "object",
+							"additionalProperties": false
+						},
+						"viewType": {
+							"type": "string",
+							"enum": [
+								"singleValue"
+							]
+						},
+						"dataColor": {
+							"type": "string"
+						}
+					},
+					"required": [
+						"dataColor",
+						"name",
+						"type",
+						"viewType"
+					]
+				},
+				{
+					"additionalProperties": false,
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						},
+						"description": {
+							"description": "A short description that appears above a viz",
+							"type": "string"
+						},
+						"placeholder": {
+							"description": "A url to an image to be used when a viz is collapsed. Some vizes display small, others display a placeholder.",
+							"type": "string"
+						},
+						"periodGranularity": {
+							"enum": [
+								"day",
+								"month",
+								"one_day_at_a_time",
+								"one_month_at_a_time",
+								"one_quarter_at_a_time",
+								"one_week_at_a_time",
+								"one_year_at_a_time",
+								"quarter",
+								"week",
+								"year"
+							],
+							"type": "string"
+						},
+						"defaultTimePeriod": {
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"offset": {
+											"type": "number"
+										},
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										},
+										"end": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"end",
+										"start"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"description": "ISO Date Time",
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"start"
+									]
+								}
+							]
+						},
+						"datePickerLimits": {
+							"type": "object",
+							"properties": {
+								"start": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								"end": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								}
+							},
+							"additionalProperties": false
+						},
+						"exportConfig": {
+							"description": "Extra config options for exporting"
+						},
+						"noDataMessage": {
+							"description": "Message which shows if no data is found",
+							"type": "string"
+						},
+						"noDataFetch": {
+							"description": "If true, Tupaia will not fetch any data for this viz. Usually used with custom vizes of type: component, e.g. ProjectDescription.",
+							"default": false,
+							"type": "boolean"
+						},
+						"drillDown": {
+							"type": "object",
+							"properties": {
+								"keyLink": {
+									"type": "string"
+								},
+								"itemCode": {
+									"type": "string"
+								},
+								"parameterLink": {
+									"type": "string"
+								},
+								"itemCodeByEntry": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "string"
+									}
+								}
+							},
+							"additionalProperties": false
+						},
+						"entityHeader": {
+							"description": "",
+							"type": "string"
+						},
+						"reference": {
+							"description": "If provided shows an (i) icon next to the viz title, which allows linking to the source data",
+							"type": "object",
+							"properties": {
+								"link": {
+									"description": "url",
+									"type": "string"
+								},
+								"name": {
+									"description": "label",
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"link",
+								"name"
+							]
+						},
+						"source": {
+							"description": "If specified allows the frontend to know where the data is coming from, so if there is no data it can show a custom no-data message e.g. \"Requires mSupply\".",
+							"type": "string"
+						},
+						"displayOnEntityConditions": {
+							"description": "If specified will only show this viz if the conditions are met against the current Entity.",
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"attributes": {
+											"type": "object",
+											"additionalProperties": {
+												"type": [
+													"string",
+													"number",
+													"boolean"
+												]
+											}
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"attributes"
+									]
+								},
+								{
+									"type": "object",
+									"additionalProperties": {
+										"type": [
+											"string",
+											"number",
+											"boolean"
+										]
+									}
+								}
+							]
+						},
+						"weekDisplayFormat": {
+							"description": "Allows customising how weeks are displayed, e.g. 'W/C 6 Jan 2020' or 'ISO Week 2 2020'",
+							"default": "'WEEK_COMMENCING_ABBR'",
+							"enum": [
+								"ISO_WEEK_NUMBER",
+								"WEEK_COMMENCING",
+								"WEEK_COMMENCING_ABBR",
+								"WEEK_ENDING",
+								"WEEK_ENDING_ABBR"
+							],
+							"type": "string"
+						},
+						"type": {
+							"type": "string",
+							"enum": [
+								"view"
+							]
+						},
+						"valueType": {
+							"enum": [
+								"boolean",
+								"color",
+								"currency",
+								"fraction",
+								"fractionAndPercentage",
+								"number",
+								"oneDecimalPlace",
+								"percentage",
+								"text",
+								"view"
+							],
+							"type": "string"
+						},
+						"value_metadata": {
+							"type": "object",
+							"additionalProperties": false
+						},
+						"viewType": {
+							"type": "string",
+							"enum": [
+								"multiPhotograph"
+							]
+						}
+					},
+					"required": [
+						"name",
+						"type",
+						"viewType"
+					]
+				},
+				{
+					"additionalProperties": false,
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						},
+						"description": {
+							"description": "A short description that appears above a viz",
+							"type": "string"
+						},
+						"placeholder": {
+							"description": "A url to an image to be used when a viz is collapsed. Some vizes display small, others display a placeholder.",
+							"type": "string"
+						},
+						"periodGranularity": {
+							"enum": [
+								"day",
+								"month",
+								"one_day_at_a_time",
+								"one_month_at_a_time",
+								"one_quarter_at_a_time",
+								"one_week_at_a_time",
+								"one_year_at_a_time",
+								"quarter",
+								"week",
+								"year"
+							],
+							"type": "string"
+						},
+						"defaultTimePeriod": {
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"offset": {
+											"type": "number"
+										},
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										},
+										"end": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"end",
+										"start"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"description": "ISO Date Time",
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"start"
+									]
+								}
+							]
+						},
+						"datePickerLimits": {
+							"type": "object",
+							"properties": {
+								"start": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								"end": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								}
+							},
+							"additionalProperties": false
+						},
+						"exportConfig": {
+							"description": "Extra config options for exporting"
+						},
+						"noDataMessage": {
+							"description": "Message which shows if no data is found",
+							"type": "string"
+						},
+						"noDataFetch": {
+							"description": "If true, Tupaia will not fetch any data for this viz. Usually used with custom vizes of type: component, e.g. ProjectDescription.",
+							"default": false,
+							"type": "boolean"
+						},
+						"drillDown": {
+							"type": "object",
+							"properties": {
+								"keyLink": {
+									"type": "string"
+								},
+								"itemCode": {
+									"type": "string"
+								},
+								"parameterLink": {
+									"type": "string"
+								},
+								"itemCodeByEntry": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "string"
+									}
+								}
+							},
+							"additionalProperties": false
+						},
+						"entityHeader": {
+							"description": "",
+							"type": "string"
+						},
+						"reference": {
+							"description": "If provided shows an (i) icon next to the viz title, which allows linking to the source data",
+							"type": "object",
+							"properties": {
+								"link": {
+									"description": "url",
+									"type": "string"
+								},
+								"name": {
+									"description": "label",
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"link",
+								"name"
+							]
+						},
+						"source": {
+							"description": "If specified allows the frontend to know where the data is coming from, so if there is no data it can show a custom no-data message e.g. \"Requires mSupply\".",
+							"type": "string"
+						},
+						"displayOnEntityConditions": {
+							"description": "If specified will only show this viz if the conditions are met against the current Entity.",
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"attributes": {
+											"type": "object",
+											"additionalProperties": {
+												"type": [
+													"string",
+													"number",
+													"boolean"
+												]
+											}
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"attributes"
+									]
+								},
+								{
+									"type": "object",
+									"additionalProperties": {
+										"type": [
+											"string",
+											"number",
+											"boolean"
+										]
+									}
+								}
+							]
+						},
+						"weekDisplayFormat": {
+							"description": "Allows customising how weeks are displayed, e.g. 'W/C 6 Jan 2020' or 'ISO Week 2 2020'",
+							"default": "'WEEK_COMMENCING_ABBR'",
+							"enum": [
+								"ISO_WEEK_NUMBER",
+								"WEEK_COMMENCING",
+								"WEEK_COMMENCING_ABBR",
+								"WEEK_ENDING",
+								"WEEK_ENDING_ABBR"
+							],
+							"type": "string"
+						},
+						"type": {
+							"type": "string",
+							"enum": [
+								"view"
+							]
+						},
+						"valueType": {
+							"enum": [
+								"boolean",
+								"color",
+								"currency",
+								"fraction",
+								"fractionAndPercentage",
+								"number",
+								"oneDecimalPlace",
+								"percentage",
+								"text",
+								"view"
+							],
+							"type": "string"
+						},
+						"value_metadata": {
+							"type": "object",
+							"additionalProperties": false
+						},
+						"viewType": {
+							"type": "string",
+							"enum": [
+								"multiSingleValue"
+							]
+						}
+					},
+					"required": [
+						"name",
+						"type",
+						"viewType"
+					]
+				},
+				{
+					"additionalProperties": false,
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						},
+						"description": {
+							"description": "A short description that appears above a viz",
+							"type": "string"
+						},
+						"placeholder": {
+							"description": "A url to an image to be used when a viz is collapsed. Some vizes display small, others display a placeholder.",
+							"type": "string"
+						},
+						"periodGranularity": {
+							"enum": [
+								"day",
+								"month",
+								"one_day_at_a_time",
+								"one_month_at_a_time",
+								"one_quarter_at_a_time",
+								"one_week_at_a_time",
+								"one_year_at_a_time",
+								"quarter",
+								"week",
+								"year"
+							],
+							"type": "string"
+						},
+						"defaultTimePeriod": {
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"offset": {
+											"type": "number"
+										},
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										},
+										"end": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"end",
+										"start"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"description": "ISO Date Time",
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"start"
+									]
+								}
+							]
+						},
+						"datePickerLimits": {
+							"type": "object",
+							"properties": {
+								"start": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								"end": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								}
+							},
+							"additionalProperties": false
+						},
+						"exportConfig": {
+							"description": "Extra config options for exporting"
+						},
+						"noDataMessage": {
+							"description": "Message which shows if no data is found",
+							"type": "string"
+						},
+						"noDataFetch": {
+							"description": "If true, Tupaia will not fetch any data for this viz. Usually used with custom vizes of type: component, e.g. ProjectDescription.",
+							"default": false,
+							"type": "boolean"
+						},
+						"drillDown": {
+							"type": "object",
+							"properties": {
+								"keyLink": {
+									"type": "string"
+								},
+								"itemCode": {
+									"type": "string"
+								},
+								"parameterLink": {
+									"type": "string"
+								},
+								"itemCodeByEntry": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "string"
+									}
+								}
+							},
+							"additionalProperties": false
+						},
+						"entityHeader": {
+							"description": "",
+							"type": "string"
+						},
+						"reference": {
+							"description": "If provided shows an (i) icon next to the viz title, which allows linking to the source data",
+							"type": "object",
+							"properties": {
+								"link": {
+									"description": "url",
+									"type": "string"
+								},
+								"name": {
+									"description": "label",
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"link",
+								"name"
+							]
+						},
+						"source": {
+							"description": "If specified allows the frontend to know where the data is coming from, so if there is no data it can show a custom no-data message e.g. \"Requires mSupply\".",
+							"type": "string"
+						},
+						"displayOnEntityConditions": {
+							"description": "If specified will only show this viz if the conditions are met against the current Entity.",
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"attributes": {
+											"type": "object",
+											"additionalProperties": {
+												"type": [
+													"string",
+													"number",
+													"boolean"
+												]
+											}
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"attributes"
+									]
+								},
+								{
+									"type": "object",
+									"additionalProperties": {
+										"type": [
+											"string",
+											"number",
+											"boolean"
+										]
+									}
+								}
+							]
+						},
+						"weekDisplayFormat": {
+							"description": "Allows customising how weeks are displayed, e.g. 'W/C 6 Jan 2020' or 'ISO Week 2 2020'",
+							"default": "'WEEK_COMMENCING_ABBR'",
+							"enum": [
+								"ISO_WEEK_NUMBER",
+								"WEEK_COMMENCING",
+								"WEEK_COMMENCING_ABBR",
+								"WEEK_ENDING",
+								"WEEK_ENDING_ABBR"
+							],
+							"type": "string"
+						},
+						"type": {
+							"type": "string",
+							"enum": [
+								"view"
+							]
+						},
+						"valueType": {
+							"enum": [
+								"boolean",
+								"color",
+								"currency",
+								"fraction",
+								"fractionAndPercentage",
+								"number",
+								"oneDecimalPlace",
+								"percentage",
+								"text",
+								"view"
+							],
+							"type": "string"
+						},
+						"value_metadata": {
+							"type": "object",
+							"additionalProperties": false
+						},
+						"viewType": {
+							"type": "string",
+							"enum": [
+								"singleDownloadLink"
+							]
+						}
+					},
+					"required": [
+						"name",
+						"type",
+						"viewType"
+					]
+				},
+				{
+					"additionalProperties": false,
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						},
+						"description": {
+							"description": "A short description that appears above a viz",
+							"type": "string"
+						},
+						"placeholder": {
+							"description": "A url to an image to be used when a viz is collapsed. Some vizes display small, others display a placeholder.",
+							"type": "string"
+						},
+						"periodGranularity": {
+							"enum": [
+								"day",
+								"month",
+								"one_day_at_a_time",
+								"one_month_at_a_time",
+								"one_quarter_at_a_time",
+								"one_week_at_a_time",
+								"one_year_at_a_time",
+								"quarter",
+								"week",
+								"year"
+							],
+							"type": "string"
+						},
+						"defaultTimePeriod": {
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"offset": {
+											"type": "number"
+										},
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										},
+										"end": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"end",
+										"start"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"description": "ISO Date Time",
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"start"
+									]
+								}
+							]
+						},
+						"datePickerLimits": {
+							"type": "object",
+							"properties": {
+								"start": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								"end": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								}
+							},
+							"additionalProperties": false
+						},
+						"exportConfig": {
+							"description": "Extra config options for exporting"
+						},
+						"noDataMessage": {
+							"description": "Message which shows if no data is found",
+							"type": "string"
+						},
+						"noDataFetch": {
+							"description": "If true, Tupaia will not fetch any data for this viz. Usually used with custom vizes of type: component, e.g. ProjectDescription.",
+							"default": false,
+							"type": "boolean"
+						},
+						"drillDown": {
+							"type": "object",
+							"properties": {
+								"keyLink": {
+									"type": "string"
+								},
+								"itemCode": {
+									"type": "string"
+								},
+								"parameterLink": {
+									"type": "string"
+								},
+								"itemCodeByEntry": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "string"
+									}
+								}
+							},
+							"additionalProperties": false
+						},
+						"entityHeader": {
+							"description": "",
+							"type": "string"
+						},
+						"reference": {
+							"description": "If provided shows an (i) icon next to the viz title, which allows linking to the source data",
+							"type": "object",
+							"properties": {
+								"link": {
+									"description": "url",
+									"type": "string"
+								},
+								"name": {
+									"description": "label",
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"link",
+								"name"
+							]
+						},
+						"source": {
+							"description": "If specified allows the frontend to know where the data is coming from, so if there is no data it can show a custom no-data message e.g. \"Requires mSupply\".",
+							"type": "string"
+						},
+						"displayOnEntityConditions": {
+							"description": "If specified will only show this viz if the conditions are met against the current Entity.",
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"attributes": {
+											"type": "object",
+											"additionalProperties": {
+												"type": [
+													"string",
+													"number",
+													"boolean"
+												]
+											}
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"attributes"
+									]
+								},
+								{
+									"type": "object",
+									"additionalProperties": {
+										"type": [
+											"string",
+											"number",
+											"boolean"
+										]
+									}
+								}
+							]
+						},
+						"weekDisplayFormat": {
+							"description": "Allows customising how weeks are displayed, e.g. 'W/C 6 Jan 2020' or 'ISO Week 2 2020'",
+							"default": "'WEEK_COMMENCING_ABBR'",
+							"enum": [
+								"ISO_WEEK_NUMBER",
+								"WEEK_COMMENCING",
+								"WEEK_COMMENCING_ABBR",
+								"WEEK_ENDING",
+								"WEEK_ENDING_ABBR"
+							],
+							"type": "string"
+						},
+						"type": {
+							"type": "string",
+							"enum": [
+								"view"
+							]
+						},
+						"valueType": {
+							"enum": [
+								"boolean",
+								"color",
+								"currency",
+								"fraction",
+								"fractionAndPercentage",
+								"number",
+								"oneDecimalPlace",
+								"percentage",
+								"text",
+								"view"
+							],
+							"type": "string"
+						},
+						"value_metadata": {
+							"type": "object",
+							"additionalProperties": false
+						},
+						"viewType": {
+							"type": "string",
+							"enum": [
+								"multiValueRow"
+							]
+						},
+						"presentationOptions": {
+							"additionalProperties": false,
+							"type": "object",
+							"properties": {
+								"color": {
+									"type": "string"
+								},
+								"header": {
+									"type": "string"
+								},
+								"dataPairNames": {
+									"type": "array",
+									"items": {
+										"type": "string"
+									}
+								},
+								"rowHeader": {
+									"additionalProperties": false,
+									"type": "object",
+									"properties": {
+										"color": {
+											"type": "string"
+										},
+										"name": {
+											"type": "string"
+										}
+									},
+									"required": [
+										"color"
+									]
+								},
+								"leftColumn": {
+									"additionalProperties": false,
+									"type": "object",
+									"properties": {
+										"color": {
+											"type": "string"
+										},
+										"header": {
+											"type": "string"
+										}
+									},
+									"required": [
+										"color",
+										"header"
+									]
+								},
+								"rightColumn": {
+									"additionalProperties": false,
+									"type": "object",
+									"properties": {
+										"color": {
+											"type": "string"
+										},
+										"header": {
+											"type": "string"
+										}
+									},
+									"required": [
+										"color",
+										"header"
+									]
+								},
+								"middleColumn": {
+									"additionalProperties": false,
+									"type": "object",
+									"properties": {
+										"color": {
+											"type": "string"
+										},
+										"header": {
+											"type": "string"
+										}
+									},
+									"required": [
+										"color",
+										"header"
+									]
+								}
+							},
+							"required": [
+								"color",
+								"header"
+							]
+						}
+					},
+					"required": [
+						"name",
+						"type",
+						"viewType"
+					]
+				},
+				{
+					"additionalProperties": false,
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						},
+						"description": {
+							"description": "A short description that appears above a viz",
+							"type": "string"
+						},
+						"placeholder": {
+							"description": "A url to an image to be used when a viz is collapsed. Some vizes display small, others display a placeholder.",
+							"type": "string"
+						},
+						"periodGranularity": {
+							"enum": [
+								"day",
+								"month",
+								"one_day_at_a_time",
+								"one_month_at_a_time",
+								"one_quarter_at_a_time",
+								"one_week_at_a_time",
+								"one_year_at_a_time",
+								"quarter",
+								"week",
+								"year"
+							],
+							"type": "string"
+						},
+						"defaultTimePeriod": {
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"offset": {
+											"type": "number"
+										},
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										},
+										"end": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"end",
+										"start"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"description": "ISO Date Time",
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"start"
+									]
+								}
+							]
+						},
+						"datePickerLimits": {
+							"type": "object",
+							"properties": {
+								"start": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								"end": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								}
+							},
+							"additionalProperties": false
+						},
+						"exportConfig": {
+							"description": "Extra config options for exporting"
+						},
+						"noDataMessage": {
+							"description": "Message which shows if no data is found",
+							"type": "string"
+						},
+						"noDataFetch": {
+							"description": "If true, Tupaia will not fetch any data for this viz. Usually used with custom vizes of type: component, e.g. ProjectDescription.",
+							"default": false,
+							"type": "boolean"
+						},
+						"drillDown": {
+							"type": "object",
+							"properties": {
+								"keyLink": {
+									"type": "string"
+								},
+								"itemCode": {
+									"type": "string"
+								},
+								"parameterLink": {
+									"type": "string"
+								},
+								"itemCodeByEntry": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "string"
+									}
+								}
+							},
+							"additionalProperties": false
+						},
+						"entityHeader": {
+							"description": "",
+							"type": "string"
+						},
+						"reference": {
+							"description": "If provided shows an (i) icon next to the viz title, which allows linking to the source data",
+							"type": "object",
+							"properties": {
+								"link": {
+									"description": "url",
+									"type": "string"
+								},
+								"name": {
+									"description": "label",
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"link",
+								"name"
+							]
+						},
+						"source": {
+							"description": "If specified allows the frontend to know where the data is coming from, so if there is no data it can show a custom no-data message e.g. \"Requires mSupply\".",
+							"type": "string"
+						},
+						"displayOnEntityConditions": {
+							"description": "If specified will only show this viz if the conditions are met against the current Entity.",
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"attributes": {
+											"type": "object",
+											"additionalProperties": {
+												"type": [
+													"string",
+													"number",
+													"boolean"
+												]
+											}
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"attributes"
+									]
+								},
+								{
+									"type": "object",
+									"additionalProperties": {
+										"type": [
+											"string",
+											"number",
+											"boolean"
+										]
+									}
+								}
+							]
+						},
+						"weekDisplayFormat": {
+							"description": "Allows customising how weeks are displayed, e.g. 'W/C 6 Jan 2020' or 'ISO Week 2 2020'",
+							"default": "'WEEK_COMMENCING_ABBR'",
+							"enum": [
+								"ISO_WEEK_NUMBER",
+								"WEEK_COMMENCING",
+								"WEEK_COMMENCING_ABBR",
+								"WEEK_ENDING",
+								"WEEK_ENDING_ABBR"
+							],
+							"type": "string"
+						},
+						"type": {
+							"type": "string",
+							"enum": [
+								"view"
+							]
+						},
+						"valueType": {
+							"enum": [
+								"boolean",
+								"color",
+								"currency",
+								"fraction",
+								"fractionAndPercentage",
+								"number",
+								"oneDecimalPlace",
+								"percentage",
+								"text",
+								"view"
+							],
+							"type": "string"
+						},
+						"value_metadata": {
+							"type": "object",
+							"additionalProperties": false
+						},
+						"viewType": {
+							"type": "string",
+							"enum": [
+								"dataDownload"
+							]
+						}
+					},
+					"required": [
+						"name",
+						"type",
+						"viewType"
+					]
+				},
+				{
+					"additionalProperties": false,
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						},
+						"description": {
+							"description": "A short description that appears above a viz",
+							"type": "string"
+						},
+						"placeholder": {
+							"description": "A url to an image to be used when a viz is collapsed. Some vizes display small, others display a placeholder.",
+							"type": "string"
+						},
+						"periodGranularity": {
+							"enum": [
+								"day",
+								"month",
+								"one_day_at_a_time",
+								"one_month_at_a_time",
+								"one_quarter_at_a_time",
+								"one_week_at_a_time",
+								"one_year_at_a_time",
+								"quarter",
+								"week",
+								"year"
+							],
+							"type": "string"
+						},
+						"defaultTimePeriod": {
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"offset": {
+											"type": "number"
+										},
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										},
+										"end": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"end",
+										"start"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"description": "ISO Date Time",
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"start"
+									]
+								}
+							]
+						},
+						"datePickerLimits": {
+							"type": "object",
+							"properties": {
+								"start": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								"end": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								}
+							},
+							"additionalProperties": false
+						},
+						"exportConfig": {
+							"description": "Extra config options for exporting"
+						},
+						"noDataMessage": {
+							"description": "Message which shows if no data is found",
+							"type": "string"
+						},
+						"noDataFetch": {
+							"description": "If true, Tupaia will not fetch any data for this viz. Usually used with custom vizes of type: component, e.g. ProjectDescription.",
+							"default": false,
+							"type": "boolean"
+						},
+						"drillDown": {
+							"type": "object",
+							"properties": {
+								"keyLink": {
+									"type": "string"
+								},
+								"itemCode": {
+									"type": "string"
+								},
+								"parameterLink": {
+									"type": "string"
+								},
+								"itemCodeByEntry": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "string"
+									}
+								}
+							},
+							"additionalProperties": false
+						},
+						"entityHeader": {
+							"description": "",
+							"type": "string"
+						},
+						"reference": {
+							"description": "If provided shows an (i) icon next to the viz title, which allows linking to the source data",
+							"type": "object",
+							"properties": {
+								"link": {
+									"description": "url",
+									"type": "string"
+								},
+								"name": {
+									"description": "label",
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"link",
+								"name"
+							]
+						},
+						"source": {
+							"description": "If specified allows the frontend to know where the data is coming from, so if there is no data it can show a custom no-data message e.g. \"Requires mSupply\".",
+							"type": "string"
+						},
+						"displayOnEntityConditions": {
+							"description": "If specified will only show this viz if the conditions are met against the current Entity.",
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"attributes": {
+											"type": "object",
+											"additionalProperties": {
+												"type": [
+													"string",
+													"number",
+													"boolean"
+												]
+											}
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"attributes"
+									]
+								},
+								{
+									"type": "object",
+									"additionalProperties": {
+										"type": [
+											"string",
+											"number",
+											"boolean"
+										]
+									}
+								}
+							]
+						},
+						"weekDisplayFormat": {
+							"description": "Allows customising how weeks are displayed, e.g. 'W/C 6 Jan 2020' or 'ISO Week 2 2020'",
+							"default": "'WEEK_COMMENCING_ABBR'",
+							"enum": [
+								"ISO_WEEK_NUMBER",
+								"WEEK_COMMENCING",
+								"WEEK_COMMENCING_ABBR",
+								"WEEK_ENDING",
+								"WEEK_ENDING_ABBR"
+							],
+							"type": "string"
+						},
+						"type": {
+							"type": "string",
+							"enum": [
+								"view"
+							]
+						},
+						"valueType": {
+							"enum": [
+								"boolean",
+								"color",
+								"currency",
+								"fraction",
+								"fractionAndPercentage",
+								"number",
+								"oneDecimalPlace",
+								"percentage",
+								"text",
+								"view"
+							],
+							"type": "string"
+						},
+						"value_metadata": {
+							"type": "object",
+							"additionalProperties": false
+						},
+						"viewType": {
+							"type": "string",
+							"enum": [
+								"singleDate"
+							]
+						}
+					},
+					"required": [
+						"name",
+						"type",
+						"viewType"
+					]
+				},
+				{
+					"additionalProperties": false,
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						},
+						"description": {
+							"description": "A short description that appears above a viz",
+							"type": "string"
+						},
+						"placeholder": {
+							"description": "A url to an image to be used when a viz is collapsed. Some vizes display small, others display a placeholder.",
+							"type": "string"
+						},
+						"periodGranularity": {
+							"enum": [
+								"day",
+								"month",
+								"one_day_at_a_time",
+								"one_month_at_a_time",
+								"one_quarter_at_a_time",
+								"one_week_at_a_time",
+								"one_year_at_a_time",
+								"quarter",
+								"week",
+								"year"
+							],
+							"type": "string"
+						},
+						"defaultTimePeriod": {
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"offset": {
+											"type": "number"
+										},
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										},
+										"end": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"end",
+										"start"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"description": "ISO Date Time",
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"start"
+									]
+								}
+							]
+						},
+						"datePickerLimits": {
+							"type": "object",
+							"properties": {
+								"start": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								"end": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								}
+							},
+							"additionalProperties": false
+						},
+						"exportConfig": {
+							"description": "Extra config options for exporting"
+						},
+						"noDataMessage": {
+							"description": "Message which shows if no data is found",
+							"type": "string"
+						},
+						"noDataFetch": {
+							"description": "If true, Tupaia will not fetch any data for this viz. Usually used with custom vizes of type: component, e.g. ProjectDescription.",
+							"default": false,
+							"type": "boolean"
+						},
+						"drillDown": {
+							"type": "object",
+							"properties": {
+								"keyLink": {
+									"type": "string"
+								},
+								"itemCode": {
+									"type": "string"
+								},
+								"parameterLink": {
+									"type": "string"
+								},
+								"itemCodeByEntry": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "string"
+									}
+								}
+							},
+							"additionalProperties": false
+						},
+						"entityHeader": {
+							"description": "",
+							"type": "string"
+						},
+						"reference": {
+							"description": "If provided shows an (i) icon next to the viz title, which allows linking to the source data",
+							"type": "object",
+							"properties": {
+								"link": {
+									"description": "url",
+									"type": "string"
+								},
+								"name": {
+									"description": "label",
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"link",
+								"name"
+							]
+						},
+						"source": {
+							"description": "If specified allows the frontend to know where the data is coming from, so if there is no data it can show a custom no-data message e.g. \"Requires mSupply\".",
+							"type": "string"
+						},
+						"displayOnEntityConditions": {
+							"description": "If specified will only show this viz if the conditions are met against the current Entity.",
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"attributes": {
+											"type": "object",
+											"additionalProperties": {
+												"type": [
+													"string",
+													"number",
+													"boolean"
+												]
+											}
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"attributes"
+									]
+								},
+								{
+									"type": "object",
+									"additionalProperties": {
+										"type": [
+											"string",
+											"number",
+											"boolean"
+										]
+									}
+								}
+							]
+						},
+						"weekDisplayFormat": {
+							"description": "Allows customising how weeks are displayed, e.g. 'W/C 6 Jan 2020' or 'ISO Week 2 2020'",
+							"default": "'WEEK_COMMENCING_ABBR'",
+							"enum": [
+								"ISO_WEEK_NUMBER",
+								"WEEK_COMMENCING",
+								"WEEK_COMMENCING_ABBR",
+								"WEEK_ENDING",
+								"WEEK_ENDING_ABBR"
+							],
+							"type": "string"
+						},
+						"type": {
+							"type": "string",
+							"enum": [
+								"view"
+							]
+						},
+						"valueType": {
+							"enum": [
+								"boolean",
+								"color",
+								"currency",
+								"fraction",
+								"fractionAndPercentage",
+								"number",
+								"oneDecimalPlace",
+								"percentage",
+								"text",
+								"view"
+							],
+							"type": "string"
+						},
+						"value_metadata": {
+							"type": "object",
+							"additionalProperties": false
+						},
+						"viewType": {
+							"type": "string",
+							"enum": [
+								"filesDownload"
+							]
+						}
+					},
+					"required": [
+						"name",
+						"type",
+						"viewType"
+					]
+				},
+				{
+					"additionalProperties": false,
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						},
+						"description": {
+							"description": "A short description that appears above a viz",
+							"type": "string"
+						},
+						"placeholder": {
+							"description": "A url to an image to be used when a viz is collapsed. Some vizes display small, others display a placeholder.",
+							"type": "string"
+						},
+						"periodGranularity": {
+							"enum": [
+								"day",
+								"month",
+								"one_day_at_a_time",
+								"one_month_at_a_time",
+								"one_quarter_at_a_time",
+								"one_week_at_a_time",
+								"one_year_at_a_time",
+								"quarter",
+								"week",
+								"year"
+							],
+							"type": "string"
+						},
+						"defaultTimePeriod": {
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"offset": {
+											"type": "number"
+										},
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										},
+										"end": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"end",
+										"start"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"description": "ISO Date Time",
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"start"
+									]
+								}
+							]
+						},
+						"datePickerLimits": {
+							"type": "object",
+							"properties": {
+								"start": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								"end": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								}
+							},
+							"additionalProperties": false
+						},
+						"exportConfig": {
+							"description": "Extra config options for exporting"
+						},
+						"noDataMessage": {
+							"description": "Message which shows if no data is found",
+							"type": "string"
+						},
+						"noDataFetch": {
+							"description": "If true, Tupaia will not fetch any data for this viz. Usually used with custom vizes of type: component, e.g. ProjectDescription.",
+							"default": false,
+							"type": "boolean"
+						},
+						"drillDown": {
+							"type": "object",
+							"properties": {
+								"keyLink": {
+									"type": "string"
+								},
+								"itemCode": {
+									"type": "string"
+								},
+								"parameterLink": {
+									"type": "string"
+								},
+								"itemCodeByEntry": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "string"
+									}
+								}
+							},
+							"additionalProperties": false
+						},
+						"entityHeader": {
+							"description": "",
+							"type": "string"
+						},
+						"reference": {
+							"description": "If provided shows an (i) icon next to the viz title, which allows linking to the source data",
+							"type": "object",
+							"properties": {
+								"link": {
+									"description": "url",
+									"type": "string"
+								},
+								"name": {
+									"description": "label",
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"link",
+								"name"
+							]
+						},
+						"source": {
+							"description": "If specified allows the frontend to know where the data is coming from, so if there is no data it can show a custom no-data message e.g. \"Requires mSupply\".",
+							"type": "string"
+						},
+						"displayOnEntityConditions": {
+							"description": "If specified will only show this viz if the conditions are met against the current Entity.",
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"attributes": {
+											"type": "object",
+											"additionalProperties": {
+												"type": [
+													"string",
+													"number",
+													"boolean"
+												]
+											}
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"attributes"
+									]
+								},
+								{
+									"type": "object",
+									"additionalProperties": {
+										"type": [
+											"string",
+											"number",
+											"boolean"
+										]
+									}
+								}
+							]
+						},
+						"weekDisplayFormat": {
+							"description": "Allows customising how weeks are displayed, e.g. 'W/C 6 Jan 2020' or 'ISO Week 2 2020'",
+							"default": "'WEEK_COMMENCING_ABBR'",
+							"enum": [
+								"ISO_WEEK_NUMBER",
+								"WEEK_COMMENCING",
+								"WEEK_COMMENCING_ABBR",
+								"WEEK_ENDING",
+								"WEEK_ENDING_ABBR"
+							],
+							"type": "string"
+						},
+						"type": {
+							"type": "string",
+							"enum": [
+								"view"
+							]
+						},
+						"valueType": {
+							"enum": [
+								"boolean",
+								"color",
+								"currency",
+								"fraction",
+								"fractionAndPercentage",
+								"number",
+								"oneDecimalPlace",
+								"percentage",
+								"text",
+								"view"
+							],
+							"type": "string"
+						},
+						"value_metadata": {
+							"type": "object",
+							"additionalProperties": false
+						},
+						"viewType": {
+							"type": "string",
+							"enum": [
+								"multiValue"
+							]
+						},
+						"presentationOptions": {
+							"additionalProperties": false,
+							"type": "object",
+							"properties": {
+								"isTitleVisible": {
+									"type": "boolean"
+								},
+								"valueFormat": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"required": [
+						"name",
+						"type",
+						"viewType"
+					]
+				},
+				{
+					"additionalProperties": false,
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						},
+						"description": {
+							"description": "A short description that appears above a viz",
+							"type": "string"
+						},
+						"placeholder": {
+							"description": "A url to an image to be used when a viz is collapsed. Some vizes display small, others display a placeholder.",
+							"type": "string"
+						},
+						"periodGranularity": {
+							"enum": [
+								"day",
+								"month",
+								"one_day_at_a_time",
+								"one_month_at_a_time",
+								"one_quarter_at_a_time",
+								"one_week_at_a_time",
+								"one_year_at_a_time",
+								"quarter",
+								"week",
+								"year"
+							],
+							"type": "string"
+						},
+						"defaultTimePeriod": {
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"offset": {
+											"type": "number"
+										},
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										},
+										"end": {
+											"type": "object",
+											"properties": {
+												"unit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												},
+												"offset": {
+													"type": "number"
+												},
+												"modifier": {
+													"enum": [
+														"end_of",
+														"start_of"
+													],
+													"type": "string"
+												},
+												"modifierUnit": {
+													"enum": [
+														"day",
+														"month",
+														"quarter",
+														"week",
+														"year"
+													],
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": [
+												"offset",
+												"unit"
+											]
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"end",
+										"start"
+									]
+								},
+								{
+									"type": "object",
+									"properties": {
+										"start": {
+											"description": "ISO Date Time",
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"start"
+									]
+								}
+							]
+						},
+						"datePickerLimits": {
+							"type": "object",
+							"properties": {
+								"start": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								},
+								"end": {
+									"type": "object",
+									"properties": {
+										"unit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										},
+										"offset": {
+											"type": "number"
+										},
+										"modifier": {
+											"enum": [
+												"end_of",
+												"start_of"
+											],
+											"type": "string"
+										},
+										"modifierUnit": {
+											"enum": [
+												"day",
+												"month",
+												"quarter",
+												"week",
+												"year"
+											],
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"offset",
+										"unit"
+									]
+								}
+							},
+							"additionalProperties": false
+						},
+						"exportConfig": {
+							"description": "Extra config options for exporting"
+						},
+						"noDataMessage": {
+							"description": "Message which shows if no data is found",
+							"type": "string"
+						},
+						"noDataFetch": {
+							"description": "If true, Tupaia will not fetch any data for this viz. Usually used with custom vizes of type: component, e.g. ProjectDescription.",
+							"default": false,
+							"type": "boolean"
+						},
+						"drillDown": {
+							"type": "object",
+							"properties": {
+								"keyLink": {
+									"type": "string"
+								},
+								"itemCode": {
+									"type": "string"
+								},
+								"parameterLink": {
+									"type": "string"
+								},
+								"itemCodeByEntry": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "string"
+									}
+								}
+							},
+							"additionalProperties": false
+						},
+						"entityHeader": {
+							"description": "",
+							"type": "string"
+						},
+						"reference": {
+							"description": "If provided shows an (i) icon next to the viz title, which allows linking to the source data",
+							"type": "object",
+							"properties": {
+								"link": {
+									"description": "url",
+									"type": "string"
+								},
+								"name": {
+									"description": "label",
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"link",
+								"name"
+							]
+						},
+						"source": {
+							"description": "If specified allows the frontend to know where the data is coming from, so if there is no data it can show a custom no-data message e.g. \"Requires mSupply\".",
+							"type": "string"
+						},
+						"displayOnEntityConditions": {
+							"description": "If specified will only show this viz if the conditions are met against the current Entity.",
+							"anyOf": [
+								{
+									"type": "object",
+									"properties": {
+										"attributes": {
+											"type": "object",
+											"additionalProperties": {
+												"type": [
+													"string",
+													"number",
+													"boolean"
+												]
+											}
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"attributes"
+									]
+								},
+								{
+									"type": "object",
+									"additionalProperties": {
+										"type": [
+											"string",
+											"number",
+											"boolean"
+										]
+									}
+								}
+							]
+						},
+						"weekDisplayFormat": {
+							"description": "Allows customising how weeks are displayed, e.g. 'W/C 6 Jan 2020' or 'ISO Week 2 2020'",
+							"default": "'WEEK_COMMENCING_ABBR'",
+							"enum": [
+								"ISO_WEEK_NUMBER",
+								"WEEK_COMMENCING",
+								"WEEK_COMMENCING_ABBR",
+								"WEEK_ENDING",
+								"WEEK_ENDING_ABBR"
+							],
+							"type": "string"
+						},
+						"type": {
+							"type": "string",
+							"enum": [
+								"view"
+							]
+						},
+						"valueType": {
+							"enum": [
+								"boolean",
+								"color",
+								"currency",
+								"fraction",
+								"fractionAndPercentage",
+								"number",
+								"oneDecimalPlace",
+								"percentage",
+								"text",
+								"view"
+							],
+							"type": "string"
+						},
+						"value_metadata": {
+							"type": "object",
+							"additionalProperties": false
+						},
+						"viewType": {
+							"type": "string",
+							"enum": [
+								"qrCodeVisual"
+							]
+						}
+					},
+					"required": [
+						"name",
+						"type",
+						"viewType"
+					]
+				}
+			]
+		},
+		"id": {
+			"type": "string"
+		},
+		"legacy": {
+			"type": "boolean"
+		},
+		"permission_group_ids": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"report_code": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const DashboardRelationSchema = {
@@ -34916,8 +51639,77 @@ export const DashboardRelationSchema = {
 		"entity_types",
 		"id",
 		"permission_groups",
+		"project_codes",
+		"sort_order"
+	]
+} 
+
+export const DashboardRelationCreateSchema = {
+	"type": "object",
+	"properties": {
+		"child_id": {
+			"type": "string"
+		},
+		"dashboard_id": {
+			"type": "string"
+		},
+		"entity_types": {},
+		"permission_groups": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"project_codes": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"sort_order": {
+			"type": "number"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"child_id",
+		"dashboard_id",
+		"entity_types",
+		"permission_groups",
 		"project_codes"
 	]
+} 
+
+export const DashboardRelationUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"child_id": {
+			"type": "string"
+		},
+		"dashboard_id": {
+			"type": "string"
+		},
+		"entity_types": {},
+		"id": {
+			"type": "string"
+		},
+		"permission_groups": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"project_codes": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"sort_order": {
+			"type": "number"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const DataElementSchema = {
@@ -34955,9 +51747,83 @@ export const DataElementSchema = {
 	"additionalProperties": false,
 	"required": [
 		"code",
+		"config",
 		"id",
+		"m_row$",
+		"permission_groups",
 		"service_type"
 	]
+} 
+
+export const DataElementCreateSchema = {
+	"type": "object",
+	"properties": {
+		"code": {
+			"type": "string"
+		},
+		"config": {},
+		"m_row$": {
+			"type": "string"
+		},
+		"permission_groups": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"service_type": {
+			"enum": [
+				"data-lake",
+				"dhis",
+				"indicator",
+				"kobo",
+				"superset",
+				"tupaia",
+				"weather"
+			],
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"code",
+		"service_type"
+	]
+} 
+
+export const DataElementUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"code": {
+			"type": "string"
+		},
+		"config": {},
+		"id": {
+			"type": "string"
+		},
+		"m_row$": {
+			"type": "string"
+		},
+		"permission_groups": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"service_type": {
+			"enum": [
+				"data-lake",
+				"dhis",
+				"indicator",
+				"kobo",
+				"superset",
+				"tupaia",
+				"weather"
+			],
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const DataElementDataGroupSchema = {
@@ -34979,6 +51845,39 @@ export const DataElementDataGroupSchema = {
 		"data_group_id",
 		"id"
 	]
+} 
+
+export const DataElementDataGroupCreateSchema = {
+	"type": "object",
+	"properties": {
+		"data_element_id": {
+			"type": "string"
+		},
+		"data_group_id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"data_element_id",
+		"data_group_id"
+	]
+} 
+
+export const DataElementDataGroupUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"data_element_id": {
+			"type": "string"
+		},
+		"data_group_id": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const DataElementDataServiceSchema = {
@@ -35012,8 +51911,69 @@ export const DataElementDataServiceSchema = {
 		"country_code",
 		"data_element_code",
 		"id",
+		"service_config",
 		"service_type"
 	]
+} 
+
+export const DataElementDataServiceCreateSchema = {
+	"type": "object",
+	"properties": {
+		"country_code": {
+			"type": "string"
+		},
+		"data_element_code": {
+			"type": "string"
+		},
+		"service_config": {},
+		"service_type": {
+			"enum": [
+				"data-lake",
+				"dhis",
+				"indicator",
+				"kobo",
+				"superset",
+				"tupaia",
+				"weather"
+			],
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"country_code",
+		"data_element_code",
+		"service_type"
+	]
+} 
+
+export const DataElementDataServiceUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"country_code": {
+			"type": "string"
+		},
+		"data_element_code": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"service_config": {},
+		"service_type": {
+			"enum": [
+				"data-lake",
+				"dhis",
+				"indicator",
+				"kobo",
+				"superset",
+				"tupaia",
+				"weather"
+			],
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const DataGroupSchema = {
@@ -35042,9 +52002,63 @@ export const DataGroupSchema = {
 	"additionalProperties": false,
 	"required": [
 		"code",
+		"config",
 		"id",
 		"service_type"
 	]
+} 
+
+export const DataGroupCreateSchema = {
+	"type": "object",
+	"properties": {
+		"code": {
+			"type": "string"
+		},
+		"config": {},
+		"service_type": {
+			"enum": [
+				"data-lake",
+				"dhis",
+				"indicator",
+				"kobo",
+				"superset",
+				"tupaia",
+				"weather"
+			],
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"code",
+		"service_type"
+	]
+} 
+
+export const DataGroupUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"code": {
+			"type": "string"
+		},
+		"config": {},
+		"id": {
+			"type": "string"
+		},
+		"service_type": {
+			"enum": [
+				"data-lake",
+				"dhis",
+				"indicator",
+				"kobo",
+				"superset",
+				"tupaia",
+				"weather"
+			],
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const DataServiceEntitySchema = {
@@ -35064,6 +52078,35 @@ export const DataServiceEntitySchema = {
 		"entity_code",
 		"id"
 	]
+} 
+
+export const DataServiceEntityCreateSchema = {
+	"type": "object",
+	"properties": {
+		"config": {},
+		"entity_code": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"config",
+		"entity_code"
+	]
+} 
+
+export const DataServiceEntityUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"config": {},
+		"entity_code": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const DataServiceSyncGroupSchema = {
@@ -35109,8 +52152,93 @@ export const DataServiceSyncGroupSchema = {
 		"config",
 		"data_group_code",
 		"id",
+		"service_type",
+		"sync_cursor",
+		"sync_status"
+	]
+} 
+
+export const DataServiceSyncGroupCreateSchema = {
+	"type": "object",
+	"properties": {
+		"code": {
+			"type": "string"
+		},
+		"config": {},
+		"data_group_code": {
+			"type": "string"
+		},
+		"service_type": {
+			"enum": [
+				"data-lake",
+				"dhis",
+				"indicator",
+				"kobo",
+				"superset",
+				"tupaia",
+				"weather"
+			],
+			"type": "string"
+		},
+		"sync_cursor": {
+			"type": "string"
+		},
+		"sync_status": {
+			"enum": [
+				"ERROR",
+				"IDLE",
+				"SYNCING"
+			],
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"code",
+		"config",
+		"data_group_code",
 		"service_type"
 	]
+} 
+
+export const DataServiceSyncGroupUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"code": {
+			"type": "string"
+		},
+		"config": {},
+		"data_group_code": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"service_type": {
+			"enum": [
+				"data-lake",
+				"dhis",
+				"indicator",
+				"kobo",
+				"superset",
+				"tupaia",
+				"weather"
+			],
+			"type": "string"
+		},
+		"sync_cursor": {
+			"type": "string"
+		},
+		"sync_status": {
+			"enum": [
+				"ERROR",
+				"IDLE",
+				"SYNCING"
+			],
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const DataTableSchema = {
@@ -35149,10 +52277,86 @@ export const DataTableSchema = {
 	"additionalProperties": false,
 	"required": [
 		"code",
+		"config",
+		"description",
 		"id",
 		"permission_groups",
 		"type"
 	]
+} 
+
+export const DataTableCreateSchema = {
+	"type": "object",
+	"properties": {
+		"code": {
+			"type": "string"
+		},
+		"config": {},
+		"description": {
+			"type": "string"
+		},
+		"permission_groups": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"type": {
+			"enum": [
+				"analytics",
+				"data_element_metadata",
+				"data_group_metadata",
+				"entities",
+				"entity_attributes",
+				"entity_relations",
+				"events",
+				"sql"
+			],
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"code",
+		"permission_groups",
+		"type"
+	]
+} 
+
+export const DataTableUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"code": {
+			"type": "string"
+		},
+		"config": {},
+		"description": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"permission_groups": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"type": {
+			"enum": [
+				"analytics",
+				"data_element_metadata",
+				"data_group_metadata",
+				"entities",
+				"entity_attributes",
+				"entity_relations",
+				"events",
+				"sql"
+			],
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const DatatrakSessionSchema = {
@@ -35186,6 +52390,56 @@ export const DatatrakSessionSchema = {
 	]
 } 
 
+export const DatatrakSessionCreateSchema = {
+	"type": "object",
+	"properties": {
+		"access_policy": {},
+		"access_token": {
+			"type": "string"
+		},
+		"access_token_expiry": {
+			"type": "string"
+		},
+		"email": {
+			"type": "string"
+		},
+		"refresh_token": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"access_policy",
+		"access_token",
+		"access_token_expiry",
+		"email",
+		"refresh_token"
+	]
+} 
+
+export const DatatrakSessionUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"access_policy": {},
+		"access_token": {
+			"type": "string"
+		},
+		"access_token_expiry": {
+			"type": "string"
+		},
+		"email": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"refresh_token": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
+} 
+
 export const DhisInstanceSchema = {
 	"type": "object",
 	"properties": {
@@ -35207,6 +52461,42 @@ export const DhisInstanceSchema = {
 		"id",
 		"readonly"
 	]
+} 
+
+export const DhisInstanceCreateSchema = {
+	"type": "object",
+	"properties": {
+		"code": {
+			"type": "string"
+		},
+		"config": {},
+		"readonly": {
+			"type": "boolean"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"code",
+		"config",
+		"readonly"
+	]
+} 
+
+export const DhisInstanceUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"code": {
+			"type": "string"
+		},
+		"config": {},
+		"id": {
+			"type": "string"
+		},
+		"readonly": {
+			"type": "boolean"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const DhisSyncLogSchema = {
@@ -35245,10 +52535,92 @@ export const DhisSyncLogSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
+		"data",
+		"deleted",
+		"dhis_reference",
+		"error_list",
 		"id",
+		"ignored",
+		"imported",
+		"record_id",
+		"record_type",
+		"updated"
+	]
+} 
+
+export const DhisSyncLogCreateSchema = {
+	"type": "object",
+	"properties": {
+		"data": {
+			"type": "string"
+		},
+		"deleted": {
+			"type": "number"
+		},
+		"dhis_reference": {
+			"type": "string"
+		},
+		"error_list": {
+			"type": "string"
+		},
+		"ignored": {
+			"type": "number"
+		},
+		"imported": {
+			"type": "number"
+		},
+		"record_id": {
+			"type": "string"
+		},
+		"record_type": {
+			"type": "string"
+		},
+		"updated": {
+			"type": "number"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
 		"record_id",
 		"record_type"
 	]
+} 
+
+export const DhisSyncLogUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"data": {
+			"type": "string"
+		},
+		"deleted": {
+			"type": "number"
+		},
+		"dhis_reference": {
+			"type": "string"
+		},
+		"error_list": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"ignored": {
+			"type": "number"
+		},
+		"imported": {
+			"type": "number"
+		},
+		"record_id": {
+			"type": "string"
+		},
+		"record_type": {
+			"type": "string"
+		},
+		"updated": {
+			"type": "number"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const DhisSyncQueueSchema = {
@@ -35287,11 +52659,93 @@ export const DhisSyncQueueSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
+		"bad_request_count",
+		"change_time",
+		"details",
 		"id",
+		"is_dead_letter",
+		"is_deleted",
+		"priority",
 		"record_id",
 		"record_type",
 		"type"
 	]
+} 
+
+export const DhisSyncQueueCreateSchema = {
+	"type": "object",
+	"properties": {
+		"bad_request_count": {
+			"type": "number"
+		},
+		"change_time": {
+			"type": "number"
+		},
+		"details": {
+			"type": "string"
+		},
+		"is_dead_letter": {
+			"type": "boolean"
+		},
+		"is_deleted": {
+			"type": "boolean"
+		},
+		"priority": {
+			"type": "number"
+		},
+		"record_id": {
+			"type": "string"
+		},
+		"record_type": {
+			"type": "string"
+		},
+		"type": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"record_id",
+		"record_type",
+		"type"
+	]
+} 
+
+export const DhisSyncQueueUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"bad_request_count": {
+			"type": "number"
+		},
+		"change_time": {
+			"type": "number"
+		},
+		"details": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"is_dead_letter": {
+			"type": "boolean"
+		},
+		"is_deleted": {
+			"type": "boolean"
+		},
+		"priority": {
+			"type": "number"
+		},
+		"record_id": {
+			"type": "string"
+		},
+		"record_type": {
+			"type": "string"
+		},
+		"type": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const DisasterSchema = {
@@ -35323,10 +52777,71 @@ export const DisasterSchema = {
 	"additionalProperties": false,
 	"required": [
 		"countryCode",
+		"description",
 		"id",
 		"name",
 		"type"
 	]
+} 
+
+export const DisasterCreateSchema = {
+	"type": "object",
+	"properties": {
+		"countryCode": {
+			"type": "string"
+		},
+		"description": {
+			"type": "string"
+		},
+		"name": {
+			"type": "string"
+		},
+		"type": {
+			"enum": [
+				"cyclone",
+				"earthquake",
+				"eruption",
+				"flood",
+				"tsunami"
+			],
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"countryCode",
+		"name",
+		"type"
+	]
+} 
+
+export const DisasterUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"countryCode": {
+			"type": "string"
+		},
+		"description": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"name": {
+			"type": "string"
+		},
+		"type": {
+			"enum": [
+				"cyclone",
+				"earthquake",
+				"eruption",
+				"flood",
+				"tsunami"
+			],
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const DisasterEventSchema = {
@@ -35362,6 +52877,65 @@ export const DisasterEventSchema = {
 		"organisationUnitCode",
 		"type"
 	]
+} 
+
+export const DisasterEventCreateSchema = {
+	"type": "object",
+	"properties": {
+		"date": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"disasterId": {
+			"type": "string"
+		},
+		"organisationUnitCode": {
+			"type": "string"
+		},
+		"type": {
+			"enum": [
+				"end",
+				"resolve",
+				"start"
+			],
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"date",
+		"disasterId",
+		"organisationUnitCode",
+		"type"
+	]
+} 
+
+export const DisasterEventUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"date": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"disasterId": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"organisationUnitCode": {
+			"type": "string"
+		},
+		"type": {
+			"enum": [
+				"end",
+				"resolve",
+				"start"
+			],
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const EntitySchema = {
@@ -35437,10 +53011,169 @@ export const EntitySchema = {
 	},
 	"additionalProperties": false,
 	"required": [
+		"attributes",
+		"bounds",
 		"code",
+		"country_code",
 		"id",
+		"image_url",
+		"m_row$",
+		"metadata",
+		"name",
+		"parent_id",
+		"point",
+		"region",
+		"type"
+	]
+} 
+
+export const EntityCreateSchema = {
+	"type": "object",
+	"properties": {
+		"attributes": {},
+		"bounds": {},
+		"code": {
+			"type": "string"
+		},
+		"country_code": {
+			"type": "string"
+		},
+		"image_url": {
+			"type": "string"
+		},
+		"m_row$": {
+			"type": "string"
+		},
+		"metadata": {},
+		"name": {
+			"type": "string"
+		},
+		"parent_id": {
+			"type": "string"
+		},
+		"point": {},
+		"region": {},
+		"type": {
+			"enum": [
+				"asset",
+				"case",
+				"case_contact",
+				"catchment",
+				"city",
+				"complaint",
+				"country",
+				"disaster",
+				"district",
+				"facility",
+				"farm",
+				"fetp_graduate",
+				"field_station",
+				"fiji_aspen_facility",
+				"household",
+				"incident",
+				"incident_reported",
+				"individual",
+				"institute",
+				"larval_habitat",
+				"local_government",
+				"medical_area",
+				"msupply_store",
+				"nursing_zone",
+				"postcode",
+				"project",
+				"repair_request",
+				"school",
+				"sub_catchment",
+				"sub_district",
+				"sub_facility",
+				"trap",
+				"village",
+				"water_sample",
+				"wish_sub_district",
+				"world"
+			],
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"code",
 		"name"
 	]
+} 
+
+export const EntityUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"attributes": {},
+		"bounds": {},
+		"code": {
+			"type": "string"
+		},
+		"country_code": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"image_url": {
+			"type": "string"
+		},
+		"m_row$": {
+			"type": "string"
+		},
+		"metadata": {},
+		"name": {
+			"type": "string"
+		},
+		"parent_id": {
+			"type": "string"
+		},
+		"point": {},
+		"region": {},
+		"type": {
+			"enum": [
+				"asset",
+				"case",
+				"case_contact",
+				"catchment",
+				"city",
+				"complaint",
+				"country",
+				"disaster",
+				"district",
+				"facility",
+				"farm",
+				"fetp_graduate",
+				"field_station",
+				"fiji_aspen_facility",
+				"household",
+				"incident",
+				"incident_reported",
+				"individual",
+				"institute",
+				"larval_habitat",
+				"local_government",
+				"medical_area",
+				"msupply_store",
+				"nursing_zone",
+				"postcode",
+				"project",
+				"repair_request",
+				"school",
+				"sub_catchment",
+				"sub_district",
+				"sub_facility",
+				"trap",
+				"village",
+				"water_sample",
+				"wish_sub_district",
+				"world"
+			],
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const EntityHierarchySchema = {
@@ -35461,9 +53194,48 @@ export const EntityHierarchySchema = {
 	},
 	"additionalProperties": false,
 	"required": [
+		"canonical_types",
 		"id",
 		"name"
 	]
+} 
+
+export const EntityHierarchyCreateSchema = {
+	"type": "object",
+	"properties": {
+		"canonical_types": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"name": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"name"
+	]
+} 
+
+export const EntityHierarchyUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"canonical_types": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"id": {
+			"type": "string"
+		},
+		"name": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const EntityRelationSchema = {
@@ -35491,6 +53263,46 @@ export const EntityRelationSchema = {
 	]
 } 
 
+export const EntityRelationCreateSchema = {
+	"type": "object",
+	"properties": {
+		"child_id": {
+			"type": "string"
+		},
+		"entity_hierarchy_id": {
+			"type": "string"
+		},
+		"parent_id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"child_id",
+		"entity_hierarchy_id",
+		"parent_id"
+	]
+} 
+
+export const EntityRelationUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"child_id": {
+			"type": "string"
+		},
+		"entity_hierarchy_id": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"parent_id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
+} 
+
 export const ErrorLogSchema = {
 	"type": "object",
 	"properties": {
@@ -35513,8 +53325,55 @@ export const ErrorLogSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
-		"id"
+		"api_request_log_id",
+		"error_time",
+		"id",
+		"message",
+		"type"
 	]
+} 
+
+export const ErrorLogCreateSchema = {
+	"type": "object",
+	"properties": {
+		"api_request_log_id": {
+			"type": "string"
+		},
+		"error_time": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"message": {
+			"type": "string"
+		},
+		"type": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
+} 
+
+export const ErrorLogUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"api_request_log_id": {
+			"type": "string"
+		},
+		"error_time": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"id": {
+			"type": "string"
+		},
+		"message": {
+			"type": "string"
+		},
+		"type": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const ExternalDatabaseConnectionSchema = {
@@ -35542,9 +53401,62 @@ export const ExternalDatabaseConnectionSchema = {
 	"additionalProperties": false,
 	"required": [
 		"code",
+		"description",
 		"id",
+		"name",
+		"permission_groups"
+	]
+} 
+
+export const ExternalDatabaseConnectionCreateSchema = {
+	"type": "object",
+	"properties": {
+		"code": {
+			"type": "string"
+		},
+		"description": {
+			"type": "string"
+		},
+		"name": {
+			"type": "string"
+		},
+		"permission_groups": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"code",
 		"name"
 	]
+} 
+
+export const ExternalDatabaseConnectionUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"code": {
+			"type": "string"
+		},
+		"description": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"name": {
+			"type": "string"
+		},
+		"permission_groups": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const FeedItemSchema = {
@@ -35590,8 +53502,101 @@ export const FeedItemSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
-		"id"
+		"country_id",
+		"creation_date",
+		"geographical_area_id",
+		"id",
+		"permission_group_id",
+		"record_id",
+		"template_variables",
+		"type",
+		"user_id"
 	]
+} 
+
+export const FeedItemCreateSchema = {
+	"type": "object",
+	"properties": {
+		"country_id": {
+			"type": "string"
+		},
+		"creation_date": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"geographical_area_id": {
+			"type": "string"
+		},
+		"permission_group_id": {
+			"type": "string"
+		},
+		"record_id": {
+			"type": "string"
+		},
+		"template_variables": {
+			"type": "object",
+			"properties": {
+				"constructor": {
+					"$ref": "#/definitions/Function"
+				}
+			},
+			"additionalProperties": false,
+			"required": [
+				"constructor"
+			]
+		},
+		"type": {
+			"type": "string"
+		},
+		"user_id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
+} 
+
+export const FeedItemUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"country_id": {
+			"type": "string"
+		},
+		"creation_date": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"geographical_area_id": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"permission_group_id": {
+			"type": "string"
+		},
+		"record_id": {
+			"type": "string"
+		},
+		"template_variables": {
+			"type": "object",
+			"properties": {
+				"constructor": {
+					"$ref": "#/definitions/Function"
+				}
+			},
+			"additionalProperties": false,
+			"required": [
+				"constructor"
+			]
+		},
+		"type": {
+			"type": "string"
+		},
+		"user_id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const GeographicalAreaSchema = {
@@ -35621,12 +53626,73 @@ export const GeographicalAreaSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
+		"code",
 		"country_id",
 		"id",
 		"level_code",
 		"level_name",
+		"name",
+		"parent_id"
+	]
+} 
+
+export const GeographicalAreaCreateSchema = {
+	"type": "object",
+	"properties": {
+		"code": {
+			"type": "string"
+		},
+		"country_id": {
+			"type": "string"
+		},
+		"level_code": {
+			"type": "string"
+		},
+		"level_name": {
+			"type": "string"
+		},
+		"name": {
+			"type": "string"
+		},
+		"parent_id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"country_id",
+		"level_code",
+		"level_name",
 		"name"
 	]
+} 
+
+export const GeographicalAreaUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"code": {
+			"type": "string"
+		},
+		"country_id": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"level_code": {
+			"type": "string"
+		},
+		"level_name": {
+			"type": "string"
+		},
+		"name": {
+			"type": "string"
+		},
+		"parent_id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const IndicatorSchema = {
@@ -35647,8 +53713,44 @@ export const IndicatorSchema = {
 	"required": [
 		"builder",
 		"code",
+		"config",
 		"id"
 	]
+} 
+
+export const IndicatorCreateSchema = {
+	"type": "object",
+	"properties": {
+		"builder": {
+			"type": "string"
+		},
+		"code": {
+			"type": "string"
+		},
+		"config": {}
+	},
+	"additionalProperties": false,
+	"required": [
+		"builder",
+		"code"
+	]
+} 
+
+export const IndicatorUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"builder": {
+			"type": "string"
+		},
+		"code": {
+			"type": "string"
+		},
+		"config": {},
+		"id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const LandingPageSchema = {
@@ -35705,10 +53807,133 @@ export const LandingPageSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
+		"contact_us",
+		"extended_title",
+		"external_link",
 		"id",
+		"image_url",
+		"include_name_in_header",
+		"logo_url",
+		"long_bio",
+		"name",
+		"phone_number",
+		"primary_hexcode",
+		"project_codes",
+		"secondary_hexcode",
+		"url_segment",
+		"website_url"
+	]
+} 
+
+export const LandingPageCreateSchema = {
+	"type": "object",
+	"properties": {
+		"contact_us": {
+			"type": "string"
+		},
+		"extended_title": {
+			"type": "string"
+		},
+		"external_link": {
+			"type": "string"
+		},
+		"image_url": {
+			"type": "string"
+		},
+		"include_name_in_header": {
+			"type": "boolean"
+		},
+		"logo_url": {
+			"type": "string"
+		},
+		"long_bio": {
+			"type": "string"
+		},
+		"name": {
+			"type": "string"
+		},
+		"phone_number": {
+			"type": "string"
+		},
+		"primary_hexcode": {
+			"type": "string"
+		},
+		"project_codes": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"secondary_hexcode": {
+			"type": "string"
+		},
+		"url_segment": {
+			"type": "string"
+		},
+		"website_url": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
 		"name",
 		"url_segment"
 	]
+} 
+
+export const LandingPageUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"contact_us": {
+			"type": "string"
+		},
+		"extended_title": {
+			"type": "string"
+		},
+		"external_link": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"image_url": {
+			"type": "string"
+		},
+		"include_name_in_header": {
+			"type": "boolean"
+		},
+		"logo_url": {
+			"type": "string"
+		},
+		"long_bio": {
+			"type": "string"
+		},
+		"name": {
+			"type": "string"
+		},
+		"phone_number": {
+			"type": "string"
+		},
+		"primary_hexcode": {
+			"type": "string"
+		},
+		"project_codes": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"secondary_hexcode": {
+			"type": "string"
+		},
+		"url_segment": {
+			"type": "string"
+		},
+		"website_url": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const LegacyReportSchema = {
@@ -35729,8 +53954,47 @@ export const LegacyReportSchema = {
 	"additionalProperties": false,
 	"required": [
 		"code",
+		"data_builder",
+		"data_builder_config",
+		"data_services",
 		"id"
 	]
+} 
+
+export const LegacyReportCreateSchema = {
+	"type": "object",
+	"properties": {
+		"code": {
+			"type": "string"
+		},
+		"data_builder": {
+			"type": "string"
+		},
+		"data_builder_config": {},
+		"data_services": {}
+	},
+	"additionalProperties": false,
+	"required": [
+		"code"
+	]
+} 
+
+export const LegacyReportUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"code": {
+			"type": "string"
+		},
+		"data_builder": {
+			"type": "string"
+		},
+		"data_builder_config": {},
+		"data_services": {},
+		"id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const LesmisSessionSchema = {
@@ -35762,6 +54026,56 @@ export const LesmisSessionSchema = {
 		"id",
 		"refresh_token"
 	]
+} 
+
+export const LesmisSessionCreateSchema = {
+	"type": "object",
+	"properties": {
+		"access_policy": {},
+		"access_token": {
+			"type": "string"
+		},
+		"access_token_expiry": {
+			"type": "string"
+		},
+		"email": {
+			"type": "string"
+		},
+		"refresh_token": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"access_policy",
+		"access_token",
+		"access_token_expiry",
+		"email",
+		"refresh_token"
+	]
+} 
+
+export const LesmisSessionUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"access_policy": {},
+		"access_token": {
+			"type": "string"
+		},
+		"access_token_expiry": {
+			"type": "string"
+		},
+		"email": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"refresh_token": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const MapOverlaySchema = {
@@ -36264,9 +54578,1019 @@ export const MapOverlaySchema = {
 	"additionalProperties": false,
 	"required": [
 		"code",
+		"config",
+		"country_codes",
+		"data_services",
+		"id",
+		"legacy",
+		"linked_measures",
+		"name",
+		"permission_group",
+		"project_codes",
+		"report_code"
+	]
+} 
+
+export const MapOverlayCreateSchema = {
+	"type": "object",
+	"properties": {
+		"code": {
+			"type": "string"
+		},
+		"config": {
+			"type": "object",
+			"properties": {
+				"customColors": {
+					"type": "string"
+				},
+				"customLabel": {
+					"type": "string"
+				},
+				"datePickerLimits": {
+					"type": "object",
+					"properties": {
+						"start": {
+							"type": "object",
+							"properties": {
+								"unit": {
+									"enum": [
+										"day",
+										"month",
+										"quarter",
+										"week",
+										"year"
+									],
+									"type": "string"
+								},
+								"offset": {
+									"type": "number"
+								},
+								"modifier": {
+									"enum": [
+										"end_of",
+										"start_of"
+									],
+									"type": "string"
+								},
+								"modifierUnit": {
+									"enum": [
+										"day",
+										"month",
+										"quarter",
+										"week",
+										"year"
+									],
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"offset",
+								"unit"
+							]
+						},
+						"end": {
+							"type": "object",
+							"properties": {
+								"unit": {
+									"enum": [
+										"day",
+										"month",
+										"quarter",
+										"week",
+										"year"
+									],
+									"type": "string"
+								},
+								"offset": {
+									"type": "number"
+								},
+								"modifier": {
+									"enum": [
+										"end_of",
+										"start_of"
+									],
+									"type": "string"
+								},
+								"modifierUnit": {
+									"enum": [
+										"day",
+										"month",
+										"quarter",
+										"week",
+										"year"
+									],
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"offset",
+								"unit"
+							]
+						}
+					},
+					"additionalProperties": false
+				},
+				"defaultTimePeriod": {
+					"type": "object",
+					"properties": {
+						"unit": {
+							"enum": [
+								"day",
+								"month",
+								"quarter",
+								"week",
+								"year"
+							],
+							"type": "string"
+						},
+						"offset": {
+							"type": "number"
+						},
+						"modifier": {
+							"enum": [
+								"end_of",
+								"start_of"
+							],
+							"type": "string"
+						},
+						"modifierUnit": {
+							"enum": [
+								"day",
+								"month",
+								"quarter",
+								"week",
+								"year"
+							],
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"offset",
+						"unit"
+					]
+				},
+				"disableRenameLegend": {
+					"type": "boolean"
+				},
+				"displayLevel": {
+					"enum": [
+						"Country",
+						"Disaster",
+						"District",
+						"Facility",
+						"SubDistrict"
+					],
+					"type": "string"
+				},
+				"displayOnLevel": {
+					"enum": [
+						"Country",
+						"Disaster",
+						"District",
+						"Facility",
+						"SubDistrict"
+					],
+					"type": "string"
+				},
+				"displayType": {
+					"enum": [
+						"color",
+						"icon",
+						"popup-only",
+						"radius",
+						"shaded-spectrum",
+						"shading",
+						"spectrum"
+					],
+					"type": "string"
+				},
+				"displayedValueKey": {
+					"enum": [
+						"facilityTypeName",
+						"name",
+						"originalValue",
+						"schoolTypeName"
+					],
+					"type": "string"
+				},
+				"hideByDefault": {
+					"type": "object",
+					"additionalProperties": false
+				},
+				"hideFromLegend": {
+					"type": "boolean"
+				},
+				"hideFromMenu": {
+					"type": "boolean"
+				},
+				"hideFromPopup": {
+					"type": "boolean"
+				},
+				"icon": {
+					"enum": [
+						"checkbox",
+						"circle",
+						"downArrow",
+						"empty",
+						"fade",
+						"h",
+						"healthPin",
+						"help",
+						"hidden",
+						"pentagon",
+						"pin",
+						"radius",
+						"rightArrow",
+						"ring",
+						"square",
+						"triangle",
+						"upArrow",
+						"warning",
+						"x"
+					],
+					"type": "string"
+				},
+				"info": {
+					"type": "object",
+					"properties": {
+						"reference": {
+							"type": "object",
+							"properties": {
+								"link": {
+									"type": "string"
+								},
+								"name": {
+									"type": "string"
+								},
+								"text": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"reference"
+					]
+				},
+				"isTimePeriodEditable": {
+					"type": "boolean"
+				},
+				"measureConfig": {
+					"type": "object",
+					"additionalProperties": false
+				},
+				"measureLevel": {
+					"enum": [
+						"Country",
+						"Disaster",
+						"District",
+						"Facility",
+						"SubDistrict"
+					],
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"noDataColour": {
+					"type": "string"
+				},
+				"periodGranularity": {
+					"enum": [
+						"day",
+						"month",
+						"one_day_at_a_time",
+						"one_month_at_a_time",
+						"one_quarter_at_a_time",
+						"one_week_at_a_time",
+						"one_year_at_a_time",
+						"quarter",
+						"week",
+						"year"
+					],
+					"type": "string"
+				},
+				"popupHeaderFormat": {
+					"type": "string"
+				},
+				"scaleBounds": {
+					"type": "object",
+					"properties": {
+						"left": {
+							"type": "object",
+							"properties": {
+								"min": {
+									"anyOf": [
+										{
+											"enum": [
+												"auto"
+											],
+											"type": "string"
+										},
+										{
+											"type": "number"
+										}
+									]
+								},
+								"max": {
+									"anyOf": [
+										{
+											"enum": [
+												"auto"
+											],
+											"type": "string"
+										},
+										{
+											"type": "number"
+										}
+									]
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"max",
+								"min"
+							]
+						},
+						"right": {
+							"type": "object",
+							"properties": {
+								"min": {
+									"anyOf": [
+										{
+											"enum": [
+												"auto"
+											],
+											"type": "string"
+										},
+										{
+											"type": "number"
+										}
+									]
+								},
+								"max": {
+									"anyOf": [
+										{
+											"enum": [
+												"auto"
+											],
+											"type": "string"
+										},
+										{
+											"type": "number"
+										}
+									]
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"max",
+								"min"
+							]
+						}
+					},
+					"additionalProperties": false
+				},
+				"scaleColorScheme": {
+					"enum": [
+						"default",
+						"default-reverse",
+						"gpi",
+						"performance",
+						"time"
+					],
+					"type": "string"
+				},
+				"scaleType": {
+					"enum": [
+						"gpi",
+						"neutral",
+						"neutralReverse",
+						"performance",
+						"performanceDesc",
+						"time"
+					],
+					"type": "string"
+				},
+				"valueType": {
+					"enum": [
+						"boolean",
+						"currency",
+						"fraction",
+						"fractionAndPercentage",
+						"number",
+						"numberAndPercentage",
+						"oneDecimalPlace",
+						"percentage",
+						"text"
+					],
+					"type": "string"
+				},
+				"values": {
+					"type": "array",
+					"items": {
+						"type": "object",
+						"properties": {
+							"color": {
+								"type": "string"
+							},
+							"hideFromLegend": {
+								"type": "boolean"
+							},
+							"hideFromPopup": {
+								"type": "boolean"
+							},
+							"icon": {
+								"enum": [
+									"checkbox",
+									"circle",
+									"downArrow",
+									"empty",
+									"fade",
+									"h",
+									"healthPin",
+									"help",
+									"hidden",
+									"pentagon",
+									"pin",
+									"radius",
+									"rightArrow",
+									"ring",
+									"square",
+									"triangle",
+									"upArrow",
+									"warning",
+									"x"
+								],
+								"type": "string"
+							},
+							"name": {
+								"type": "string"
+							},
+							"value": {
+								"type": [
+									"string",
+									"number"
+								]
+							}
+						},
+						"additionalProperties": false,
+						"required": [
+							"icon",
+							"name",
+							"value"
+						]
+					}
+				}
+			},
+			"additionalProperties": false,
+			"required": [
+				"displayType"
+			]
+		},
+		"country_codes": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"data_services": {},
+		"legacy": {
+			"type": "boolean"
+		},
+		"linked_measures": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"name": {
+			"type": "string"
+		},
+		"permission_group": {
+			"type": "string"
+		},
+		"project_codes": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"report_code": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"code",
 		"name",
 		"permission_group"
 	]
+} 
+
+export const MapOverlayUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"code": {
+			"type": "string"
+		},
+		"config": {
+			"type": "object",
+			"properties": {
+				"customColors": {
+					"type": "string"
+				},
+				"customLabel": {
+					"type": "string"
+				},
+				"datePickerLimits": {
+					"type": "object",
+					"properties": {
+						"start": {
+							"type": "object",
+							"properties": {
+								"unit": {
+									"enum": [
+										"day",
+										"month",
+										"quarter",
+										"week",
+										"year"
+									],
+									"type": "string"
+								},
+								"offset": {
+									"type": "number"
+								},
+								"modifier": {
+									"enum": [
+										"end_of",
+										"start_of"
+									],
+									"type": "string"
+								},
+								"modifierUnit": {
+									"enum": [
+										"day",
+										"month",
+										"quarter",
+										"week",
+										"year"
+									],
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"offset",
+								"unit"
+							]
+						},
+						"end": {
+							"type": "object",
+							"properties": {
+								"unit": {
+									"enum": [
+										"day",
+										"month",
+										"quarter",
+										"week",
+										"year"
+									],
+									"type": "string"
+								},
+								"offset": {
+									"type": "number"
+								},
+								"modifier": {
+									"enum": [
+										"end_of",
+										"start_of"
+									],
+									"type": "string"
+								},
+								"modifierUnit": {
+									"enum": [
+										"day",
+										"month",
+										"quarter",
+										"week",
+										"year"
+									],
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"offset",
+								"unit"
+							]
+						}
+					},
+					"additionalProperties": false
+				},
+				"defaultTimePeriod": {
+					"type": "object",
+					"properties": {
+						"unit": {
+							"enum": [
+								"day",
+								"month",
+								"quarter",
+								"week",
+								"year"
+							],
+							"type": "string"
+						},
+						"offset": {
+							"type": "number"
+						},
+						"modifier": {
+							"enum": [
+								"end_of",
+								"start_of"
+							],
+							"type": "string"
+						},
+						"modifierUnit": {
+							"enum": [
+								"day",
+								"month",
+								"quarter",
+								"week",
+								"year"
+							],
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"offset",
+						"unit"
+					]
+				},
+				"disableRenameLegend": {
+					"type": "boolean"
+				},
+				"displayLevel": {
+					"enum": [
+						"Country",
+						"Disaster",
+						"District",
+						"Facility",
+						"SubDistrict"
+					],
+					"type": "string"
+				},
+				"displayOnLevel": {
+					"enum": [
+						"Country",
+						"Disaster",
+						"District",
+						"Facility",
+						"SubDistrict"
+					],
+					"type": "string"
+				},
+				"displayType": {
+					"enum": [
+						"color",
+						"icon",
+						"popup-only",
+						"radius",
+						"shaded-spectrum",
+						"shading",
+						"spectrum"
+					],
+					"type": "string"
+				},
+				"displayedValueKey": {
+					"enum": [
+						"facilityTypeName",
+						"name",
+						"originalValue",
+						"schoolTypeName"
+					],
+					"type": "string"
+				},
+				"hideByDefault": {
+					"type": "object",
+					"additionalProperties": false
+				},
+				"hideFromLegend": {
+					"type": "boolean"
+				},
+				"hideFromMenu": {
+					"type": "boolean"
+				},
+				"hideFromPopup": {
+					"type": "boolean"
+				},
+				"icon": {
+					"enum": [
+						"checkbox",
+						"circle",
+						"downArrow",
+						"empty",
+						"fade",
+						"h",
+						"healthPin",
+						"help",
+						"hidden",
+						"pentagon",
+						"pin",
+						"radius",
+						"rightArrow",
+						"ring",
+						"square",
+						"triangle",
+						"upArrow",
+						"warning",
+						"x"
+					],
+					"type": "string"
+				},
+				"info": {
+					"type": "object",
+					"properties": {
+						"reference": {
+							"type": "object",
+							"properties": {
+								"link": {
+									"type": "string"
+								},
+								"name": {
+									"type": "string"
+								},
+								"text": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"reference"
+					]
+				},
+				"isTimePeriodEditable": {
+					"type": "boolean"
+				},
+				"measureConfig": {
+					"type": "object",
+					"additionalProperties": false
+				},
+				"measureLevel": {
+					"enum": [
+						"Country",
+						"Disaster",
+						"District",
+						"Facility",
+						"SubDistrict"
+					],
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"noDataColour": {
+					"type": "string"
+				},
+				"periodGranularity": {
+					"enum": [
+						"day",
+						"month",
+						"one_day_at_a_time",
+						"one_month_at_a_time",
+						"one_quarter_at_a_time",
+						"one_week_at_a_time",
+						"one_year_at_a_time",
+						"quarter",
+						"week",
+						"year"
+					],
+					"type": "string"
+				},
+				"popupHeaderFormat": {
+					"type": "string"
+				},
+				"scaleBounds": {
+					"type": "object",
+					"properties": {
+						"left": {
+							"type": "object",
+							"properties": {
+								"min": {
+									"anyOf": [
+										{
+											"enum": [
+												"auto"
+											],
+											"type": "string"
+										},
+										{
+											"type": "number"
+										}
+									]
+								},
+								"max": {
+									"anyOf": [
+										{
+											"enum": [
+												"auto"
+											],
+											"type": "string"
+										},
+										{
+											"type": "number"
+										}
+									]
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"max",
+								"min"
+							]
+						},
+						"right": {
+							"type": "object",
+							"properties": {
+								"min": {
+									"anyOf": [
+										{
+											"enum": [
+												"auto"
+											],
+											"type": "string"
+										},
+										{
+											"type": "number"
+										}
+									]
+								},
+								"max": {
+									"anyOf": [
+										{
+											"enum": [
+												"auto"
+											],
+											"type": "string"
+										},
+										{
+											"type": "number"
+										}
+									]
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"max",
+								"min"
+							]
+						}
+					},
+					"additionalProperties": false
+				},
+				"scaleColorScheme": {
+					"enum": [
+						"default",
+						"default-reverse",
+						"gpi",
+						"performance",
+						"time"
+					],
+					"type": "string"
+				},
+				"scaleType": {
+					"enum": [
+						"gpi",
+						"neutral",
+						"neutralReverse",
+						"performance",
+						"performanceDesc",
+						"time"
+					],
+					"type": "string"
+				},
+				"valueType": {
+					"enum": [
+						"boolean",
+						"currency",
+						"fraction",
+						"fractionAndPercentage",
+						"number",
+						"numberAndPercentage",
+						"oneDecimalPlace",
+						"percentage",
+						"text"
+					],
+					"type": "string"
+				},
+				"values": {
+					"type": "array",
+					"items": {
+						"type": "object",
+						"properties": {
+							"color": {
+								"type": "string"
+							},
+							"hideFromLegend": {
+								"type": "boolean"
+							},
+							"hideFromPopup": {
+								"type": "boolean"
+							},
+							"icon": {
+								"enum": [
+									"checkbox",
+									"circle",
+									"downArrow",
+									"empty",
+									"fade",
+									"h",
+									"healthPin",
+									"help",
+									"hidden",
+									"pentagon",
+									"pin",
+									"radius",
+									"rightArrow",
+									"ring",
+									"square",
+									"triangle",
+									"upArrow",
+									"warning",
+									"x"
+								],
+								"type": "string"
+							},
+							"name": {
+								"type": "string"
+							},
+							"value": {
+								"type": [
+									"string",
+									"number"
+								]
+							}
+						},
+						"additionalProperties": false,
+						"required": [
+							"icon",
+							"name",
+							"value"
+						]
+					}
+				}
+			},
+			"additionalProperties": false,
+			"required": [
+				"displayType"
+			]
+		},
+		"country_codes": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"data_services": {},
+		"id": {
+			"type": "string"
+		},
+		"legacy": {
+			"type": "boolean"
+		},
+		"linked_measures": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"name": {
+			"type": "string"
+		},
+		"permission_group": {
+			"type": "string"
+		},
+		"project_codes": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"report_code": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const MapOverlayGroupSchema = {
@@ -36288,6 +55612,39 @@ export const MapOverlayGroupSchema = {
 		"id",
 		"name"
 	]
+} 
+
+export const MapOverlayGroupCreateSchema = {
+	"type": "object",
+	"properties": {
+		"code": {
+			"type": "string"
+		},
+		"name": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"code",
+		"name"
+	]
+} 
+
+export const MapOverlayGroupUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"code": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"name": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const MapOverlayGroupRelationSchema = {
@@ -36314,8 +55671,55 @@ export const MapOverlayGroupRelationSchema = {
 		"child_id",
 		"child_type",
 		"id",
+		"map_overlay_group_id",
+		"sort_order"
+	]
+} 
+
+export const MapOverlayGroupRelationCreateSchema = {
+	"type": "object",
+	"properties": {
+		"child_id": {
+			"type": "string"
+		},
+		"child_type": {
+			"type": "string"
+		},
+		"map_overlay_group_id": {
+			"type": "string"
+		},
+		"sort_order": {
+			"type": "number"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"child_id",
+		"child_type",
 		"map_overlay_group_id"
 	]
+} 
+
+export const MapOverlayGroupRelationUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"child_id": {
+			"type": "string"
+		},
+		"child_type": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"map_overlay_group_id": {
+			"type": "string"
+		},
+		"sort_order": {
+			"type": "number"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const MeditrakDeviceSchema = {
@@ -36340,10 +55744,60 @@ export const MeditrakDeviceSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
+		"app_version",
+		"config",
 		"id",
+		"install_id",
+		"platform",
+		"user_id"
+	]
+} 
+
+export const MeditrakDeviceCreateSchema = {
+	"type": "object",
+	"properties": {
+		"app_version": {
+			"type": "string"
+		},
+		"config": {},
+		"install_id": {
+			"type": "string"
+		},
+		"platform": {
+			"type": "string"
+		},
+		"user_id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
 		"install_id",
 		"user_id"
 	]
+} 
+
+export const MeditrakDeviceUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"app_version": {
+			"type": "string"
+		},
+		"config": {},
+		"id": {
+			"type": "string"
+		},
+		"install_id": {
+			"type": "string"
+		},
+		"platform": {
+			"type": "string"
+		},
+		"user_id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const MeditrakSyncQueueSchema = {
@@ -36367,11 +55821,58 @@ export const MeditrakSyncQueueSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
+		"change_time",
 		"id",
 		"record_id",
 		"record_type",
 		"type"
 	]
+} 
+
+export const MeditrakSyncQueueCreateSchema = {
+	"type": "object",
+	"properties": {
+		"change_time": {
+			"type": "number"
+		},
+		"record_id": {
+			"type": "string"
+		},
+		"record_type": {
+			"type": "string"
+		},
+		"type": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"record_id",
+		"record_type",
+		"type"
+	]
+} 
+
+export const MeditrakSyncQueueUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"change_time": {
+			"type": "number"
+		},
+		"id": {
+			"type": "string"
+		},
+		"record_id": {
+			"type": "string"
+		},
+		"record_type": {
+			"type": "string"
+		},
+		"type": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const Ms1SyncLogSchema = {
@@ -36401,10 +55902,71 @@ export const Ms1SyncLogSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
+		"count",
+		"data",
+		"endpoint",
+		"error_list",
 		"id",
 		"record_id",
 		"record_type"
 	]
+} 
+
+export const Ms1SyncLogCreateSchema = {
+	"type": "object",
+	"properties": {
+		"count": {
+			"type": "number"
+		},
+		"data": {
+			"type": "string"
+		},
+		"endpoint": {
+			"type": "string"
+		},
+		"error_list": {
+			"type": "string"
+		},
+		"record_id": {
+			"type": "string"
+		},
+		"record_type": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"record_id",
+		"record_type"
+	]
+} 
+
+export const Ms1SyncLogUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"count": {
+			"type": "number"
+		},
+		"data": {
+			"type": "string"
+		},
+		"endpoint": {
+			"type": "string"
+		},
+		"error_list": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"record_id": {
+			"type": "string"
+		},
+		"record_type": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const Ms1SyncQueueSchema = {
@@ -36443,11 +56005,93 @@ export const Ms1SyncQueueSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
+		"bad_request_count",
+		"change_time",
+		"details",
 		"id",
+		"is_dead_letter",
+		"is_deleted",
+		"priority",
 		"record_id",
 		"record_type",
 		"type"
 	]
+} 
+
+export const Ms1SyncQueueCreateSchema = {
+	"type": "object",
+	"properties": {
+		"bad_request_count": {
+			"type": "number"
+		},
+		"change_time": {
+			"type": "number"
+		},
+		"details": {
+			"type": "string"
+		},
+		"is_dead_letter": {
+			"type": "boolean"
+		},
+		"is_deleted": {
+			"type": "boolean"
+		},
+		"priority": {
+			"type": "number"
+		},
+		"record_id": {
+			"type": "string"
+		},
+		"record_type": {
+			"type": "string"
+		},
+		"type": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"record_id",
+		"record_type",
+		"type"
+	]
+} 
+
+export const Ms1SyncQueueUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"bad_request_count": {
+			"type": "number"
+		},
+		"change_time": {
+			"type": "number"
+		},
+		"details": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"is_dead_letter": {
+			"type": "boolean"
+		},
+		"is_deleted": {
+			"type": "boolean"
+		},
+		"priority": {
+			"type": "number"
+		},
+		"record_id": {
+			"type": "string"
+		},
+		"record_type": {
+			"type": "string"
+		},
+		"type": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const OneTimeLoginSchema = {
@@ -36473,10 +56117,61 @@ export const OneTimeLoginSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
+		"creation_date",
 		"id",
+		"token",
+		"use_date",
+		"user_id"
+	]
+} 
+
+export const OneTimeLoginCreateSchema = {
+	"type": "object",
+	"properties": {
+		"creation_date": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"token": {
+			"type": "string"
+		},
+		"use_date": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"user_id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
 		"token",
 		"user_id"
 	]
+} 
+
+export const OneTimeLoginUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"creation_date": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"id": {
+			"type": "string"
+		},
+		"token": {
+			"type": "string"
+		},
+		"use_date": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"user_id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const OptionSchema = {
@@ -36501,10 +56196,60 @@ export const OptionSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
+		"attributes",
 		"id",
+		"label",
+		"option_set_id",
+		"sort_order",
+		"value"
+	]
+} 
+
+export const OptionCreateSchema = {
+	"type": "object",
+	"properties": {
+		"attributes": {},
+		"label": {
+			"type": "string"
+		},
+		"option_set_id": {
+			"type": "string"
+		},
+		"sort_order": {
+			"type": "number"
+		},
+		"value": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
 		"option_set_id",
 		"value"
 	]
+} 
+
+export const OptionUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"attributes": {},
+		"id": {
+			"type": "string"
+		},
+		"label": {
+			"type": "string"
+		},
+		"option_set_id": {
+			"type": "string"
+		},
+		"sort_order": {
+			"type": "number"
+		},
+		"value": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const OptionSetSchema = {
@@ -36524,6 +56269,32 @@ export const OptionSetSchema = {
 	]
 } 
 
+export const OptionSetCreateSchema = {
+	"type": "object",
+	"properties": {
+		"name": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"name"
+	]
+} 
+
+export const OptionSetUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"id": {
+			"type": "string"
+		},
+		"name": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
+} 
+
 export const PermissionGroupSchema = {
 	"type": "object",
 	"properties": {
@@ -36540,11 +56311,201 @@ export const PermissionGroupSchema = {
 	"additionalProperties": false,
 	"required": [
 		"id",
+		"name",
+		"parent_id"
+	]
+} 
+
+export const PermissionGroupCreateSchema = {
+	"type": "object",
+	"properties": {
+		"name": {
+			"type": "string"
+		},
+		"parent_id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
 		"name"
 	]
 } 
 
+export const PermissionGroupUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"id": {
+			"type": "string"
+		},
+		"name": {
+			"type": "string"
+		},
+		"parent_id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
+} 
+
 export const PermissionsBasedMeditrakSyncQueueSchema = {
+	"type": "object",
+	"properties": {
+		"change_time": {
+			"type": "number"
+		},
+		"country_ids": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"entity_type": {
+			"enum": [
+				"asset",
+				"case",
+				"case_contact",
+				"catchment",
+				"city",
+				"complaint",
+				"country",
+				"disaster",
+				"district",
+				"facility",
+				"farm",
+				"fetp_graduate",
+				"field_station",
+				"fiji_aspen_facility",
+				"household",
+				"incident",
+				"incident_reported",
+				"individual",
+				"institute",
+				"larval_habitat",
+				"local_government",
+				"medical_area",
+				"msupply_store",
+				"nursing_zone",
+				"postcode",
+				"project",
+				"repair_request",
+				"school",
+				"sub_catchment",
+				"sub_district",
+				"sub_facility",
+				"trap",
+				"village",
+				"water_sample",
+				"wish_sub_district",
+				"world"
+			],
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"permission_groups": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"record_id": {
+			"type": "string"
+		},
+		"record_type": {
+			"type": "string"
+		},
+		"type": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"change_time",
+		"country_ids",
+		"entity_type",
+		"id",
+		"permission_groups",
+		"record_id",
+		"record_type",
+		"type"
+	]
+} 
+
+export const PermissionsBasedMeditrakSyncQueueCreateSchema = {
+	"type": "object",
+	"properties": {
+		"change_time": {
+			"type": "number"
+		},
+		"country_ids": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"entity_type": {
+			"enum": [
+				"asset",
+				"case",
+				"case_contact",
+				"catchment",
+				"city",
+				"complaint",
+				"country",
+				"disaster",
+				"district",
+				"facility",
+				"farm",
+				"fetp_graduate",
+				"field_station",
+				"fiji_aspen_facility",
+				"household",
+				"incident",
+				"incident_reported",
+				"individual",
+				"institute",
+				"larval_habitat",
+				"local_government",
+				"medical_area",
+				"msupply_store",
+				"nursing_zone",
+				"postcode",
+				"project",
+				"repair_request",
+				"school",
+				"sub_catchment",
+				"sub_district",
+				"sub_facility",
+				"trap",
+				"village",
+				"water_sample",
+				"wish_sub_district",
+				"world"
+			],
+			"type": "string"
+		},
+		"permission_groups": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"record_id": {
+			"type": "string"
+		},
+		"record_type": {
+			"type": "string"
+		},
+		"type": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
+} 
+
+export const PermissionsBasedMeditrakSyncQueueUpdateSchema = {
 	"type": "object",
 	"properties": {
 		"change_time": {
@@ -36663,8 +56624,106 @@ export const ProjectSchema = {
 	"additionalProperties": false,
 	"required": [
 		"code",
-		"id"
+		"config",
+		"dashboard_group_name",
+		"default_measure",
+		"description",
+		"entity_hierarchy_id",
+		"entity_id",
+		"id",
+		"image_url",
+		"logo_url",
+		"permission_groups",
+		"sort_order"
 	]
+} 
+
+export const ProjectCreateSchema = {
+	"type": "object",
+	"properties": {
+		"code": {
+			"type": "string"
+		},
+		"config": {},
+		"dashboard_group_name": {
+			"type": "string"
+		},
+		"default_measure": {
+			"type": "string"
+		},
+		"description": {
+			"type": "string"
+		},
+		"entity_hierarchy_id": {
+			"type": "string"
+		},
+		"entity_id": {
+			"type": "string"
+		},
+		"image_url": {
+			"type": "string"
+		},
+		"logo_url": {
+			"type": "string"
+		},
+		"permission_groups": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"sort_order": {
+			"type": "number"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"code"
+	]
+} 
+
+export const ProjectUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"code": {
+			"type": "string"
+		},
+		"config": {},
+		"dashboard_group_name": {
+			"type": "string"
+		},
+		"default_measure": {
+			"type": "string"
+		},
+		"description": {
+			"type": "string"
+		},
+		"entity_hierarchy_id": {
+			"type": "string"
+		},
+		"entity_id": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"image_url": {
+			"type": "string"
+		},
+		"logo_url": {
+			"type": "string"
+		},
+		"permission_groups": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"sort_order": {
+			"type": "number"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const PsssSessionSchema = {
@@ -36696,6 +56755,56 @@ export const PsssSessionSchema = {
 		"id",
 		"refresh_token"
 	]
+} 
+
+export const PsssSessionCreateSchema = {
+	"type": "object",
+	"properties": {
+		"access_policy": {},
+		"access_token": {
+			"type": "string"
+		},
+		"access_token_expiry": {
+			"type": "string"
+		},
+		"email": {
+			"type": "string"
+		},
+		"refresh_token": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"access_policy",
+		"access_token",
+		"access_token_expiry",
+		"email",
+		"refresh_token"
+	]
+} 
+
+export const PsssSessionUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"access_policy": {},
+		"access_token": {
+			"type": "string"
+		},
+		"access_token_expiry": {
+			"type": "string"
+		},
+		"email": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"refresh_token": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const QuestionSchema = {
@@ -36761,10 +56870,147 @@ export const QuestionSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
+		"code",
+		"data_element_id",
+		"detail",
+		"hook",
 		"id",
+		"m_row$",
+		"name",
+		"option_set_id",
+		"options",
 		"text",
 		"type"
 	]
+} 
+
+export const QuestionCreateSchema = {
+	"type": "object",
+	"properties": {
+		"code": {
+			"type": "string"
+		},
+		"data_element_id": {
+			"type": "string"
+		},
+		"detail": {
+			"type": "string"
+		},
+		"hook": {
+			"type": "string"
+		},
+		"m_row$": {
+			"type": "string"
+		},
+		"name": {
+			"type": "string"
+		},
+		"option_set_id": {
+			"type": "string"
+		},
+		"options": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"text": {
+			"type": "string"
+		},
+		"type": {
+			"enum": [
+				"Arithmetic",
+				"Autocomplete",
+				"Binary",
+				"Checkbox",
+				"CodeGenerator",
+				"Condition",
+				"Date",
+				"DateOfData",
+				"DateTime",
+				"Entity",
+				"File",
+				"FreeText",
+				"Geolocate",
+				"Instruction",
+				"Number",
+				"Photo",
+				"PrimaryEntity",
+				"Radio",
+				"SubmissionDate"
+			],
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"text",
+		"type"
+	]
+} 
+
+export const QuestionUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"code": {
+			"type": "string"
+		},
+		"data_element_id": {
+			"type": "string"
+		},
+		"detail": {
+			"type": "string"
+		},
+		"hook": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"m_row$": {
+			"type": "string"
+		},
+		"name": {
+			"type": "string"
+		},
+		"option_set_id": {
+			"type": "string"
+		},
+		"options": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"text": {
+			"type": "string"
+		},
+		"type": {
+			"enum": [
+				"Arithmetic",
+				"Autocomplete",
+				"Binary",
+				"Checkbox",
+				"CodeGenerator",
+				"Condition",
+				"Date",
+				"DateOfData",
+				"DateTime",
+				"Entity",
+				"File",
+				"FreeText",
+				"Geolocate",
+				"Instruction",
+				"Number",
+				"Photo",
+				"PrimaryEntity",
+				"Radio",
+				"SubmissionDate"
+			],
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const RefreshTokenSchema = {
@@ -36791,10 +57037,64 @@ export const RefreshTokenSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
+		"device",
+		"expiry",
 		"id",
+		"meditrak_device_id",
 		"token",
 		"user_id"
 	]
+} 
+
+export const RefreshTokenCreateSchema = {
+	"type": "object",
+	"properties": {
+		"device": {
+			"type": "string"
+		},
+		"expiry": {
+			"type": "number"
+		},
+		"meditrak_device_id": {
+			"type": "string"
+		},
+		"token": {
+			"type": "string"
+		},
+		"user_id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"token",
+		"user_id"
+	]
+} 
+
+export const RefreshTokenUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"device": {
+			"type": "string"
+		},
+		"expiry": {
+			"type": "number"
+		},
+		"id": {
+			"type": "string"
+		},
+		"meditrak_device_id": {
+			"type": "string"
+		},
+		"token": {
+			"type": "string"
+		},
+		"user_id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const ReportSchema = {
@@ -36862,6 +57162,126 @@ export const ReportSchema = {
 	]
 } 
 
+export const ReportCreateSchema = {
+	"type": "object",
+	"properties": {
+		"code": {
+			"type": "string"
+		},
+		"config": {
+			"anyOf": [
+				{
+					"type": "object",
+					"properties": {
+						"transform": {
+							"type": "array",
+							"items": {
+								"anyOf": [
+									{
+										"type": "object",
+										"additionalProperties": false
+									},
+									{
+										"type": "string"
+									}
+								]
+							}
+						},
+						"output": {
+							"type": "object",
+							"additionalProperties": false
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"transform"
+					]
+				},
+				{
+					"type": "object",
+					"properties": {
+						"customReport": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"customReport"
+					]
+				}
+			]
+		},
+		"permission_group_id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"code",
+		"config",
+		"permission_group_id"
+	]
+} 
+
+export const ReportUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"code": {
+			"type": "string"
+		},
+		"config": {
+			"anyOf": [
+				{
+					"type": "object",
+					"properties": {
+						"transform": {
+							"type": "array",
+							"items": {
+								"anyOf": [
+									{
+										"type": "object",
+										"additionalProperties": false
+									},
+									{
+										"type": "string"
+									}
+								]
+							}
+						},
+						"output": {
+							"type": "object",
+							"additionalProperties": false
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"transform"
+					]
+				},
+				{
+					"type": "object",
+					"properties": {
+						"customReport": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"customReport"
+					]
+				}
+			]
+		},
+		"id": {
+			"type": "string"
+		},
+		"permission_group_id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
+} 
+
 export const SettingSchema = {
 	"type": "object",
 	"properties": {
@@ -36878,8 +57298,41 @@ export const SettingSchema = {
 	"additionalProperties": false,
 	"required": [
 		"id",
+		"key",
+		"value"
+	]
+} 
+
+export const SettingCreateSchema = {
+	"type": "object",
+	"properties": {
+		"key": {
+			"type": "string"
+		},
+		"value": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
 		"key"
 	]
+} 
+
+export const SettingUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"id": {
+			"type": "string"
+		},
+		"key": {
+			"type": "string"
+		},
+		"value": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const SupersetInstanceSchema = {
@@ -36899,6 +57352,35 @@ export const SupersetInstanceSchema = {
 		"config",
 		"id"
 	]
+} 
+
+export const SupersetInstanceCreateSchema = {
+	"type": "object",
+	"properties": {
+		"code": {
+			"type": "string"
+		},
+		"config": {}
+	},
+	"additionalProperties": false,
+	"required": [
+		"code",
+		"config"
+	]
+} 
+
+export const SupersetInstanceUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"code": {
+			"type": "string"
+		},
+		"config": {},
+		"id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const SurveySchema = {
@@ -36951,10 +57433,122 @@ export const SurveySchema = {
 	},
 	"additionalProperties": false,
 	"required": [
+		"can_repeat",
 		"code",
+		"country_ids",
+		"data_group_id",
 		"id",
+		"integration_metadata",
+		"m_row$",
+		"name",
+		"period_granularity",
+		"permission_group_id",
+		"requires_approval",
+		"survey_group_id"
+	]
+} 
+
+export const SurveyCreateSchema = {
+	"type": "object",
+	"properties": {
+		"can_repeat": {
+			"type": "boolean"
+		},
+		"code": {
+			"type": "string"
+		},
+		"country_ids": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"data_group_id": {
+			"type": "string"
+		},
+		"integration_metadata": {},
+		"m_row$": {
+			"type": "string"
+		},
+		"name": {
+			"type": "string"
+		},
+		"period_granularity": {
+			"enum": [
+				"daily",
+				"monthly",
+				"quarterly",
+				"weekly",
+				"yearly"
+			],
+			"type": "string"
+		},
+		"permission_group_id": {
+			"type": "string"
+		},
+		"requires_approval": {
+			"type": "boolean"
+		},
+		"survey_group_id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"code",
 		"name"
 	]
+} 
+
+export const SurveyUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"can_repeat": {
+			"type": "boolean"
+		},
+		"code": {
+			"type": "string"
+		},
+		"country_ids": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"data_group_id": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"integration_metadata": {},
+		"m_row$": {
+			"type": "string"
+		},
+		"name": {
+			"type": "string"
+		},
+		"period_granularity": {
+			"enum": [
+				"daily",
+				"monthly",
+				"quarterly",
+				"weekly",
+				"yearly"
+			],
+			"type": "string"
+		},
+		"permission_group_id": {
+			"type": "string"
+		},
+		"requires_approval": {
+			"type": "boolean"
+		},
+		"survey_group_id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const SurveyGroupSchema = {
@@ -36972,6 +57566,32 @@ export const SurveyGroupSchema = {
 		"id",
 		"name"
 	]
+} 
+
+export const SurveyGroupCreateSchema = {
+	"type": "object",
+	"properties": {
+		"name": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"name"
+	]
+} 
+
+export const SurveyGroupUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"id": {
+			"type": "string"
+		},
+		"name": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const SurveyResponseSchema = {
@@ -37028,14 +57648,135 @@ export const SurveyResponseSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
+		"approval_status",
 		"assessor_name",
+		"data_time",
 		"end_time",
 		"entity_id",
 		"id",
+		"m_row$",
+		"metadata",
+		"outdated",
+		"start_time",
+		"survey_id",
+		"timezone",
+		"user_id"
+	]
+} 
+
+export const SurveyResponseCreateSchema = {
+	"type": "object",
+	"properties": {
+		"approval_status": {
+			"enum": [
+				"approved",
+				"not_required",
+				"pending",
+				"rejected"
+			],
+			"type": "string"
+		},
+		"assessor_name": {
+			"type": "string"
+		},
+		"data_time": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"end_time": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"entity_id": {
+			"type": "string"
+		},
+		"m_row$": {
+			"type": "string"
+		},
+		"metadata": {
+			"type": "string"
+		},
+		"outdated": {
+			"type": "boolean"
+		},
+		"start_time": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"survey_id": {
+			"type": "string"
+		},
+		"timezone": {
+			"type": "string"
+		},
+		"user_id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"assessor_name",
+		"end_time",
+		"entity_id",
 		"start_time",
 		"survey_id",
 		"user_id"
 	]
+} 
+
+export const SurveyResponseUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"approval_status": {
+			"enum": [
+				"approved",
+				"not_required",
+				"pending",
+				"rejected"
+			],
+			"type": "string"
+		},
+		"assessor_name": {
+			"type": "string"
+		},
+		"data_time": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"end_time": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"entity_id": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"m_row$": {
+			"type": "string"
+		},
+		"metadata": {
+			"type": "string"
+		},
+		"outdated": {
+			"type": "boolean"
+		},
+		"start_time": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"survey_id": {
+			"type": "string"
+		},
+		"timezone": {
+			"type": "string"
+		},
+		"user_id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const SurveyResponseCommentSchema = {
@@ -37059,6 +57800,39 @@ export const SurveyResponseCommentSchema = {
 	]
 } 
 
+export const SurveyResponseCommentCreateSchema = {
+	"type": "object",
+	"properties": {
+		"comment_id": {
+			"type": "string"
+		},
+		"survey_response_id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"comment_id",
+		"survey_response_id"
+	]
+} 
+
+export const SurveyResponseCommentUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"comment_id": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"survey_response_id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
+} 
+
 export const SurveyScreenSchema = {
 	"type": "object",
 	"properties": {
@@ -37078,6 +57852,39 @@ export const SurveyScreenSchema = {
 		"screen_number",
 		"survey_id"
 	]
+} 
+
+export const SurveyScreenCreateSchema = {
+	"type": "object",
+	"properties": {
+		"screen_number": {
+			"type": "number"
+		},
+		"survey_id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"screen_number",
+		"survey_id"
+	]
+} 
+
+export const SurveyScreenUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"id": {
+			"type": "string"
+		},
+		"screen_number": {
+			"type": "number"
+		},
+		"survey_id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const SurveyScreenComponentSchema = {
@@ -37122,11 +57929,106 @@ export const SurveyScreenComponentSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
+		"answers_enabling_follow_up",
 		"component_number",
+		"config",
+		"detail_label",
 		"id",
+		"is_follow_up",
+		"question_id",
+		"question_label",
+		"screen_id",
+		"validation_criteria",
+		"visibility_criteria"
+	]
+} 
+
+export const SurveyScreenComponentCreateSchema = {
+	"type": "object",
+	"properties": {
+		"answers_enabling_follow_up": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"component_number": {
+			"type": "number"
+		},
+		"config": {
+			"type": "string"
+		},
+		"detail_label": {
+			"type": "string"
+		},
+		"is_follow_up": {
+			"type": "boolean"
+		},
+		"question_id": {
+			"type": "string"
+		},
+		"question_label": {
+			"type": "string"
+		},
+		"screen_id": {
+			"type": "string"
+		},
+		"validation_criteria": {
+			"type": "string"
+		},
+		"visibility_criteria": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"component_number",
 		"question_id",
 		"screen_id"
 	]
+} 
+
+export const SurveyScreenComponentUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"answers_enabling_follow_up": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"component_number": {
+			"type": "number"
+		},
+		"config": {
+			"type": "string"
+		},
+		"detail_label": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"is_follow_up": {
+			"type": "boolean"
+		},
+		"question_id": {
+			"type": "string"
+		},
+		"question_label": {
+			"type": "string"
+		},
+		"screen_id": {
+			"type": "string"
+		},
+		"validation_criteria": {
+			"type": "string"
+		},
+		"visibility_criteria": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const SyncGroupLogSchema = {
@@ -37163,8 +58065,75 @@ export const SyncGroupLogSchema = {
 		"id",
 		"log_message",
 		"service_type",
+		"sync_group_code",
+		"timestamp"
+	]
+} 
+
+export const SyncGroupLogCreateSchema = {
+	"type": "object",
+	"properties": {
+		"log_message": {
+			"type": "string"
+		},
+		"service_type": {
+			"enum": [
+				"data-lake",
+				"dhis",
+				"indicator",
+				"kobo",
+				"superset",
+				"tupaia",
+				"weather"
+			],
+			"type": "string"
+		},
+		"sync_group_code": {
+			"type": "string"
+		},
+		"timestamp": {
+			"type": "string",
+			"format": "date-time"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"log_message",
+		"service_type",
 		"sync_group_code"
 	]
+} 
+
+export const SyncGroupLogUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"id": {
+			"type": "string"
+		},
+		"log_message": {
+			"type": "string"
+		},
+		"service_type": {
+			"enum": [
+				"data-lake",
+				"dhis",
+				"indicator",
+				"kobo",
+				"superset",
+				"tupaia",
+				"weather"
+			],
+			"type": "string"
+		},
+		"sync_group_code": {
+			"type": "string"
+		},
+		"timestamp": {
+			"type": "string",
+			"format": "date-time"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const TupaiaWebSessionSchema = {
@@ -37196,6 +58165,56 @@ export const TupaiaWebSessionSchema = {
 		"id",
 		"refresh_token"
 	]
+} 
+
+export const TupaiaWebSessionCreateSchema = {
+	"type": "object",
+	"properties": {
+		"access_policy": {},
+		"access_token": {
+			"type": "string"
+		},
+		"access_token_expiry": {
+			"type": "string"
+		},
+		"email": {
+			"type": "string"
+		},
+		"refresh_token": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"access_policy",
+		"access_token",
+		"access_token_expiry",
+		"email",
+		"refresh_token"
+	]
+} 
+
+export const TupaiaWebSessionUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"access_policy": {},
+		"access_token": {
+			"type": "string"
+		},
+		"access_token_expiry": {
+			"type": "string"
+		},
+		"email": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"refresh_token": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const UserAccountSchema = {
@@ -37257,11 +58276,144 @@ export const UserAccountSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
+		"creation_date",
 		"email",
+		"employer",
+		"first_name",
+		"gender",
 		"id",
+		"last_name",
+		"mobile_number",
+		"password_hash",
+		"password_salt",
+		"position",
+		"preferences",
+		"primary_platform",
+		"profile_image",
+		"verified_email"
+	]
+} 
+
+export const UserAccountCreateSchema = {
+	"type": "object",
+	"properties": {
+		"creation_date": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"email": {
+			"type": "string"
+		},
+		"employer": {
+			"type": "string"
+		},
+		"first_name": {
+			"type": "string"
+		},
+		"gender": {
+			"type": "string"
+		},
+		"last_name": {
+			"type": "string"
+		},
+		"mobile_number": {
+			"type": "string"
+		},
+		"password_hash": {
+			"type": "string"
+		},
+		"password_salt": {
+			"type": "string"
+		},
+		"position": {
+			"type": "string"
+		},
+		"preferences": {},
+		"primary_platform": {
+			"enum": [
+				"lesmis",
+				"tupaia"
+			],
+			"type": "string"
+		},
+		"profile_image": {
+			"type": "string"
+		},
+		"verified_email": {
+			"enum": [
+				"new_user",
+				"unverified",
+				"verified"
+			],
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"email",
 		"password_hash",
 		"password_salt"
 	]
+} 
+
+export const UserAccountUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"creation_date": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"email": {
+			"type": "string"
+		},
+		"employer": {
+			"type": "string"
+		},
+		"first_name": {
+			"type": "string"
+		},
+		"gender": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"last_name": {
+			"type": "string"
+		},
+		"mobile_number": {
+			"type": "string"
+		},
+		"password_hash": {
+			"type": "string"
+		},
+		"password_salt": {
+			"type": "string"
+		},
+		"position": {
+			"type": "string"
+		},
+		"preferences": {},
+		"primary_platform": {
+			"enum": [
+				"lesmis",
+				"tupaia"
+			],
+			"type": "string"
+		},
+		"profile_image": {
+			"type": "string"
+		},
+		"verified_email": {
+			"enum": [
+				"new_user",
+				"unverified",
+				"verified"
+			],
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const UserEntityPermissionSchema = {
@@ -37282,8 +58434,46 @@ export const UserEntityPermissionSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
-		"id"
+		"entity_id",
+		"id",
+		"permission_group_id",
+		"user_id"
 	]
+} 
+
+export const UserEntityPermissionCreateSchema = {
+	"type": "object",
+	"properties": {
+		"entity_id": {
+			"type": "string"
+		},
+		"permission_group_id": {
+			"type": "string"
+		},
+		"user_id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
+} 
+
+export const UserEntityPermissionUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"entity_id": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"permission_group_id": {
+			"type": "string"
+		},
+		"user_id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const UserFavouriteDashboardItemSchema = {
@@ -37305,6 +58495,39 @@ export const UserFavouriteDashboardItemSchema = {
 		"id",
 		"user_id"
 	]
+} 
+
+export const UserFavouriteDashboardItemCreateSchema = {
+	"type": "object",
+	"properties": {
+		"dashboard_item_id": {
+			"type": "string"
+		},
+		"user_id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"dashboard_item_id",
+		"user_id"
+	]
+} 
+
+export const UserFavouriteDashboardItemUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"dashboard_item_id": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"user_id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const UserSessionSchema = {
@@ -37329,10 +58552,60 @@ export const UserSessionSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
+		"accessPolicy",
+		"accessToken",
+		"access_token_expiry",
 		"id",
 		"refreshToken",
 		"userName"
 	]
+} 
+
+export const UserSessionCreateSchema = {
+	"type": "object",
+	"properties": {
+		"access_token_expiry": {
+			"type": "string"
+		},
+		"accessPolicy": {},
+		"accessToken": {
+			"type": "string"
+		},
+		"refreshToken": {
+			"type": "string"
+		},
+		"userName": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"refreshToken",
+		"userName"
+	]
+} 
+
+export const UserSessionUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"access_token_expiry": {
+			"type": "string"
+		},
+		"accessPolicy": {},
+		"accessToken": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"refreshToken": {
+			"type": "string"
+		},
+		"userName": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
 } 
 
 export const VerifiedEmailSchema = {
@@ -37673,9 +58946,19 @@ export const MeditrakSurveyResponseRequestSchema = {
 				},
 				"additionalProperties": false,
 				"required": [
+					"attributes",
+					"bounds",
 					"code",
+					"country_code",
 					"id",
-					"name"
+					"image_url",
+					"m_row$",
+					"metadata",
+					"name",
+					"parent_id",
+					"point",
+					"region",
+					"type"
 				]
 			}
 		},
@@ -37700,7 +58983,10 @@ export const MeditrakSurveyResponseRequestSchema = {
 				},
 				"additionalProperties": false,
 				"required": [
+					"attributes",
+					"label",
 					"option_set_id",
+					"sort_order",
 					"value"
 				]
 			}
@@ -37757,6 +59043,8 @@ export const DataTablePreviewRequestSchema = {
 	"additionalProperties": false,
 	"required": [
 		"code",
+		"config",
+		"description",
 		"permission_groups",
 		"type"
 	]
@@ -37932,9 +59220,19 @@ export const ResBodySchema = {
 		},
 		"additionalProperties": false,
 		"required": [
+			"attributes",
+			"bounds",
 			"code",
+			"countryCode",
 			"id",
-			"name"
+			"imageUrl",
+			"mRow$",
+			"metadata",
+			"name",
+			"parentId",
+			"point",
+			"region",
+			"type"
 		]
 	}
 } 
@@ -38016,10 +59314,20 @@ export const ProjectResponseSchema = {
 	},
 	"required": [
 		"code",
+		"config",
+		"dashboardGroupName",
+		"defaultMeasure",
+		"description",
+		"entityHierarchyId",
+		"entityId",
 		"hasAccess",
 		"hasPendingAccess",
 		"id",
-		"name"
+		"imageUrl",
+		"logoUrl",
+		"name",
+		"permissionGroups",
+		"sortOrder"
 	]
 } 
 
@@ -38103,6 +59411,13 @@ export const CamelCasedQuestionSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
+		"code",
+		"dataElementId",
+		"detail",
+		"hook",
+		"mRow$",
+		"name",
+		"optionSetId",
 		"text",
 		"type"
 	]
@@ -38132,7 +59447,10 @@ export const CamelCasedComponentSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
+		"answersEnablingFollowUp",
 		"componentNumber",
+		"detailLabel",
+		"isFollowUp",
 		"questionId"
 	]
 } 
@@ -46583,7 +67901,11 @@ export const DashboardWithItemsSchema = {
 				"additionalProperties": false,
 				"required": [
 					"code",
-					"id"
+					"config",
+					"id",
+					"legacy",
+					"permission_group_ids",
+					"report_code"
 				]
 			}
 		},
@@ -46609,7 +67931,8 @@ export const DashboardWithItemsSchema = {
 		"id",
 		"items",
 		"name",
-		"root_entity_code"
+		"root_entity_code",
+		"sort_order"
 	]
 } 
 
@@ -47080,7 +68403,9 @@ export const TranslatedMapOverlaySchema = {
 	"required": [
 		"code",
 		"displayType",
-		"name"
+		"legacy",
+		"name",
+		"reportCode"
 	]
 } 
 

--- a/packages/types/src/schemas/schemas.ts
+++ b/packages/types/src/schemas/schemas.ts
@@ -26737,16 +26737,7 @@ export const AdminPanelSessionUpdateSchema = {
 export const AnalyticsSchema = {
 	"type": "object",
 	"properties": {
-		"answer_entity_m_row$": {
-			"type": "string"
-		},
-		"answer_m_row$": {
-			"type": "string"
-		},
 		"data_element_code": {
-			"type": "string"
-		},
-		"data_element_m_row$": {
 			"type": "string"
 		},
 		"data_group_code": {
@@ -26762,9 +26753,6 @@ export const AnalyticsSchema = {
 		"entity_code": {
 			"type": "string"
 		},
-		"entity_m_row$": {
-			"type": "string"
-		},
 		"entity_name": {
 			"type": "string"
 		},
@@ -26772,15 +26760,6 @@ export const AnalyticsSchema = {
 			"type": "string"
 		},
 		"month_period": {
-			"type": "string"
-		},
-		"question_m_row$": {
-			"type": "string"
-		},
-		"survey_m_row$": {
-			"type": "string"
-		},
-		"survey_response_m_row$": {
 			"type": "string"
 		},
 		"type": {
@@ -26798,21 +26777,14 @@ export const AnalyticsSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
-		"answer_entity_m_row$",
-		"answer_m_row$",
 		"data_element_code",
-		"data_element_m_row$",
 		"data_group_code",
 		"date",
 		"day_period",
 		"entity_code",
-		"entity_m_row$",
 		"entity_name",
 		"event_id",
 		"month_period",
-		"question_m_row$",
-		"survey_m_row$",
-		"survey_response_m_row$",
 		"type",
 		"value",
 		"week_period",
@@ -26823,16 +26795,7 @@ export const AnalyticsSchema = {
 export const AnalyticsCreateSchema = {
 	"type": "object",
 	"properties": {
-		"answer_entity_m_row$": {
-			"type": "string"
-		},
-		"answer_m_row$": {
-			"type": "string"
-		},
 		"data_element_code": {
-			"type": "string"
-		},
-		"data_element_m_row$": {
 			"type": "string"
 		},
 		"data_group_code": {
@@ -26848,9 +26811,6 @@ export const AnalyticsCreateSchema = {
 		"entity_code": {
 			"type": "string"
 		},
-		"entity_m_row$": {
-			"type": "string"
-		},
 		"entity_name": {
 			"type": "string"
 		},
@@ -26858,15 +26818,6 @@ export const AnalyticsCreateSchema = {
 			"type": "string"
 		},
 		"month_period": {
-			"type": "string"
-		},
-		"question_m_row$": {
-			"type": "string"
-		},
-		"survey_m_row$": {
-			"type": "string"
-		},
-		"survey_response_m_row$": {
 			"type": "string"
 		},
 		"type": {
@@ -26888,16 +26839,7 @@ export const AnalyticsCreateSchema = {
 export const AnalyticsUpdateSchema = {
 	"type": "object",
 	"properties": {
-		"answer_entity_m_row$": {
-			"type": "string"
-		},
-		"answer_m_row$": {
-			"type": "string"
-		},
 		"data_element_code": {
-			"type": "string"
-		},
-		"data_element_m_row$": {
 			"type": "string"
 		},
 		"data_group_code": {
@@ -26913,9 +26855,6 @@ export const AnalyticsUpdateSchema = {
 		"entity_code": {
 			"type": "string"
 		},
-		"entity_m_row$": {
-			"type": "string"
-		},
 		"entity_name": {
 			"type": "string"
 		},
@@ -26923,15 +26862,6 @@ export const AnalyticsUpdateSchema = {
 			"type": "string"
 		},
 		"month_period": {
-			"type": "string"
-		},
-		"question_m_row$": {
-			"type": "string"
-		},
-		"survey_m_row$": {
-			"type": "string"
-		},
-		"survey_response_m_row$": {
 			"type": "string"
 		},
 		"type": {
@@ -27032,9 +26962,6 @@ export const AnswerSchema = {
 		"id": {
 			"type": "string"
 		},
-		"m_row$": {
-			"type": "string"
-		},
 		"question_id": {
 			"type": "string"
 		},
@@ -27051,7 +26978,6 @@ export const AnswerSchema = {
 	"additionalProperties": false,
 	"required": [
 		"id",
-		"m_row$",
 		"question_id",
 		"survey_response_id",
 		"text",
@@ -27062,9 +26988,6 @@ export const AnswerSchema = {
 export const AnswerCreateSchema = {
 	"type": "object",
 	"properties": {
-		"m_row$": {
-			"type": "string"
-		},
 		"question_id": {
 			"type": "string"
 		},
@@ -27090,9 +27013,6 @@ export const AnswerUpdateSchema = {
 	"type": "object",
 	"properties": {
 		"id": {
-			"type": "string"
-		},
-		"m_row$": {
 			"type": "string"
 		},
 		"question_id": {
@@ -51722,9 +51642,6 @@ export const DataElementSchema = {
 		"id": {
 			"type": "string"
 		},
-		"m_row$": {
-			"type": "string"
-		},
 		"permission_groups": {
 			"type": "array",
 			"items": {
@@ -51749,7 +51666,6 @@ export const DataElementSchema = {
 		"code",
 		"config",
 		"id",
-		"m_row$",
 		"permission_groups",
 		"service_type"
 	]
@@ -51762,9 +51678,6 @@ export const DataElementCreateSchema = {
 			"type": "string"
 		},
 		"config": {},
-		"m_row$": {
-			"type": "string"
-		},
 		"permission_groups": {
 			"type": "array",
 			"items": {
@@ -51799,9 +51712,6 @@ export const DataElementUpdateSchema = {
 		},
 		"config": {},
 		"id": {
-			"type": "string"
-		},
-		"m_row$": {
 			"type": "string"
 		},
 		"permission_groups": {
@@ -52955,9 +52865,6 @@ export const EntitySchema = {
 		"image_url": {
 			"type": "string"
 		},
-		"m_row$": {
-			"type": "string"
-		},
 		"metadata": {},
 		"name": {
 			"type": "string"
@@ -53017,7 +52924,6 @@ export const EntitySchema = {
 		"country_code",
 		"id",
 		"image_url",
-		"m_row$",
 		"metadata",
 		"name",
 		"parent_id",
@@ -53039,9 +52945,6 @@ export const EntityCreateSchema = {
 			"type": "string"
 		},
 		"image_url": {
-			"type": "string"
-		},
-		"m_row$": {
 			"type": "string"
 		},
 		"metadata": {},
@@ -53117,9 +53020,6 @@ export const EntityUpdateSchema = {
 			"type": "string"
 		},
 		"image_url": {
-			"type": "string"
-		},
-		"m_row$": {
 			"type": "string"
 		},
 		"metadata": {},
@@ -56825,9 +56725,6 @@ export const QuestionSchema = {
 		"id": {
 			"type": "string"
 		},
-		"m_row$": {
-			"type": "string"
-		},
 		"name": {
 			"type": "string"
 		},
@@ -56875,7 +56772,6 @@ export const QuestionSchema = {
 		"detail",
 		"hook",
 		"id",
-		"m_row$",
 		"name",
 		"option_set_id",
 		"options",
@@ -56897,9 +56793,6 @@ export const QuestionCreateSchema = {
 			"type": "string"
 		},
 		"hook": {
-			"type": "string"
-		},
-		"m_row$": {
 			"type": "string"
 		},
 		"name": {
@@ -56965,9 +56858,6 @@ export const QuestionUpdateSchema = {
 			"type": "string"
 		},
 		"id": {
-			"type": "string"
-		},
-		"m_row$": {
 			"type": "string"
 		},
 		"name": {
@@ -57405,9 +57295,6 @@ export const SurveySchema = {
 			"type": "string"
 		},
 		"integration_metadata": {},
-		"m_row$": {
-			"type": "string"
-		},
 		"name": {
 			"type": "string"
 		},
@@ -57439,7 +57326,6 @@ export const SurveySchema = {
 		"data_group_id",
 		"id",
 		"integration_metadata",
-		"m_row$",
 		"name",
 		"period_granularity",
 		"permission_group_id",
@@ -57467,9 +57353,6 @@ export const SurveyCreateSchema = {
 			"type": "string"
 		},
 		"integration_metadata": {},
-		"m_row$": {
-			"type": "string"
-		},
 		"name": {
 			"type": "string"
 		},
@@ -57522,9 +57405,6 @@ export const SurveyUpdateSchema = {
 			"type": "string"
 		},
 		"integration_metadata": {},
-		"m_row$": {
-			"type": "string"
-		},
 		"name": {
 			"type": "string"
 		},
@@ -57623,9 +57503,6 @@ export const SurveyResponseSchema = {
 		"id": {
 			"type": "string"
 		},
-		"m_row$": {
-			"type": "string"
-		},
 		"metadata": {
 			"type": "string"
 		},
@@ -57654,7 +57531,6 @@ export const SurveyResponseSchema = {
 		"end_time",
 		"entity_id",
 		"id",
-		"m_row$",
 		"metadata",
 		"outdated",
 		"start_time",
@@ -57688,9 +57564,6 @@ export const SurveyResponseCreateSchema = {
 			"format": "date-time"
 		},
 		"entity_id": {
-			"type": "string"
-		},
-		"m_row$": {
 			"type": "string"
 		},
 		"metadata": {
@@ -57751,9 +57624,6 @@ export const SurveyResponseUpdateSchema = {
 			"type": "string"
 		},
 		"id": {
-			"type": "string"
-		},
-		"m_row$": {
 			"type": "string"
 		},
 		"metadata": {
@@ -58890,9 +58760,6 @@ export const MeditrakSurveyResponseRequestSchema = {
 					"image_url": {
 						"type": "string"
 					},
-					"m_row$": {
-						"type": "string"
-					},
 					"metadata": {},
 					"name": {
 						"type": "string"
@@ -58952,7 +58819,6 @@ export const MeditrakSurveyResponseRequestSchema = {
 					"country_code",
 					"id",
 					"image_url",
-					"m_row$",
 					"metadata",
 					"name",
 					"parent_id",
@@ -59122,9 +58988,6 @@ export const ResBodySchema = {
 			"imageUrl": {
 				"type": "string"
 			},
-			"mRow$": {
-				"type": "string"
-			},
 			"metadata": {
 				"anyOf": [
 					{
@@ -59226,7 +59089,6 @@ export const ResBodySchema = {
 			"countryCode",
 			"id",
 			"imageUrl",
-			"mRow$",
 			"metadata",
 			"name",
 			"parentId",
@@ -59402,9 +59264,6 @@ export const CamelCasedQuestionSchema = {
 		"hook": {
 			"type": "string"
 		},
-		"mRow$": {
-			"type": "string"
-		},
 		"optionSetId": {
 			"type": "string"
 		}
@@ -59415,7 +59274,6 @@ export const CamelCasedQuestionSchema = {
 		"dataElementId",
 		"detail",
 		"hook",
-		"mRow$",
 		"name",
 		"optionSetId",
 		"text",

--- a/packages/types/src/types/models.ts
+++ b/packages/types/src/types/models.ts
@@ -73,63 +73,42 @@ export interface AdminPanelSessionUpdate {
   'refresh_token'?: string;
 }
 export interface Analytics {
-  'answer_entity_m_row$': string | null;
-  'answer_m_row$': string | null;
   'data_element_code': string | null;
-  'data_element_m_row$': string | null;
   'data_group_code': string | null;
   'date': Date | null;
   'day_period': string | null;
   'entity_code': string | null;
-  'entity_m_row$': string | null;
   'entity_name': string | null;
   'event_id': string | null;
   'month_period': string | null;
-  'question_m_row$': string | null;
-  'survey_m_row$': string | null;
-  'survey_response_m_row$': string | null;
   'type': string | null;
   'value': string | null;
   'week_period': string | null;
   'year_period': string | null;
 }
 export interface AnalyticsCreate {
-  'answer_entity_m_row$'?: string | null;
-  'answer_m_row$'?: string | null;
   'data_element_code'?: string | null;
-  'data_element_m_row$'?: string | null;
   'data_group_code'?: string | null;
   'date'?: Date | null;
   'day_period'?: string | null;
   'entity_code'?: string | null;
-  'entity_m_row$'?: string | null;
   'entity_name'?: string | null;
   'event_id'?: string | null;
   'month_period'?: string | null;
-  'question_m_row$'?: string | null;
-  'survey_m_row$'?: string | null;
-  'survey_response_m_row$'?: string | null;
   'type'?: string | null;
   'value'?: string | null;
   'week_period'?: string | null;
   'year_period'?: string | null;
 }
 export interface AnalyticsUpdate {
-  'answer_entity_m_row$'?: string | null;
-  'answer_m_row$'?: string | null;
   'data_element_code'?: string | null;
-  'data_element_m_row$'?: string | null;
   'data_group_code'?: string | null;
   'date'?: Date | null;
   'day_period'?: string | null;
   'entity_code'?: string | null;
-  'entity_m_row$'?: string | null;
   'entity_name'?: string | null;
   'event_id'?: string | null;
   'month_period'?: string | null;
-  'question_m_row$'?: string | null;
-  'survey_m_row$'?: string | null;
-  'survey_response_m_row$'?: string | null;
   'type'?: string | null;
   'value'?: string | null;
   'week_period'?: string | null;
@@ -157,14 +136,12 @@ export interface AncestorDescendantRelationUpdate {
 }
 export interface Answer {
   'id': string;
-  'm_row$': string;
   'question_id': string;
   'survey_response_id': string;
   'text': string | null;
   'type': string;
 }
 export interface AnswerCreate {
-  'm_row$'?: string;
   'question_id': string;
   'survey_response_id': string;
   'text'?: string | null;
@@ -172,7 +149,6 @@ export interface AnswerCreate {
 }
 export interface AnswerUpdate {
   'id'?: string;
-  'm_row$'?: string;
   'question_id'?: string;
   'survey_response_id'?: string;
   'text'?: string | null;
@@ -366,14 +342,12 @@ export interface DataElement {
   'code': string;
   'config': any;
   'id': string;
-  'm_row$': string;
   'permission_groups': string[];
   'service_type': ServiceType;
 }
 export interface DataElementCreate {
   'code': string;
   'config'?: any;
-  'm_row$'?: string;
   'permission_groups'?: string[];
   'service_type': ServiceType;
 }
@@ -381,7 +355,6 @@ export interface DataElementUpdate {
   'code'?: string;
   'config'?: any;
   'id'?: string;
-  'm_row$'?: string;
   'permission_groups'?: string[];
   'service_type'?: ServiceType;
 }
@@ -656,7 +629,6 @@ export interface Entity {
   'country_code': string | null;
   'id': string;
   'image_url': string | null;
-  'm_row$': string;
   'metadata': any | null;
   'name': string;
   'parent_id': string | null;
@@ -670,7 +642,6 @@ export interface EntityCreate {
   'code': string;
   'country_code'?: string | null;
   'image_url'?: string | null;
-  'm_row$'?: string;
   'metadata'?: any | null;
   'name': string;
   'parent_id'?: string | null;
@@ -685,7 +656,6 @@ export interface EntityUpdate {
   'country_code'?: string | null;
   'id'?: string;
   'image_url'?: string | null;
-  'm_row$'?: string;
   'metadata'?: any | null;
   'name'?: string;
   'parent_id'?: string | null;
@@ -1275,7 +1245,6 @@ export interface Question {
   'detail': string | null;
   'hook': string | null;
   'id': string;
-  'm_row$': string;
   'name': string | null;
   'option_set_id': string | null;
   'options': string[] | null;
@@ -1287,7 +1256,6 @@ export interface QuestionCreate {
   'data_element_id'?: string | null;
   'detail'?: string | null;
   'hook'?: string | null;
-  'm_row$'?: string;
   'name'?: string | null;
   'option_set_id'?: string | null;
   'options'?: string[] | null;
@@ -1300,7 +1268,6 @@ export interface QuestionUpdate {
   'detail'?: string | null;
   'hook'?: string | null;
   'id'?: string;
-  'm_row$'?: string;
   'name'?: string | null;
   'option_set_id'?: string | null;
   'options'?: string[] | null;
@@ -1382,7 +1349,6 @@ export interface Survey {
   'data_group_id': string | null;
   'id': string;
   'integration_metadata': any | null;
-  'm_row$': string;
   'name': string;
   'period_granularity': PeriodGranularity | null;
   'permission_group_id': string | null;
@@ -1395,7 +1361,6 @@ export interface SurveyCreate {
   'country_ids'?: string[] | null;
   'data_group_id'?: string | null;
   'integration_metadata'?: any | null;
-  'm_row$'?: string;
   'name': string;
   'period_granularity'?: PeriodGranularity | null;
   'permission_group_id'?: string | null;
@@ -1409,7 +1374,6 @@ export interface SurveyUpdate {
   'data_group_id'?: string | null;
   'id'?: string;
   'integration_metadata'?: any | null;
-  'm_row$'?: string;
   'name'?: string;
   'period_granularity'?: PeriodGranularity | null;
   'permission_group_id'?: string | null;
@@ -1434,7 +1398,6 @@ export interface SurveyResponse {
   'end_time': Date;
   'entity_id': string;
   'id': string;
-  'm_row$': string;
   'metadata': string | null;
   'outdated': boolean | null;
   'start_time': Date;
@@ -1448,7 +1411,6 @@ export interface SurveyResponseCreate {
   'data_time'?: Date | null;
   'end_time': Date;
   'entity_id': string;
-  'm_row$'?: string;
   'metadata'?: string | null;
   'outdated'?: boolean | null;
   'start_time': Date;
@@ -1463,7 +1425,6 @@ export interface SurveyResponseUpdate {
   'end_time'?: Date;
   'entity_id'?: string;
   'id'?: string;
-  'm_row$'?: string;
   'metadata'?: string | null;
   'outdated'?: boolean | null;
   'start_time'?: Date;

--- a/packages/types/src/types/models.ts
+++ b/packages/types/src/types/models.ts
@@ -12,17 +12,17 @@ import { DashboardItemConfig } from './models-extra';
 import { MapOverlayConfig } from './models-extra';
 
 export interface AccessRequest {
-  'approved': boolean | null;
-  'created_time': Date;
-  'entity_id': string | null;
+  'approved'?: boolean | null;
+  'created_time'?: Date;
+  'entity_id'?: string | null;
   'id': string;
-  'message': string | null;
-  'note': string | null;
-  'permission_group_id': string | null;
-  'processed_by': string | null;
-  'processed_date': Date | null;
-  'project_id': string | null;
-  'user_id': string | null;
+  'message'?: string | null;
+  'note'?: string | null;
+  'permission_group_id'?: string | null;
+  'processed_by'?: string | null;
+  'processed_date'?: Date | null;
+  'project_id'?: string | null;
+  'user_id'?: string | null;
 }
 export interface AccessRequestCreate {
   'approved'?: boolean | null;
@@ -73,18 +73,18 @@ export interface AdminPanelSessionUpdate {
   'refresh_token'?: string;
 }
 export interface Analytics {
-  'data_element_code': string | null;
-  'data_group_code': string | null;
-  'date': Date | null;
-  'day_period': string | null;
-  'entity_code': string | null;
-  'entity_name': string | null;
-  'event_id': string | null;
-  'month_period': string | null;
-  'type': string | null;
-  'value': string | null;
-  'week_period': string | null;
-  'year_period': string | null;
+  'data_element_code'?: string | null;
+  'data_group_code'?: string | null;
+  'date'?: Date | null;
+  'day_period'?: string | null;
+  'entity_code'?: string | null;
+  'entity_name'?: string | null;
+  'event_id'?: string | null;
+  'month_period'?: string | null;
+  'type'?: string | null;
+  'value'?: string | null;
+  'week_period'?: string | null;
+  'year_period'?: string | null;
 }
 export interface AnalyticsCreate {
   'data_element_code'?: string | null;
@@ -138,7 +138,7 @@ export interface Answer {
   'id': string;
   'question_id': string;
   'survey_response_id': string;
-  'text': string | null;
+  'text'?: string | null;
   'type': string;
 }
 export interface AnswerCreate {
@@ -157,7 +157,7 @@ export interface AnswerUpdate {
 export interface ApiClient {
   'id': string;
   'secret_key_hash': string;
-  'user_account_id': string | null;
+  'user_account_id'?: string | null;
   'username': string;
 }
 export interface ApiClientCreate {
@@ -175,12 +175,12 @@ export interface ApiRequestLog {
   'api': string;
   'endpoint': string;
   'id': string;
-  'metadata': any | null;
-  'method': string | null;
-  'query': any | null;
-  'refresh_token': string | null;
-  'request_time': Date | null;
-  'user_id': string | null;
+  'metadata'?: any | null;
+  'method'?: string | null;
+  'query'?: any | null;
+  'refresh_token'?: string | null;
+  'request_time'?: Date | null;
+  'user_id'?: string | null;
   'version': number;
 }
 export interface ApiRequestLogCreate {
@@ -207,14 +207,14 @@ export interface ApiRequestLogUpdate {
   'version'?: number;
 }
 export interface Clinic {
-  'category_code': string | null;
+  'category_code'?: string | null;
   'code': string;
   'country_id': string;
   'geographical_area_id': string;
   'id': string;
   'name': string;
-  'type': string | null;
-  'type_name': string | null;
+  'type'?: string | null;
+  'type_name'?: string | null;
 }
 export interface ClinicCreate {
   'category_code'?: string | null;
@@ -236,11 +236,11 @@ export interface ClinicUpdate {
   'type_name'?: string | null;
 }
 export interface Comment {
-  'created_time': Date;
+  'created_time'?: Date;
   'id': string;
-  'last_modified_time': Date;
+  'last_modified_time'?: Date;
   'text': string;
-  'user_id': string | null;
+  'user_id'?: string | null;
 }
 export interface CommentCreate {
   'created_time'?: Date;
@@ -274,7 +274,7 @@ export interface Dashboard {
   'id': string;
   'name': string;
   'root_entity_code': string;
-  'sort_order': number | null;
+  'sort_order'?: number | null;
 }
 export interface DashboardCreate {
   'code': string;
@@ -291,11 +291,11 @@ export interface DashboardUpdate {
 }
 export interface DashboardItem {
   'code': string;
-  'config': DashboardItemConfig;
+  'config'?: DashboardItemConfig;
   'id': string;
-  'legacy': boolean;
-  'permission_group_ids': string[] | null;
-  'report_code': string | null;
+  'legacy'?: boolean;
+  'permission_group_ids'?: string[] | null;
+  'report_code'?: string | null;
 }
 export interface DashboardItemCreate {
   'code': string;
@@ -319,7 +319,7 @@ export interface DashboardRelation {
   'id': string;
   'permission_groups': string[];
   'project_codes': string[];
-  'sort_order': number | null;
+  'sort_order'?: number | null;
 }
 export interface DashboardRelationCreate {
   'child_id': string;
@@ -340,9 +340,9 @@ export interface DashboardRelationUpdate {
 }
 export interface DataElement {
   'code': string;
-  'config': any;
+  'config'?: any;
   'id': string;
-  'permission_groups': string[];
+  'permission_groups'?: string[];
   'service_type': ServiceType;
 }
 export interface DataElementCreate {
@@ -376,7 +376,7 @@ export interface DataElementDataService {
   'country_code': string;
   'data_element_code': string;
   'id': string;
-  'service_config': any;
+  'service_config'?: any;
   'service_type': ServiceType;
 }
 export interface DataElementDataServiceCreate {
@@ -394,7 +394,7 @@ export interface DataElementDataServiceUpdate {
 }
 export interface DataGroup {
   'code': string;
-  'config': any;
+  'config'?: any;
   'id': string;
   'service_type': ServiceType;
 }
@@ -429,8 +429,8 @@ export interface DataServiceSyncGroup {
   'data_group_code': string;
   'id': string;
   'service_type': ServiceType;
-  'sync_cursor': string | null;
-  'sync_status': SyncGroupSyncStatus | null;
+  'sync_cursor'?: string | null;
+  'sync_status'?: SyncGroupSyncStatus | null;
 }
 export interface DataServiceSyncGroupCreate {
   'code': string;
@@ -451,8 +451,8 @@ export interface DataServiceSyncGroupUpdate {
 }
 export interface DataTable {
   'code': string;
-  'config': any;
-  'description': string | null;
+  'config'?: any;
+  'description'?: string | null;
   'id': string;
   'permission_groups': string[];
   'type': DataTableType;
@@ -513,16 +513,16 @@ export interface DhisInstanceUpdate {
   'readonly'?: boolean;
 }
 export interface DhisSyncLog {
-  'data': string | null;
-  'deleted': number | null;
-  'dhis_reference': string | null;
-  'error_list': string | null;
+  'data'?: string | null;
+  'deleted'?: number | null;
+  'dhis_reference'?: string | null;
+  'error_list'?: string | null;
   'id': string;
-  'ignored': number | null;
-  'imported': number | null;
+  'ignored'?: number | null;
+  'imported'?: number | null;
   'record_id': string;
   'record_type': string;
-  'updated': number | null;
+  'updated'?: number | null;
 }
 export interface DhisSyncLogCreate {
   'data'?: string | null;
@@ -548,13 +548,13 @@ export interface DhisSyncLogUpdate {
   'updated'?: number | null;
 }
 export interface DhisSyncQueue {
-  'bad_request_count': number | null;
-  'change_time': number | null;
-  'details': string | null;
+  'bad_request_count'?: number | null;
+  'change_time'?: number | null;
+  'details'?: string | null;
   'id': string;
-  'is_dead_letter': boolean | null;
-  'is_deleted': boolean | null;
-  'priority': number | null;
+  'is_dead_letter'?: boolean | null;
+  'is_deleted'?: boolean | null;
+  'priority'?: number | null;
   'record_id': string;
   'record_type': string;
   'type': string;
@@ -584,7 +584,7 @@ export interface DhisSyncQueueUpdate {
 }
 export interface Disaster {
   'countryCode': string;
-  'description': string | null;
+  'description'?: string | null;
   'id': string;
   'name': string;
   'type': DisasterType;
@@ -623,18 +623,18 @@ export interface DisasterEventUpdate {
   'type'?: DisasterEventType;
 }
 export interface Entity {
-  'attributes': any | null;
-  'bounds': any | null;
+  'attributes'?: any | null;
+  'bounds'?: any | null;
   'code': string;
-  'country_code': string | null;
+  'country_code'?: string | null;
   'id': string;
-  'image_url': string | null;
-  'metadata': any | null;
+  'image_url'?: string | null;
+  'metadata'?: any | null;
   'name': string;
-  'parent_id': string | null;
-  'point': any | null;
-  'region': any | null;
-  'type': EntityType | null;
+  'parent_id'?: string | null;
+  'point'?: any | null;
+  'region'?: any | null;
+  'type'?: EntityType | null;
 }
 export interface EntityCreate {
   'attributes'?: any | null;
@@ -664,7 +664,7 @@ export interface EntityUpdate {
   'type'?: EntityType | null;
 }
 export interface EntityHierarchy {
-  'canonical_types': string[] | null;
+  'canonical_types'?: string[] | null;
   'id': string;
   'name': string;
 }
@@ -695,11 +695,11 @@ export interface EntityRelationUpdate {
   'parent_id'?: string;
 }
 export interface ErrorLog {
-  'api_request_log_id': string | null;
-  'error_time': Date | null;
+  'api_request_log_id'?: string | null;
+  'error_time'?: Date | null;
   'id': string;
-  'message': string | null;
-  'type': string | null;
+  'message'?: string | null;
+  'type'?: string | null;
 }
 export interface ErrorLogCreate {
   'api_request_log_id'?: string | null;
@@ -716,10 +716,10 @@ export interface ErrorLogUpdate {
 }
 export interface ExternalDatabaseConnection {
   'code': string;
-  'description': string | null;
+  'description'?: string | null;
   'id': string;
   'name': string;
-  'permission_groups': string[];
+  'permission_groups'?: string[];
 }
 export interface ExternalDatabaseConnectionCreate {
   'code': string;
@@ -735,15 +735,15 @@ export interface ExternalDatabaseConnectionUpdate {
   'permission_groups'?: string[];
 }
 export interface FeedItem {
-  'country_id': string | null;
-  'creation_date': Date | null;
-  'geographical_area_id': string | null;
+  'country_id'?: string | null;
+  'creation_date'?: Date | null;
+  'geographical_area_id'?: string | null;
   'id': string;
-  'permission_group_id': string | null;
-  'record_id': string | null;
-  'template_variables': Object | null;
-  'type': string | null;
-  'user_id': string | null;
+  'permission_group_id'?: string | null;
+  'record_id'?: string | null;
+  'template_variables'?: Object | null;
+  'type'?: string | null;
+  'user_id'?: string | null;
 }
 export interface FeedItemCreate {
   'country_id'?: string | null;
@@ -767,13 +767,13 @@ export interface FeedItemUpdate {
   'user_id'?: string | null;
 }
 export interface GeographicalArea {
-  'code': string | null;
+  'code'?: string | null;
   'country_id': string;
   'id': string;
   'level_code': string;
   'level_name': string;
   'name': string;
-  'parent_id': string | null;
+  'parent_id'?: string | null;
 }
 export interface GeographicalAreaCreate {
   'code'?: string | null;
@@ -795,7 +795,7 @@ export interface GeographicalAreaUpdate {
 export interface Indicator {
   'builder': string;
   'code': string;
-  'config': any;
+  'config'?: any;
   'id': string;
 }
 export interface IndicatorCreate {
@@ -810,21 +810,21 @@ export interface IndicatorUpdate {
   'id'?: string;
 }
 export interface LandingPage {
-  'contact_us': string | null;
-  'extended_title': string | null;
-  'external_link': string | null;
+  'contact_us'?: string | null;
+  'extended_title'?: string | null;
+  'external_link'?: string | null;
   'id': string;
-  'image_url': string | null;
-  'include_name_in_header': boolean | null;
-  'logo_url': string | null;
-  'long_bio': string | null;
+  'image_url'?: string | null;
+  'include_name_in_header'?: boolean | null;
+  'logo_url'?: string | null;
+  'long_bio'?: string | null;
   'name': string;
-  'phone_number': string | null;
-  'primary_hexcode': string | null;
-  'project_codes': string[] | null;
-  'secondary_hexcode': string | null;
+  'phone_number'?: string | null;
+  'primary_hexcode'?: string | null;
+  'project_codes'?: string[] | null;
+  'secondary_hexcode'?: string | null;
   'url_segment': string;
-  'website_url': string | null;
+  'website_url'?: string | null;
 }
 export interface LandingPageCreate {
   'contact_us'?: string | null;
@@ -861,9 +861,9 @@ export interface LandingPageUpdate {
 }
 export interface LegacyReport {
   'code': string;
-  'data_builder': string | null;
-  'data_builder_config': any | null;
-  'data_services': any | null;
+  'data_builder'?: string | null;
+  'data_builder_config'?: any | null;
+  'data_services'?: any | null;
   'id': string;
 }
 export interface LegacyReportCreate {
@@ -904,16 +904,16 @@ export interface LesmisSessionUpdate {
 }
 export interface MapOverlay {
   'code': string;
-  'config': MapOverlayConfig;
-  'country_codes': string[] | null;
-  'data_services': any | null;
-  'id': string;
-  'legacy': boolean;
-  'linked_measures': string[] | null;
+  'config'?: MapOverlayConfig;
+  'country_codes'?: string[] | null;
+  'data_services'?: any | null;
+  'id'?: string;
+  'legacy'?: boolean;
+  'linked_measures'?: string[] | null;
   'name': string;
   'permission_group': string;
-  'project_codes': string[] | null;
-  'report_code': string | null;
+  'project_codes'?: string[] | null;
+  'report_code'?: string | null;
 }
 export interface MapOverlayCreate {
   'code': string;
@@ -959,7 +959,7 @@ export interface MapOverlayGroupRelation {
   'child_type': string;
   'id': string;
   'map_overlay_group_id': string;
-  'sort_order': number | null;
+  'sort_order'?: number | null;
 }
 export interface MapOverlayGroupRelationCreate {
   'child_id': string;
@@ -975,11 +975,11 @@ export interface MapOverlayGroupRelationUpdate {
   'sort_order'?: number | null;
 }
 export interface MeditrakDevice {
-  'app_version': string | null;
-  'config': any | null;
+  'app_version'?: string | null;
+  'config'?: any | null;
   'id': string;
   'install_id': string;
-  'platform': string | null;
+  'platform'?: string | null;
   'user_id': string;
 }
 export interface MeditrakDeviceCreate {
@@ -998,7 +998,7 @@ export interface MeditrakDeviceUpdate {
   'user_id'?: string;
 }
 export interface MeditrakSyncQueue {
-  'change_time': number | null;
+  'change_time'?: number | null;
   'id': string;
   'record_id': string;
   'record_type': string;
@@ -1018,10 +1018,10 @@ export interface MeditrakSyncQueueUpdate {
   'type'?: string;
 }
 export interface Ms1SyncLog {
-  'count': number | null;
-  'data': string | null;
-  'endpoint': string | null;
-  'error_list': string | null;
+  'count'?: number | null;
+  'data'?: string | null;
+  'endpoint'?: string | null;
+  'error_list'?: string | null;
   'id': string;
   'record_id': string;
   'record_type': string;
@@ -1044,13 +1044,13 @@ export interface Ms1SyncLogUpdate {
   'record_type'?: string;
 }
 export interface Ms1SyncQueue {
-  'bad_request_count': number | null;
-  'change_time': number | null;
-  'details': string | null;
+  'bad_request_count'?: number | null;
+  'change_time'?: number | null;
+  'details'?: string | null;
   'id': string;
-  'is_dead_letter': boolean | null;
-  'is_deleted': boolean | null;
-  'priority': number | null;
+  'is_dead_letter'?: boolean | null;
+  'is_deleted'?: boolean | null;
+  'priority'?: number | null;
   'record_id': string;
   'record_type': string;
   'type': string;
@@ -1079,10 +1079,10 @@ export interface Ms1SyncQueueUpdate {
   'type'?: string;
 }
 export interface OneTimeLogin {
-  'creation_date': Date | null;
+  'creation_date'?: Date | null;
   'id': string;
   'token': string;
-  'use_date': Date | null;
+  'use_date'?: Date | null;
   'user_id': string;
 }
 export interface OneTimeLoginCreate {
@@ -1099,11 +1099,11 @@ export interface OneTimeLoginUpdate {
   'user_id'?: string;
 }
 export interface Option {
-  'attributes': any | null;
+  'attributes'?: any | null;
   'id': string;
-  'label': string | null;
+  'label'?: string | null;
   'option_set_id': string;
-  'sort_order': number | null;
+  'sort_order'?: number | null;
   'value': string;
 }
 export interface OptionCreate {
@@ -1135,7 +1135,7 @@ export interface OptionSetUpdate {
 export interface PermissionGroup {
   'id': string;
   'name': string;
-  'parent_id': string | null;
+  'parent_id'?: string | null;
 }
 export interface PermissionGroupCreate {
   'name': string;
@@ -1147,14 +1147,14 @@ export interface PermissionGroupUpdate {
   'parent_id'?: string | null;
 }
 export interface PermissionsBasedMeditrakSyncQueue {
-  'change_time': number | null;
-  'country_ids': string[] | null;
-  'entity_type': EntityType | null;
-  'id': string | null;
-  'permission_groups': string[] | null;
-  'record_id': string | null;
-  'record_type': string | null;
-  'type': string | null;
+  'change_time'?: number | null;
+  'country_ids'?: string[] | null;
+  'entity_type'?: EntityType | null;
+  'id'?: string | null;
+  'permission_groups'?: string[] | null;
+  'record_id'?: string | null;
+  'record_type'?: string | null;
+  'type'?: string | null;
 }
 export interface PermissionsBasedMeditrakSyncQueueCreate {
   'change_time'?: number | null;
@@ -1177,17 +1177,17 @@ export interface PermissionsBasedMeditrakSyncQueueUpdate {
 }
 export interface Project {
   'code': string;
-  'config': any | null;
-  'dashboard_group_name': string | null;
-  'default_measure': string | null;
-  'description': string | null;
-  'entity_hierarchy_id': string | null;
-  'entity_id': string | null;
+  'config'?: any | null;
+  'dashboard_group_name'?: string | null;
+  'default_measure'?: string | null;
+  'description'?: string | null;
+  'entity_hierarchy_id'?: string | null;
+  'entity_id'?: string | null;
   'id': string;
-  'image_url': string | null;
-  'logo_url': string | null;
-  'permission_groups': string[] | null;
-  'sort_order': number | null;
+  'image_url'?: string | null;
+  'logo_url'?: string | null;
+  'permission_groups'?: string[] | null;
+  'sort_order'?: number | null;
 }
 export interface ProjectCreate {
   'code': string;
@@ -1240,14 +1240,14 @@ export interface PsssSessionUpdate {
   'refresh_token'?: string;
 }
 export interface Question {
-  'code': string | null;
-  'data_element_id': string | null;
-  'detail': string | null;
-  'hook': string | null;
+  'code'?: string | null;
+  'data_element_id'?: string | null;
+  'detail'?: string | null;
+  'hook'?: string | null;
   'id': string;
-  'name': string | null;
-  'option_set_id': string | null;
-  'options': string[] | null;
+  'name'?: string | null;
+  'option_set_id'?: string | null;
+  'options'?: string[] | null;
   'text': string;
   'type': QuestionType;
 }
@@ -1275,10 +1275,10 @@ export interface QuestionUpdate {
   'type'?: QuestionType;
 }
 export interface RefreshToken {
-  'device': string | null;
-  'expiry': number | null;
+  'device'?: string | null;
+  'expiry'?: number | null;
   'id': string;
-  'meditrak_device_id': string | null;
+  'meditrak_device_id'?: string | null;
   'token': string;
   'user_id': string;
 }
@@ -1317,7 +1317,7 @@ export interface ReportUpdate {
 export interface Setting {
   'id': string;
   'key': string;
-  'value': string | null;
+  'value'?: string | null;
 }
 export interface SettingCreate {
   'key': string;
@@ -1343,17 +1343,17 @@ export interface SupersetInstanceUpdate {
   'id'?: string;
 }
 export interface Survey {
-  'can_repeat': boolean | null;
+  'can_repeat'?: boolean | null;
   'code': string;
-  'country_ids': string[] | null;
-  'data_group_id': string | null;
+  'country_ids'?: string[] | null;
+  'data_group_id'?: string | null;
   'id': string;
-  'integration_metadata': any | null;
+  'integration_metadata'?: any | null;
   'name': string;
-  'period_granularity': PeriodGranularity | null;
-  'permission_group_id': string | null;
-  'requires_approval': boolean | null;
-  'survey_group_id': string | null;
+  'period_granularity'?: PeriodGranularity | null;
+  'permission_group_id'?: string | null;
+  'requires_approval'?: boolean | null;
+  'survey_group_id'?: string | null;
 }
 export interface SurveyCreate {
   'can_repeat'?: boolean | null;
@@ -1392,17 +1392,17 @@ export interface SurveyGroupUpdate {
   'name'?: string;
 }
 export interface SurveyResponse {
-  'approval_status': ApprovalStatus | null;
+  'approval_status'?: ApprovalStatus | null;
   'assessor_name': string;
-  'data_time': Date | null;
+  'data_time'?: Date | null;
   'end_time': Date;
   'entity_id': string;
   'id': string;
-  'metadata': string | null;
-  'outdated': boolean | null;
+  'metadata'?: string | null;
+  'outdated'?: boolean | null;
   'start_time': Date;
   'survey_id': string;
-  'timezone': string | null;
+  'timezone'?: string | null;
   'user_id': string;
 }
 export interface SurveyResponseCreate {
@@ -1461,17 +1461,17 @@ export interface SurveyScreenUpdate {
   'survey_id'?: string;
 }
 export interface SurveyScreenComponent {
-  'answers_enabling_follow_up': string[] | null;
+  'answers_enabling_follow_up'?: string[] | null;
   'component_number': number;
-  'config': string | null;
-  'detail_label': string | null;
+  'config'?: string | null;
+  'detail_label'?: string | null;
   'id': string;
-  'is_follow_up': boolean | null;
+  'is_follow_up'?: boolean | null;
   'question_id': string;
-  'question_label': string | null;
+  'question_label'?: string | null;
   'screen_id': string;
-  'validation_criteria': string | null;
-  'visibility_criteria': string | null;
+  'validation_criteria'?: string | null;
+  'visibility_criteria'?: string | null;
 }
 export interface SurveyScreenComponentCreate {
   'answers_enabling_follow_up'?: string[] | null;
@@ -1503,7 +1503,7 @@ export interface SyncGroupLog {
   'log_message': string;
   'service_type': ServiceType;
   'sync_group_code': string;
-  'timestamp': Date | null;
+  'timestamp'?: Date | null;
 }
 export interface SyncGroupLogCreate {
   'log_message': string;
@@ -1542,21 +1542,21 @@ export interface TupaiaWebSessionUpdate {
   'refresh_token'?: string;
 }
 export interface UserAccount {
-  'creation_date': Date | null;
+  'creation_date'?: Date | null;
   'email': string;
-  'employer': string | null;
-  'first_name': string | null;
-  'gender': string | null;
+  'employer'?: string | null;
+  'first_name'?: string | null;
+  'gender'?: string | null;
   'id': string;
-  'last_name': string | null;
-  'mobile_number': string | null;
+  'last_name'?: string | null;
+  'mobile_number'?: string | null;
   'password_hash': string;
   'password_salt': string;
-  'position': string | null;
-  'preferences': any;
-  'primary_platform': PrimaryPlatform | null;
-  'profile_image': string | null;
-  'verified_email': VerifiedEmail | null;
+  'position'?: string | null;
+  'preferences'?: any;
+  'primary_platform'?: PrimaryPlatform | null;
+  'profile_image'?: string | null;
+  'verified_email'?: VerifiedEmail | null;
 }
 export interface UserAccountCreate {
   'creation_date'?: Date | null;
@@ -1592,10 +1592,10 @@ export interface UserAccountUpdate {
   'verified_email'?: VerifiedEmail | null;
 }
 export interface UserEntityPermission {
-  'entity_id': string | null;
+  'entity_id'?: string | null;
   'id': string;
-  'permission_group_id': string | null;
-  'user_id': string | null;
+  'permission_group_id'?: string | null;
+  'user_id'?: string | null;
 }
 export interface UserEntityPermissionCreate {
   'entity_id'?: string | null;
@@ -1623,9 +1623,9 @@ export interface UserFavouriteDashboardItemUpdate {
   'user_id'?: string;
 }
 export interface UserSession {
-  'access_token_expiry': string;
-  'accessPolicy': any | null;
-  'accessToken': string | null;
+  'access_token_expiry'?: string;
+  'accessPolicy'?: any | null;
+  'accessToken'?: string | null;
   'id': string;
   'refreshToken': string;
   'userName': string;

--- a/packages/types/src/types/models.ts
+++ b/packages/types/src/types/models.ts
@@ -12,10 +12,35 @@ import { DashboardItemConfig } from './models-extra';
 import { MapOverlayConfig } from './models-extra';
 
 export interface AccessRequest {
+  'approved': boolean | null;
+  'created_time': Date;
+  'entity_id': string | null;
+  'id': string;
+  'message': string | null;
+  'note': string | null;
+  'permission_group_id': string | null;
+  'processed_by': string | null;
+  'processed_date': Date | null;
+  'project_id': string | null;
+  'user_id': string | null;
+}
+export interface AccessRequestCreate {
   'approved'?: boolean | null;
   'created_time'?: Date;
   'entity_id'?: string | null;
-  'id': string;
+  'message'?: string | null;
+  'note'?: string | null;
+  'permission_group_id'?: string | null;
+  'processed_by'?: string | null;
+  'processed_date'?: Date | null;
+  'project_id'?: string | null;
+  'user_id'?: string | null;
+}
+export interface AccessRequestUpdate {
+  'approved'?: boolean | null;
+  'created_time'?: Date;
+  'entity_id'?: string | null;
+  'id'?: string;
   'message'?: string | null;
   'note'?: string | null;
   'permission_group_id'?: string | null;
@@ -32,7 +57,64 @@ export interface AdminPanelSession {
   'id': string;
   'refresh_token': string;
 }
+export interface AdminPanelSessionCreate {
+  'access_policy': any;
+  'access_token': string;
+  'access_token_expiry': string;
+  'email': string;
+  'refresh_token': string;
+}
+export interface AdminPanelSessionUpdate {
+  'access_policy'?: any;
+  'access_token'?: string;
+  'access_token_expiry'?: string;
+  'email'?: string;
+  'id'?: string;
+  'refresh_token'?: string;
+}
 export interface Analytics {
+  'answer_entity_m_row$': string | null;
+  'answer_m_row$': string | null;
+  'data_element_code': string | null;
+  'data_element_m_row$': string | null;
+  'data_group_code': string | null;
+  'date': Date | null;
+  'day_period': string | null;
+  'entity_code': string | null;
+  'entity_m_row$': string | null;
+  'entity_name': string | null;
+  'event_id': string | null;
+  'month_period': string | null;
+  'question_m_row$': string | null;
+  'survey_m_row$': string | null;
+  'survey_response_m_row$': string | null;
+  'type': string | null;
+  'value': string | null;
+  'week_period': string | null;
+  'year_period': string | null;
+}
+export interface AnalyticsCreate {
+  'answer_entity_m_row$'?: string | null;
+  'answer_m_row$'?: string | null;
+  'data_element_code'?: string | null;
+  'data_element_m_row$'?: string | null;
+  'data_group_code'?: string | null;
+  'date'?: Date | null;
+  'day_period'?: string | null;
+  'entity_code'?: string | null;
+  'entity_m_row$'?: string | null;
+  'entity_name'?: string | null;
+  'event_id'?: string | null;
+  'month_period'?: string | null;
+  'question_m_row$'?: string | null;
+  'survey_m_row$'?: string | null;
+  'survey_response_m_row$'?: string | null;
+  'type'?: string | null;
+  'value'?: string | null;
+  'week_period'?: string | null;
+  'year_period'?: string | null;
+}
+export interface AnalyticsUpdate {
   'answer_entity_m_row$'?: string | null;
   'answer_m_row$'?: string | null;
   'data_element_code'?: string | null;
@@ -60,24 +142,74 @@ export interface AncestorDescendantRelation {
   'generational_distance': number;
   'id': string;
 }
+export interface AncestorDescendantRelationCreate {
+  'ancestor_id': string;
+  'descendant_id': string;
+  'entity_hierarchy_id': string;
+  'generational_distance': number;
+}
+export interface AncestorDescendantRelationUpdate {
+  'ancestor_id'?: string;
+  'descendant_id'?: string;
+  'entity_hierarchy_id'?: string;
+  'generational_distance'?: number;
+  'id'?: string;
+}
 export interface Answer {
   'id': string;
+  'm_row$': string;
+  'question_id': string;
+  'survey_response_id': string;
+  'text': string | null;
+  'type': string;
+}
+export interface AnswerCreate {
   'm_row$'?: string;
   'question_id': string;
   'survey_response_id': string;
   'text'?: string | null;
   'type': string;
 }
+export interface AnswerUpdate {
+  'id'?: string;
+  'm_row$'?: string;
+  'question_id'?: string;
+  'survey_response_id'?: string;
+  'text'?: string | null;
+  'type'?: string;
+}
 export interface ApiClient {
   'id': string;
   'secret_key_hash': string;
+  'user_account_id': string | null;
+  'username': string;
+}
+export interface ApiClientCreate {
+  'secret_key_hash': string;
   'user_account_id'?: string | null;
   'username': string;
+}
+export interface ApiClientUpdate {
+  'id'?: string;
+  'secret_key_hash'?: string;
+  'user_account_id'?: string | null;
+  'username'?: string;
 }
 export interface ApiRequestLog {
   'api': string;
   'endpoint': string;
   'id': string;
+  'metadata': any | null;
+  'method': string | null;
+  'query': any | null;
+  'refresh_token': string | null;
+  'request_time': Date | null;
+  'user_id': string | null;
+  'version': number;
+}
+export interface ApiRequestLogCreate {
+  'api': string;
+  'endpoint': string;
   'metadata'?: any | null;
   'method'?: string | null;
   'query'?: any | null;
@@ -86,21 +218,65 @@ export interface ApiRequestLog {
   'user_id'?: string | null;
   'version': number;
 }
+export interface ApiRequestLogUpdate {
+  'api'?: string;
+  'endpoint'?: string;
+  'id'?: string;
+  'metadata'?: any | null;
+  'method'?: string | null;
+  'query'?: any | null;
+  'refresh_token'?: string | null;
+  'request_time'?: Date | null;
+  'user_id'?: string | null;
+  'version'?: number;
+}
 export interface Clinic {
-  'category_code'?: string | null;
+  'category_code': string | null;
   'code': string;
   'country_id': string;
   'geographical_area_id': string;
   'id': string;
   'name': string;
+  'type': string | null;
+  'type_name': string | null;
+}
+export interface ClinicCreate {
+  'category_code'?: string | null;
+  'code': string;
+  'country_id': string;
+  'geographical_area_id': string;
+  'name': string;
+  'type'?: string | null;
+  'type_name'?: string | null;
+}
+export interface ClinicUpdate {
+  'category_code'?: string | null;
+  'code'?: string;
+  'country_id'?: string;
+  'geographical_area_id'?: string;
+  'id'?: string;
+  'name'?: string;
   'type'?: string | null;
   'type_name'?: string | null;
 }
 export interface Comment {
-  'created_time'?: Date;
+  'created_time': Date;
   'id': string;
+  'last_modified_time': Date;
+  'text': string;
+  'user_id': string | null;
+}
+export interface CommentCreate {
+  'created_time'?: Date;
   'last_modified_time'?: Date;
   'text': string;
+  'user_id'?: string | null;
+}
+export interface CommentUpdate {
+  'created_time'?: Date;
+  'id'?: string;
+  'last_modified_time'?: Date;
+  'text'?: string;
   'user_id'?: string | null;
 }
 export interface Country {
@@ -108,17 +284,54 @@ export interface Country {
   'id': string;
   'name': string;
 }
+export interface CountryCreate {
+  'code': string;
+  'name': string;
+}
+export interface CountryUpdate {
+  'code'?: string;
+  'id'?: string;
+  'name'?: string;
+}
 export interface Dashboard {
   'code': string;
   'id': string;
   'name': string;
   'root_entity_code': string;
+  'sort_order': number | null;
+}
+export interface DashboardCreate {
+  'code': string;
+  'name': string;
+  'root_entity_code': string;
+  'sort_order'?: number | null;
+}
+export interface DashboardUpdate {
+  'code'?: string;
+  'id'?: string;
+  'name'?: string;
+  'root_entity_code'?: string;
   'sort_order'?: number | null;
 }
 export interface DashboardItem {
   'code': string;
-  'config'?: DashboardItemConfig;
+  'config': DashboardItemConfig;
   'id': string;
+  'legacy': boolean;
+  'permission_group_ids': string[] | null;
+  'report_code': string | null;
+}
+export interface DashboardItemCreate {
+  'code': string;
+  'config'?: DashboardItemConfig;
+  'legacy'?: boolean;
+  'permission_group_ids'?: string[] | null;
+  'report_code'?: string | null;
+}
+export interface DashboardItemUpdate {
+  'code'?: string;
+  'config'?: DashboardItemConfig;
+  'id'?: string;
   'legacy'?: boolean;
   'permission_group_ids'?: string[] | null;
   'report_code'?: string | null;
@@ -130,38 +343,112 @@ export interface DashboardRelation {
   'id': string;
   'permission_groups': string[];
   'project_codes': string[];
+  'sort_order': number | null;
+}
+export interface DashboardRelationCreate {
+  'child_id': string;
+  'dashboard_id': string;
+  'entity_types': any;
+  'permission_groups': string[];
+  'project_codes': string[];
+  'sort_order'?: number | null;
+}
+export interface DashboardRelationUpdate {
+  'child_id'?: string;
+  'dashboard_id'?: string;
+  'entity_types'?: any;
+  'id'?: string;
+  'permission_groups'?: string[];
+  'project_codes'?: string[];
   'sort_order'?: number | null;
 }
 export interface DataElement {
   'code': string;
-  'config'?: any;
+  'config': any;
   'id': string;
+  'm_row$': string;
+  'permission_groups': string[];
+  'service_type': ServiceType;
+}
+export interface DataElementCreate {
+  'code': string;
+  'config'?: any;
   'm_row$'?: string;
   'permission_groups'?: string[];
   'service_type': ServiceType;
+}
+export interface DataElementUpdate {
+  'code'?: string;
+  'config'?: any;
+  'id'?: string;
+  'm_row$'?: string;
+  'permission_groups'?: string[];
+  'service_type'?: ServiceType;
 }
 export interface DataElementDataGroup {
   'data_element_id': string;
   'data_group_id': string;
   'id': string;
 }
+export interface DataElementDataGroupCreate {
+  'data_element_id': string;
+  'data_group_id': string;
+}
+export interface DataElementDataGroupUpdate {
+  'data_element_id'?: string;
+  'data_group_id'?: string;
+  'id'?: string;
+}
 export interface DataElementDataService {
   'country_code': string;
   'data_element_code': string;
   'id': string;
+  'service_config': any;
+  'service_type': ServiceType;
+}
+export interface DataElementDataServiceCreate {
+  'country_code': string;
+  'data_element_code': string;
   'service_config'?: any;
   'service_type': ServiceType;
 }
+export interface DataElementDataServiceUpdate {
+  'country_code'?: string;
+  'data_element_code'?: string;
+  'id'?: string;
+  'service_config'?: any;
+  'service_type'?: ServiceType;
+}
 export interface DataGroup {
   'code': string;
-  'config'?: any;
+  'config': any;
   'id': string;
   'service_type': ServiceType;
+}
+export interface DataGroupCreate {
+  'code': string;
+  'config'?: any;
+  'service_type': ServiceType;
+}
+export interface DataGroupUpdate {
+  'code'?: string;
+  'config'?: any;
+  'id'?: string;
+  'service_type'?: ServiceType;
 }
 export interface DataServiceEntity {
   'config': any;
   'entity_code': string;
   'id': string;
+}
+export interface DataServiceEntityCreate {
+  'config': any;
+  'entity_code': string;
+}
+export interface DataServiceEntityUpdate {
+  'config'?: any;
+  'entity_code'?: string;
+  'id'?: string;
 }
 export interface DataServiceSyncGroup {
   'code': string;
@@ -169,16 +456,48 @@ export interface DataServiceSyncGroup {
   'data_group_code': string;
   'id': string;
   'service_type': ServiceType;
+  'sync_cursor': string | null;
+  'sync_status': SyncGroupSyncStatus | null;
+}
+export interface DataServiceSyncGroupCreate {
+  'code': string;
+  'config': any;
+  'data_group_code': string;
+  'service_type': ServiceType;
+  'sync_cursor'?: string | null;
+  'sync_status'?: SyncGroupSyncStatus | null;
+}
+export interface DataServiceSyncGroupUpdate {
+  'code'?: string;
+  'config'?: any;
+  'data_group_code'?: string;
+  'id'?: string;
+  'service_type'?: ServiceType;
   'sync_cursor'?: string | null;
   'sync_status'?: SyncGroupSyncStatus | null;
 }
 export interface DataTable {
   'code': string;
-  'config'?: any;
-  'description'?: string | null;
+  'config': any;
+  'description': string | null;
   'id': string;
   'permission_groups': string[];
   'type': DataTableType;
+}
+export interface DataTableCreate {
+  'code': string;
+  'config'?: any;
+  'description'?: string | null;
+  'permission_groups': string[];
+  'type': DataTableType;
+}
+export interface DataTableUpdate {
+  'code'?: string;
+  'config'?: any;
+  'description'?: string | null;
+  'id'?: string;
+  'permission_groups'?: string[];
+  'type'?: DataTableType;
 }
 export interface DatatrakSession {
   'access_policy': any;
@@ -188,29 +507,89 @@ export interface DatatrakSession {
   'id': string;
   'refresh_token': string;
 }
+export interface DatatrakSessionCreate {
+  'access_policy': any;
+  'access_token': string;
+  'access_token_expiry': string;
+  'email': string;
+  'refresh_token': string;
+}
+export interface DatatrakSessionUpdate {
+  'access_policy'?: any;
+  'access_token'?: string;
+  'access_token_expiry'?: string;
+  'email'?: string;
+  'id'?: string;
+  'refresh_token'?: string;
+}
 export interface DhisInstance {
   'code': string;
   'config': any;
   'id': string;
   'readonly': boolean;
 }
+export interface DhisInstanceCreate {
+  'code': string;
+  'config': any;
+  'readonly': boolean;
+}
+export interface DhisInstanceUpdate {
+  'code'?: string;
+  'config'?: any;
+  'id'?: string;
+  'readonly'?: boolean;
+}
 export interface DhisSyncLog {
+  'data': string | null;
+  'deleted': number | null;
+  'dhis_reference': string | null;
+  'error_list': string | null;
+  'id': string;
+  'ignored': number | null;
+  'imported': number | null;
+  'record_id': string;
+  'record_type': string;
+  'updated': number | null;
+}
+export interface DhisSyncLogCreate {
   'data'?: string | null;
   'deleted'?: number | null;
   'dhis_reference'?: string | null;
   'error_list'?: string | null;
-  'id': string;
   'ignored'?: number | null;
   'imported'?: number | null;
   'record_id': string;
   'record_type': string;
   'updated'?: number | null;
 }
+export interface DhisSyncLogUpdate {
+  'data'?: string | null;
+  'deleted'?: number | null;
+  'dhis_reference'?: string | null;
+  'error_list'?: string | null;
+  'id'?: string;
+  'ignored'?: number | null;
+  'imported'?: number | null;
+  'record_id'?: string;
+  'record_type'?: string;
+  'updated'?: number | null;
+}
 export interface DhisSyncQueue {
+  'bad_request_count': number | null;
+  'change_time': number | null;
+  'details': string | null;
+  'id': string;
+  'is_dead_letter': boolean | null;
+  'is_deleted': boolean | null;
+  'priority': number | null;
+  'record_id': string;
+  'record_type': string;
+  'type': string;
+}
+export interface DhisSyncQueueCreate {
   'bad_request_count'?: number | null;
   'change_time'?: number | null;
   'details'?: string | null;
-  'id': string;
   'is_dead_letter'?: boolean | null;
   'is_deleted'?: boolean | null;
   'priority'?: number | null;
@@ -218,12 +597,37 @@ export interface DhisSyncQueue {
   'record_type': string;
   'type': string;
 }
+export interface DhisSyncQueueUpdate {
+  'bad_request_count'?: number | null;
+  'change_time'?: number | null;
+  'details'?: string | null;
+  'id'?: string;
+  'is_dead_letter'?: boolean | null;
+  'is_deleted'?: boolean | null;
+  'priority'?: number | null;
+  'record_id'?: string;
+  'record_type'?: string;
+  'type'?: string;
+}
 export interface Disaster {
   'countryCode': string;
-  'description'?: string | null;
+  'description': string | null;
   'id': string;
   'name': string;
   'type': DisasterType;
+}
+export interface DisasterCreate {
+  'countryCode': string;
+  'description'?: string | null;
+  'name': string;
+  'type': DisasterType;
+}
+export interface DisasterUpdate {
+  'countryCode'?: string;
+  'description'?: string | null;
+  'id'?: string;
+  'name'?: string;
+  'type'?: DisasterType;
 }
 export interface DisasterEvent {
   'date': Date;
@@ -232,12 +636,39 @@ export interface DisasterEvent {
   'organisationUnitCode': string;
   'type': DisasterEventType;
 }
+export interface DisasterEventCreate {
+  'date': Date;
+  'disasterId': string;
+  'organisationUnitCode': string;
+  'type': DisasterEventType;
+}
+export interface DisasterEventUpdate {
+  'date'?: Date;
+  'disasterId'?: string;
+  'id'?: string;
+  'organisationUnitCode'?: string;
+  'type'?: DisasterEventType;
+}
 export interface Entity {
+  'attributes': any | null;
+  'bounds': any | null;
+  'code': string;
+  'country_code': string | null;
+  'id': string;
+  'image_url': string | null;
+  'm_row$': string;
+  'metadata': any | null;
+  'name': string;
+  'parent_id': string | null;
+  'point': any | null;
+  'region': any | null;
+  'type': EntityType | null;
+}
+export interface EntityCreate {
   'attributes'?: any | null;
   'bounds'?: any | null;
   'code': string;
   'country_code'?: string | null;
-  'id': string;
   'image_url'?: string | null;
   'm_row$'?: string;
   'metadata'?: any | null;
@@ -247,10 +678,34 @@ export interface Entity {
   'region'?: any | null;
   'type'?: EntityType | null;
 }
+export interface EntityUpdate {
+  'attributes'?: any | null;
+  'bounds'?: any | null;
+  'code'?: string;
+  'country_code'?: string | null;
+  'id'?: string;
+  'image_url'?: string | null;
+  'm_row$'?: string;
+  'metadata'?: any | null;
+  'name'?: string;
+  'parent_id'?: string | null;
+  'point'?: any | null;
+  'region'?: any | null;
+  'type'?: EntityType | null;
+}
 export interface EntityHierarchy {
-  'canonical_types'?: string[] | null;
+  'canonical_types': string[] | null;
   'id': string;
   'name': string;
+}
+export interface EntityHierarchyCreate {
+  'canonical_types'?: string[] | null;
+  'name': string;
+}
+export interface EntityHierarchyUpdate {
+  'canonical_types'?: string[] | null;
+  'id'?: string;
+  'name'?: string;
 }
 export interface EntityRelation {
   'child_id': string;
@@ -258,25 +713,83 @@ export interface EntityRelation {
   'id': string;
   'parent_id': string;
 }
+export interface EntityRelationCreate {
+  'child_id': string;
+  'entity_hierarchy_id': string;
+  'parent_id': string;
+}
+export interface EntityRelationUpdate {
+  'child_id'?: string;
+  'entity_hierarchy_id'?: string;
+  'id'?: string;
+  'parent_id'?: string;
+}
 export interface ErrorLog {
+  'api_request_log_id': string | null;
+  'error_time': Date | null;
+  'id': string;
+  'message': string | null;
+  'type': string | null;
+}
+export interface ErrorLogCreate {
   'api_request_log_id'?: string | null;
   'error_time'?: Date | null;
-  'id': string;
+  'message'?: string | null;
+  'type'?: string | null;
+}
+export interface ErrorLogUpdate {
+  'api_request_log_id'?: string | null;
+  'error_time'?: Date | null;
+  'id'?: string;
   'message'?: string | null;
   'type'?: string | null;
 }
 export interface ExternalDatabaseConnection {
   'code': string;
-  'description'?: string | null;
+  'description': string | null;
   'id': string;
+  'name': string;
+  'permission_groups': string[];
+}
+export interface ExternalDatabaseConnectionCreate {
+  'code': string;
+  'description'?: string | null;
   'name': string;
   'permission_groups'?: string[];
 }
+export interface ExternalDatabaseConnectionUpdate {
+  'code'?: string;
+  'description'?: string | null;
+  'id'?: string;
+  'name'?: string;
+  'permission_groups'?: string[];
+}
 export interface FeedItem {
+  'country_id': string | null;
+  'creation_date': Date | null;
+  'geographical_area_id': string | null;
+  'id': string;
+  'permission_group_id': string | null;
+  'record_id': string | null;
+  'template_variables': Object | null;
+  'type': string | null;
+  'user_id': string | null;
+}
+export interface FeedItemCreate {
   'country_id'?: string | null;
   'creation_date'?: Date | null;
   'geographical_area_id'?: string | null;
-  'id': string;
+  'permission_group_id'?: string | null;
+  'record_id'?: string | null;
+  'template_variables'?: Object | null;
+  'type'?: string | null;
+  'user_id'?: string | null;
+}
+export interface FeedItemUpdate {
+  'country_id'?: string | null;
+  'creation_date'?: Date | null;
+  'geographical_area_id'?: string | null;
+  'id'?: string;
   'permission_group_id'?: string | null;
   'record_id'?: string | null;
   'template_variables'?: Object | null;
@@ -284,25 +797,69 @@ export interface FeedItem {
   'user_id'?: string | null;
 }
 export interface GeographicalArea {
-  'code'?: string | null;
+  'code': string | null;
   'country_id': string;
   'id': string;
   'level_code': string;
   'level_name': string;
   'name': string;
+  'parent_id': string | null;
+}
+export interface GeographicalAreaCreate {
+  'code'?: string | null;
+  'country_id': string;
+  'level_code': string;
+  'level_name': string;
+  'name': string;
+  'parent_id'?: string | null;
+}
+export interface GeographicalAreaUpdate {
+  'code'?: string | null;
+  'country_id'?: string;
+  'id'?: string;
+  'level_code'?: string;
+  'level_name'?: string;
+  'name'?: string;
   'parent_id'?: string | null;
 }
 export interface Indicator {
   'builder': string;
   'code': string;
-  'config'?: any;
+  'config': any;
   'id': string;
 }
+export interface IndicatorCreate {
+  'builder': string;
+  'code': string;
+  'config'?: any;
+}
+export interface IndicatorUpdate {
+  'builder'?: string;
+  'code'?: string;
+  'config'?: any;
+  'id'?: string;
+}
 export interface LandingPage {
+  'contact_us': string | null;
+  'extended_title': string | null;
+  'external_link': string | null;
+  'id': string;
+  'image_url': string | null;
+  'include_name_in_header': boolean | null;
+  'logo_url': string | null;
+  'long_bio': string | null;
+  'name': string;
+  'phone_number': string | null;
+  'primary_hexcode': string | null;
+  'project_codes': string[] | null;
+  'secondary_hexcode': string | null;
+  'url_segment': string;
+  'website_url': string | null;
+}
+export interface LandingPageCreate {
   'contact_us'?: string | null;
   'extended_title'?: string | null;
   'external_link'?: string | null;
-  'id': string;
   'image_url'?: string | null;
   'include_name_in_header'?: boolean | null;
   'logo_url'?: string | null;
@@ -315,12 +872,42 @@ export interface LandingPage {
   'url_segment': string;
   'website_url'?: string | null;
 }
+export interface LandingPageUpdate {
+  'contact_us'?: string | null;
+  'extended_title'?: string | null;
+  'external_link'?: string | null;
+  'id'?: string;
+  'image_url'?: string | null;
+  'include_name_in_header'?: boolean | null;
+  'logo_url'?: string | null;
+  'long_bio'?: string | null;
+  'name'?: string;
+  'phone_number'?: string | null;
+  'primary_hexcode'?: string | null;
+  'project_codes'?: string[] | null;
+  'secondary_hexcode'?: string | null;
+  'url_segment'?: string;
+  'website_url'?: string | null;
+}
 export interface LegacyReport {
+  'code': string;
+  'data_builder': string | null;
+  'data_builder_config': any | null;
+  'data_services': any | null;
+  'id': string;
+}
+export interface LegacyReportCreate {
   'code': string;
   'data_builder'?: string | null;
   'data_builder_config'?: any | null;
   'data_services'?: any | null;
-  'id': string;
+}
+export interface LegacyReportUpdate {
+  'code'?: string;
+  'data_builder'?: string | null;
+  'data_builder_config'?: any | null;
+  'data_services'?: any | null;
+  'id'?: string;
 }
 export interface LesmisSession {
   'access_policy': any;
@@ -330,16 +917,56 @@ export interface LesmisSession {
   'id': string;
   'refresh_token': string;
 }
+export interface LesmisSessionCreate {
+  'access_policy': any;
+  'access_token': string;
+  'access_token_expiry': string;
+  'email': string;
+  'refresh_token': string;
+}
+export interface LesmisSessionUpdate {
+  'access_policy'?: any;
+  'access_token'?: string;
+  'access_token_expiry'?: string;
+  'email'?: string;
+  'id'?: string;
+  'refresh_token'?: string;
+}
 export interface MapOverlay {
   'code': string;
+  'config': MapOverlayConfig;
+  'country_codes': string[] | null;
+  'data_services': any | null;
+  'id': string;
+  'legacy': boolean;
+  'linked_measures': string[] | null;
+  'name': string;
+  'permission_group': string;
+  'project_codes': string[] | null;
+  'report_code': string | null;
+}
+export interface MapOverlayCreate {
+  'code': string;
+  'config'?: MapOverlayConfig;
+  'country_codes'?: string[] | null;
+  'data_services'?: any | null;
+  'legacy'?: boolean;
+  'linked_measures'?: string[] | null;
+  'name': string;
+  'permission_group': string;
+  'project_codes'?: string[] | null;
+  'report_code'?: string | null;
+}
+export interface MapOverlayUpdate {
+  'code'?: string;
   'config'?: MapOverlayConfig;
   'country_codes'?: string[] | null;
   'data_services'?: any | null;
   'id'?: string;
   'legacy'?: boolean;
   'linked_measures'?: string[] | null;
-  'name': string;
-  'permission_group': string;
+  'name'?: string;
+  'permission_group'?: string;
   'project_codes'?: string[] | null;
   'report_code'?: string | null;
 }
@@ -348,42 +975,120 @@ export interface MapOverlayGroup {
   'id': string;
   'name': string;
 }
+export interface MapOverlayGroupCreate {
+  'code': string;
+  'name': string;
+}
+export interface MapOverlayGroupUpdate {
+  'code'?: string;
+  'id'?: string;
+  'name'?: string;
+}
 export interface MapOverlayGroupRelation {
   'child_id': string;
   'child_type': string;
   'id': string;
   'map_overlay_group_id': string;
+  'sort_order': number | null;
+}
+export interface MapOverlayGroupRelationCreate {
+  'child_id': string;
+  'child_type': string;
+  'map_overlay_group_id': string;
+  'sort_order'?: number | null;
+}
+export interface MapOverlayGroupRelationUpdate {
+  'child_id'?: string;
+  'child_type'?: string;
+  'id'?: string;
+  'map_overlay_group_id'?: string;
   'sort_order'?: number | null;
 }
 export interface MeditrakDevice {
+  'app_version': string | null;
+  'config': any | null;
+  'id': string;
+  'install_id': string;
+  'platform': string | null;
+  'user_id': string;
+}
+export interface MeditrakDeviceCreate {
   'app_version'?: string | null;
   'config'?: any | null;
-  'id': string;
   'install_id': string;
   'platform'?: string | null;
   'user_id': string;
 }
+export interface MeditrakDeviceUpdate {
+  'app_version'?: string | null;
+  'config'?: any | null;
+  'id'?: string;
+  'install_id'?: string;
+  'platform'?: string | null;
+  'user_id'?: string;
+}
 export interface MeditrakSyncQueue {
-  'change_time'?: number | null;
+  'change_time': number | null;
   'id': string;
   'record_id': string;
   'record_type': string;
   'type': string;
 }
+export interface MeditrakSyncQueueCreate {
+  'change_time'?: number | null;
+  'record_id': string;
+  'record_type': string;
+  'type': string;
+}
+export interface MeditrakSyncQueueUpdate {
+  'change_time'?: number | null;
+  'id'?: string;
+  'record_id'?: string;
+  'record_type'?: string;
+  'type'?: string;
+}
 export interface Ms1SyncLog {
-  'count'?: number | null;
-  'data'?: string | null;
-  'endpoint'?: string | null;
-  'error_list'?: string | null;
+  'count': number | null;
+  'data': string | null;
+  'endpoint': string | null;
+  'error_list': string | null;
   'id': string;
   'record_id': string;
   'record_type': string;
 }
+export interface Ms1SyncLogCreate {
+  'count'?: number | null;
+  'data'?: string | null;
+  'endpoint'?: string | null;
+  'error_list'?: string | null;
+  'record_id': string;
+  'record_type': string;
+}
+export interface Ms1SyncLogUpdate {
+  'count'?: number | null;
+  'data'?: string | null;
+  'endpoint'?: string | null;
+  'error_list'?: string | null;
+  'id'?: string;
+  'record_id'?: string;
+  'record_type'?: string;
+}
 export interface Ms1SyncQueue {
+  'bad_request_count': number | null;
+  'change_time': number | null;
+  'details': string | null;
+  'id': string;
+  'is_dead_letter': boolean | null;
+  'is_deleted': boolean | null;
+  'priority': number | null;
+  'record_id': string;
+  'record_type': string;
+  'type': string;
+}
+export interface Ms1SyncQueueCreate {
   'bad_request_count'?: number | null;
   'change_time'?: number | null;
   'details'?: string | null;
-  'id': string;
   'is_dead_letter'?: boolean | null;
   'is_deleted'?: boolean | null;
   'priority'?: number | null;
@@ -391,31 +1096,106 @@ export interface Ms1SyncQueue {
   'record_type': string;
   'type': string;
 }
+export interface Ms1SyncQueueUpdate {
+  'bad_request_count'?: number | null;
+  'change_time'?: number | null;
+  'details'?: string | null;
+  'id'?: string;
+  'is_dead_letter'?: boolean | null;
+  'is_deleted'?: boolean | null;
+  'priority'?: number | null;
+  'record_id'?: string;
+  'record_type'?: string;
+  'type'?: string;
+}
 export interface OneTimeLogin {
-  'creation_date'?: Date | null;
+  'creation_date': Date | null;
   'id': string;
+  'token': string;
+  'use_date': Date | null;
+  'user_id': string;
+}
+export interface OneTimeLoginCreate {
+  'creation_date'?: Date | null;
   'token': string;
   'use_date'?: Date | null;
   'user_id': string;
 }
+export interface OneTimeLoginUpdate {
+  'creation_date'?: Date | null;
+  'id'?: string;
+  'token'?: string;
+  'use_date'?: Date | null;
+  'user_id'?: string;
+}
 export interface Option {
-  'attributes'?: any | null;
+  'attributes': any | null;
   'id': string;
+  'label': string | null;
+  'option_set_id': string;
+  'sort_order': number | null;
+  'value': string;
+}
+export interface OptionCreate {
+  'attributes'?: any | null;
   'label'?: string | null;
   'option_set_id': string;
   'sort_order'?: number | null;
   'value': string;
 }
+export interface OptionUpdate {
+  'attributes'?: any | null;
+  'id'?: string;
+  'label'?: string | null;
+  'option_set_id'?: string;
+  'sort_order'?: number | null;
+  'value'?: string;
+}
 export interface OptionSet {
   'id': string;
   'name': string;
 }
+export interface OptionSetCreate {
+  'name': string;
+}
+export interface OptionSetUpdate {
+  'id'?: string;
+  'name'?: string;
+}
 export interface PermissionGroup {
   'id': string;
   'name': string;
+  'parent_id': string | null;
+}
+export interface PermissionGroupCreate {
+  'name': string;
+  'parent_id'?: string | null;
+}
+export interface PermissionGroupUpdate {
+  'id'?: string;
+  'name'?: string;
   'parent_id'?: string | null;
 }
 export interface PermissionsBasedMeditrakSyncQueue {
+  'change_time': number | null;
+  'country_ids': string[] | null;
+  'entity_type': EntityType | null;
+  'id': string | null;
+  'permission_groups': string[] | null;
+  'record_id': string | null;
+  'record_type': string | null;
+  'type': string | null;
+}
+export interface PermissionsBasedMeditrakSyncQueueCreate {
+  'change_time'?: number | null;
+  'country_ids'?: string[] | null;
+  'entity_type'?: EntityType | null;
+  'permission_groups'?: string[] | null;
+  'record_id'?: string | null;
+  'record_type'?: string | null;
+  'type'?: string | null;
+}
+export interface PermissionsBasedMeditrakSyncQueueUpdate {
   'change_time'?: number | null;
   'country_ids'?: string[] | null;
   'entity_type'?: EntityType | null;
@@ -427,13 +1207,40 @@ export interface PermissionsBasedMeditrakSyncQueue {
 }
 export interface Project {
   'code': string;
+  'config': any | null;
+  'dashboard_group_name': string | null;
+  'default_measure': string | null;
+  'description': string | null;
+  'entity_hierarchy_id': string | null;
+  'entity_id': string | null;
+  'id': string;
+  'image_url': string | null;
+  'logo_url': string | null;
+  'permission_groups': string[] | null;
+  'sort_order': number | null;
+}
+export interface ProjectCreate {
+  'code': string;
   'config'?: any | null;
   'dashboard_group_name'?: string | null;
   'default_measure'?: string | null;
   'description'?: string | null;
   'entity_hierarchy_id'?: string | null;
   'entity_id'?: string | null;
-  'id': string;
+  'image_url'?: string | null;
+  'logo_url'?: string | null;
+  'permission_groups'?: string[] | null;
+  'sort_order'?: number | null;
+}
+export interface ProjectUpdate {
+  'code'?: string;
+  'config'?: any | null;
+  'dashboard_group_name'?: string | null;
+  'default_measure'?: string | null;
+  'description'?: string | null;
+  'entity_hierarchy_id'?: string | null;
+  'entity_id'?: string | null;
+  'id'?: string;
   'image_url'?: string | null;
   'logo_url'?: string | null;
   'permission_groups'?: string[] | null;
@@ -447,12 +1254,39 @@ export interface PsssSession {
   'id': string;
   'refresh_token': string;
 }
+export interface PsssSessionCreate {
+  'access_policy': any;
+  'access_token': string;
+  'access_token_expiry': string;
+  'email': string;
+  'refresh_token': string;
+}
+export interface PsssSessionUpdate {
+  'access_policy'?: any;
+  'access_token'?: string;
+  'access_token_expiry'?: string;
+  'email'?: string;
+  'id'?: string;
+  'refresh_token'?: string;
+}
 export interface Question {
+  'code': string | null;
+  'data_element_id': string | null;
+  'detail': string | null;
+  'hook': string | null;
+  'id': string;
+  'm_row$': string;
+  'name': string | null;
+  'option_set_id': string | null;
+  'options': string[] | null;
+  'text': string;
+  'type': QuestionType;
+}
+export interface QuestionCreate {
   'code'?: string | null;
   'data_element_id'?: string | null;
   'detail'?: string | null;
   'hook'?: string | null;
-  'id': string;
   'm_row$'?: string;
   'name'?: string | null;
   'option_set_id'?: string | null;
@@ -460,13 +1294,41 @@ export interface Question {
   'text': string;
   'type': QuestionType;
 }
+export interface QuestionUpdate {
+  'code'?: string | null;
+  'data_element_id'?: string | null;
+  'detail'?: string | null;
+  'hook'?: string | null;
+  'id'?: string;
+  'm_row$'?: string;
+  'name'?: string | null;
+  'option_set_id'?: string | null;
+  'options'?: string[] | null;
+  'text'?: string;
+  'type'?: QuestionType;
+}
 export interface RefreshToken {
+  'device': string | null;
+  'expiry': number | null;
+  'id': string;
+  'meditrak_device_id': string | null;
+  'token': string;
+  'user_id': string;
+}
+export interface RefreshTokenCreate {
   'device'?: string | null;
   'expiry'?: number | null;
-  'id': string;
   'meditrak_device_id'?: string | null;
   'token': string;
   'user_id': string;
+}
+export interface RefreshTokenUpdate {
+  'device'?: string | null;
+  'expiry'?: number | null;
+  'id'?: string;
+  'meditrak_device_id'?: string | null;
+  'token'?: string;
+  'user_id'?: string;
 }
 export interface Report {
   'code': string;
@@ -474,9 +1336,29 @@ export interface Report {
   'id': string;
   'permission_group_id': string;
 }
+export interface ReportCreate {
+  'code': string;
+  'config': ReportConfig;
+  'permission_group_id': string;
+}
+export interface ReportUpdate {
+  'code'?: string;
+  'config'?: ReportConfig;
+  'id'?: string;
+  'permission_group_id'?: string;
+}
 export interface Setting {
   'id': string;
   'key': string;
+  'value': string | null;
+}
+export interface SettingCreate {
+  'key': string;
+  'value'?: string | null;
+}
+export interface SettingUpdate {
+  'id'?: string;
+  'key'?: string;
   'value'?: string | null;
 }
 export interface SupersetInstance {
@@ -484,15 +1366,51 @@ export interface SupersetInstance {
   'config': any;
   'id': string;
 }
+export interface SupersetInstanceCreate {
+  'code': string;
+  'config': any;
+}
+export interface SupersetInstanceUpdate {
+  'code'?: string;
+  'config'?: any;
+  'id'?: string;
+}
 export interface Survey {
+  'can_repeat': boolean | null;
+  'code': string;
+  'country_ids': string[] | null;
+  'data_group_id': string | null;
+  'id': string;
+  'integration_metadata': any | null;
+  'm_row$': string;
+  'name': string;
+  'period_granularity': PeriodGranularity | null;
+  'permission_group_id': string | null;
+  'requires_approval': boolean | null;
+  'survey_group_id': string | null;
+}
+export interface SurveyCreate {
   'can_repeat'?: boolean | null;
   'code': string;
   'country_ids'?: string[] | null;
   'data_group_id'?: string | null;
-  'id': string;
   'integration_metadata'?: any | null;
   'm_row$'?: string;
   'name': string;
+  'period_granularity'?: PeriodGranularity | null;
+  'permission_group_id'?: string | null;
+  'requires_approval'?: boolean | null;
+  'survey_group_id'?: string | null;
+}
+export interface SurveyUpdate {
+  'can_repeat'?: boolean | null;
+  'code'?: string;
+  'country_ids'?: string[] | null;
+  'data_group_id'?: string | null;
+  'id'?: string;
+  'integration_metadata'?: any | null;
+  'm_row$'?: string;
+  'name'?: string;
   'period_granularity'?: PeriodGranularity | null;
   'permission_group_id'?: string | null;
   'requires_approval'?: boolean | null;
@@ -502,13 +1420,34 @@ export interface SurveyGroup {
   'id': string;
   'name': string;
 }
+export interface SurveyGroupCreate {
+  'name': string;
+}
+export interface SurveyGroupUpdate {
+  'id'?: string;
+  'name'?: string;
+}
 export interface SurveyResponse {
+  'approval_status': ApprovalStatus | null;
+  'assessor_name': string;
+  'data_time': Date | null;
+  'end_time': Date;
+  'entity_id': string;
+  'id': string;
+  'm_row$': string;
+  'metadata': string | null;
+  'outdated': boolean | null;
+  'start_time': Date;
+  'survey_id': string;
+  'timezone': string | null;
+  'user_id': string;
+}
+export interface SurveyResponseCreate {
   'approval_status'?: ApprovalStatus | null;
   'assessor_name': string;
   'data_time'?: Date | null;
   'end_time': Date;
   'entity_id': string;
-  'id': string;
   'm_row$'?: string;
   'metadata'?: string | null;
   'outdated'?: boolean | null;
@@ -517,26 +1456,84 @@ export interface SurveyResponse {
   'timezone'?: string | null;
   'user_id': string;
 }
+export interface SurveyResponseUpdate {
+  'approval_status'?: ApprovalStatus | null;
+  'assessor_name'?: string;
+  'data_time'?: Date | null;
+  'end_time'?: Date;
+  'entity_id'?: string;
+  'id'?: string;
+  'm_row$'?: string;
+  'metadata'?: string | null;
+  'outdated'?: boolean | null;
+  'start_time'?: Date;
+  'survey_id'?: string;
+  'timezone'?: string | null;
+  'user_id'?: string;
+}
 export interface SurveyResponseComment {
   'comment_id': string;
   'id': string;
   'survey_response_id': string;
+}
+export interface SurveyResponseCommentCreate {
+  'comment_id': string;
+  'survey_response_id': string;
+}
+export interface SurveyResponseCommentUpdate {
+  'comment_id'?: string;
+  'id'?: string;
+  'survey_response_id'?: string;
 }
 export interface SurveyScreen {
   'id': string;
   'screen_number': number;
   'survey_id': string;
 }
+export interface SurveyScreenCreate {
+  'screen_number': number;
+  'survey_id': string;
+}
+export interface SurveyScreenUpdate {
+  'id'?: string;
+  'screen_number'?: number;
+  'survey_id'?: string;
+}
 export interface SurveyScreenComponent {
+  'answers_enabling_follow_up': string[] | null;
+  'component_number': number;
+  'config': string | null;
+  'detail_label': string | null;
+  'id': string;
+  'is_follow_up': boolean | null;
+  'question_id': string;
+  'question_label': string | null;
+  'screen_id': string;
+  'validation_criteria': string | null;
+  'visibility_criteria': string | null;
+}
+export interface SurveyScreenComponentCreate {
   'answers_enabling_follow_up'?: string[] | null;
   'component_number': number;
   'config'?: string | null;
   'detail_label'?: string | null;
-  'id': string;
   'is_follow_up'?: boolean | null;
   'question_id': string;
   'question_label'?: string | null;
   'screen_id': string;
+  'validation_criteria'?: string | null;
+  'visibility_criteria'?: string | null;
+}
+export interface SurveyScreenComponentUpdate {
+  'answers_enabling_follow_up'?: string[] | null;
+  'component_number'?: number;
+  'config'?: string | null;
+  'detail_label'?: string | null;
+  'id'?: string;
+  'is_follow_up'?: boolean | null;
+  'question_id'?: string;
+  'question_label'?: string | null;
+  'screen_id'?: string;
   'validation_criteria'?: string | null;
   'visibility_criteria'?: string | null;
 }
@@ -545,6 +1542,19 @@ export interface SyncGroupLog {
   'log_message': string;
   'service_type': ServiceType;
   'sync_group_code': string;
+  'timestamp': Date | null;
+}
+export interface SyncGroupLogCreate {
+  'log_message': string;
+  'service_type': ServiceType;
+  'sync_group_code': string;
+  'timestamp'?: Date | null;
+}
+export interface SyncGroupLogUpdate {
+  'id'?: string;
+  'log_message'?: string;
+  'service_type'?: ServiceType;
+  'sync_group_code'?: string;
   'timestamp'?: Date | null;
 }
 export interface TupaiaWebSession {
@@ -555,13 +1565,44 @@ export interface TupaiaWebSession {
   'id': string;
   'refresh_token': string;
 }
+export interface TupaiaWebSessionCreate {
+  'access_policy': any;
+  'access_token': string;
+  'access_token_expiry': string;
+  'email': string;
+  'refresh_token': string;
+}
+export interface TupaiaWebSessionUpdate {
+  'access_policy'?: any;
+  'access_token'?: string;
+  'access_token_expiry'?: string;
+  'email'?: string;
+  'id'?: string;
+  'refresh_token'?: string;
+}
 export interface UserAccount {
+  'creation_date': Date | null;
+  'email': string;
+  'employer': string | null;
+  'first_name': string | null;
+  'gender': string | null;
+  'id': string;
+  'last_name': string | null;
+  'mobile_number': string | null;
+  'password_hash': string;
+  'password_salt': string;
+  'position': string | null;
+  'preferences': any;
+  'primary_platform': PrimaryPlatform | null;
+  'profile_image': string | null;
+  'verified_email': VerifiedEmail | null;
+}
+export interface UserAccountCreate {
   'creation_date'?: Date | null;
   'email': string;
   'employer'?: string | null;
   'first_name'?: string | null;
   'gender'?: string | null;
-  'id': string;
   'last_name'?: string | null;
   'mobile_number'?: string | null;
   'password_hash': string;
@@ -572,9 +1613,37 @@ export interface UserAccount {
   'profile_image'?: string | null;
   'verified_email'?: VerifiedEmail | null;
 }
+export interface UserAccountUpdate {
+  'creation_date'?: Date | null;
+  'email'?: string;
+  'employer'?: string | null;
+  'first_name'?: string | null;
+  'gender'?: string | null;
+  'id'?: string;
+  'last_name'?: string | null;
+  'mobile_number'?: string | null;
+  'password_hash'?: string;
+  'password_salt'?: string;
+  'position'?: string | null;
+  'preferences'?: any;
+  'primary_platform'?: PrimaryPlatform | null;
+  'profile_image'?: string | null;
+  'verified_email'?: VerifiedEmail | null;
+}
 export interface UserEntityPermission {
-  'entity_id'?: string | null;
+  'entity_id': string | null;
   'id': string;
+  'permission_group_id': string | null;
+  'user_id': string | null;
+}
+export interface UserEntityPermissionCreate {
+  'entity_id'?: string | null;
+  'permission_group_id'?: string | null;
+  'user_id'?: string | null;
+}
+export interface UserEntityPermissionUpdate {
+  'entity_id'?: string | null;
+  'id'?: string;
   'permission_group_id'?: string | null;
   'user_id'?: string | null;
 }
@@ -583,13 +1652,37 @@ export interface UserFavouriteDashboardItem {
   'id': string;
   'user_id': string;
 }
+export interface UserFavouriteDashboardItemCreate {
+  'dashboard_item_id': string;
+  'user_id': string;
+}
+export interface UserFavouriteDashboardItemUpdate {
+  'dashboard_item_id'?: string;
+  'id'?: string;
+  'user_id'?: string;
+}
 export interface UserSession {
-  'access_token_expiry'?: string;
-  'accessPolicy'?: any | null;
-  'accessToken'?: string | null;
+  'access_token_expiry': string;
+  'accessPolicy': any | null;
+  'accessToken': string | null;
   'id': string;
   'refreshToken': string;
   'userName': string;
+}
+export interface UserSessionCreate {
+  'access_token_expiry'?: string;
+  'accessPolicy'?: any | null;
+  'accessToken'?: string | null;
+  'refreshToken': string;
+  'userName': string;
+}
+export interface UserSessionUpdate {
+  'access_token_expiry'?: string;
+  'accessPolicy'?: any | null;
+  'accessToken'?: string | null;
+  'id'?: string;
+  'refreshToken'?: string;
+  'userName'?: string;
 }
 export enum VerifiedEmail {
   'unverified' = 'unverified',


### PR DESCRIPTION
Reworked this one a bit: https://github.com/beyondessential/tupaia/pull/5098

Decided to add 2 more types for each table, Create and Update.

Create omits the `id` column.
Update has all columns be optional.

I also tested with setting all columns on the base type to required, since they will be still have `null` as an option if they are nullable. But that was a bit unweildy and felt like it was tying these types a bit too closely to their database implementation. Conceptually a nullable column is an optional field in almost all cases.

Also filtered out all the mvrefresh columns (eg. `m_row$`) from the type defs.