### PR TITLE
RN-1060: (task) Added dashboards/:project/:entity/:dashboard/export route to tupaia-web-server

### DIFF
--- a/packages/tupaia-web-server/package.json
+++ b/packages/tupaia-web-server/package.json
@@ -31,6 +31,7 @@
     "@tupaia/auth": "1.0.0",
     "@tupaia/database": "1.0.0",
     "@tupaia/server-boilerplate": "1.0.0",
+    "@tupaia/server-utils": "1.0.0",
     "@tupaia/tsutils": "1.0.0",
     "@tupaia/types": "1.0.0",
     "@tupaia/utils": "1.0.0",

--- a/packages/tupaia-web-server/src/app/createApp.ts
+++ b/packages/tupaia-web-server/src/app/createApp.ts
@@ -48,6 +48,10 @@ export function createApp(db: TupaiaDatabase = new TupaiaDatabase()) {
       'dashboards/:projectCode/:entityCode',
       handleWith(routes.DashboardsRoute),
     )
+    .post<routes.ExportDashboardRequest>(
+      'dashboards/:projectCode/:entityCode/:dashboardName/export',
+      handleWith(routes.ExportDashboardRoute),
+    )
     .get<routes.CountryAccessListRequest>(
       'countryAccessList',
       handleWith(routes.CountryAccessListRoute),

--- a/packages/tupaia-web-server/src/routes/ExportDashboardRoute.ts
+++ b/packages/tupaia-web-server/src/routes/ExportDashboardRoute.ts
@@ -1,0 +1,36 @@
+/*
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ *
+ */
+
+import { Request } from 'express';
+import { Route } from '@tupaia/server-boilerplate';
+import { TupaiaWebExportDashboardRequest } from '@tupaia/types';
+import { downloadPageAsPDF } from '@tupaia/server-utils';
+import { stringifyQuery } from '@tupaia/utils';
+
+export type ExportDashboardRequest = Request<
+  TupaiaWebExportDashboardRequest.Params,
+  TupaiaWebExportDashboardRequest.ResBody,
+  TupaiaWebExportDashboardRequest.ReqBody,
+  TupaiaWebExportDashboardRequest.ReqQuery
+>;
+
+export class ExportDashboardRoute extends Route<ExportDashboardRequest> {
+  protected type = 'download' as const;
+
+  public async buildResponse() {
+    const { projectCode, entityCode, dashboardName } = this.req.params;
+    const { baseUrl, selectedDashboardItems, cookieDomain } = this.req.body;
+    const { cookie } = this.req.headers;
+
+    const endpoint = `${projectCode}/${entityCode}/${dashboardName}/pdf-export`;
+    const pdfPageUrl = stringifyQuery(baseUrl, endpoint, {
+      selectedDashboardItems: selectedDashboardItems?.join(','),
+    });
+
+    const buffer = await downloadPageAsPDF(pdfPageUrl, cookie, cookieDomain);
+    return { contents: buffer, type: 'application/pdf' };
+  }
+}

--- a/packages/tupaia-web-server/src/routes/index.ts
+++ b/packages/tupaia-web-server/src/routes/index.ts
@@ -20,6 +20,7 @@ export {
 } from './LegacyMapOverlayReportRoute';
 export { MapOverlaysRequest, MapOverlaysRoute } from './MapOverlaysRoute';
 export { UserRequest, UserRoute } from './UserRoute';
+export { ExportDashboardRequest, ExportDashboardRoute } from './ExportDashboardRoute';
 export { ProjectRequest, ProjectRoute } from './ProjectRoute';
 export { CountryAccessListRequest, CountryAccessListRoute } from './CountryAccessListRoute';
 export {

--- a/packages/tupaia-web/src/api/mutations/useExportDashboard.tsx
+++ b/packages/tupaia-web/src/api/mutations/useExportDashboard.tsx
@@ -3,7 +3,6 @@
  *  Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
  */
 import { useMutation } from 'react-query';
-import { stringifyQuery } from '@tupaia/utils';
 import { API_URL, post } from '../api';
 import { DashboardItem, DashboardName, EntityCode, ProjectCode } from '../../types';
 
@@ -18,18 +17,17 @@ type ExportDashboardBody = {
 export const useExportDashboard = ({ onSuccess }: { onSuccess?: (data: Blob) => void }) => {
   return useMutation<any, Error, ExportDashboardBody, unknown>(
     ({ projectCode, entityCode, dashboardName, selectedDashboardItems }: ExportDashboardBody) => {
-      const hostname = `${window.location.protocol}/${window.location.host}`;
-      const endpoint = `${projectCode}/${entityCode}/${dashboardName}/pdf-export`;
-      const pdfPageUrl = stringifyQuery(hostname, endpoint, {
-        selectedDashboardItems: selectedDashboardItems?.join(','),
-      });
+      const baseUrl = `${window.location.protocol}/${window.location.host}`;
+
       // Auth cookies are saved against this domain. Pass this to server, so that when it pretends to be us, it can do the same.
       const cookieDomain = new URL(API_URL).hostname;
-      return post('pdf', {
+
+      return post(`dashboards/${projectCode}/${entityCode}/${dashboardName}/export`, {
         responseType: 'blob',
         data: {
           cookieDomain,
-          pdfPageUrl,
+          baseUrl,
+          selectedDashboardItems,
         },
       });
     },

--- a/packages/types/src/types/requests/index.ts
+++ b/packages/types/src/types/requests/index.ts
@@ -19,6 +19,7 @@ export {
   TupaiaWebChangePasswordRequest,
   TupaiaWebCountryAccessListRequest,
   TupaiaWebDashboardsRequest,
+  TupaiaWebExportDashboardRequest,
   TupaiaWebEntitiesRequest,
   TupaiaWebEntityRequest,
   TupaiaWebEntitySearchRequest,

--- a/packages/types/src/types/requests/tupaia-web-server/ExportDashboardRequest.ts
+++ b/packages/types/src/types/requests/tupaia-web-server/ExportDashboardRequest.ts
@@ -1,0 +1,21 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+export interface Params {
+  projectCode: string;
+  entityCode: string;
+  dashboardName: string;
+}
+export interface ResBody {
+  contents: Buffer;
+  filePath?: string;
+  type: string;
+}
+export type ReqBody = {
+  cookieDomain: string;
+  baseUrl: string;
+  selectedDashboardItems?: string[];
+};
+export type ReqQuery = Record<string, string>;

--- a/packages/types/src/types/requests/tupaia-web-server/index.ts
+++ b/packages/types/src/types/requests/tupaia-web-server/index.ts
@@ -6,6 +6,7 @@
 export * as TupaiaWebChangePasswordRequest from './ChangePasswordRequest';
 export * as TupaiaWebCountryAccessListRequest from './CountryAccessListRequest';
 export * as TupaiaWebDashboardsRequest from './DashboardsRequest';
+export * as TupaiaWebExportDashboardRequest from './ExportDashboardRequest';
 export * as TupaiaWebEntitiesRequest from './EntitiesRequest';
 export * as TupaiaWebEntityRequest from './EntityRequest';
 export * as TupaiaWebEntitySearchRequest from './EntitySearchRequest';

--- a/yarn.lock
+++ b/yarn.lock
@@ -10491,6 +10491,7 @@ __metadata:
     "@tupaia/auth": 1.0.0
     "@tupaia/database": 1.0.0
     "@tupaia/server-boilerplate": 1.0.0
+    "@tupaia/server-utils": 1.0.0
     "@tupaia/tsutils": 1.0.0
     "@tupaia/types": 1.0.0
     "@tupaia/utils": 1.0.0


### PR DESCRIPTION
### Issue RN-1060:

Since we're adding custom functionality to this route as part of the email work, decided to port it over from web-config-server.

Also chose to rename the route from a generic `/pdf` to `/dashboards/:project/:entity/:dashboard/export`. Since this route is really just being used once, I feel it's nice if we capture the business case as part of the route interface.