### PR TITLE
no-issue: Recommend REST Client & Partial Diff VSC extensions

### DIFF
--- a/tupaia-packages.code-workspace
+++ b/tupaia-packages.code-workspace
@@ -256,6 +256,8 @@
       "dbaeumer.vscode-eslint",
       "eamodio.gitlens",
       "esbenp.prettier-vscode",
+      "humao.rest-client",
+      "ryu1kn.partial-diff",
       "streetsidesoftware.code-spell-checker",
       "visualstudioexptteam.vscodeintellicode",
       "wayou.vscode-todo-highlight"


### PR DESCRIPTION
### Changes:

Added [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) and [Partial Diff](https://marketplace.visualstudio.com/items?itemName=ryu1kn.partial-diff) and as recommended extensions in the VS Code workspace file. Developer now prompted to install these when opening the monorepo as a workspace.

---

### Screenshots:

![Screenshot 2023-11-09T153358](https://github.com/beyondessential/tupaia/assets/33956381/349251ea-5b61-48e2-94e0-2d1a79f98ab3)
