### PR TITLE
no-issue: Fix errors in viz-builder when creating an orderColumns transform

### DIFF
--- a/packages/report-server/src/reportBuilder/transform/functions/orderColumns/orderColumns.ts
+++ b/packages/report-server/src/reportBuilder/transform/functions/orderColumns/orderColumns.ts
@@ -22,7 +22,9 @@ const sortByValidator = yup
 export const paramsValidator = yup.object().shape({
   order: yup.array().of(yup.string().required()),
   sortBy: yupTsUtils.describableLazy(() => sortByValidator, [sortByValidator]),
-  direction: ascOrDescValidator.default('asc'),
+  direction: yupTsUtils.describableLazy(() => ascOrDescValidator.default('asc'), [
+    ascOrDescValidator.default('asc'),
+  ]),
 });
 
 const orderColumns = (table: TransformTable, params: OrderColumnsParams) => {


### PR DESCRIPTION
### Issue https://beyondessential.slack.com/archives/C02649511JM/p1698727738832049:

Seems we have to wrap mixed validators in describableLazy. Feels a little awkward but I don't think now's the time to refactor this.
