### PR TITLE
RN-1060: (task) Add `allowSendToMailingListPermissionGroups` flag to the project.config

### DIFF
--- a/packages/database/src/migrations/20231031011521-RemoveNullableFromProjectConfig-modifies-schema.js
+++ b/packages/database/src/migrations/20231031011521-RemoveNullableFromProjectConfig-modifies-schema.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function (db) {
+  return db.runSql(`ALTER TABLE project ALTER COLUMN config SET NOT NULL`);
+};
+
+exports.down = function (db) {
+  return db.runSql(`ALTER TABLE project ALTER COLUMN config DROP NOT NULL`);
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/packages/types/config/models/config.json
+++ b/packages/types/config/models/config.json
@@ -19,15 +19,16 @@
   "typeOverrides": {
     "public.report.config": "ReportConfig",
     "public.dashboard_item.config": "DashboardItemConfig",
-    "public.map_overlay.config": "MapOverlayConfig"
+    "public.map_overlay.config": "MapOverlayConfig",
+    "public.project.config": "ProjectConfig"
   },
   "template": "config/models/template.handlebars",
   "custom": {
     "imports": {
       "ReportConfig": "./models-extra",
       "DashboardItemConfig": "./models-extra",
-      "MapOverlayConfig": "./models-extra"
+      "MapOverlayConfig": "./models-extra",
+      "ProjectConfig": "./models-extra"
     }
   }
 }
-

--- a/packages/types/generate-schemas.ts
+++ b/packages/types/generate-schemas.ts
@@ -14,6 +14,18 @@ const settings: TJS.PartialArgs = {
   noExtraProps: true,
 };
 
+function getTsFiles(dir: string): string[] {
+  const dirContents = fs.readdirSync(dir);
+  const files = dirContents
+    .map(dirItem => {
+      const res = resolve(dir, dirItem);
+      return fs.statSync(res).isDirectory() ? getTsFiles(res) : res;
+    })
+    .flat();
+
+  return files.filter(fileName => fileName.endsWith('.ts'));
+}
+
 const HEADER = `/*
  * Tupaia
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
@@ -26,10 +38,13 @@ const HEADER = `/*
  */
 `;
 
+const rootDir = 'src/types';
+const filesToBuildSchemasFor = getTsFiles(rootDir);
+
 const { filename, typesPath } = config as any;
 
 const program = TJS.getProgramFromFiles([resolve(typesPath)]);
-const schemas = TJS.generateSchema(program, '*', settings);
+const schemas = TJS.generateSchema(program, '*', settings, filesToBuildSchemasFor);
 
 if (schemas?.definitions) {
   let fileContents = HEADER;

--- a/packages/types/src/schemas/schemas.ts
+++ b/packages/types/src/schemas/schemas.ts
@@ -26457,6 +26457,18 @@ export const IconKeySchema = {
 	"type": "string"
 } 
 
+export const ScaleTypeSchema = {
+	"enum": [
+		"gpi",
+		"neutral",
+		"neutralReverse",
+		"performance",
+		"performanceDesc",
+		"time"
+	],
+	"type": "string"
+} 
+
 export const MeasureTypeSchema = {
 	"enum": [
 		"color",
@@ -27641,6 +27653,34 @@ export const ClinicUpdateSchema = {
 		}
 	},
 	"additionalProperties": false
+} 
+
+export const CommentSchema = {
+	"type": "object",
+	"properties": {
+		"created_time": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"id": {
+			"type": "string"
+		},
+		"last_modified_time": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"text": {
+			"type": "string"
+		},
+		"user_id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"id",
+		"text"
+	]
 } 
 
 export const CommentCreateSchema = {
@@ -59075,27 +59115,8 @@ export const DataTablePreviewRequestSchema = {
 	]
 } 
 
-export const CamelCaseSchema = {
+export const ParamsSchema = {
 	"description": "Tupaia\nCopyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd",
-	"type": "array",
-	"items": {
-		"type": "string"
-	}
-} 
-
-export const CamelCasePartSchema = {
-	"type": "array",
-	"items": {
-		"type": "string"
-	}
-} 
-
-export const ObjectToCamelSchema = {
-	"type": "object",
-	"additionalProperties": false
-} 
-
-export const KeysToCamelCaseSchema = {
 	"type": "object",
 	"additionalProperties": false
 } 

--- a/packages/types/src/schemas/schemas.ts
+++ b/packages/types/src/schemas/schemas.ts
@@ -26937,6 +26937,12 @@ export const ProjectConfigSchema = {
 					"types"
 				]
 			}
+		},
+		"allowSendToMailingListPermissionGroups": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
 		}
 	},
 	"additionalProperties": false
@@ -56858,6 +56864,12 @@ export const ProjectSchema = {
 							"types"
 						]
 					}
+				},
+				"allowSendToMailingListPermissionGroups": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
 				}
 			},
 			"additionalProperties": false
@@ -56958,6 +56970,12 @@ export const ProjectCreateSchema = {
 							"types"
 						]
 					}
+				},
+				"allowSendToMailingListPermissionGroups": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
 				}
 			},
 			"additionalProperties": false
@@ -57052,6 +57070,12 @@ export const ProjectUpdateSchema = {
 						"required": [
 							"types"
 						]
+					}
+				},
+				"allowSendToMailingListPermissionGroups": {
+					"type": "array",
+					"items": {
+						"type": "string"
 					}
 				}
 			},
@@ -59542,6 +59566,12 @@ export const ProjectResponseSchema = {
 						"required": [
 							"types"
 						]
+					}
+				},
+				"allowSendToMailingListPermissionGroups": {
+					"type": "array",
+					"items": {
+						"type": "string"
 					}
 				}
 			},

--- a/packages/types/src/schemas/schemas.ts
+++ b/packages/types/src/schemas/schemas.ts
@@ -26889,6 +26889,59 @@ export const SurveyScreenComponentConfigSchema = {
 	"additionalProperties": false
 } 
 
+export const ProjectConfigSchema = {
+	"description": "Tupaia\nCopyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd",
+	"type": "object",
+	"properties": {
+		"permanentRegionLabels": {
+			"type": "boolean"
+		},
+		"tileSets": {
+			"type": "string"
+		},
+		"includeDefaultTileSets": {
+			"type": "boolean"
+		},
+		"projectDashboardHeader": {
+			"type": "string"
+		},
+		"frontendExcluded": {
+			"type": "array",
+			"items": {
+				"type": "object",
+				"properties": {
+					"types": {
+						"type": "array",
+						"items": {
+							"type": "string"
+						}
+					},
+					"exceptions": {
+						"type": "object",
+						"properties": {
+							"permissionGroups": {
+								"type": "array",
+								"items": {
+									"type": "string"
+								}
+							}
+						},
+						"additionalProperties": false,
+						"required": [
+							"permissionGroups"
+						]
+					}
+				},
+				"additionalProperties": false,
+				"required": [
+					"types"
+				]
+			}
+		}
+	},
+	"additionalProperties": false
+} 
+
 export const AccessRequestSchema = {
 	"type": "object",
 	"properties": {
@@ -27678,7 +27731,9 @@ export const CommentSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
+		"created_time",
 		"id",
+		"last_modified_time",
 		"text"
 	]
 } 
@@ -56755,7 +56810,58 @@ export const ProjectSchema = {
 		"code": {
 			"type": "string"
 		},
-		"config": {},
+		"config": {
+			"description": "Tupaia\nCopyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd",
+			"type": "object",
+			"properties": {
+				"permanentRegionLabels": {
+					"type": "boolean"
+				},
+				"tileSets": {
+					"type": "string"
+				},
+				"includeDefaultTileSets": {
+					"type": "boolean"
+				},
+				"projectDashboardHeader": {
+					"type": "string"
+				},
+				"frontendExcluded": {
+					"type": "array",
+					"items": {
+						"type": "object",
+						"properties": {
+							"types": {
+								"type": "array",
+								"items": {
+									"type": "string"
+								}
+							},
+							"exceptions": {
+								"type": "object",
+								"properties": {
+									"permissionGroups": {
+										"type": "array",
+										"items": {
+											"type": "string"
+										}
+									}
+								},
+								"additionalProperties": false,
+								"required": [
+									"permissionGroups"
+								]
+							}
+						},
+						"additionalProperties": false,
+						"required": [
+							"types"
+						]
+					}
+				}
+			},
+			"additionalProperties": false
+		},
 		"dashboard_group_name": {
 			"type": "string"
 		},
@@ -56803,7 +56909,58 @@ export const ProjectCreateSchema = {
 		"code": {
 			"type": "string"
 		},
-		"config": {},
+		"config": {
+			"description": "Tupaia\nCopyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd",
+			"type": "object",
+			"properties": {
+				"permanentRegionLabels": {
+					"type": "boolean"
+				},
+				"tileSets": {
+					"type": "string"
+				},
+				"includeDefaultTileSets": {
+					"type": "boolean"
+				},
+				"projectDashboardHeader": {
+					"type": "string"
+				},
+				"frontendExcluded": {
+					"type": "array",
+					"items": {
+						"type": "object",
+						"properties": {
+							"types": {
+								"type": "array",
+								"items": {
+									"type": "string"
+								}
+							},
+							"exceptions": {
+								"type": "object",
+								"properties": {
+									"permissionGroups": {
+										"type": "array",
+										"items": {
+											"type": "string"
+										}
+									}
+								},
+								"additionalProperties": false,
+								"required": [
+									"permissionGroups"
+								]
+							}
+						},
+						"additionalProperties": false,
+						"required": [
+							"types"
+						]
+					}
+				}
+			},
+			"additionalProperties": false
+		},
 		"dashboard_group_name": {
 			"type": "string"
 		},
@@ -56847,7 +57004,58 @@ export const ProjectUpdateSchema = {
 		"code": {
 			"type": "string"
 		},
-		"config": {},
+		"config": {
+			"description": "Tupaia\nCopyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd",
+			"type": "object",
+			"properties": {
+				"permanentRegionLabels": {
+					"type": "boolean"
+				},
+				"tileSets": {
+					"type": "string"
+				},
+				"includeDefaultTileSets": {
+					"type": "boolean"
+				},
+				"projectDashboardHeader": {
+					"type": "string"
+				},
+				"frontendExcluded": {
+					"type": "array",
+					"items": {
+						"type": "object",
+						"properties": {
+							"types": {
+								"type": "array",
+								"items": {
+									"type": "string"
+								}
+							},
+							"exceptions": {
+								"type": "object",
+								"properties": {
+									"permissionGroups": {
+										"type": "array",
+										"items": {
+											"type": "string"
+										}
+									}
+								},
+								"additionalProperties": false,
+								"required": [
+									"permissionGroups"
+								]
+							}
+						},
+						"additionalProperties": false,
+						"required": [
+							"types"
+						]
+					}
+				}
+			},
+			"additionalProperties": false
+		},
 		"dashboard_group_name": {
 			"type": "string"
 		},
@@ -59288,19 +59496,55 @@ export const ProjectResponseSchema = {
 			"type": "string"
 		},
 		"config": {
-			"anyOf": [
-				{
+			"type": "object",
+			"properties": {
+				"permanentRegionLabels": {
+					"type": "boolean"
+				},
+				"tileSets": {
+					"type": "string"
+				},
+				"includeDefaultTileSets": {
+					"type": "boolean"
+				},
+				"projectDashboardHeader": {
+					"type": "string"
+				},
+				"frontendExcluded": {
 					"type": "array",
 					"items": {
 						"type": "object",
-						"additionalProperties": false
+						"properties": {
+							"types": {
+								"type": "array",
+								"items": {
+									"type": "string"
+								}
+							},
+							"exceptions": {
+								"type": "object",
+								"properties": {
+									"permissionGroups": {
+										"type": "array",
+										"items": {
+											"type": "string"
+										}
+									}
+								},
+								"additionalProperties": false,
+								"required": [
+									"permissionGroups"
+								]
+							}
+						},
+						"additionalProperties": false,
+						"required": [
+							"types"
+						]
 					}
-				},
-				{
-					"type": "object",
-					"additionalProperties": false
 				}
-			]
+			},
+			"additionalProperties": false
 		},
 		"dashboardGroupName": {
 			"type": "string"

--- a/packages/types/src/schemas/schemas.ts
+++ b/packages/types/src/schemas/schemas.ts
@@ -56899,6 +56899,7 @@ export const ProjectSchema = {
 	"additionalProperties": false,
 	"required": [
 		"code",
+		"config",
 		"id"
 	]
 } 
@@ -59591,6 +59592,7 @@ export const ProjectResponseSchema = {
 	},
 	"required": [
 		"code",
+		"config",
 		"hasAccess",
 		"hasPendingAccess",
 		"id",

--- a/packages/types/src/types/models-extra/index.ts
+++ b/packages/types/src/types/models-extra/index.ts
@@ -58,3 +58,4 @@ export {
   ConditionQuestionConfig,
   ArithmeticQuestionConfig,
 } from './survey';
+export { ProjectConfig } from './project';

--- a/packages/types/src/types/models-extra/project.ts
+++ b/packages/types/src/types/models-extra/project.ts
@@ -12,4 +12,5 @@ export interface ProjectConfig {
     types: string[];
     exceptions?: { permissionGroups: string[] };
   }[];
+  allowSendToMailingListPermissionGroups?: string[];
 }

--- a/packages/types/src/types/models-extra/project.ts
+++ b/packages/types/src/types/models-extra/project.ts
@@ -1,0 +1,15 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+export interface ProjectConfig {
+  permanentRegionLabels?: boolean;
+  tileSets?: string;
+  includeDefaultTileSets?: boolean;
+  projectDashboardHeader?: string;
+  frontendExcluded?: {
+    types: string[];
+    exceptions?: { permissionGroups: string[] };
+  }[];
+}

--- a/packages/types/src/types/models.ts
+++ b/packages/types/src/types/models.ts
@@ -10,6 +10,7 @@
 import { ReportConfig } from './models-extra';
 import { DashboardItemConfig } from './models-extra';
 import { MapOverlayConfig } from './models-extra';
+import { ProjectConfig } from './models-extra';
 
 export interface AccessRequest {
   'approved'?: boolean | null;
@@ -1177,7 +1178,7 @@ export interface PermissionsBasedMeditrakSyncQueueUpdate {
 }
 export interface Project {
   'code': string;
-  'config'?: any | null;
+  'config'?: ProjectConfig | null;
   'dashboard_group_name'?: string | null;
   'default_measure'?: string | null;
   'description'?: string | null;
@@ -1191,7 +1192,7 @@ export interface Project {
 }
 export interface ProjectCreate {
   'code': string;
-  'config'?: any | null;
+  'config'?: ProjectConfig | null;
   'dashboard_group_name'?: string | null;
   'default_measure'?: string | null;
   'description'?: string | null;
@@ -1204,7 +1205,7 @@ export interface ProjectCreate {
 }
 export interface ProjectUpdate {
   'code'?: string;
-  'config'?: any | null;
+  'config'?: ProjectConfig | null;
   'dashboard_group_name'?: string | null;
   'default_measure'?: string | null;
   'description'?: string | null;

--- a/packages/types/src/types/models.ts
+++ b/packages/types/src/types/models.ts
@@ -1178,7 +1178,7 @@ export interface PermissionsBasedMeditrakSyncQueueUpdate {
 }
 export interface Project {
   'code': string;
-  'config'?: ProjectConfig | null;
+  'config': ProjectConfig;
   'dashboard_group_name'?: string | null;
   'default_measure'?: string | null;
   'description'?: string | null;
@@ -1192,7 +1192,7 @@ export interface Project {
 }
 export interface ProjectCreate {
   'code': string;
-  'config'?: ProjectConfig | null;
+  'config'?: ProjectConfig;
   'dashboard_group_name'?: string | null;
   'default_measure'?: string | null;
   'description'?: string | null;
@@ -1205,7 +1205,7 @@ export interface ProjectCreate {
 }
 export interface ProjectUpdate {
   'code'?: string;
-  'config'?: ProjectConfig | null;
+  'config'?: ProjectConfig;
   'dashboard_group_name'?: string | null;
   'default_measure'?: string | null;
   'description'?: string | null;

--- a/packages/types/src/utils/casing.ts
+++ b/packages/types/src/utils/casing.ts
@@ -16,14 +16,10 @@ type CamelCasePart<S extends string> = S extends `${infer First}_${infer Rest}`
 
 // Converts a type object to camel case, from snake case
 export type ObjectToCamel<T> = {
-  [K in keyof T as CamelCase<string & K>]: T[K] extends Record<string, any>
-    ? KeysToCamelCase<T[K]>
-    : T[K];
+  [K in keyof T as CamelCase<string & K>]: KeysToCamelCase<T[K]>;
 };
 
 // Converts type objects or arrays to camel case
-export type KeysToCamelCase<T> = {
-  [K in keyof T as CamelCase<string & K>]: T[K] extends Array<any>
-    ? KeysToCamelCase<T[K][number]>[]
-    : ObjectToCamel<T[K]>;
-};
+export type KeysToCamelCase<T> = T extends Array<infer ArrayElm>
+  ? KeysToCamelCase<ArrayElm>[] // If array, camel case items
+  : ObjectToCamel<T>; // If object, camel case keys;


### PR DESCRIPTION
### Issue RN-1060 (task):

Added a new `allowSendToMailingListPermissionGroups` config to control which users can send out the dashboard export to the mailing list.

Ran into some issues with the `KeysToCamelCase` type which required changing how to generate the schema, so decided to break this out into a separate PR.