### PR TITLE
 RN-963 Meditrak ios features

### DIFF
--- a/packages/meditrak-app/app/assessment/QrCodeScreen.jsx
+++ b/packages/meditrak-app/app/assessment/QrCodeScreen.jsx
@@ -40,7 +40,7 @@ const downloadQrCode = async (qrCodeRef, filename, onSuccess, onFail) => {
       const filenameWithExtension = `${filename}.png`;
       const filePath = `${RNFS.DocumentDirectoryPath}/${filenameWithExtension}`;
       await RNFS.writeFile(filePath, dataURL, 'base64');
-      await CameraRoll.save(filePath, {album: 'Meditrak QR Codes'});
+      await CameraRoll.save(filePath, {album: 'Tupaia MediTrak QR Codes'});
       onSuccess();
     } catch (error) {
       onFail(error.message);

--- a/packages/meditrak-app/app/assessment/QrCodeScreen.jsx
+++ b/packages/meditrak-app/app/assessment/QrCodeScreen.jsx
@@ -9,7 +9,6 @@ import {connect} from 'react-redux';
 import {ScrollView, StyleSheet, View} from 'react-native';
 import Share from 'react-native-share';
 import RNFS from 'react-native-fs';
-import {FileSystem} from 'react-native-file-access';
 import {CameraRoll} from '@react-native-camera-roll/camera-roll';
 
 import {addMessage} from '../messages';

--- a/packages/meditrak-app/app/assessment/QrCodeScreen.jsx
+++ b/packages/meditrak-app/app/assessment/QrCodeScreen.jsx
@@ -3,19 +3,20 @@
  * Copyright (c) 2017 Beyond Essential Systems Pty Ltd
  */
 
-import React, { useRef } from 'react';
+import React, {useRef} from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import { ScrollView, StyleSheet, View } from 'react-native';
+import {connect} from 'react-redux';
+import {ScrollView, StyleSheet, View} from 'react-native';
 import Share from 'react-native-share';
 import RNFS from 'react-native-fs';
-import { FileSystem } from 'react-native-file-access';
+import {FileSystem} from 'react-native-file-access';
+import {CameraRoll} from '@react-native-camera-roll/camera-roll';
 
-import { addMessage } from '../messages';
-import { Heading, TupaiaBackground, Button, Divider, QrCode } from '../widgets';
-import { THEME_COLOR_ONE, THEME_FONT_SIZE_ONE } from '../globalStyles';
-import { formatPlural } from '../utilities';
-import { requestWritePermission } from '../utilities/writePermission/permission';
+import {addMessage} from '../messages';
+import {Heading, TupaiaBackground, Button, Divider, QrCode} from '../widgets';
+import {THEME_COLOR_ONE, THEME_FONT_SIZE_ONE} from '../globalStyles';
+import {formatPlural} from '../utilities';
+import {requestWritePermission} from '../utilities/writePermission/permission';
 
 const shareQrCode = (qrCodeRef, filename) => {
   qrCodeRef.toDataURL(dataURL => {
@@ -36,10 +37,10 @@ const downloadQrCode = async (qrCodeRef, filename, onSuccess, onFail) => {
   }
   qrCodeRef.toDataURL(async dataURL => {
     try {
-      const fullFilename = `${filename}.png`;
-      const filePath = `${RNFS.DocumentDirectoryPath}/${fullFilename}`;
+      const filenameWithExtension = `${filename}.png`;
+      const filePath = `${RNFS.DocumentDirectoryPath}/${filenameWithExtension}`;
       await RNFS.writeFile(filePath, dataURL, 'base64');
-      await FileSystem.cpExternal(filePath, fullFilename, 'downloads');
+      await CameraRoll.save(filePath, {album: 'Meditrak QR Codes'});
       onSuccess();
     } catch (error) {
       onFail(error.message);
@@ -48,8 +49,8 @@ const downloadQrCode = async (qrCodeRef, filename, onSuccess, onFail) => {
 };
 
 const QrCodeScreenComponent = props => {
-  const { displayDownloadMessage } = props;
-  const { qrCodes = [], onClose = () => {} } = props.navigation.state.params;
+  const {displayDownloadMessage} = props;
+  const {qrCodes = [], onClose = () => {}} = props.navigation.state.params;
   const qrCodeImgsRef = useRef(new Array(qrCodes.length));
 
   return (
@@ -59,7 +60,7 @@ const QrCodeScreenComponent = props => {
         style={localStyles.heading}
       />
       <ScrollView>
-        {qrCodes.map(({ data, name }, index) => (
+        {qrCodes.map(({data, name}, index) => (
           <View key={data} style={localStyles.qrCodeContainer}>
             <QrCode
               getRef={ref => {
@@ -117,7 +118,7 @@ QrCodeScreenComponent.propTypes = {
   displayDownloadMessage: PropTypes.func.isRequired,
 };
 
-QrCodeScreenComponent.navigationOptions = ({ navigation }) => ({
+QrCodeScreenComponent.navigationOptions = ({navigation}) => ({
   headerTitle: navigation.state.params.title,
 });
 
@@ -149,8 +150,8 @@ const localStyles = StyleSheet.create({
     marginBottom: 20,
     width: 300,
   },
-  smallButton: { marginTop: 20, marginBottom: 5, width: 142 },
-  downloadButton: { marginRight: 16 },
+  smallButton: {marginTop: 20, marginBottom: 5, width: 142},
+  downloadButton: {marginRight: 16},
   buttonLabel: {
     fontWeight: 'bold',
   },

--- a/packages/meditrak-app/ios/Podfile.lock
+++ b/packages/meditrak-app/ios/Podfile.lock
@@ -377,6 +377,8 @@ PODS:
   - React-jsinspector (0.72.5)
   - React-logger (0.72.5):
     - glog
+  - react-native-cameraroll (6.0.0):
+    - React-Core
   - react-native-config (1.5.1):
     - react-native-config/App (= 1.5.1)
   - react-native-config/App (1.5.1):
@@ -385,7 +387,7 @@ PODS:
     - React-Core
   - react-native-geolocation (3.1.0):
     - React-Core
-  - react-native-image-picker (7.0.1):
+  - react-native-image-picker (7.0.2):
     - React-Core
   - react-native-netinfo (9.4.1):
     - React-Core
@@ -516,7 +518,7 @@ PODS:
     - React-Core
   - RNFS (2.20.0):
     - React-Core
-  - RNGestureHandler (2.13.3):
+  - RNGestureHandler (2.13.4):
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
   - RNLocalize (3.0.2):
@@ -525,7 +527,8 @@ PODS:
     - React-Core
   - RNSVG (13.14.0):
     - React-Core
-  - RNVectorIcons (10.0.0):
+  - RNVectorIcons (10.0.1):
+    - RCT-Folly (= 2021.07.22.00)
     - React-Core
   - SocketRocket (0.6.1)
   - VisionCamera (3.4.1):
@@ -584,6 +587,7 @@ DEPENDENCIES:
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
+  - "react-native-cameraroll (from `../node_modules/@react-native-camera-roll/camera-roll`)"
   - react-native-config (from `../node_modules/react-native-config`)
   - react-native-document-picker (from `../node_modules/react-native-document-picker`)
   - "react-native-geolocation (from `../node_modules/@react-native-community/geolocation`)"
@@ -686,6 +690,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/jsinspector"
   React-logger:
     :path: "../node_modules/react-native/ReactCommon/logger"
+  react-native-cameraroll:
+    :path: "../node_modules/@react-native-camera-roll/camera-roll"
   react-native-config:
     :path: "../node_modules/react-native-config"
   react-native-document-picker:
@@ -796,10 +802,11 @@ SPEC CHECKSUMS:
   React-jsiexecutor: ff70a72027dea5cc7d71cfcc6fad7f599f63987a
   React-jsinspector: aef73cbd43b70675f572214d10fa438c89bf11ba
   React-logger: 2e4aee3e11b3ec4fa6cfd8004610bbb3b8d6cca4
+  react-native-cameraroll: 121cab3d7fe2972d9a26ef40558d78d4053356a8
   react-native-config: 86038147314e2e6d10ea9972022aa171e6b1d4d8
   react-native-document-picker: 2b8f18667caee73a96708a82b284a4f40b30a156
   react-native-geolocation: ef66fb798d96284c6043f0b16c15d9d1d4955db4
-  react-native-image-picker: 1569cfade34b3a011191ce262423e6ce2f8db5a1
+  react-native-image-picker: 2e2e82aba9b6a91a7c78f7d9afde341a2659c7b8
   react-native-netinfo: fefd4e98d75cbdd6e85fc530f7111a8afdf2b0c5
   react-native-safe-area-context: 7aa8e6d9d0f3100a820efb1a98af68aa747f9284
   react-native-webview: 8fc09f66a1a5b16bbe37c3878fda27d5982bb776
@@ -826,11 +833,11 @@ SPEC CHECKSUMS:
   RNDateTimePicker: 8fb39263b721223e095248acaf6f406d5b7f6713
   RNDeviceInfo: bf8a32acbcb875f568217285d1793b0e8588c974
   RNFS: 4ac0f0ea233904cb798630b3c077808c06931688
-  RNGestureHandler: fa40ab6b6cafaa7609294d31f8e8fbbd0cce8ea6
+  RNGestureHandler: 6e46dde1f87e5f018a54fe5d40cd0e0b942b49ee
   RNLocalize: dbea38dcb344bf80ff18a1757b1becf11f70cae4
   RNShare: 32e97adc8d8c97d4a26bcdd3c45516882184f8b6
   RNSVG: d00c8f91c3cbf6d476451313a18f04d220d4f396
-  RNVectorIcons: 8b5bb0fa61d54cd2020af4f24a51841ce365c7e9
+  RNVectorIcons: ace237de89f1574ef3c963ae9d5da3bd6fbeb02a
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   VisionCamera: 3a1ba1518517f718d70486fdc4580723a6f2c891
   Yoga: 86fed2e4d425ee4c6eab3813ba1791101ee153c6

--- a/packages/meditrak-app/ios/TupaiaMediTrak.xcodeproj/project.pbxproj
+++ b/packages/meditrak-app/ios/TupaiaMediTrak.xcodeproj/project.pbxproj
@@ -486,6 +486,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 130;
+				DEVELOPMENT_TEAM = 352QMCKRKJ;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = TupaiaMediTrak/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -513,6 +514,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 130;
+				DEVELOPMENT_TEAM = 352QMCKRKJ;
 				INFOPLIST_FILE = TupaiaMediTrak/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -602,8 +604,8 @@
 				);
 				OTHER_LDFLAGS = (
 					"$(inherited)",
-					" ",
-					"-Wl -ld_classic ",
+					"-Wl",
+					"-ld_classic",
 				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
@@ -676,8 +678,8 @@
 				);
 				OTHER_LDFLAGS = (
 					"$(inherited)",
-					" ",
-					"-Wl -ld_classic ",
+					"-Wl",
+					"-ld_classic",
 				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;

--- a/packages/meditrak-app/package.json
+++ b/packages/meditrak-app/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "^1.19.3",
+    "@react-native-camera-roll/camera-roll": "^6.0.0",
     "@react-native-community/datetimepicker": "^7.6.1",
     "@react-native-community/geolocation": "^3.1.0",
     "@react-native-community/netinfo": "^9.4.1",

--- a/packages/meditrak-app/package.json
+++ b/packages/meditrak-app/package.json
@@ -27,7 +27,6 @@
     "react-native-database": "^0.3.3",
     "react-native-device-info": "^10.9.0",
     "react-native-document-picker": "^9.0.1",
-    "react-native-file-access": "^3.0.4",
     "react-native-fs": "^2.20.0",
     "react-native-gesture-handler": "^2.13.0",
     "react-native-image-picker": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7831,6 +7831,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native-camera-roll/camera-roll@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "@react-native-camera-roll/camera-roll@npm:6.0.0"
+  peerDependencies:
+    react-native: ">=0.59"
+  checksum: b94e2c7e37e6102969c44ba98b1249583f05a5d4de4d8cb01c7b3c31d948f2629591759fb45007c52f0ff427ea75c9efc700db3c11166a81b6cce712714d337c
+  languageName: node
+  linkType: hard
+
 "@react-native-community/cli-clean@npm:11.3.7":
   version: 11.3.7
   resolution: "@react-native-community/cli-clean@npm:11.3.7"
@@ -11455,6 +11464,7 @@ __metadata:
     "@babel/preset-env": ^7.20.0
     "@babel/runtime": ^7.20.0
     "@react-native-async-storage/async-storage": ^1.19.3
+    "@react-native-camera-roll/camera-roll": ^6.0.0
     "@react-native-community/datetimepicker": ^7.6.1
     "@react-native-community/geolocation": ^3.1.0
     "@react-native-community/netinfo": ^9.4.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -11490,7 +11490,6 @@ __metadata:
     react-native-database: ^0.3.3
     react-native-device-info: ^10.9.0
     react-native-document-picker: ^9.0.1
-    react-native-file-access: ^3.0.4
     react-native-fs: ^2.20.0
     react-native-gesture-handler: ^2.13.0
     react-native-image-picker: ^7.0.0
@@ -38990,16 +38989,6 @@ __metadata:
     react-native-windows:
       optional: true
   checksum: a8ad0bc2ed13290e8d7ff5f77aa7e35ffda9fa380a7d01d1286111e92656415985d61469a50567b8bcb67e42c41a36b89e879d0d08b40d3fdda171eaa08721e4
-  languageName: node
-  linkType: hard
-
-"react-native-file-access@npm:^3.0.4":
-  version: 3.0.4
-  resolution: "react-native-file-access@npm:3.0.4"
-  peerDependencies:
-    react: "*"
-    react-native: "*"
-  checksum: 05ad071c77747b8242435db88fee4672f12021cd1bf39b9949c2d11b56bbd7262842eeb443c04bf0094b480b03fb602b6d4f7b31a8d54d16fb09ec37b91fc164
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue #: RN-963

As far as I can tell the only thing missing from Meditrak iOS that is in Meditrak Android was saving QR codes to camera roll.

Green build: https://appcenter.ms/orgs/Beyond-Essential/apps/Tupaia-MediTrak/build/branches/rn-963-meditrak-ios-features/builds/268

CI/CD issues will fixed in `bump-node-to-v16` branch

Screenshots in card.