### PR TITLE
No issue: Update branch name validation script

### DIFF
--- a/packages/devops/scripts/ci/validateBranchName.sh
+++ b/packages/devops/scripts/ci/validateBranchName.sh
@@ -21,6 +21,11 @@ function validate_name_ending() {
             log_error "❌ Invalid branch name ending: '$suffix'"
             exit 1
         fi
+        # api is one of our suffixes so makes sure [branch]-api doesn't match any other api suffixes
+        if [[ "$suffix" == *-api && $branch_name-api == *$suffix ]]; then
+            log_error "❌ Invalid branch name ending: '$suffix'"
+            exit 1
+        fi
     done
 }
 


### PR DESCRIPTION
### Issue #: No issue

### Changes:

- `api` is one of our suffixes. In some cases like `data-table-api` and `tupaia-web-api` we don't have an equivalent non `api` suffix so we don't catch invalid branch names
  - e.g. `branch-data-table` would generate `branch-data-table-api` _and_ `branch-data-table-data-table-api` both of which match `*-data-table-api`