### PR TITLE
no-issue: Move SurveyScreenComponent config types

### DIFF
--- a/packages/datatrak-web-server/src/routes/SubmitSurvey/buildUpsertEntity.ts
+++ b/packages/datatrak-web-server/src/routes/SubmitSurvey/buildUpsertEntity.ts
@@ -6,16 +6,15 @@
 import { generateId } from '@tupaia/database';
 import {
   DatatrakWebSubmitSurveyRequest,
-  DatatrakWebSurveyRequest,
   Entity,
   Country,
+  SurveyScreenComponentConfig,
 } from '@tupaia/types';
 
 type Answers = DatatrakWebSubmitSurveyRequest.ReqBody['answers'];
-type ConfigT = DatatrakWebSurveyRequest.SurveyScreenComponentConfig;
 
 export const buildUpsertEntity = async (
-  config: ConfigT,
+  config: SurveyScreenComponentConfig,
   questionId: string,
   answers: Answers,
   countryId: Country['id'],

--- a/packages/datatrak-web-server/src/routes/SubmitSurvey/processSurveyResponse.ts
+++ b/packages/datatrak-web-server/src/routes/SubmitSurvey/processSurveyResponse.ts
@@ -5,19 +5,18 @@
 import { getBrowserTimeZone } from '@tupaia/utils';
 import {
   DatatrakWebSubmitSurveyRequest,
-  DatatrakWebSurveyRequest,
   Entity,
   MeditrakSurveyResponseRequest,
   QuestionType,
+  SurveyScreenComponentConfig,
 } from '@tupaia/types';
 import { buildUpsertEntity } from './buildUpsertEntity';
 
-type ConfigT = DatatrakWebSurveyRequest.SurveyScreenComponentConfig;
 type SurveyRequestT = DatatrakWebSubmitSurveyRequest.ReqBody;
 type AnswerT = DatatrakWebSubmitSurveyRequest.Answer;
 type AutocompleteAnswerT = DatatrakWebSubmitSurveyRequest.AutocompleteAnswer;
 
-export const isUpsertEntityQuestion = (config?: ConfigT) => {
+export const isUpsertEntityQuestion = (config?: SurveyScreenComponentConfig) => {
   if (!config?.entity) {
     return false;
   }
@@ -64,7 +63,7 @@ export const processSurveyResponse = async (
   for (const question of questions) {
     const { questionId, type } = question;
     let answer = answers[questionId] as AnswerT | Entity;
-    const config = question?.config as ConfigT;
+    const config = question?.config as SurveyScreenComponentConfig;
 
     // If the question is an entity question and an entity should be created by this question, build the entity object. We need to do this before we get to the check for the answer being empty, because most of the time these questions are hidden and therefore the answer will always be empty
     if (

--- a/packages/datatrak-web/src/features/Questions/EntityQuestion/utils.ts
+++ b/packages/datatrak-web/src/features/Questions/EntityQuestion/utils.ts
@@ -2,13 +2,11 @@
  * Tupaia
  *  Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
  */
-import { DatatrakWebSurveyRequest } from '@tupaia/types';
+import { SurveyScreenComponentConfig } from '@tupaia/types';
 import { useUser } from '../../../api/queries';
 import { useSurveyForm } from '../../Survey';
 
-export const useEntityBaseFilters = (
-  config: DatatrakWebSurveyRequest.SurveyScreenComponentConfig,
-) => {
+export const useEntityBaseFilters = (config: SurveyScreenComponentConfig) => {
   const { getAnswerByQuestionId } = useSurveyForm();
   const { data: userData } = useUser();
   const countryCode = userData?.country?.code;
@@ -38,9 +36,7 @@ export const useEntityBaseFilters = (
 /*
  * Returns a function that filters entities based on configured attribute values and questions
  */
-export const useAttributeFilter = (
-  questionConfig: DatatrakWebSurveyRequest.SurveyScreenComponentConfig,
-) => {
+export const useAttributeFilter = (questionConfig: SurveyScreenComponentConfig) => {
   const { getAnswerByQuestionId } = useSurveyForm();
   const attributes = questionConfig.entity?.filter?.attributes;
   if (!attributes) {

--- a/packages/datatrak-web/src/features/Survey/SurveyContext/generateId.ts
+++ b/packages/datatrak-web/src/features/Survey/SurveyContext/generateId.ts
@@ -5,7 +5,7 @@
 
 import generate from 'nanoid/non-secure/generate';
 import generateUUID from 'bson-objectid';
-import { DatatrakWebSurveyRequest } from '@tupaia/types';
+import { CodeGeneratorQuestionConfig } from '@tupaia/types';
 
 // With this config, in order to reach a 1% probability of at least one collision:
 // You would need: 1000 IDs generated per hour for ~211 years.
@@ -22,9 +22,7 @@ export const SHORT_ID = 'shortid';
 export const MONGO_ID = 'mongoid';
 
 // e.g. '632-NFO-LEU-I1QI'
-export const generateShortId = (
-  codeGeneratorConfig?: DatatrakWebSurveyRequest.CodeGeneratorConfig,
-) => {
+export const generateShortId = (codeGeneratorConfig?: CodeGeneratorQuestionConfig) => {
   // Use defaults for any missing config params, allowing users to specify some or all custom configurations
   const { alphabet, length, chunkLength, prefix } = {
     ...DEFAULT_SHORT_ID_CONFIG,

--- a/packages/datatrak-web/src/features/Survey/SurveyContext/utils.ts
+++ b/packages/datatrak-web/src/features/Survey/SurveyContext/utils.ts
@@ -4,13 +4,10 @@
  */
 
 import { BooleanExpressionParser, ExpressionParser } from '@tupaia/expression-parser';
-import { DatatrakWebSurveyRequest, QuestionType } from '@tupaia/types';
+import { ArithmeticQuestionConfig, ConditionQuestionConfig, QuestionType } from '@tupaia/types';
 import { SurveyScreenComponent } from '../../../types';
 import { formatSurveyScreenQuestions } from '../utils';
 import { generateMongoId, generateShortId } from './generateId';
-
-type ConditionConfig = DatatrakWebSurveyRequest.ConditionConfig;
-type ArithmeticConfig = DatatrakWebSurveyRequest.ArithmeticConfig;
 
 export const getIsQuestionVisible = (
   question: SurveyScreenComponent,
@@ -168,7 +165,7 @@ const updateDependentQuestions = (
   screenComponents?.forEach(question => {
     const { config, type, questionId } = question;
     if (type === QuestionType.Condition) {
-      const { conditions } = config?.condition as ConditionConfig;
+      const { conditions } = config?.condition as ConditionQuestionConfig;
       const result = Object.keys(conditions).find(resultValue =>
         getConditionIsMet(booleanExpressionParser, formDataCopy, conditions[resultValue]),
       );
@@ -180,7 +177,7 @@ const updateDependentQuestions = (
       const result = getArithmeticResult(
         expressionParser,
         formDataCopy,
-        config?.arithmetic as ArithmeticConfig,
+        config?.arithmetic as ArithmeticQuestionConfig,
       );
       if (result) {
         formDataCopy[questionId] = result;
@@ -216,7 +213,7 @@ export const getArithmeticDisplayAnswer = (config, answer, formData) => {
     valueTranslation = {},
     defaultValues = {},
     answerDisplayText = '',
-  } = config?.arithmetic as ArithmeticConfig;
+  } = config?.arithmetic as ArithmeticQuestionConfig;
   if (!answerDisplayText) return answer;
   const variables = expressionParser.getVariables(formula);
 

--- a/packages/types/src/schemas/schemas.ts
+++ b/packages/types/src/schemas/schemas.ts
@@ -26517,6 +26517,366 @@ export const MeasureColorSchemeSchema = {
 	"type": "string"
 } 
 
+export const CodeGeneratorQuestionConfigSchema = {
+	"type": "object",
+	"properties": {
+		"type": {
+			"enum": [
+				"mongoid",
+				"shortid"
+			],
+			"type": "string"
+		},
+		"prefix": {
+			"type": "string"
+		},
+		"length": {
+			"type": "number"
+		},
+		"chunkLength": {
+			"type": "number"
+		},
+		"alphabet": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"type"
+	]
+} 
+
+export const AutocompleteQuestionConfigSchema = {
+	"type": "object",
+	"properties": {
+		"createNew": {
+			"type": "boolean"
+		},
+		"attributes": {
+			"type": "object",
+			"additionalProperties": {
+				"type": "object",
+				"properties": {
+					"questionId": {
+						"type": "string"
+					}
+				},
+				"additionalProperties": false,
+				"required": [
+					"questionId"
+				]
+			}
+		}
+	},
+	"additionalProperties": false
+} 
+
+export const ConditionQuestionConfigSchema = {
+	"type": "object",
+	"properties": {
+		"conditions": {
+			"type": "object",
+			"additionalProperties": {
+				"type": "object",
+				"properties": {
+					"formula": {
+						"type": "string"
+					},
+					"defaultValues": {
+						"type": "object",
+						"additionalProperties": false
+					}
+				},
+				"additionalProperties": false,
+				"required": [
+					"formula"
+				]
+			}
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"conditions"
+	]
+} 
+
+export const EntityQuestionConfigSchema = {
+	"type": "object",
+	"additionalProperties": {},
+	"properties": {
+		"createNew": {
+			"type": "boolean"
+		},
+		"fields": {
+			"type": "object",
+			"additionalProperties": false
+		},
+		"filter": {
+			"type": "object",
+			"properties": {
+				"type": {
+					"anyOf": [
+						{
+							"type": "array",
+							"items": {
+								"type": "string"
+							}
+						},
+						{
+							"type": "string"
+						}
+					]
+				},
+				"grandparentId": {
+					"type": "object",
+					"properties": {
+						"questionId": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"questionId"
+					]
+				},
+				"parentId": {
+					"type": "object",
+					"properties": {
+						"questionId": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"questionId"
+					]
+				},
+				"attributes": {
+					"type": "object",
+					"additionalProperties": {
+						"type": "object",
+						"properties": {
+							"questionId": {
+								"type": "string"
+							}
+						},
+						"additionalProperties": false,
+						"required": [
+							"questionId"
+						]
+					}
+				}
+			},
+			"additionalProperties": false
+		}
+	}
+} 
+
+export const ArithmeticQuestionConfigSchema = {
+	"type": "object",
+	"properties": {
+		"formula": {
+			"type": "string"
+		},
+		"defaultValues": {
+			"type": "object",
+			"additionalProperties": false
+		},
+		"answerDisplayText": {
+			"type": "string"
+		},
+		"valueTranslation": {
+			"type": "object",
+			"additionalProperties": false
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"formula"
+	]
+} 
+
+export const SurveyScreenComponentConfigSchema = {
+	"type": "object",
+	"properties": {
+		"codeGenerator": {
+			"type": "object",
+			"properties": {
+				"type": {
+					"enum": [
+						"mongoid",
+						"shortid"
+					],
+					"type": "string"
+				},
+				"prefix": {
+					"type": "string"
+				},
+				"length": {
+					"type": "number"
+				},
+				"chunkLength": {
+					"type": "number"
+				},
+				"alphabet": {
+					"type": "string"
+				}
+			},
+			"additionalProperties": false,
+			"required": [
+				"type"
+			]
+		},
+		"autocomplete": {
+			"type": "object",
+			"properties": {
+				"createNew": {
+					"type": "boolean"
+				},
+				"attributes": {
+					"type": "object",
+					"additionalProperties": {
+						"type": "object",
+						"properties": {
+							"questionId": {
+								"type": "string"
+							}
+						},
+						"additionalProperties": false,
+						"required": [
+							"questionId"
+						]
+					}
+				}
+			},
+			"additionalProperties": false
+		},
+		"entity": {
+			"type": "object",
+			"additionalProperties": {},
+			"properties": {
+				"createNew": {
+					"type": "boolean"
+				},
+				"fields": {
+					"type": "object",
+					"additionalProperties": false
+				},
+				"filter": {
+					"type": "object",
+					"properties": {
+						"type": {
+							"anyOf": [
+								{
+									"type": "array",
+									"items": {
+										"type": "string"
+									}
+								},
+								{
+									"type": "string"
+								}
+							]
+						},
+						"grandparentId": {
+							"type": "object",
+							"properties": {
+								"questionId": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"questionId"
+							]
+						},
+						"parentId": {
+							"type": "object",
+							"properties": {
+								"questionId": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"questionId"
+							]
+						},
+						"attributes": {
+							"type": "object",
+							"additionalProperties": {
+								"type": "object",
+								"properties": {
+									"questionId": {
+										"type": "string"
+									}
+								},
+								"additionalProperties": false,
+								"required": [
+									"questionId"
+								]
+							}
+						}
+					},
+					"additionalProperties": false
+				}
+			}
+		},
+		"condition": {
+			"type": "object",
+			"properties": {
+				"conditions": {
+					"type": "object",
+					"additionalProperties": {
+						"type": "object",
+						"properties": {
+							"formula": {
+								"type": "string"
+							},
+							"defaultValues": {
+								"type": "object",
+								"additionalProperties": false
+							}
+						},
+						"additionalProperties": false,
+						"required": [
+							"formula"
+						]
+					}
+				}
+			},
+			"additionalProperties": false,
+			"required": [
+				"conditions"
+			]
+		},
+		"arithmetic": {
+			"type": "object",
+			"properties": {
+				"formula": {
+					"type": "string"
+				},
+				"defaultValues": {
+					"type": "object",
+					"additionalProperties": false
+				},
+				"answerDisplayText": {
+					"type": "string"
+				},
+				"valueTranslation": {
+					"type": "object",
+					"additionalProperties": false
+				}
+			},
+			"additionalProperties": false,
+			"required": [
+				"formula"
+			]
+		}
+	},
+	"additionalProperties": false
+} 
+
 export const AccessRequestSchema = {
 	"type": "object",
 	"properties": {
@@ -59082,366 +59442,6 @@ export const CamelCasedComponentSchema = {
 		"componentNumber",
 		"questionId"
 	]
-} 
-
-export const CodeGeneratorConfigSchema = {
-	"type": "object",
-	"properties": {
-		"type": {
-			"enum": [
-				"mongoid",
-				"shortid"
-			],
-			"type": "string"
-		},
-		"prefix": {
-			"type": "string"
-		},
-		"length": {
-			"type": "number"
-		},
-		"chunkLength": {
-			"type": "number"
-		},
-		"alphabet": {
-			"type": "string"
-		}
-	},
-	"additionalProperties": false,
-	"required": [
-		"type"
-	]
-} 
-
-export const AutocompleteConfigSchema = {
-	"type": "object",
-	"properties": {
-		"createNew": {
-			"type": "boolean"
-		},
-		"attributes": {
-			"type": "object",
-			"additionalProperties": {
-				"type": "object",
-				"properties": {
-					"questionId": {
-						"type": "string"
-					}
-				},
-				"additionalProperties": false,
-				"required": [
-					"questionId"
-				]
-			}
-		}
-	},
-	"additionalProperties": false
-} 
-
-export const ConditionConfigSchema = {
-	"type": "object",
-	"properties": {
-		"conditions": {
-			"type": "object",
-			"additionalProperties": {
-				"type": "object",
-				"properties": {
-					"formula": {
-						"type": "string"
-					},
-					"defaultValues": {
-						"type": "object",
-						"additionalProperties": false
-					}
-				},
-				"additionalProperties": false,
-				"required": [
-					"formula"
-				]
-			}
-		}
-	},
-	"additionalProperties": false,
-	"required": [
-		"conditions"
-	]
-} 
-
-export const EntityQuestionConfigSchema = {
-	"type": "object",
-	"additionalProperties": {},
-	"properties": {
-		"createNew": {
-			"type": "boolean"
-		},
-		"fields": {
-			"type": "object",
-			"additionalProperties": false
-		},
-		"filter": {
-			"type": "object",
-			"properties": {
-				"type": {
-					"anyOf": [
-						{
-							"type": "array",
-							"items": {
-								"type": "string"
-							}
-						},
-						{
-							"type": "string"
-						}
-					]
-				},
-				"grandparentId": {
-					"type": "object",
-					"properties": {
-						"questionId": {
-							"type": "string"
-						}
-					},
-					"additionalProperties": false,
-					"required": [
-						"questionId"
-					]
-				},
-				"parentId": {
-					"type": "object",
-					"properties": {
-						"questionId": {
-							"type": "string"
-						}
-					},
-					"additionalProperties": false,
-					"required": [
-						"questionId"
-					]
-				},
-				"attributes": {
-					"type": "object",
-					"additionalProperties": {
-						"type": "object",
-						"properties": {
-							"questionId": {
-								"type": "string"
-							}
-						},
-						"additionalProperties": false,
-						"required": [
-							"questionId"
-						]
-					}
-				}
-			},
-			"additionalProperties": false
-		}
-	}
-} 
-
-export const ArithmeticConfigSchema = {
-	"type": "object",
-	"properties": {
-		"formula": {
-			"type": "string"
-		},
-		"defaultValues": {
-			"type": "object",
-			"additionalProperties": false
-		},
-		"answerDisplayText": {
-			"type": "string"
-		},
-		"valueTranslation": {
-			"type": "object",
-			"additionalProperties": false
-		}
-	},
-	"additionalProperties": false,
-	"required": [
-		"formula"
-	]
-} 
-
-export const SurveyScreenComponentConfigSchema = {
-	"type": "object",
-	"properties": {
-		"codeGenerator": {
-			"type": "object",
-			"properties": {
-				"type": {
-					"enum": [
-						"mongoid",
-						"shortid"
-					],
-					"type": "string"
-				},
-				"prefix": {
-					"type": "string"
-				},
-				"length": {
-					"type": "number"
-				},
-				"chunkLength": {
-					"type": "number"
-				},
-				"alphabet": {
-					"type": "string"
-				}
-			},
-			"additionalProperties": false,
-			"required": [
-				"type"
-			]
-		},
-		"autocomplete": {
-			"type": "object",
-			"properties": {
-				"createNew": {
-					"type": "boolean"
-				},
-				"attributes": {
-					"type": "object",
-					"additionalProperties": {
-						"type": "object",
-						"properties": {
-							"questionId": {
-								"type": "string"
-							}
-						},
-						"additionalProperties": false,
-						"required": [
-							"questionId"
-						]
-					}
-				}
-			},
-			"additionalProperties": false
-		},
-		"entity": {
-			"type": "object",
-			"additionalProperties": {},
-			"properties": {
-				"createNew": {
-					"type": "boolean"
-				},
-				"fields": {
-					"type": "object",
-					"additionalProperties": false
-				},
-				"filter": {
-					"type": "object",
-					"properties": {
-						"type": {
-							"anyOf": [
-								{
-									"type": "array",
-									"items": {
-										"type": "string"
-									}
-								},
-								{
-									"type": "string"
-								}
-							]
-						},
-						"grandparentId": {
-							"type": "object",
-							"properties": {
-								"questionId": {
-									"type": "string"
-								}
-							},
-							"additionalProperties": false,
-							"required": [
-								"questionId"
-							]
-						},
-						"parentId": {
-							"type": "object",
-							"properties": {
-								"questionId": {
-									"type": "string"
-								}
-							},
-							"additionalProperties": false,
-							"required": [
-								"questionId"
-							]
-						},
-						"attributes": {
-							"type": "object",
-							"additionalProperties": {
-								"type": "object",
-								"properties": {
-									"questionId": {
-										"type": "string"
-									}
-								},
-								"additionalProperties": false,
-								"required": [
-									"questionId"
-								]
-							}
-						}
-					},
-					"additionalProperties": false
-				}
-			}
-		},
-		"condition": {
-			"type": "object",
-			"properties": {
-				"conditions": {
-					"type": "object",
-					"additionalProperties": {
-						"type": "object",
-						"properties": {
-							"formula": {
-								"type": "string"
-							},
-							"defaultValues": {
-								"type": "object",
-								"additionalProperties": false
-							}
-						},
-						"additionalProperties": false,
-						"required": [
-							"formula"
-						]
-					}
-				}
-			},
-			"additionalProperties": false,
-			"required": [
-				"conditions"
-			]
-		},
-		"arithmetic": {
-			"type": "object",
-			"properties": {
-				"formula": {
-					"type": "string"
-				},
-				"defaultValues": {
-					"type": "object",
-					"additionalProperties": false
-				},
-				"answerDisplayText": {
-					"type": "string"
-				},
-				"valueTranslation": {
-					"type": "object",
-					"additionalProperties": false
-				}
-			},
-			"additionalProperties": false,
-			"required": [
-				"formula"
-			]
-		}
-	},
-	"additionalProperties": false
 } 
 
 export const CamelCasedSurveyScreenSchema = {

--- a/packages/types/src/types/index.ts
+++ b/packages/types/src/types/index.ts
@@ -46,6 +46,12 @@ export {
   MatrixReportRow,
   MatrixReportColumn,
   MatrixReport,
+  SurveyScreenComponentConfig,
+  CodeGeneratorQuestionConfig,
+  AutocompleteQuestionConfig,
+  EntityQuestionConfig,
+  ConditionQuestionConfig,
+  ArithmeticQuestionConfig,
 } from './models-extra';
 export * from './requests';
 export * from './css';

--- a/packages/types/src/types/models-extra/index.ts
+++ b/packages/types/src/types/models-extra/index.ts
@@ -50,3 +50,11 @@ export {
   ScaleType,
   MeasureColorScheme,
 } from './mapOverlay';
+export {
+  SurveyScreenComponentConfig,
+  CodeGeneratorQuestionConfig,
+  AutocompleteQuestionConfig,
+  EntityQuestionConfig,
+  ConditionQuestionConfig,
+  ArithmeticQuestionConfig,
+} from './survey';

--- a/packages/types/src/types/models-extra/survey/index.ts
+++ b/packages/types/src/types/models-extra/survey/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+export {
+  SurveyScreenComponentConfig,
+  CodeGeneratorQuestionConfig,
+  AutocompleteQuestionConfig,
+  EntityQuestionConfig,
+  ConditionQuestionConfig,
+  ArithmeticQuestionConfig,
+} from './surveyScreenComponent';

--- a/packages/types/src/types/models-extra/survey/surveyScreenComponent.ts
+++ b/packages/types/src/types/models-extra/survey/surveyScreenComponent.ts
@@ -1,0 +1,65 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+import { Question } from '../../models';
+
+export type CodeGeneratorQuestionConfig = {
+  type: 'shortid' | 'mongoid';
+  prefix?: string;
+  length?: number;
+  chunkLength?: number;
+  alphabet?: string;
+};
+
+export type AutocompleteQuestionConfig = {
+  createNew?: boolean;
+  attributes?: {
+    [key: string]: { questionId: Question['id'] };
+  };
+};
+
+export type ConditionQuestionConfig = {
+  conditions: {
+    [key: string]: {
+      formula: string;
+      defaultValues?: Record<Question['id'], any>;
+    };
+  };
+};
+
+export type EntityQuestionConfig = {
+  createNew?: boolean;
+  fields?: Record<string, string | { questionId: Question['id'] }>;
+  filter?: {
+    type?: string[] | string;
+    grandparentId?: { questionId: Question['id'] };
+    parentId?: { questionId: Question['id'] };
+    attributes?: {
+      [key: string]: { questionId: Question['id'] };
+    };
+  };
+  // This is needed to support the old format of the entity question config
+  [key: string]: any;
+};
+
+export type ArithmeticQuestionConfig = {
+  formula: string;
+  defaultValues?: Record<Question['id'], any>;
+  answerDisplayText?: string;
+  valueTranslation?: Record<
+    Question['id'],
+    {
+      [key: string]: string | number;
+    }
+  >;
+};
+
+export type SurveyScreenComponentConfig = {
+  codeGenerator?: CodeGeneratorQuestionConfig;
+  autocomplete?: AutocompleteQuestionConfig;
+  entity?: EntityQuestionConfig;
+  condition?: ConditionQuestionConfig;
+  arithmetic?: ArithmeticQuestionConfig;
+};

--- a/packages/types/src/types/requests/datatrak-web-server/SurveyRequest.ts
+++ b/packages/types/src/types/requests/datatrak-web-server/SurveyRequest.ts
@@ -11,6 +11,7 @@ import {
   Option as BaseOption,
 } from '../../models';
 import { KeysToCamelCase } from '../../../utils/casing';
+import { SurveyScreenComponentConfig } from '../../models-extra';
 
 export type Params = Record<string, never>;
 
@@ -40,65 +41,6 @@ type CamelCasedComponent = KeysToCamelCase<
     | 'type'
   >
 >;
-
-export type CodeGeneratorConfig = {
-  type: 'shortid' | 'mongoid';
-  prefix?: string;
-  length?: number;
-  chunkLength?: number;
-  alphabet?: string;
-};
-
-export type AutocompleteConfig = {
-  createNew?: boolean;
-  attributes?: {
-    [key: string]: { questionId: Question['id'] };
-  };
-};
-
-export type ConditionConfig = {
-  conditions: {
-    [key: string]: {
-      formula: string;
-      defaultValues?: Record<Question['id'], any>;
-    };
-  };
-};
-
-type EntityQuestionConfig = {
-  createNew?: boolean;
-  fields?: Record<string, string | { questionId: Question['id'] }>;
-  filter?: {
-    type?: string[] | string;
-    grandparentId?: { questionId: Question['id'] };
-    parentId?: { questionId: Question['id'] };
-    attributes?: {
-      [key: string]: { questionId: Question['id'] };
-    };
-  };
-  // This is needed to support the old format of the entity question config
-  [key: string]: any;
-};
-
-export type ArithmeticConfig = {
-  formula: string;
-  defaultValues?: Record<Question['id'], any>;
-  answerDisplayText?: string;
-  valueTranslation?: Record<
-    Question['id'],
-    {
-      [key: string]: string | number;
-    }
-  >;
-};
-
-export type SurveyScreenComponentConfig = {
-  codeGenerator?: CodeGeneratorConfig;
-  autocomplete?: AutocompleteConfig;
-  entity?: EntityQuestionConfig;
-  condition?: ConditionConfig;
-  arithmetic?: ArithmeticConfig;
-};
 
 export type Option = Pick<BaseOption, 'value' | 'label'> & {
   color?: string;


### PR DESCRIPTION
@tcaiger and I paired on this and decided to move them into models-extra for now. Ideally we'd put them on the survey_screen_component model itself, but since the underlying config field is text for now, best to just define them separately.