### PR TITLE
WAITP-1463: Cap survey name length at 50 characters

### DIFF
--- a/packages/admin-panel/src/pages/resources/SurveysPage.jsx
+++ b/packages/admin-panel/src/pages/resources/SurveysPage.jsx
@@ -26,6 +26,10 @@ const SURVEY_FIELDS = {
     Header: 'Name',
     source: 'name',
     type: 'tooltip',
+    editConfig: {
+      maxLength: 50,
+      secondaryLabel: 'Max length: 50 characters',
+    },
   },
   code: {
     Header: 'Code',

--- a/packages/admin-panel/src/widgets/InputField/registerInputFields.jsx
+++ b/packages/admin-panel/src/widgets/InputField/registerInputFields.jsx
@@ -252,6 +252,10 @@ export const registerInputFields = () => {
         startAdornment: props.startAdornment ? (
           <InputAdornment position="start">{props.startAdornment}</InputAdornment>
         ) : null,
+      }}
+      // disable eslint rule as we want to allow the use of minLength and maxLength, and inputProps and InputProps are valid mui component props
+      // eslint-disable-next-line react/jsx-no-duplicate-props
+      inputProps={{
         minLength: props.minLength,
         maxLength: props.maxLength,
       }}

--- a/packages/central-server/src/apiV2/utilities/constructNewRecordValidationRules.js
+++ b/packages/central-server/src/apiV2/utilities/constructNewRecordValidationRules.js
@@ -351,7 +351,7 @@ export const constructForSingle = (models, recordType) => {
     case TYPES.SURVEY:
       return {
         code: [constructRecordNotExistsWithField(models.survey, 'code')],
-        name: [isAString],
+        name: [isAString, constructIsShorterThan(50)],
         'permission_group.name': [constructRecordExistsWithField(models.permissionGroup, 'name')],
         countryNames: [
           async countryNames => {


### PR DESCRIPTION
### Issue WAITP-1463: Cap survey name length at 50 characters

### Changes:
- Add HTML validation settings for maxlength of text on survey name (no validation message will show until we have implemented inline validation messages)
- Add length validation for name when creating a survey in central-server
