### PR TITLE
WAITP-1224 Add an additional filter to MapOverlaysRoute

### DIFF
--- a/packages/tupaia-web-server/src/routes/MapOverlaysRoute.ts
+++ b/packages/tupaia-web-server/src/routes/MapOverlaysRoute.ts
@@ -58,7 +58,7 @@ const integrateMapOverlayItemsReference = (children: OverlayChild[]) => {
   // Delete all the same references
   const noReferenceMapOverlayItems = children.map(mapOverlayItem => {
     const { info, ...restValues } = mapOverlayItem;
-    delete info!['reference'];
+    delete info!.reference;
     return { ...restValues, info };
   });
 
@@ -70,26 +70,35 @@ const integrateMapOverlayItemsReference = (children: OverlayChild[]) => {
 
 export class MapOverlaysRoute extends Route<MapOverlaysRequest> {
   public async buildResponse() {
-    const { query, params, ctx } = this.req;
+    const { query, params, ctx, accessPolicy } = this.req;
     const { projectCode, entityCode } = params;
     const { pageSize } = query;
 
     const entity = await ctx.services.entity.getEntity(projectCode, entityCode);
+    const rootEntityCode = entity.country_code || entity.code;
+
     // Do the initial overlay fetch from the central server, since that enforces permissions
-    const mapOverlays = await ctx.services.central.fetchResources('mapOverlays', {
-      filter: {
-        country_codes: {
-          comparator: '@>',
-          // Project entities do not have a country_code
-          comparisonValue: [entity.country_code || entity.code],
+    const mapOverlays = (
+      await ctx.services.central.fetchResources('mapOverlays', {
+        filter: {
+          country_codes: {
+            comparator: '@>',
+            // Project entities do not have a country_code
+            comparisonValue: [rootEntityCode],
+          },
+          project_codes: {
+            comparator: '@>',
+            comparisonValue: [projectCode],
+          },
         },
-        project_codes: {
-          comparator: '@>',
-          comparisonValue: [projectCode],
-        },
-      },
-      pageSize: pageSize || DEFAULT_PAGE_SIZE,
-    });
+        pageSize: pageSize || DEFAULT_PAGE_SIZE,
+      })
+    ).filter(
+      // Central returns overlays you can view in at least one of its countries
+      // We run an additional filter here to narrow down to the specific country we're requesting for
+      (overlay: MapOverlay) =>
+        accessPolicy.getPermissionGroups([rootEntityCode]).includes(overlay.permission_group),
+    );
 
     if (mapOverlays.length === 0) {
       return {


### PR DESCRIPTION
### Issue #: WAITP-1224

When fetching map overlays from `central-server` we don't fetch in the context of an entity. So if a map overlay is available in both `DL` and `VU` for example, we will return it if you have appropriate permissions to either country. When we fetch for `tupaia-web-server` we want to filter specifically for the entity we're looking at.

### Changes:

- Add an additional permission filter for map overlays

---

### Screenshots:
