### PR TITLE
RN-1060: (task) Add dashboard_mailing_list table and CRUD routes

### DIFF
--- a/packages/central-server/src/apiV2/dashboardMailingListEntries/CreateDashboardMailingListEntry.js
+++ b/packages/central-server/src/apiV2/dashboardMailingListEntries/CreateDashboardMailingListEntry.js
@@ -1,0 +1,41 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+
+import { CreateHandler } from '../CreateHandler';
+import { assertAnyPermissions, assertBESAdminAccess } from '../../permissions';
+import {
+  assertDashboardEditPermissions,
+  assertDashboardGetPermissions,
+} from '../dashboards/assertDashboardsPermissions';
+import { assertIsOwnEmail } from './assertDashboardMailingListEntryPermissions';
+
+export class CreateDashboardMailingListEntry extends CreateHandler {
+  async assertUserHasAccess() {
+    const dashboardMailingList = await this.models.dashboardMailingList.findById(
+      this.newRecordData.dashboard_mailing_list_id,
+    );
+    const dashboardEditChecker = accessPolicy =>
+      assertDashboardEditPermissions(accessPolicy, this.models, dashboardMailingList.dashboard_id);
+
+    const isOwnEmailChecker = () =>
+      assertIsOwnEmail(this.req.userId, this.models, this.newRecordData.email);
+
+    // User either has edit access to the dashboard or it's their own email in order to create a mailing list entry
+    await this.assertPermissions(
+      assertAnyPermissions([assertBESAdminAccess, dashboardEditChecker, isOwnEmailChecker]),
+    );
+
+    // Must have read access to the new dashboard to create the mailing list entry
+    const dashboardReadChecker = accessPolicy =>
+      assertDashboardGetPermissions(accessPolicy, this.models, dashboardMailingList.dashboard_id);
+    await this.assertPermissions(
+      assertAnyPermissions([assertBESAdminAccess, dashboardReadChecker]),
+    );
+  }
+
+  async createRecord() {
+    return this.insertRecord();
+  }
+}

--- a/packages/central-server/src/apiV2/dashboardMailingListEntries/DeleteDashboardMailingListEntry.js
+++ b/packages/central-server/src/apiV2/dashboardMailingListEntries/DeleteDashboardMailingListEntry.js
@@ -1,0 +1,29 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+
+import { DeleteHandler } from '../DeleteHandler';
+import { assertAnyPermissions, assertBESAdminAccess } from '../../permissions';
+import { assertDashboardEditPermissions } from '../dashboards/assertDashboardsPermissions';
+import { assertIsOwnEmail } from './assertDashboardMailingListEntryPermissions';
+
+export class DeleteDashboardMailingListEntry extends DeleteHandler {
+  async assertUserHasAccess() {
+    const dashboardMailingListEntry = await this.models.dashboardMailingListEntry.findById(
+      this.recordId,
+    );
+    const dashboard = await dashboardMailingListEntry.dashboard();
+    // Must have edit permissions to a dashboard to delete entries from mailing list
+    const dashboardChecker = accessPolicy =>
+      assertDashboardEditPermissions(accessPolicy, this.models, dashboard.id);
+
+    // Can delete own email from mailing list
+    const isOwnEmailChecker = () =>
+      assertIsOwnEmail(this.req.userId, this.models, dashboardMailingListEntry.email);
+
+    await this.assertPermissions(
+      assertAnyPermissions([assertBESAdminAccess, dashboardChecker, isOwnEmailChecker]),
+    );
+  }
+}

--- a/packages/central-server/src/apiV2/dashboardMailingListEntries/EditDashboardMailingListEntry.js
+++ b/packages/central-server/src/apiV2/dashboardMailingListEntries/EditDashboardMailingListEntry.js
@@ -1,0 +1,55 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+
+import { isNotNullish } from '@tupaia/tsutils';
+import { EditHandler } from '../EditHandler';
+import { assertAnyPermissions, assertBESAdminAccess } from '../../permissions';
+import {
+  assertDashboardGetPermissions,
+  assertDashboardEditPermissions,
+} from '../dashboards/assertDashboardsPermissions';
+import { assertIsOwnEmail } from './assertDashboardMailingListEntryPermissions';
+
+export class EditDashboardMailingListEntry extends EditHandler {
+  async assertUserHasAccess() {
+    const dashboardMailingListEntry = await this.models.dashboardMailingListEntry.findById(
+      this.recordId,
+    );
+    const dashboard = await dashboardMailingListEntry.dashboard();
+    const dashboardEditChecker = accessPolicy =>
+      assertDashboardEditPermissions(accessPolicy, this.models, dashboard.id);
+
+    const isOwnEmailChecker = () =>
+      assertIsOwnEmail(this.req.userId, this.models, dashboardMailingListEntry.email);
+
+    // User either has edit access to the dashboard or it's their own email in order to edit a mailing list entry
+    await this.assertPermissions(
+      assertAnyPermissions([assertBESAdminAccess, dashboardEditChecker, isOwnEmailChecker]),
+    );
+
+    const newDashboardMailingListId =
+      this.updatedFields.dashboard_mailing_list_id ||
+      dashboardMailingListEntry.dashboard_mailing_list_id;
+    const newMailingList = await this.models.dashboardMailingList.findById(
+      newDashboardMailingListId,
+    );
+    const subscribed = isNotNullish(this.updatedFields.subscribed)
+      ? this.updatedFields.subscribed
+      : dashboardMailingListEntry.subscribed;
+
+    if (subscribed) {
+      // If we are subscribing, must have read access to the dashboard to update the mailing list entry
+      const dashboardReadChecker = accessPolicy =>
+        assertDashboardGetPermissions(accessPolicy, this.models, newMailingList.dashboard_id);
+      await this.assertPermissions(
+        assertAnyPermissions([assertBESAdminAccess, dashboardReadChecker]),
+      );
+    }
+  }
+
+  async editRecord() {
+    await this.updateRecord();
+  }
+}

--- a/packages/central-server/src/apiV2/dashboardMailingListEntries/GETDashboardMailingListEntries.js
+++ b/packages/central-server/src/apiV2/dashboardMailingListEntries/GETDashboardMailingListEntries.js
@@ -1,0 +1,63 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+
+import { TYPES } from '@tupaia/database';
+import { GETHandler } from '../GETHandler';
+import { assertAnyPermissions, assertBESAdminAccess } from '../../permissions';
+import {
+  assertDashboardEditPermissions,
+  getDashboardsDBFilter,
+} from '../dashboards/assertDashboardsPermissions';
+import { mergeMultiJoin } from '../utilities';
+
+/**
+ * Handles endpoints:
+ * - /dashboardMailingListEntries
+ * - /dashboardMailingListEntries/:dashboardMailingListEntryId
+ */
+export class GETDashboardMailingListEntries extends GETHandler {
+  permissionsFilteredInternally = true;
+
+  async findSingleRecord(dashboardMailingListEntryId, options) {
+    const dashboardMailingListEntry = await super.findSingleRecord(
+      dashboardMailingListEntryId,
+      options,
+    );
+    const dashboardMailingList = await this.models.dashboardMailingList.findById(
+      dashboardMailingListEntry.dashboard_mailing_list_id,
+    );
+
+    // Must have edit permissions to a dashboard to view its mailing list
+    const dashboardChecker = accessPolicy =>
+      assertDashboardEditPermissions(accessPolicy, this.models, dashboardMailingList.dashboard_id);
+
+    await this.assertPermissions(assertAnyPermissions([assertBESAdminAccess, dashboardChecker]));
+
+    return dashboardMailingListEntry;
+  }
+
+  async getPermissionsFilter(criteria, options) {
+    // Get all dashboards the user has permission to and join on dashboard_mailing_list
+    const dbConditions = await getDashboardsDBFilter(this.accessPolicy, this.models, {});
+    const dbOptions = { ...options };
+    dbOptions.multiJoin = mergeMultiJoin(
+      [
+        {
+          joinWith: TYPES.DASHBOARD_MAILING_LIST,
+          joinCondition: [
+            'dashboard_mailing_list_entry.dashboard_mailing_list_id',
+            'dashboard_mailing_list.id',
+          ],
+        },
+        {
+          joinWith: TYPES.DASHBOARD,
+          joinCondition: ['dashboard_mailing_list.dashboard_id', 'dashboard.id'],
+        },
+      ],
+      dbOptions.multiJoin,
+    );
+    return { dbConditions, dbOptions };
+  }
+}

--- a/packages/central-server/src/apiV2/dashboardMailingListEntries/assertDashboardMailingListEntryPermissions.js
+++ b/packages/central-server/src/apiV2/dashboardMailingListEntries/assertDashboardMailingListEntryPermissions.js
@@ -1,0 +1,13 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+export const assertIsOwnEmail = async (userId, models, dashboardMailingListEmail) => {
+  const user = await models.user.findById(userId);
+  if (user.email !== dashboardMailingListEmail) {
+    throw new Error(`Dashboard mailing list entry must belong to user`);
+  }
+
+  return true;
+};

--- a/packages/central-server/src/apiV2/dashboardMailingListEntries/index.js
+++ b/packages/central-server/src/apiV2/dashboardMailingListEntries/index.js
@@ -1,0 +1,9 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+export { CreateDashboardMailingListEntry } from './CreateDashboardMailingListEntry';
+export { DeleteDashboardMailingListEntry } from './DeleteDashboardMailingListEntry';
+export { EditDashboardMailingListEntry } from './EditDashboardMailingListEntry';
+export { GETDashboardMailingListEntries } from './GETDashboardMailingListEntries';

--- a/packages/central-server/src/apiV2/dashboardMailingLists/CreateDashboardMailingList.js
+++ b/packages/central-server/src/apiV2/dashboardMailingLists/CreateDashboardMailingList.js
@@ -1,0 +1,24 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+
+import { CreateHandler } from '../CreateHandler';
+import { assertAnyPermissions, assertBESAdminAccess } from '../../permissions';
+import { assertDashboardEditPermissions } from '../dashboards/assertDashboardsPermissions';
+
+export class CreateDashboardMailingList extends CreateHandler {
+  async assertUserHasAccess() {
+    const dashboardEditChecker = accessPolicy =>
+      assertDashboardEditPermissions(accessPolicy, this.models, this.newRecordData.dashboard_id);
+
+    // User must have edit access to the dashboard in order to create a mailing list
+    await this.assertPermissions(
+      assertAnyPermissions([assertBESAdminAccess, dashboardEditChecker]),
+    );
+  }
+
+  async createRecord() {
+    return this.insertRecord();
+  }
+}

--- a/packages/central-server/src/apiV2/dashboardMailingLists/DeleteDashboardMailingList.js
+++ b/packages/central-server/src/apiV2/dashboardMailingLists/DeleteDashboardMailingList.js
@@ -1,0 +1,19 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+
+import { DeleteHandler } from '../DeleteHandler';
+import { assertAnyPermissions, assertBESAdminAccess } from '../../permissions';
+import { assertDashboardEditPermissions } from '../dashboards/assertDashboardsPermissions';
+
+export class DeleteDashboardMailingList extends DeleteHandler {
+  async assertUserHasAccess() {
+    const dashboardMailingList = await this.models.dashboardMailingList.findById(this.recordId);
+    // Must have edit permissions to a dashboard to delete mailing list
+    const dashboardChecker = accessPolicy =>
+      assertDashboardEditPermissions(accessPolicy, this.models, dashboardMailingList.dashboard_id);
+
+    await this.assertPermissions(assertAnyPermissions([assertBESAdminAccess, dashboardChecker]));
+  }
+}

--- a/packages/central-server/src/apiV2/dashboardMailingLists/EditDashboardMailingList.js
+++ b/packages/central-server/src/apiV2/dashboardMailingLists/EditDashboardMailingList.js
@@ -1,0 +1,33 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+
+import { EditHandler } from '../EditHandler';
+import { assertAnyPermissions, assertBESAdminAccess } from '../../permissions';
+import { assertDashboardEditPermissions } from '../dashboards/assertDashboardsPermissions';
+
+export class EditDashboardMailingList extends EditHandler {
+  async assertUserHasAccess() {
+    const dashboardMailingList = await this.models.dashboardMailingList.findById(this.recordId);
+    const existingDashboardEditChecker = accessPolicy =>
+      assertDashboardEditPermissions(accessPolicy, this.models, dashboardMailingList.dashboard_id);
+
+    // User must have edit access to the existing dashboard to edit a mailing list
+    await this.assertPermissions(
+      assertAnyPermissions([assertBESAdminAccess, existingDashboardEditChecker]),
+    );
+
+    const newDashboardId = this.updatedFields.dashboard_id || dashboardMailingList.dashboard_id;
+    const newDashboardEditChecker = accessPolicy =>
+      assertDashboardEditPermissions(accessPolicy, this.models, newDashboardId);
+    // User must have edit access to the new dashboard to edit a mailing list
+    await this.assertPermissions(
+      assertAnyPermissions([assertBESAdminAccess, newDashboardEditChecker]),
+    );
+  }
+
+  async editRecord() {
+    await this.updateRecord();
+  }
+}

--- a/packages/central-server/src/apiV2/dashboardMailingLists/GETDashboardMailingLists.js
+++ b/packages/central-server/src/apiV2/dashboardMailingLists/GETDashboardMailingLists.js
@@ -1,0 +1,13 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+import { allowNoPermissions } from '../../permissions';
+import { GETHandler } from '../GETHandler';
+
+export class GETDashboardMailingLists extends GETHandler {
+  async assertUserHasAccess() {
+    await this.assertPermissions(allowNoPermissions);
+  }
+}

--- a/packages/central-server/src/apiV2/dashboardMailingLists/index.js
+++ b/packages/central-server/src/apiV2/dashboardMailingLists/index.js
@@ -1,0 +1,9 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+export { CreateDashboardMailingList } from './CreateDashboardMailingList';
+export { DeleteDashboardMailingList } from './DeleteDashboardMailingList';
+export { EditDashboardMailingList } from './EditDashboardMailingList';
+export { GETDashboardMailingLists } from './GETDashboardMailingLists';

--- a/packages/central-server/src/apiV2/index.js
+++ b/packages/central-server/src/apiV2/index.js
@@ -127,6 +127,18 @@ import {
 import { CreateLandingPage, EditLandingPage } from './landingPages';
 import { DownloadFiles } from './DownloadFiles';
 import { suggestSurveyCode } from './suggestSurveyCode';
+import {
+  CreateDashboardMailingList,
+  DeleteDashboardMailingList,
+  EditDashboardMailingList,
+  GETDashboardMailingLists,
+} from './dashboardMailingLists';
+import {
+  CreateDashboardMailingListEntry,
+  DeleteDashboardMailingListEntry,
+  EditDashboardMailingListEntry,
+  GETDashboardMailingListEntries,
+} from './dashboardMailingListEntries';
 
 // quick and dirty permission wrapper for open endpoints
 const allowAnyone = routeHandler => (req, res, next) => {
@@ -177,6 +189,11 @@ apiV2.get(
   useRouteHandler(GETDashboardRelations),
 );
 apiV2.get('/dashboardItems/:recordId?', useRouteHandler(GETDashboardItems));
+apiV2.get('/dashboardMailingLists/:recordId?', useRouteHandler(GETDashboardMailingLists));
+apiV2.get(
+  '/dashboardMailingListEntries/:recordId?',
+  useRouteHandler(GETDashboardMailingListEntries),
+);
 apiV2.get('/dashboardRelations/:recordId?', useRouteHandler(GETDashboardRelations));
 apiV2.get('/dashboardVisualisations/:recordId?', useRouteHandler(GETDashboardVisualisations));
 apiV2.get('/mapOverlayVisualisations/:recordId?', useRouteHandler(GETMapOverlayVisualisations));
@@ -277,6 +294,8 @@ apiV2.post('/dataElements', useRouteHandler(BESAdminCreateHandler));
 apiV2.post('/dataGroups', useRouteHandler(BESAdminCreateHandler));
 apiV2.post('/dataTables', useRouteHandler(BESAdminCreateHandler));
 apiV2.post('/dashboards', useRouteHandler(CreateDashboard));
+apiV2.post('/dashboardMailingLists', useRouteHandler(CreateDashboardMailingList));
+apiV2.post('/dashboardMailingListEntries', useRouteHandler(CreateDashboardMailingListEntry));
 apiV2.post('/mapOverlayGroups', useRouteHandler(CreateMapOverlayGroups));
 apiV2.post('/disasters', useRouteHandler(BESAdminCreateHandler));
 apiV2.post('/feedItems', useRouteHandler(CreateFeedItems));
@@ -314,6 +333,8 @@ apiV2.put('/optionSets/:recordId', useRouteHandler(EditOptionSets));
 apiV2.put('/questions/:recordId', useRouteHandler(EditQuestions));
 apiV2.put('/dashboards/:recordId', useRouteHandler(EditDashboard));
 apiV2.put('/dashboardItems/:recordId', useRouteHandler(EditDashboardItem));
+apiV2.put('/dashboardMailingLists/:recordId', useRouteHandler(EditDashboardMailingList));
+apiV2.put('/dashboardMailingListEntries/:recordId', useRouteHandler(EditDashboardMailingListEntry));
 apiV2.put('/dashboardRelations/:recordId', useRouteHandler(EditDashboardRelation));
 apiV2.put('/dashboardVisualisations/:recordId', useRouteHandler(EditDashboardVisualisation));
 apiV2.put('/mapOverlayVisualisations/:recordId', useRouteHandler(EditMapOverlayVisualisation));
@@ -352,6 +373,11 @@ apiV2.delete('/optionSets/:recordId', useRouteHandler(DeleteOptionSets));
 apiV2.delete('/questions/:recordId', useRouteHandler(DeleteQuestions));
 apiV2.delete('/dashboards/:recordId', useRouteHandler(DeleteDashboard));
 apiV2.delete('/dashboardItems/:recordId', useRouteHandler(DeleteDashboardItem));
+apiV2.delete('/dashboardMailingLists/:recordId', useRouteHandler(DeleteDashboardMailingList));
+apiV2.delete(
+  '/dashboardMailingListEntries/:recordId',
+  useRouteHandler(DeleteDashboardMailingListEntry),
+);
 apiV2.delete('/dashboardRelations/:recordId', useRouteHandler(DeleteDashboardRelation));
 apiV2.delete('/legacyReports/:recordId', useRouteHandler(DeleteLegacyReport));
 apiV2.delete('/mapOverlays/:recordId', useRouteHandler(DeleteMapOverlays));

--- a/packages/central-server/src/apiV2/utilities/constructNewRecordValidationRules.js
+++ b/packages/central-server/src/apiV2/utilities/constructNewRecordValidationRules.js
@@ -170,6 +170,17 @@ export const constructForSingle = (models, recordType) => {
         report_code: [hasContent],
         legacy: [hasContent, isBoolean],
       };
+    case TYPES.DASHBOARD_MAILING_LIST:
+      return {
+        dashboard_id: [hasContent],
+        project_id: [hasContent],
+        entity_id: [hasContent],
+      };
+    case TYPES.DASHBOARD_MAILING_LIST_ENTRY:
+      return {
+        dashboard_mailing_list_id: [hasContent],
+        email: [hasContent, isEmail],
+      };
     case TYPES.MAP_OVERLAY_GROUP_RELATION:
       return {
         map_overlay_group_id: [constructRecordExistsWithId(models.mapOverlayGroup)],

--- a/packages/central-server/src/tests/apiV2/accessRequests.test.js
+++ b/packages/central-server/src/tests/apiV2/accessRequests.test.js
@@ -5,7 +5,7 @@
 
 import { expect } from 'chai';
 import { findOrCreateDummyRecord } from '@tupaia/database';
-import { TestableApp } from '../testUtilities';
+import { TEST_USER_EMAIL, TestableApp } from '../testUtilities';
 
 describe('Access Requests', () => {
   const app = new TestableApp();
@@ -47,7 +47,7 @@ describe('Access Requests', () => {
   describe('User Entity Permission via Access Request', () => {
     it('creates permission when approved', async () => {
       const { userId, entityId, permissionGroupId } = await createData(
-        'test.user@tupaia.org',
+        TEST_USER_EMAIL,
         'KI',
         'unfpa',
         'UNFPA',
@@ -80,7 +80,7 @@ describe('Access Requests', () => {
 
     it('does not create permission when rejected', async () => {
       const { userId, entityId, permissionGroupId } = await createData(
-        'test.user@tupaia.org',
+        TEST_USER_EMAIL,
         'VE',
         'unfpa',
         'UNFPA',

--- a/packages/central-server/src/tests/apiV2/dashboardMailingListEntries/CreateDashboardMailingListEntry.test.js
+++ b/packages/central-server/src/tests/apiV2/dashboardMailingListEntries/CreateDashboardMailingListEntry.test.js
@@ -1,0 +1,183 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
+ */
+
+import { expect } from 'chai';
+import {
+  buildAndInsertProjectsAndHierarchies,
+  clearTestData,
+  findOrCreateDummyRecord,
+} from '@tupaia/database';
+import {
+  BES_ADMIN_PERMISSION_GROUP,
+  TUPAIA_ADMIN_PANEL_PERMISSION_GROUP,
+} from '../../../permissions';
+import {
+  TEST_USER_EMAIL,
+  TestableApp,
+  resetTestData,
+  setupDashboardTestData,
+} from '../../testUtilities';
+
+describe('Permissions checker for CreateDashboardMailingListEntry', async () => {
+  const DEFAULT_POLICY = {
+    DL: ['Public'],
+    KI: ['Admin'],
+  };
+
+  const BES_ADMIN_POLICY = {
+    SB: [BES_ADMIN_PERMISSION_GROUP],
+  };
+
+  const app = new TestableApp();
+  const { models } = app;
+  let nationalDashboard1MailingList;
+  let nationalDashboard2MailingList;
+
+  before(async () => {
+    await resetTestData();
+
+    const [{ project, entities }] = await buildAndInsertProjectsAndHierarchies(models, [
+      {
+        code: 'test_project',
+        name: 'Test Project',
+        entities: [
+          { code: 'KI', country_code: 'KI' },
+          { code: 'VU', country_code: 'VU' },
+          { code: 'TO', country_code: 'TO' },
+          { code: 'SB', country_code: 'SB' },
+          { code: 'LA', country_code: 'LA' },
+        ],
+      },
+    ]);
+
+    const { nationalDashboard1, nationalDashboard2 } = await setupDashboardTestData(models);
+    nationalDashboard1MailingList = await findOrCreateDummyRecord(models.dashboardMailingList, {
+      dashboard_id: nationalDashboard1.id,
+      project_id: project.id,
+      entity_id: entities.find(({ code }) => code === 'KI').id,
+    });
+    nationalDashboard2MailingList = await findOrCreateDummyRecord(models.dashboardMailingList, {
+      dashboard_id: nationalDashboard2.id,
+      project_id: project.id,
+      entity_id: entities.find(({ code }) => code === 'LA').id,
+    });
+  });
+
+  afterEach(async () => {
+    app.revokeAccess();
+  });
+
+  after(async () => {
+    await clearTestData(models.database);
+  });
+
+  describe('POST /dashboardMailingListEntries', async () => {
+    describe('Insufficient permission', async () => {
+      it('Throw an exception when trying to create a dashboard mailing list entry to a dashboard we do not have access to', async () => {
+        await app.grantAccess(DEFAULT_POLICY);
+        const { body: result } = await app.post(`dashboardMailingListEntries`, {
+          body: {
+            dashboard_mailing_list_id: nationalDashboard2MailingList.id,
+            email: TEST_USER_EMAIL,
+          },
+        });
+
+        expect(result).to.have.keys('error');
+      });
+
+      it('Throw an exception when trying to create a dashboard mailing list entry to a dashboard we do not have edit access to if the email is not for the users', async () => {
+        await app.grantAccess(DEFAULT_POLICY);
+        const { body: result } = await app.post(`dashboardMailingListEntries`, {
+          body: {
+            dashboard_mailing_list_id: nationalDashboard1MailingList.id,
+            email: 'not.my.email@domain.com',
+          },
+        });
+
+        expect(result).to.have.keys('error');
+      });
+    });
+
+    describe('Sufficient permission', async () => {
+      it('Allow creation of a dashboard mailing list entry for a dashboard we have permission for', async () => {
+        await app.grantAccess(DEFAULT_POLICY);
+        await app.post(`dashboardMailingListEntries`, {
+          body: {
+            dashboard_mailing_list_id: nationalDashboard1MailingList.id,
+            email: TEST_USER_EMAIL,
+          },
+        });
+        const result = await models.dashboardMailingListEntry.find({
+          dashboard_mailing_list_id: nationalDashboard1MailingList.id,
+        });
+
+        expect(result.length).to.equal(1);
+        expect(result[0].email).to.equal(TEST_USER_EMAIL);
+        await models.dashboardMailingListEntry.delete({ id: result[0].id }); // Clean up
+      });
+
+      it('Allow creation of a dashboard mailing list entry for a dashboard we have edit permission for with a different users email', async () => {
+        await app.grantAccess({
+          DL: ['Public'],
+          KI: [TUPAIA_ADMIN_PANEL_PERMISSION_GROUP, 'Admin'],
+        });
+        await app.post(`dashboardMailingListEntries`, {
+          body: {
+            dashboard_mailing_list_id: nationalDashboard1MailingList.id,
+            email: 'not.my.email@domain.com',
+          },
+        });
+        const result = await models.dashboardMailingListEntry.find({
+          dashboard_mailing_list_id: nationalDashboard1MailingList.id,
+        });
+
+        expect(result.length).to.equal(1);
+        expect(result[0].email).to.equal('not.my.email@domain.com');
+        await models.dashboardMailingListEntry.delete({ id: result[0].id }); // Clean up
+      });
+
+      it('Allow creation of a dashboard mailing list entry for Tupaia Admin user', async () => {
+        await app.grantAccess(BES_ADMIN_POLICY);
+        await app.post(`dashboardMailingListEntries`, {
+          body: {
+            dashboard_mailing_list_id: nationalDashboard1MailingList.id,
+            email: TEST_USER_EMAIL,
+          },
+        });
+        const result = await models.dashboardMailingListEntry.find({
+          dashboard_mailing_list_id: nationalDashboard1MailingList.id,
+        });
+
+        expect(result.length).to.equal(1);
+        expect(result[0].email).to.equal(TEST_USER_EMAIL);
+        await models.dashboardMailingListEntry.delete({ id: result[0].id }); // Clean up
+      });
+    });
+
+    describe('Invalid input', async () => {
+      it('Throw a input validation error if we do not have email', async () => {
+        await app.grantAccess(DEFAULT_POLICY);
+        const { body: result } = await app.post(`dashboardMailingListEntries`, {
+          body: {
+            dashboard_mailing_list_id: nationalDashboard1MailingList.id,
+          },
+        });
+
+        expect(result).to.have.keys('error');
+      });
+
+      it('Throw a input validation error if we do not have dashboard_mailing_list_id', async () => {
+        await app.grantAccess(DEFAULT_POLICY);
+        const { body: result } = await app.post(`dashboardMailingListEntries`, {
+          body: {
+            email: TEST_USER_EMAIL,
+          },
+        });
+
+        expect(result).to.have.keys('error');
+      });
+    });
+  });
+});

--- a/packages/central-server/src/tests/apiV2/dashboardMailingListEntries/DeleteDashboardMailingListEntry.test.js
+++ b/packages/central-server/src/tests/apiV2/dashboardMailingListEntries/DeleteDashboardMailingListEntry.test.js
@@ -1,0 +1,161 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
+ */
+
+import { expect } from 'chai';
+import {
+  buildAndInsertProjectsAndHierarchies,
+  clearTestData,
+  findOrCreateDummyRecord,
+} from '@tupaia/database';
+import {
+  BES_ADMIN_PERMISSION_GROUP,
+  TUPAIA_ADMIN_PANEL_PERMISSION_GROUP,
+} from '../../../permissions';
+import {
+  TEST_USER_EMAIL,
+  TestableApp,
+  resetTestData,
+  setupDashboardTestData,
+} from '../../testUtilities';
+
+describe('Permissions checker for DeleteDashboardMailingListEntry', async () => {
+  const DEFAULT_POLICY = {
+    DL: ['Public'],
+    KI: ['Admin'],
+  };
+
+  const BES_ADMIN_POLICY = {
+    SB: [BES_ADMIN_PERMISSION_GROUP],
+  };
+
+  const app = new TestableApp();
+  const { models } = app;
+  let mailingListEntryWithAccess;
+  let mailingListEntryWithoutAccess;
+  let mailingListEntryDiffUser;
+  let mailingListEntryBesAdminUser;
+
+  before(async () => {
+    await resetTestData();
+
+    const [{ project, entities }] = await buildAndInsertProjectsAndHierarchies(models, [
+      {
+        code: 'test_project',
+        name: 'Test Project',
+        entities: [
+          { code: 'KI', country_code: 'KI' },
+          { code: 'VU', country_code: 'VU' },
+          { code: 'TO', country_code: 'TO' },
+          { code: 'SB', country_code: 'SB' },
+          { code: 'LA', country_code: 'LA' },
+        ],
+      },
+    ]);
+
+    const { nationalDashboard1, nationalDashboard2 } = await setupDashboardTestData(models);
+
+    const nationalDashboard1MailingList = await findOrCreateDummyRecord(
+      models.dashboardMailingList,
+      {
+        dashboard_id: nationalDashboard1.id,
+        project_id: project.id,
+        entity_id: entities.find(({ code }) => code === 'KI').id,
+      },
+    );
+    const nationalDashboard2MailingList = await findOrCreateDummyRecord(
+      models.dashboardMailingList,
+      {
+        dashboard_id: nationalDashboard2.id,
+        project_id: project.id,
+        entity_id: entities.find(({ code }) => code === 'LA').id,
+      },
+    );
+
+    // Create the mailing list entries
+    mailingListEntryWithAccess = await findOrCreateDummyRecord(models.dashboardMailingListEntry, {
+      dashboard_mailing_list_id: nationalDashboard1MailingList.id,
+      email: TEST_USER_EMAIL,
+      subscribed: true,
+    });
+
+    mailingListEntryDiffUser = await findOrCreateDummyRecord(models.dashboardMailingListEntry, {
+      dashboard_mailing_list_id: nationalDashboard1MailingList.id,
+      email: 'not.my.email@domain.com',
+      subscribed: true,
+    });
+
+    mailingListEntryBesAdminUser = await findOrCreateDummyRecord(models.dashboardMailingListEntry, {
+      dashboard_mailing_list_id: nationalDashboard2MailingList.id,
+      email: 'bes-admin-editme@domain.com',
+      subscribed: true,
+    });
+
+    mailingListEntryWithoutAccess = await findOrCreateDummyRecord(
+      models.dashboardMailingListEntry,
+      {
+        dashboard_mailing_list_id: nationalDashboard2MailingList.id,
+        email: TEST_USER_EMAIL,
+        subscribed: true,
+      },
+    );
+  });
+
+  afterEach(async () => {
+    app.revokeAccess();
+  });
+
+  after(async () => {
+    await clearTestData(models.database);
+  });
+
+  describe('DELETE /dashboardMailingListEntries/:id', async () => {
+    describe('Insufficient permission', async () => {
+      it('Throw an exception when trying to delete a dashboard mailing list entry for a different users email', async () => {
+        await app.grantAccess(DEFAULT_POLICY);
+        const { body: result } = await app.delete(
+          `dashboardMailingListEntries/${mailingListEntryDiffUser.id}`,
+        );
+
+        expect(result).to.have.keys('error');
+      });
+    });
+
+    describe('Sufficient permission', async () => {
+      it('Allow deleting a dashboard mailing list entry for a dashboard for our own email', async () => {
+        await app.grantAccess(DEFAULT_POLICY);
+        await app.delete(`dashboardMailingListEntries/${mailingListEntryWithAccess.id}`);
+        await app.delete(`dashboardMailingListEntries/${mailingListEntryWithoutAccess.id}`);
+        const result = await models.dashboardMailingListEntry.find({
+          email: TEST_USER_EMAIL,
+        });
+
+        expect(result.length).to.equal(0);
+      });
+
+      it('Allow deleting of a dashboard mailing list entry for a dashboard we have edit permission for with a different users email', async () => {
+        await app.grantAccess({
+          DL: ['Public'],
+          KI: [TUPAIA_ADMIN_PANEL_PERMISSION_GROUP, 'Admin'],
+        });
+        await app.delete(`dashboardMailingListEntries/${mailingListEntryDiffUser.id}`);
+        const result = await models.dashboardMailingListEntry.find({
+          email: 'not.my.email@domain.com',
+        });
+
+        expect(result.length).to.equal(0);
+      });
+
+      it('Allow deleting of a dashboard mailing list entry for Tupaia Admin user', async () => {
+        await app.grantAccess(BES_ADMIN_POLICY);
+        await app.delete(`dashboardMailingListEntries/${mailingListEntryBesAdminUser.id}`);
+        const result = await models.dashboardMailingListEntry.find({
+          email: 'bes-admin-deleteme@domain.com',
+        });
+
+        expect(result.length).to.equal(0);
+      });
+    });
+  });
+});

--- a/packages/central-server/src/tests/apiV2/dashboardMailingListEntries/EditDashboardMailingListEntry.test.js
+++ b/packages/central-server/src/tests/apiV2/dashboardMailingListEntries/EditDashboardMailingListEntry.test.js
@@ -1,0 +1,205 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
+ */
+
+import { expect } from 'chai';
+import {
+  buildAndInsertProjectsAndHierarchies,
+  clearTestData,
+  findOrCreateDummyRecord,
+} from '@tupaia/database';
+import {
+  BES_ADMIN_PERMISSION_GROUP,
+  TUPAIA_ADMIN_PANEL_PERMISSION_GROUP,
+} from '../../../permissions';
+import {
+  TEST_USER_EMAIL,
+  TestableApp,
+  resetTestData,
+  setupDashboardTestData,
+} from '../../testUtilities';
+
+describe('Permissions checker for EditDashboardMailingListEntry', async () => {
+  const DEFAULT_POLICY = {
+    DL: ['Public'],
+    KI: ['Admin'],
+  };
+
+  const BES_ADMIN_POLICY = {
+    SB: [BES_ADMIN_PERMISSION_GROUP],
+  };
+
+  const app = new TestableApp();
+  const { models } = app;
+  let nationalDashboard1MailingList;
+  let nationalDashboard2MailingList;
+  let mailingListEntryWithAccess;
+  let mailingListEntryWithoutAccess;
+  let mailingListEntryDiffUser;
+  let mailingListEntryBesAdminUser;
+
+  before(async () => {
+    await resetTestData();
+
+    const [{ project, entities }] = await buildAndInsertProjectsAndHierarchies(models, [
+      {
+        code: 'test_project',
+        name: 'Test Project',
+        entities: [
+          { code: 'KI', country_code: 'KI' },
+          { code: 'VU', country_code: 'VU' },
+          { code: 'TO', country_code: 'TO' },
+          { code: 'SB', country_code: 'SB' },
+          { code: 'LA', country_code: 'LA' },
+        ],
+      },
+    ]);
+
+    const { nationalDashboard1, nationalDashboard2 } = await setupDashboardTestData(models);
+
+    nationalDashboard1MailingList = await findOrCreateDummyRecord(models.dashboardMailingList, {
+      dashboard_id: nationalDashboard1.id,
+      project_id: project.id,
+      entity_id: entities.find(({ code }) => code === 'KI').id,
+    });
+    nationalDashboard2MailingList = await findOrCreateDummyRecord(models.dashboardMailingList, {
+      dashboard_id: nationalDashboard2.id,
+      project_id: project.id,
+      entity_id: entities.find(({ code }) => code === 'LA').id,
+    });
+
+    // Create the mailing list entries
+    mailingListEntryWithAccess = await findOrCreateDummyRecord(models.dashboardMailingListEntry, {
+      dashboard_mailing_list_id: nationalDashboard1MailingList.id,
+      email: TEST_USER_EMAIL,
+      subscribed: true,
+    });
+
+    mailingListEntryDiffUser = await findOrCreateDummyRecord(models.dashboardMailingListEntry, {
+      dashboard_mailing_list_id: nationalDashboard1MailingList.id,
+      email: 'not.my.email@domain.com',
+      subscribed: true,
+    });
+
+    mailingListEntryBesAdminUser = await findOrCreateDummyRecord(models.dashboardMailingListEntry, {
+      dashboard_mailing_list_id: nationalDashboard2MailingList.id,
+      email: 'bes-admin-editme@domain.com',
+      subscribed: true,
+    });
+
+    mailingListEntryWithoutAccess = await findOrCreateDummyRecord(
+      models.dashboardMailingListEntry,
+      {
+        dashboard_mailing_list_id: nationalDashboard2MailingList.id,
+        email: TEST_USER_EMAIL,
+        subscribed: true,
+      },
+    );
+  });
+
+  afterEach(async () => {
+    app.revokeAccess();
+  });
+
+  after(async () => {
+    await clearTestData(models.database);
+  });
+
+  describe('PUT /dashboardMailingListEntries/:id', async () => {
+    describe('Insufficient permission', async () => {
+      it('Throw an exception when trying to edit a dashboard mailing list entry to a dashboard we do not have access to', async () => {
+        await app.grantAccess(DEFAULT_POLICY);
+        const { body: result } = await app.put(
+          `dashboardMailingListEntries/${mailingListEntryWithoutAccess.id}`,
+          {
+            body: {
+              subscribed: true,
+            },
+          },
+        );
+
+        expect(result).to.have.keys('error');
+      });
+
+      it('Throw an exception when trying to edit a dashboard mailing list entry to a different dashboard we do not have read access to', async () => {
+        await app.grantAccess(DEFAULT_POLICY);
+        const { body: result } = await app.put(
+          `dashboardMailingListEntries/${mailingListEntryWithAccess.id}`,
+          {
+            body: {
+              dashboard_mailing_list_id: nationalDashboard2MailingList.id,
+            },
+          },
+        );
+
+        expect(result).to.have.keys('error');
+      });
+    });
+
+    describe('Sufficient permission', async () => {
+      it('Allow editing a dashboard mailing list entry for a dashboard we have permission for', async () => {
+        await app.grantAccess(DEFAULT_POLICY);
+        await app.put(`dashboardMailingListEntries/${mailingListEntryWithAccess.id}`, {
+          body: {
+            subscribed: false,
+          },
+        });
+        const result = await models.dashboardMailingListEntry.find({
+          dashboard_mailing_list_id: nationalDashboard1MailingList.id,
+          email: TEST_USER_EMAIL,
+        });
+
+        expect(result[0].subscribed).to.equal(false);
+      });
+
+      it('Allow unsubscribing a dashboard mailing list entry for a dashboard we do not have permission for if its our own email', async () => {
+        await app.grantAccess(DEFAULT_POLICY);
+        await app.put(`dashboardMailingListEntries/${mailingListEntryWithoutAccess.id}`, {
+          body: {
+            subscribed: false,
+          },
+        });
+        const result = await models.dashboardMailingListEntry.find({
+          dashboard_mailing_list_id: nationalDashboard2MailingList.id,
+          email: TEST_USER_EMAIL,
+        });
+
+        expect(result[0].subscribed).to.equal(false);
+      });
+
+      it('Allow editing of a dashboard mailing list entry for a dashboard we have edit permission for with a different users email', async () => {
+        await app.grantAccess({
+          DL: ['Public'],
+          KI: [TUPAIA_ADMIN_PANEL_PERMISSION_GROUP, 'Admin'],
+        });
+        await app.put(`dashboardMailingListEntries/${mailingListEntryDiffUser.id}`, {
+          body: {
+            subscribed: false,
+          },
+        });
+        const result = await models.dashboardMailingListEntry.find({
+          dashboard_mailing_list_id: nationalDashboard1MailingList.id,
+          email: 'not.my.email@domain.com',
+        });
+
+        expect(result[0].subscribed).to.equal(false);
+      });
+
+      it('Allow editing of a dashboard mailing list entry for Tupaia Admin user', async () => {
+        await app.grantAccess(BES_ADMIN_POLICY);
+        await app.put(`dashboardMailingListEntries/${mailingListEntryBesAdminUser.id}`, {
+          body: {
+            subscribed: false,
+          },
+        });
+        const result = await models.dashboardMailingListEntry.find({
+          dashboard_mailing_list_id: nationalDashboard2MailingList.id,
+          email: 'bes-admin-editme@domain.com',
+        });
+
+        expect(result[0].subscribed).to.equal(false);
+      });
+    });
+  });
+});

--- a/packages/central-server/src/tests/apiV2/dashboardMailingListEntries/GETDashboardMailingListEntries.test.js
+++ b/packages/central-server/src/tests/apiV2/dashboardMailingListEntries/GETDashboardMailingListEntries.test.js
@@ -1,0 +1,169 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+
+import { expect } from 'chai';
+import {
+  findOrCreateDummyRecord,
+  buildAndInsertProjectsAndHierarchies,
+  clearTestData,
+} from '@tupaia/database';
+import {
+  BES_ADMIN_PERMISSION_GROUP,
+  TUPAIA_ADMIN_PANEL_PERMISSION_GROUP,
+} from '../../../permissions';
+import {
+  TEST_USER_EMAIL,
+  TestableApp,
+  resetTestData,
+  setupDashboardTestData,
+} from '../../testUtilities';
+
+describe('Permissions checker for GETDashboardMailingListEntries', async () => {
+  const DEFAULT_POLICY = {
+    DL: ['Public'],
+    KI: [TUPAIA_ADMIN_PANEL_PERMISSION_GROUP, 'Admin'],
+    LA: ['Admin'],
+  };
+
+  const BES_ADMIN_POLICY = {
+    LA: [BES_ADMIN_PERMISSION_GROUP],
+  };
+
+  const app = new TestableApp();
+  const { models } = app;
+  let nationalDashboard1;
+  let nationalDashboard2;
+  const nationalDashboard1MailingListEntries = [];
+  const nationalDashboard2MailingListEntries = [];
+
+  before(async () => {
+    await resetTestData();
+
+    const [{ project, entities }] = await buildAndInsertProjectsAndHierarchies(models, [
+      {
+        code: 'test_project',
+        name: 'Test Project',
+        entities: [
+          { code: 'KI', country_code: 'KI' },
+          { code: 'VU', country_code: 'VU' },
+          { code: 'TO', country_code: 'TO' },
+          { code: 'SB', country_code: 'SB' },
+          { code: 'LA', country_code: 'LA' },
+        ],
+      },
+    ]);
+
+    ({ nationalDashboard1, nationalDashboard2 } = await setupDashboardTestData(models));
+
+    // Create the mailing list entries
+    const nationalDashboard1MailingList = await findOrCreateDummyRecord(
+      models.dashboardMailingList,
+      {
+        dashboard_id: nationalDashboard1.id,
+        project_id: project.id,
+        entity_id: entities.find(({ code }) => code === 'KI').id,
+      },
+    );
+    const nationalDashboard2MailingList = await findOrCreateDummyRecord(
+      models.dashboardMailingList,
+      {
+        dashboard_id: nationalDashboard2.id,
+        project_id: project.id,
+        entity_id: entities.find(({ code }) => code === 'LA').id,
+      },
+    );
+    nationalDashboard1MailingListEntries.push(
+      await findOrCreateDummyRecord(models.dashboardMailingListEntry, {
+        dashboard_mailing_list_id: nationalDashboard1MailingList.id,
+        email: TEST_USER_EMAIL,
+        subscribed: true,
+      }),
+    );
+    nationalDashboard2MailingListEntries.push(
+      await findOrCreateDummyRecord(models.dashboardMailingListEntry, {
+        dashboard_mailing_list_id: nationalDashboard2MailingList.id,
+        email: TEST_USER_EMAIL,
+        subscribed: true,
+      }),
+    );
+  });
+
+  afterEach(() => {
+    app.revokeAccess();
+  });
+
+  after(async () => {
+    await clearTestData(models.database);
+  });
+
+  describe('GET /dashboardMailingListEntries/:id', async () => {
+    it('Sufficient permissions: Should return a requested dashboard mailing list entry if users have access to the dashboard', async () => {
+      await app.grantAccess(DEFAULT_POLICY);
+      const { body: result } = await app.get(
+        `dashboardMailingListEntries/${nationalDashboard1MailingListEntries[0].id}`,
+      );
+
+      expect(result.id).to.equal(nationalDashboard1MailingListEntries[0].id);
+    });
+
+    it('Insufficient permissions: Should throw an exception if users do not have access to any of the inner dashboard relations', async () => {
+      // Remove Admin permission of KI to have insufficient permissions to access nationalDashboard1MailingList entries.
+      const policy = {
+        DL: ['Public'],
+        KI: [/* 'Admin' */ 'Public'],
+        LA: ['Admin', 'Public'],
+      };
+      await app.grantAccess(policy);
+      const { body: result } = await app.get(
+        `dashboardMailingListEntries/${nationalDashboard1MailingListEntries[0].id}`,
+      );
+
+      expect(result).to.have.keys('error');
+    });
+  });
+
+  describe('GET /dashboardMailingListEntries', async () => {
+    let filterString;
+    let dashboardMailingListEntryIds;
+
+    before(() => {
+      dashboardMailingListEntryIds = nationalDashboard1MailingListEntries
+        .map(({ id }) => id)
+        .concat(nationalDashboard2MailingListEntries.map(({ id }) => id));
+
+      filterString = `filter={"id":{"comparator":"in","comparisonValue":["${dashboardMailingListEntryIds.join(
+        '","',
+      )}"]}}`;
+    });
+
+    it('Sufficient permissions: Return only the mailing list entries of dashboards we have permissions for', async () => {
+      const policy = {
+        DL: ['Public'],
+        KI: ['Admin'],
+      };
+      await app.grantAccess(policy);
+      const { body: results } = await app.get(`dashboardMailingListEntries?${filterString}`);
+
+      expect(results.map(r => r.id)).to.deep.equal([nationalDashboard1MailingListEntries[0].id]);
+    });
+
+    it('Sufficient permissions: Should return the all dashboard mailing list entries if we have BES Admin access', async () => {
+      await app.grantAccess(BES_ADMIN_POLICY);
+      const { body: results } = await app.get(`dashboardMailingListEntries?${filterString}`);
+
+      expect(results.map(r => r.id).sort()).to.deep.equal(dashboardMailingListEntryIds.sort());
+    });
+
+    it('Insufficient permissions: Should return an empty array if we have permissions for no dashboards', async () => {
+      const policy = {
+        DL: ['Public'],
+      };
+      await app.grantAccess(policy);
+      const { body: results } = await app.get(`dashboardMailingListEntries?${filterString}`);
+
+      expect(results).to.be.empty;
+    });
+  });
+});

--- a/packages/central-server/src/tests/apiV2/dashboardMailingLists/CreateDashboardMailingList.test.js
+++ b/packages/central-server/src/tests/apiV2/dashboardMailingLists/CreateDashboardMailingList.test.js
@@ -1,0 +1,150 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
+ */
+
+import { expect } from 'chai';
+import { buildAndInsertProjectsAndHierarchies, clearTestData } from '@tupaia/database';
+import {
+  BES_ADMIN_PERMISSION_GROUP,
+  TUPAIA_ADMIN_PANEL_PERMISSION_GROUP,
+} from '../../../permissions';
+import { TestableApp, resetTestData, setupDashboardTestData } from '../../testUtilities';
+
+describe('Permissions checker for CreateDashboardMailingList', async () => {
+  const DEFAULT_POLICY = {
+    DL: ['Public'],
+    KI: [TUPAIA_ADMIN_PANEL_PERMISSION_GROUP, 'Admin'],
+    LA: ['Admin'],
+  };
+
+  const BES_ADMIN_POLICY = {
+    SB: [BES_ADMIN_PERMISSION_GROUP],
+  };
+
+  const app = new TestableApp();
+  const { models } = app;
+  let project;
+  let entities;
+  let nationalDashboard1;
+  let nationalDashboard2;
+
+  before(async () => {
+    await resetTestData();
+
+    [{ project, entities }] = await buildAndInsertProjectsAndHierarchies(models, [
+      {
+        code: 'test_project',
+        name: 'Test Project',
+        entities: [
+          { code: 'KI', country_code: 'KI' },
+          { code: 'VU', country_code: 'VU' },
+          { code: 'TO', country_code: 'TO' },
+          { code: 'SB', country_code: 'SB' },
+          { code: 'LA', country_code: 'LA' },
+        ],
+      },
+    ]);
+
+    ({ nationalDashboard1, nationalDashboard2 } = await setupDashboardTestData(models));
+  });
+
+  afterEach(async () => {
+    app.revokeAccess();
+  });
+
+  after(async () => {
+    await clearTestData(models.database);
+  });
+
+  describe('POST /dashboardMailingLists', async () => {
+    describe('Insufficient permission', async () => {
+      it('Throw an exception when trying to create a dashboard mailing list to a dashboard we do not have access to', async () => {
+        await app.grantAccess(DEFAULT_POLICY);
+        const { body: result } = await app.post(`dashboardMailingLists`, {
+          body: {
+            dashboard_id: nationalDashboard2.id,
+            project_id: project.id,
+            entity_id: entities.find(({ code }) => code === 'KI').id,
+          },
+        });
+
+        expect(result).to.have.keys('error');
+      });
+    });
+
+    describe('Sufficient permission', async () => {
+      it('Allow creation of a dashboard mailing list entry for a dashboard we have permission for', async () => {
+        await app.grantAccess(DEFAULT_POLICY);
+        await app.post(`dashboardMailingLists`, {
+          body: {
+            dashboard_id: nationalDashboard1.id,
+            project_id: project.id,
+            entity_id: entities.find(({ code }) => code === 'KI').id,
+          },
+        });
+        const result = await models.dashboardMailingList.find({
+          dashboard_id: nationalDashboard1.id,
+        });
+
+        expect(result.length).to.equal(1);
+        await models.dashboardMailingList.delete({ id: result[0].id }); // Clean up
+      });
+
+      it('Allow creation of a dashboard mailing list by Tupaia Admin user', async () => {
+        await app.grantAccess(BES_ADMIN_POLICY);
+        await app.post(`dashboardMailingLists`, {
+          body: {
+            dashboard_id: nationalDashboard2.id,
+            project_id: project.id,
+            entity_id: entities.find(({ code }) => code === 'KI').id,
+          },
+        });
+        const result = await models.dashboardMailingList.find({
+          dashboard_id: nationalDashboard2.id,
+        });
+
+        expect(result.length).to.equal(1);
+        await models.dashboardMailingList.delete({ id: result[0].id }); // Clean up
+      });
+    });
+
+    describe('Invalid input', async () => {
+      it('Throw a input validation error if we do not have dashboard_id', async () => {
+        await app.grantAccess(DEFAULT_POLICY);
+        const { body: result } = await app.post(`dashboardMailingLists`, {
+          body: {
+            project_id: project.id,
+            entity_id: entities.find(({ code }) => code === 'KI').id,
+          },
+        });
+
+        expect(result).to.have.keys('error');
+      });
+
+      it('Throw a input validation error if we do not have project_id', async () => {
+        await app.grantAccess(DEFAULT_POLICY);
+        const { body: result } = await app.post(`dashboardMailingLists`, {
+          body: {
+            dashboard_id: nationalDashboard1.id,
+            entity_id: entities.find(({ code }) => code === 'KI').id,
+          },
+        });
+
+        expect(result).to.have.keys('error');
+      });
+
+      it('Throw a input validation error if we do not have entity_id', async () => {
+        await app.grantAccess(DEFAULT_POLICY);
+        const { body: result } = await app.post(`dashboardMailingLists`, {
+          body: {
+            dashboard_id: nationalDashboard1.id,
+            project_id: project.id,
+          },
+        });
+
+        expect(result).to.have.keys('error');
+      });
+    });
+  });
+});

--- a/packages/central-server/src/tests/apiV2/dashboardMailingLists/DeleteDashboardMailingList.test.js
+++ b/packages/central-server/src/tests/apiV2/dashboardMailingLists/DeleteDashboardMailingList.test.js
@@ -1,0 +1,110 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
+ */
+
+import { expect } from 'chai';
+import {
+  buildAndInsertProjectsAndHierarchies,
+  clearTestData,
+  findOrCreateDummyRecord,
+} from '@tupaia/database';
+import {
+  BES_ADMIN_PERMISSION_GROUP,
+  TUPAIA_ADMIN_PANEL_PERMISSION_GROUP,
+} from '../../../permissions';
+import { TestableApp, resetTestData, setupDashboardTestData } from '../../testUtilities';
+
+describe('Permissions checker for DeleteDashboardMailingList', async () => {
+  const DEFAULT_POLICY = {
+    DL: ['Public'],
+    KI: [TUPAIA_ADMIN_PANEL_PERMISSION_GROUP, 'Admin'],
+    LA: ['Admin'],
+  };
+
+  const BES_ADMIN_POLICY = {
+    SB: [BES_ADMIN_PERMISSION_GROUP],
+  };
+
+  const app = new TestableApp();
+  const { models } = app;
+  let nationalDashboard1MailingList;
+  let nationalDashboard2MailingList;
+
+  before(async () => {
+    await resetTestData();
+
+    const [{ project, entities }] = await buildAndInsertProjectsAndHierarchies(models, [
+      {
+        code: 'test_project',
+        name: 'Test Project',
+        entities: [
+          { code: 'KI', country_code: 'KI' },
+          { code: 'VU', country_code: 'VU' },
+          { code: 'TO', country_code: 'TO' },
+          { code: 'SB', country_code: 'SB' },
+          { code: 'LA', country_code: 'LA' },
+        ],
+      },
+    ]);
+
+    const { nationalDashboard1, nationalDashboard2 } = await setupDashboardTestData(models);
+
+    nationalDashboard1MailingList = await findOrCreateDummyRecord(models.dashboardMailingList, {
+      dashboard_id: nationalDashboard1.id,
+      project_id: project.id,
+      entity_id: entities.find(({ code }) => code === 'KI').id,
+    });
+    nationalDashboard2MailingList = await findOrCreateDummyRecord(models.dashboardMailingList, {
+      dashboard_id: nationalDashboard2.id,
+      project_id: project.id,
+      entity_id: entities.find(({ code }) => code === 'LA').id,
+    });
+  });
+
+  afterEach(async () => {
+    app.revokeAccess();
+  });
+
+  after(async () => {
+    await clearTestData(models.database);
+  });
+
+  describe('DELETE /dashboardMailingLists/:id', async () => {
+    describe('Insufficient permission', async () => {
+      it('Throw an exception when trying to delete a dashboard mailing list we do not have access to', async () => {
+        await app.grantAccess(DEFAULT_POLICY);
+        const { body: result } = await app.delete(
+          `dashboardMailingLists/${nationalDashboard2MailingList.id}`,
+        );
+
+        expect(result).to.have.keys('error');
+      });
+    });
+
+    describe('Sufficient permission', async () => {
+      it('Allow deleting of a dashboard mailing list for a dashboard we have edit permission for', async () => {
+        await app.grantAccess({
+          DL: ['Public'],
+          KI: [TUPAIA_ADMIN_PANEL_PERMISSION_GROUP, 'Admin'],
+        });
+        await app.delete(`dashboardMailingLists/${nationalDashboard1MailingList.id}`);
+        const result = await models.dashboardMailingList.find({
+          id: nationalDashboard1MailingList.id,
+        });
+
+        expect(result.length).to.equal(0);
+      });
+
+      it('Allow deleting of a dashboard mailing list by Tupaia Admin user', async () => {
+        await app.grantAccess(BES_ADMIN_POLICY);
+        await app.delete(`dashboardMailingLists/${nationalDashboard2MailingList.id}`);
+        const result = await models.dashboardMailingListEntry.find({
+          id: nationalDashboard2MailingList.id,
+        });
+
+        expect(result.length).to.equal(0);
+      });
+    });
+  });
+});

--- a/packages/central-server/src/tests/apiV2/dashboardMailingLists/EditDashboardMailingList.test.js
+++ b/packages/central-server/src/tests/apiV2/dashboardMailingLists/EditDashboardMailingList.test.js
@@ -1,0 +1,136 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
+ */
+
+import { expect } from 'chai';
+import {
+  buildAndInsertProjectsAndHierarchies,
+  clearTestData,
+  findOrCreateDummyRecord,
+} from '@tupaia/database';
+import {
+  BES_ADMIN_PERMISSION_GROUP,
+  TUPAIA_ADMIN_PANEL_PERMISSION_GROUP,
+} from '../../../permissions';
+import { TestableApp, resetTestData, setupDashboardTestData } from '../../testUtilities';
+
+describe('Permissions checker for EditDashboardMailingList', async () => {
+  const DEFAULT_POLICY = {
+    DL: ['Public'],
+    KI: [TUPAIA_ADMIN_PANEL_PERMISSION_GROUP, 'Admin'],
+    LA: ['Admin'],
+  };
+
+  const BES_ADMIN_POLICY = {
+    SB: [BES_ADMIN_PERMISSION_GROUP],
+  };
+
+  const app = new TestableApp();
+  const { models } = app;
+  let project;
+  let entities;
+  let nationalDashboard1;
+  let nationalDashboard2;
+  let nationalDashboard1MailingList;
+  let nationalDashboard2MailingList;
+
+  before(async () => {
+    await resetTestData();
+
+    [{ project, entities }] = await buildAndInsertProjectsAndHierarchies(models, [
+      {
+        code: 'test_project',
+        name: 'Test Project',
+        entities: [
+          { code: 'KI', country_code: 'KI' },
+          { code: 'VU', country_code: 'VU' },
+          { code: 'TO', country_code: 'TO' },
+          { code: 'SB', country_code: 'SB' },
+          { code: 'LA', country_code: 'LA' },
+        ],
+      },
+    ]);
+
+    ({ nationalDashboard1, nationalDashboard2 } = await setupDashboardTestData(models));
+
+    nationalDashboard1MailingList = await findOrCreateDummyRecord(models.dashboardMailingList, {
+      dashboard_id: nationalDashboard1.id,
+      project_id: project.id,
+      entity_id: entities.find(({ code }) => code === 'KI').id,
+    });
+    nationalDashboard2MailingList = await findOrCreateDummyRecord(models.dashboardMailingList, {
+      dashboard_id: nationalDashboard2.id,
+      project_id: project.id,
+      entity_id: entities.find(({ code }) => code === 'LA').id,
+    });
+  });
+
+  afterEach(async () => {
+    app.revokeAccess();
+  });
+
+  after(async () => {
+    await clearTestData(models.database);
+  });
+
+  describe('PUT /dashboardMailingLists/:id', async () => {
+    describe('Insufficient permission', async () => {
+      it('Throw an exception when trying to edit a dashboard mailing list we do not have access to', async () => {
+        await app.grantAccess(DEFAULT_POLICY);
+        const { body: result } = await app.put(
+          `dashboardMailingLists/${nationalDashboard2MailingList.id}`,
+          {
+            body: {
+              project_id: project.id,
+            },
+          },
+        );
+
+        expect(result).to.have.keys('error');
+      });
+
+      it('Throw an exception when trying to edit a dashboard mailing list to a different dashboard we do not have edit access to', async () => {
+        await app.grantAccess(DEFAULT_POLICY);
+        const { body: result } = await app.put(
+          `dashboardMailingLists/${nationalDashboard1MailingList.id}`,
+          {
+            body: {
+              dashboard_id: nationalDashboard2.id,
+            },
+          },
+        );
+
+        expect(result).to.have.keys('error');
+      });
+    });
+
+    describe('Sufficient permission', async () => {
+      it('Allow editing a dashboard mailing list for a dashboard we have permission for', async () => {
+        await app.grantAccess(DEFAULT_POLICY);
+        const newEntityId = entities.find(({ code }) => code === 'SB').id;
+        await app.put(`dashboardMailingLists/${nationalDashboard1MailingList.id}`, {
+          body: {
+            entity_id: newEntityId,
+          },
+        });
+        const result = await models.dashboardMailingList.findById(nationalDashboard1MailingList.id);
+
+        expect(result.entity_id).to.equal(newEntityId);
+      });
+
+      it('Allow editing of a dashboard mailing list by Tupaia Admin user', async () => {
+        await app.grantAccess(BES_ADMIN_POLICY);
+        const newEntityId = entities.find(({ code }) => code === 'SB').id;
+        await app.put(`dashboardMailingLists/${nationalDashboard2MailingList.id}`, {
+          body: {
+            entity_id: newEntityId,
+          },
+        });
+        const result = await models.dashboardMailingList.findById(nationalDashboard2MailingList.id);
+
+        expect(result.entity_id).to.equal(newEntityId);
+      });
+    });
+  });
+});

--- a/packages/central-server/src/tests/apiV2/dashboardMailingLists/GETDashboardMailingLists.test.js
+++ b/packages/central-server/src/tests/apiV2/dashboardMailingLists/GETDashboardMailingLists.test.js
@@ -1,0 +1,88 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+
+import { expect } from 'chai';
+import {
+  findOrCreateDummyRecord,
+  buildAndInsertProjectsAndHierarchies,
+  clearTestData,
+} from '@tupaia/database';
+import { TestableApp, resetTestData, setupDashboardTestData } from '../../testUtilities';
+
+describe('Permissions checker for GETDashboardMailingLists', async () => {
+  const NO_ACCESS_POLICY = {
+    DL: ['Public'],
+  };
+
+  const app = new TestableApp();
+  const { models } = app;
+  let nationalDashboard1;
+  let nationalDashboard2;
+  let nationalDashboard1MailingList;
+  let nationalDashboard2MailingList;
+
+  before(async () => {
+    await resetTestData();
+
+    const [{ project, entities }] = await buildAndInsertProjectsAndHierarchies(models, [
+      {
+        code: 'test_project',
+        name: 'Test Project',
+        entities: [
+          { code: 'KI', country_code: 'KI' },
+          { code: 'VU', country_code: 'VU' },
+          { code: 'TO', country_code: 'TO' },
+          { code: 'SB', country_code: 'SB' },
+          { code: 'LA', country_code: 'LA' },
+        ],
+      },
+    ]);
+
+    ({ nationalDashboard1, nationalDashboard2 } = await setupDashboardTestData(models));
+
+    // Create the mailing list entries
+    nationalDashboard1MailingList = await findOrCreateDummyRecord(models.dashboardMailingList, {
+      dashboard_id: nationalDashboard1.id,
+      project_id: project.id,
+      entity_id: entities.find(({ code }) => code === 'KI').id,
+    });
+    nationalDashboard2MailingList = await findOrCreateDummyRecord(models.dashboardMailingList, {
+      dashboard_id: nationalDashboard2.id,
+      project_id: project.id,
+      entity_id: entities.find(({ code }) => code === 'LA').id,
+    });
+  });
+
+  afterEach(() => {
+    app.revokeAccess();
+  });
+
+  after(async () => {
+    await clearTestData(models.database);
+  });
+
+  describe('GET /dashboardMailingLists/:id', async () => {
+    it('Sufficient permissions: Anyone can view a dashboard mailing list', async () => {
+      await app.grantAccess(NO_ACCESS_POLICY);
+      const { body: result } = await app.get(
+        `dashboardMailingLists/${nationalDashboard1MailingList.id}`,
+      );
+
+      expect(result.id).to.equal(nationalDashboard1MailingList.id);
+    });
+  });
+
+  describe('GET /dashboardMailingLists', async () => {
+    it('Sufficient permissions: Anyone can view all dashboard mailing lists', async () => {
+      await app.grantAccess(NO_ACCESS_POLICY);
+      const { body: results } = await app.get(`dashboardMailingLists`);
+
+      expect(results.map(r => r.id)).to.deep.equal([
+        nationalDashboard1MailingList.id,
+        nationalDashboard2MailingList.id,
+      ]);
+    });
+  });
+});

--- a/packages/central-server/src/tests/apiV2/dashboards/CreateDashboards.test.js
+++ b/packages/central-server/src/tests/apiV2/dashboards/CreateDashboards.test.js
@@ -4,12 +4,12 @@
  */
 
 import { expect } from 'chai';
-import { findOrCreateDummyRecord } from '@tupaia/database';
+import { buildAndInsertProjectsAndHierarchies, findOrCreateDummyRecord } from '@tupaia/database';
 import {
   TUPAIA_ADMIN_PANEL_PERMISSION_GROUP,
   BES_ADMIN_PERMISSION_GROUP,
 } from '../../../permissions';
-import { TestableApp } from '../../testUtilities';
+import { TestableApp, resetTestData } from '../../testUtilities';
 
 describe('Permissions checker for CreateDashboards', async () => {
   const DEFAULT_POLICY = {
@@ -27,6 +27,24 @@ describe('Permissions checker for CreateDashboards', async () => {
 
   const app = new TestableApp();
   const { models } = app;
+
+  before(async () => {
+    await resetTestData();
+
+    await buildAndInsertProjectsAndHierarchies(models, [
+      {
+        code: 'test_project',
+        name: 'Test Project',
+        entities: [
+          { code: 'KI', country_code: 'KI' },
+          { code: 'VU', country_code: 'VU' },
+          { code: 'TO', country_code: 'TO' },
+          { code: 'SB', country_code: 'SB' },
+          { code: 'LA', country_code: 'LA' },
+        ],
+      },
+    ]);
+  });
 
   afterEach(() => {
     app.revokeAccess();

--- a/packages/central-server/src/tests/apiV2/dashboards/GETDashboards.test.js
+++ b/packages/central-server/src/tests/apiV2/dashboards/GETDashboards.test.js
@@ -4,16 +4,12 @@
  */
 
 import { expect } from 'chai';
-import {
-  findOrCreateDummyRecord,
-  buildAndInsertProjectsAndHierarchies,
-  addBaselineTestCountries,
-} from '@tupaia/database';
+import { buildAndInsertProjectsAndHierarchies } from '@tupaia/database';
 import {
   TUPAIA_ADMIN_PANEL_PERMISSION_GROUP,
   BES_ADMIN_PERMISSION_GROUP,
 } from '../../../permissions';
-import { TestableApp, setupDashboardTestData } from '../../testUtilities';
+import { TestableApp, resetTestData, setupDashboardTestData } from '../../testUtilities';
 
 describe('Permissions checker for GETDashboards', async () => {
   const DEFAULT_POLICY = {
@@ -37,20 +33,19 @@ describe('Permissions checker for GETDashboards', async () => {
   let projectDashboard1;
 
   before(async () => {
-    // Still create these existing entities just in case test database for some reasons do not have these records.
-    await findOrCreateDummyRecord(models.entity, {
-      code: 'KI_Phoenix Islands',
-      type: 'district',
-      country_code: 'KI',
-    });
-
-    await addBaselineTestCountries(models);
+    await resetTestData();
 
     await buildAndInsertProjectsAndHierarchies(models, [
       {
         code: 'test_project',
         name: 'Test Project',
-        entities: [{ code: 'KI' }, { code: 'VU' }, { code: 'TO' }, { code: 'SB' }],
+        entities: [
+          { code: 'KI', country_code: 'KI' },
+          { code: 'VU', country_code: 'VU' },
+          { code: 'TO', country_code: 'TO' },
+          { code: 'SB', country_code: 'SB' },
+          { code: 'LA', country_code: 'LA' },
+        ],
       },
     ]);
 

--- a/packages/central-server/src/tests/apiV2/submitMeditrakSurveyResponse.test.js
+++ b/packages/central-server/src/tests/apiV2/submitMeditrakSurveyResponse.test.js
@@ -14,7 +14,13 @@ import {
   findOrCreateDummyCountryEntity,
 } from '@tupaia/database';
 
-import { setupDummySyncQueue, TestableApp, upsertEntity, upsertQuestion } from '../testUtilities';
+import {
+  setupDummySyncQueue,
+  TEST_USER_EMAIL,
+  TestableApp,
+  upsertEntity,
+  upsertQuestion,
+} from '../testUtilities';
 
 const entityId = generateTestId();
 const surveyId = generateTestId();
@@ -113,7 +119,7 @@ describe('POST /surveyResponse', async () => {
       ]);
       await upsertEntity({ id: entityId, code: 'TEST_ENTITY' });
 
-      const user = await models.user.findOne({ email: 'test.user@tupaia.org' });
+      const user = await models.user.findOne({ email: TEST_USER_EMAIL });
       userId = user.id;
     });
 

--- a/packages/central-server/src/tests/testUtilities/TestableApp.js
+++ b/packages/central-server/src/tests/testUtilities/TestableApp.js
@@ -14,6 +14,7 @@ import { createBasicHeader, createBearerHeader } from '@tupaia/utils';
 import { BES_ADMIN_PERMISSION_GROUP } from '../../permissions';
 import { createApp } from '../../createApp';
 import { getModels } from './database';
+import { TEST_USER_EMAIL } from './constants';
 
 const DEFAULT_API_VERSION = 2;
 const getVersionedEndpoint = (endpoint, apiVersion = DEFAULT_API_VERSION) =>
@@ -57,7 +58,7 @@ export class TestableApp {
   async authenticate() {
     const headers = { authorization: getAuthorizationHeader() };
     const body = {
-      emailAddress: 'test.user@tupaia.org',
+      emailAddress: TEST_USER_EMAIL,
       password: 'test.password',
       deviceName: 'Test Device',
       installId: 'TEST-4D1AC092-4A3E-9958-C109DC56051A',

--- a/packages/central-server/src/tests/testUtilities/constants.js
+++ b/packages/central-server/src/tests/testUtilities/constants.js
@@ -1,0 +1,6 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+export const TEST_USER_EMAIL = 'test.user@tupaia.org';

--- a/packages/central-server/src/tests/testUtilities/dashboards/setupDashboardTestData.js
+++ b/packages/central-server/src/tests/testUtilities/dashboards/setupDashboardTestData.js
@@ -43,6 +43,13 @@ export const findOrCreateLegacyDashboardItem = async (models, code) => {
 };
 
 export const setupDashboardTestData = async models => {
+  // Still create these existing entities just in case test database for some reasons do not have these records.
+  await findOrCreateDummyRecord(models.entity, {
+    code: 'KI_Phoenix Islands',
+    type: 'district',
+    country_code: 'KI',
+  });
+
   // Set up legacy reports
   const [districtLegacyReport1, districtDashboardItem1] = await findOrCreateLegacyDashboardItem(
     models,

--- a/packages/central-server/src/tests/testUtilities/database/addBaselineTestData.js
+++ b/packages/central-server/src/tests/testUtilities/database/addBaselineTestData.js
@@ -8,6 +8,7 @@ import { encryptPassword } from '@tupaia/auth';
 import { generateTestId } from '@tupaia/database';
 import { createUser as createUserAccessor } from '../../../dataAccessors';
 import { getModels } from './getModels';
+import { TEST_USER_EMAIL } from '../constants';
 
 const models = getModels();
 
@@ -56,7 +57,7 @@ export async function addBaselineTestData() {
   );
 
   await createUserAccessor(models, {
-    emailAddress: 'test.user@tupaia.org',
+    emailAddress: TEST_USER_EMAIL,
     password: 'test.password',
     firstName: 'Test',
     lastName: 'User',

--- a/packages/central-server/src/tests/testUtilities/database/resetTestData.js
+++ b/packages/central-server/src/tests/testUtilities/database/resetTestData.js
@@ -2,9 +2,9 @@
  * Tupaia MediTrak
  * Copyright (c) 2019 Beyond Essential Systems Pty Ltd
  */
+import { clearAllTestData } from '@tupaia/database';
 import { addBaselineTestData } from './addBaselineTestData';
 import { getModels } from './getModels';
-import { clearAllTestData } from '@tupaia/database';
 
 export async function resetTestData() {
   const models = getModels();

--- a/packages/central-server/src/tests/testUtilities/index.js
+++ b/packages/central-server/src/tests/testUtilities/index.js
@@ -4,6 +4,7 @@
  */
 
 export * from './assertions';
+export { TEST_USER_EMAIL } from './constants';
 export * from './database';
 export { expectPermissionError, expectResponseError } from './expectResponseError';
 export { setupDummySyncQueue } from './setupDummySyncQueue';

--- a/packages/database/src/migrations/20231027053345-AddDashboardMailingListTable-modifies-schema.js
+++ b/packages/database/src/migrations/20231027053345-AddDashboardMailingListTable-modifies-schema.js
@@ -1,0 +1,100 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = async function (db) {
+  await db.createTable('dashboard_mailing_list', {
+    columns: {
+      id: { type: 'text', primaryKey: true },
+      project_id: {
+        type: 'text',
+        notNull: true,
+        foreignKey: {
+          name: `dashboard_mailing_list_project_id_fk`,
+          table: 'project',
+          rules: {
+            onDelete: 'CASCADE',
+            onUpdate: 'CASCADE',
+          },
+          mapping: 'id',
+        },
+      },
+      entity_id: {
+        type: 'text',
+        notNull: true,
+        foreignKey: {
+          name: `dashboard_mailing_list_entity_id_fk`,
+          table: 'entity',
+          rules: {
+            onDelete: 'CASCADE',
+            onUpdate: 'CASCADE',
+          },
+          mapping: 'id',
+        },
+      },
+      dashboard_id: {
+        type: 'text',
+        notNull: true,
+        foreignKey: {
+          name: `dashboard_mailing_list_dashboard_id_fk`,
+          table: 'dashboard',
+          rules: {
+            onDelete: 'CASCADE',
+            onUpdate: 'CASCADE',
+          },
+          mapping: 'id',
+        },
+      },
+    },
+    ifNotExists: true,
+  });
+  await db.createTable('dashboard_mailing_list_entry', {
+    columns: {
+      id: { type: 'text', primaryKey: true },
+      dashboard_mailing_list_id: {
+        type: 'text',
+        notNull: true,
+        foreignKey: {
+          name: `dashboard_mailing_list_entry_dashboard_mailing_list_id_fk`,
+          table: 'dashboard_mailing_list',
+          rules: {
+            onDelete: 'CASCADE',
+            onUpdate: 'CASCADE',
+          },
+          mapping: 'id',
+        },
+      },
+      email: { type: 'text', notNull: true },
+      subscribed: { type: 'boolean', defaultValue: true, notNull: true },
+      unsubscribed_time: { type: 'timestamp' },
+    },
+    ifNotExists: true,
+  });
+  await db.runSql(
+    `ALTER TABLE dashboard_mailing_list ADD CONSTRAINT dashboard_id_project_id_entity_id_unique UNIQUE (dashboard_id, project_id, entity_id)`,
+  );
+  await db.runSql(
+    `ALTER TABLE dashboard_mailing_list_entry ADD CONSTRAINT dashboard_mailing_list_id_email_unique UNIQUE (dashboard_mailing_list_id, email)`,
+  );
+};
+
+exports.down = async function (db) {
+  await db.runSql(`DROP TABLE IF EXISTS dashboard_mailing_list_entry`);
+  await db.runSql(`DROP TABLE IF EXISTS dashboard_mailing_list`);
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/packages/database/src/modelClasses/DashboardMailingList.js
+++ b/packages/database/src/modelClasses/DashboardMailingList.js
@@ -1,0 +1,18 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+
+import { DatabaseModel } from '../DatabaseModel';
+import { DatabaseType } from '../DatabaseType';
+import { TYPES } from '../types';
+
+export class DashboardMailingListType extends DatabaseType {
+  static databaseType = TYPES.DASHBOARD_MAILING_LIST;
+}
+
+export class DashboardMailingListModel extends DatabaseModel {
+  get DatabaseTypeClass() {
+    return DashboardMailingListType;
+  }
+}

--- a/packages/database/src/modelClasses/DashboardMailingListEntry.js
+++ b/packages/database/src/modelClasses/DashboardMailingListEntry.js
@@ -1,0 +1,37 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+
+import { DatabaseModel } from '../DatabaseModel';
+import { DatabaseType } from '../DatabaseType';
+import { TYPES } from '../types';
+
+export class DashboardMailingListEntryType extends DatabaseType {
+  static databaseType = TYPES.DASHBOARD_MAILING_LIST_ENTRY;
+
+  async mailingList() {
+    return this.otherModels.dashboardMailingList.findById(this.dashboard_mailing_list_id);
+  }
+
+  async project() {
+    const mailingList = await this.mailingList();
+    return this.otherModels.project.findById(mailingList.project_id);
+  }
+
+  async dashboard() {
+    const mailingList = await this.mailingList();
+    return this.otherModels.dashboard.findById(mailingList.dashboard_id);
+  }
+
+  async entity() {
+    const mailingList = await this.mailingList();
+    return this.otherModels.entity.findById(mailingList.entity_id);
+  }
+}
+
+export class DashboardMailingListEntryModel extends DatabaseModel {
+  get DatabaseTypeClass() {
+    return DashboardMailingListEntryType;
+  }
+}

--- a/packages/database/src/modelClasses/index.js
+++ b/packages/database/src/modelClasses/index.js
@@ -13,6 +13,8 @@ import { CommentModel } from './Comment';
 import { CountryModel } from './Country';
 import { DashboardModel } from './Dashboard';
 import { DashboardItemModel } from './DashboardItem';
+import { DashboardMailingListModel } from './DashboardMailingList';
+import { DashboardMailingListEntryModel } from './DashboardMailingListEntry';
 import { DashboardRelationModel } from './DashboardRelation';
 import { DataElementDataGroupModel } from './DataElementDataGroup';
 import { DataElementModel } from './DataElement';
@@ -72,6 +74,8 @@ export const modelClasses = {
   Country: CountryModel,
   Dashboard: DashboardModel,
   DashboardItem: DashboardItemModel,
+  DashboardMailingList: DashboardMailingListModel,
+  DashboardMailingListEntry: DashboardMailingListEntryModel,
   DashboardRelation: DashboardRelationModel,
   DataElementDataGroup: DataElementDataGroupModel,
   DataElementDataService: DataElementDataServiceModel,
@@ -169,4 +173,9 @@ export { UserModel, UserType } from './User';
 export { SupersetInstanceModel } from './SupersetInstance';
 export { DashboardType, DashboardModel } from './Dashboard';
 export { DashboardItemType, DashboardItemModel } from './DashboardItem';
+export { DashboardMailingListType, DashboardMailingListModel } from './DashboardMailingList';
+export {
+  DashboardMailingListEntryType,
+  DashboardMailingListEntryModel,
+} from './DashboardMailingListEntry';
 export { DashboardRelationType, DashboardRelationModel } from './DashboardRelation';

--- a/packages/database/src/types.js
+++ b/packages/database/src/types.js
@@ -14,6 +14,8 @@ export const TYPES = {
   COUNTRY: 'country',
   DASHBOARD: 'dashboard',
   DASHBOARD_ITEM: 'dashboard_item',
+  DASHBOARD_MAILING_LIST: 'dashboard_mailing_list',
+  DASHBOARD_MAILING_LIST_ENTRY: 'dashboard_mailing_list_entry',
   DASHBOARD_RELATION: 'dashboard_relation',
   DATA_ELEMENT_DATA_GROUP: 'data_element_data_group',
   DATA_ELEMENT_DATA_SERVICE: 'data_element_data_service',

--- a/packages/types/src/schemas/schemas.ts
+++ b/packages/types/src/schemas/schemas.ts
@@ -51846,6 +51846,147 @@ export const DashboardItemUpdateSchema = {
 	"additionalProperties": false
 } 
 
+export const DashboardMailingListSchema = {
+	"type": "object",
+	"properties": {
+		"dashboard_id": {
+			"type": "string"
+		},
+		"entity_id": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"project_id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"dashboard_id",
+		"entity_id",
+		"id",
+		"project_id"
+	]
+} 
+
+export const DashboardMailingListCreateSchema = {
+	"type": "object",
+	"properties": {
+		"dashboard_id": {
+			"type": "string"
+		},
+		"entity_id": {
+			"type": "string"
+		},
+		"project_id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"dashboard_id",
+		"entity_id",
+		"project_id"
+	]
+} 
+
+export const DashboardMailingListUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"dashboard_id": {
+			"type": "string"
+		},
+		"entity_id": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"project_id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
+} 
+
+export const DashboardMailingListEntrySchema = {
+	"type": "object",
+	"properties": {
+		"dashboard_mailing_list_id": {
+			"type": "string"
+		},
+		"email": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"subscribed": {
+			"type": "boolean"
+		},
+		"unsubscribed_time": {
+			"type": "string",
+			"format": "date-time"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"dashboard_mailing_list_id",
+		"email",
+		"id",
+		"subscribed"
+	]
+} 
+
+export const DashboardMailingListEntryCreateSchema = {
+	"type": "object",
+	"properties": {
+		"dashboard_mailing_list_id": {
+			"type": "string"
+		},
+		"email": {
+			"type": "string"
+		},
+		"subscribed": {
+			"type": "boolean"
+		},
+		"unsubscribed_time": {
+			"type": "string",
+			"format": "date-time"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"dashboard_mailing_list_id",
+		"email"
+	]
+} 
+
+export const DashboardMailingListEntryUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"dashboard_mailing_list_id": {
+			"type": "string"
+		},
+		"email": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"subscribed": {
+			"type": "boolean"
+		},
+		"unsubscribed_time": {
+			"type": "string",
+			"format": "date-time"
+		}
+	},
+	"additionalProperties": false
+} 
+
 export const DashboardRelationSchema = {
 	"type": "object",
 	"properties": {

--- a/packages/types/src/types/models.ts
+++ b/packages/types/src/types/models.ts
@@ -312,6 +312,43 @@ export interface DashboardItemUpdate {
   'permission_group_ids'?: string[] | null;
   'report_code'?: string | null;
 }
+export interface DashboardMailingList {
+  'dashboard_id': string;
+  'entity_id': string;
+  'id': string;
+  'project_id': string;
+}
+export interface DashboardMailingListCreate {
+  'dashboard_id': string;
+  'entity_id': string;
+  'project_id': string;
+}
+export interface DashboardMailingListUpdate {
+  'dashboard_id'?: string;
+  'entity_id'?: string;
+  'id'?: string;
+  'project_id'?: string;
+}
+export interface DashboardMailingListEntry {
+  'dashboard_mailing_list_id': string;
+  'email': string;
+  'id': string;
+  'subscribed': boolean;
+  'unsubscribed_time'?: Date | null;
+}
+export interface DashboardMailingListEntryCreate {
+  'dashboard_mailing_list_id': string;
+  'email': string;
+  'subscribed'?: boolean;
+  'unsubscribed_time'?: Date | null;
+}
+export interface DashboardMailingListEntryUpdate {
+  'dashboard_mailing_list_id'?: string;
+  'email'?: string;
+  'id'?: string;
+  'subscribed'?: boolean;
+  'unsubscribed_time'?: Date | null;
+}
 export interface DashboardRelation {
   'child_id': string;
   'dashboard_id': string;


### PR DESCRIPTION
### Issue RN-1060:

Adding the `dashboard_mailing_list` table as described in the tech design [here](https://beyond-essential.slab.com/posts/dashboard-email-tech-design-1ex9po1z)

Main complexity here is the permissions logic.