### PR TITLE
Responsive styling of dashboard leaderboard

### DIFF
--- a/packages/datatrak-web/src/components/Tile.tsx
+++ b/packages/datatrak-web/src/components/Tile.tsx
@@ -44,12 +44,14 @@ const Heading = styled(Typography)`
 const Text = styled(Typography)`
   font-size: 0.75rem;
   color: ${({ theme }) => theme.palette.text.secondary};
-  margin-bottom: 0.2rem;
   text-align: left;
   display: block;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  &:not(:last-child) {
+    margin-bottom: 0.2rem;
+  }
 `;
 
 interface TileProps {

--- a/packages/datatrak-web/src/features/Leaderboard/Leaderboard.tsx
+++ b/packages/datatrak-web/src/features/Leaderboard/Leaderboard.tsx
@@ -5,27 +5,34 @@
 
 import React from 'react';
 import styled from 'styled-components';
-import { useUserRewards } from '../../api/queries';
+import { SpinningLoader } from '@tupaia/ui-components';
+import { useLeaderboard, useUserRewards } from '../../api/queries';
 import { UserRewardsSection } from './UserRewardsSection';
 import { LeaderboardTable } from './LeaderboardTable';
+import { useCurrentUser } from '../../api';
 
 const ScrollBody = styled.div`
   overflow: auto;
   background: ${({ theme }) => theme.palette.background.paper};
   border-radius: 10px;
   max-height: 100%;
-
+  height: 100%;
+  display: flex;
+  flex-direction: column;
   ${({ theme }) => theme.breakpoints.down('md')} {
     flex: 1;
   }
 `;
 
 export const Leaderboard = () => {
+  const user = useCurrentUser();
   const { data: userRewards, isSuccess } = useUserRewards();
+  const { data: leaderboard, isLoading } = useLeaderboard(user.projectId);
+  if (isLoading) return <SpinningLoader />;
   return (
     <ScrollBody>
       {isSuccess && <UserRewardsSection pigs={userRewards.pigs} coconuts={userRewards.coconuts} />}
-      <LeaderboardTable userRewards={userRewards} />
+      <LeaderboardTable userRewards={userRewards} leaderboard={leaderboard} user={user} />
     </ScrollBody>
   );
 };

--- a/packages/datatrak-web/src/features/Leaderboard/LeaderboardTable.tsx
+++ b/packages/datatrak-web/src/features/Leaderboard/LeaderboardTable.tsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import styled from 'styled-components';
-import { UserRewards } from '../../types';
+import { DatatrakWebLeaderboardRequest, DatatrakWebUserRequest } from '@tupaia/types';
 import {
   Table,
   TableBody,
@@ -15,113 +15,126 @@ import {
   TableRow,
   TableFooter,
 } from '@material-ui/core';
-import { useLeaderboard, useCurrentUser } from '../../api';
-import { DESKTOP_MEDIA_QUERY } from '../../constants';
-
-interface LeaderboardTableProps {
-  userRewards?: UserRewards;
-}
+import { UserRewards } from '../../types';
 
 const TableContainer = styled(MuiTableContainer)`
   padding: 0.2rem 1.6rem;
-
-  td {
-    &:first-child {
-      text-align: center;
-    }
-    &:last-child {
-      text-align: right;
-    }
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  table {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+  }
+  thead,
+  tfoot {
+    display: flex;
   }
 `;
 
-const HeaderCell = styled(TableCell)`
-  border-bottom-color: ${({ theme }) => theme.palette.divider};
-  line-height: 1.4;
-  padding-top: 0.7rem;
-  padding-bottom: 0.7rem;
-  ${({ theme }) => theme.breakpoints.down('lg')} {
-    padding-top: 0.3rem;
-    padding-bottom: 0.4rem;
+const Row = styled(TableRow)`
+  display: flex;
+  width: 100%;
+`;
+
+const HeaderRow = styled(Row)`
+  border-bottom: 1px solid ${({ theme }) => theme.palette.divider};
+  padding: 0.4rem 0;
+  margin-bottom: 0.5rem;
+  @media screen and (min-height: 900px) {
+    padding: 0.6rem 0;
   }
-  ${DESKTOP_MEDIA_QUERY} {
-    padding-top: 1.2rem;
-    padding-bottom: 1.1rem;
-  }
+`;
+
+const Body = styled(TableBody)<{
+  $rowCount?: number;
+}>`
+  display: flex;
+  flex-direction: column;
+  justify-content: ${({ $rowCount = 0 }) => ($rowCount < 10 ? 'flex-start' : 'space-between')};
+  width: 100%;
+  flex: 1;
+`;
+
+const FooterRow = styled(Row)`
+  border-top: 1px solid ${({ theme }) => theme.palette.divider};
+  padding: 0.3rem 0;
+  margin-top: 0.3rem;
 `;
 
 const Cell = styled(TableCell)<{
   $isActiveUser?: boolean;
 }>`
   padding-top: 0.3rem;
-  padding-bottom: 0.6rem;
+  padding-bottom: 0.3rem;
   border: none;
   font-weight: ${({ $isActiveUser, theme }) =>
     $isActiveUser ? theme.typography.fontWeightMedium : theme.typography.fontWeightRegular};
-  &:first-child {
-    font-weight: ${({ theme }) => theme.typography.fontWeightMedium};
-  }
-
-  ${DESKTOP_MEDIA_QUERY} {
-    padding-top: 1.1rem;
-    padding-bottom: 0.6rem;
-    tr:last-child & {
-      padding-bottom: 1rem;
-    }
-  }
-`;
-
-const FooterCell = styled(TableCell)`
-  font-weight: ${({ theme }) => theme.typography.fontWeightMedium};
   font-size: 0.875rem;
   color: ${({ theme }) => theme.palette.text.primary};
-  border-bottom: none;
-  border-top: 1px solid ${({ theme }) => theme.palette.divider};
-  ${({ theme }) => theme.breakpoints.down('lg')} {
-    padding: 0.5rem 1rem;
+  width: 55%;
+  text-align: left;
+  &:first-child {
+    font-weight: ${({ theme }) => theme.typography.fontWeightMedium};
+    width: 20%;
   }
-
-  ${DESKTOP_MEDIA_QUERY} {
-    padding-top: 1.1rem;
-    padding-bottom: 0.6rem;
+  &:last-child {
+    text-align: right;
+    width: 25%;
   }
 `;
 
-export const LeaderboardTable = ({ userRewards }: LeaderboardTableProps) => {
-  const user = useCurrentUser();
-  const { data: leaderboard, isLoading } = useLeaderboard(user.projectId);
-  if (isLoading) return null;
+const HeaderCell = styled(Cell)`
+  padding-top: 0;
+  padding-bottom: 0;
+  line-height: 1.4;
+  font-weight: ${({ theme }) => theme.typography.fontWeightMedium};
+`;
 
+const FooterCell = styled(Cell)`
+  font-weight: ${({ theme }) => theme.typography.fontWeightMedium};
+`;
+
+interface LeaderboardTableProps {
+  userRewards?: UserRewards;
+  user?: DatatrakWebUserRequest.ResBody & {
+    isLoggedIn: boolean;
+  };
+  leaderboard?: DatatrakWebLeaderboardRequest.ResBody;
+}
+
+export const LeaderboardTable = ({ userRewards, user, leaderboard }: LeaderboardTableProps) => {
   return (
     <TableContainer>
       <Table>
         <TableHead>
-          <TableRow>
+          <HeaderRow>
             <HeaderCell>#</HeaderCell>
             <HeaderCell>Name</HeaderCell>
             <HeaderCell>Score</HeaderCell>
-          </TableRow>
+          </HeaderRow>
         </TableHead>
-        <TableBody>
-          {leaderboard?.map(({ userId, firstName, lastName, coconuts }, i) => {
+        <Body $rowCount={leaderboard?.length}>
+          {leaderboard.map(({ userId, firstName, lastName, coconuts }, i) => {
             const isActiveUser = user && user.id === userId;
             return (
-              <TableRow key={userId}>
+              <Row key={userId}>
                 <Cell>{i + 1}</Cell>
                 <Cell $isActiveUser={isActiveUser}>
                   {firstName} {lastName}
                 </Cell>
                 <Cell $isActiveUser={isActiveUser}>{coconuts}</Cell>
-              </TableRow>
+              </Row>
             );
           })}
-        </TableBody>
+        </Body>
         <TableFooter>
-          <TableRow>
+          <FooterRow>
             <FooterCell>-</FooterCell>
-            <FooterCell>{user.userName}</FooterCell>
+            <FooterCell>{user?.userName}</FooterCell>
             <FooterCell>{userRewards?.coconuts}</FooterCell>
-          </TableRow>
+          </FooterRow>
         </TableFooter>
       </Table>
     </TableContainer>

--- a/packages/datatrak-web/src/features/Leaderboard/LeaderboardTable.tsx
+++ b/packages/datatrak-web/src/features/Leaderboard/LeaderboardTable.tsx
@@ -116,7 +116,7 @@ export const LeaderboardTable = ({ userRewards, user, leaderboard }: Leaderboard
           </HeaderRow>
         </TableHead>
         <Body $rowCount={leaderboard?.length}>
-          {leaderboard.map(({ userId, firstName, lastName, coconuts }, i) => {
+          {leaderboard?.map(({ userId, firstName, lastName, coconuts }, i) => {
             const isActiveUser = user && user.id === userId;
             return (
               <Row key={userId}>

--- a/packages/datatrak-web/src/features/Leaderboard/UserRewardsSection.tsx
+++ b/packages/datatrak-web/src/features/Leaderboard/UserRewardsSection.tsx
@@ -16,7 +16,7 @@ const Wrapper = styled.div`
   padding: 1.1rem 2rem;
   border-bottom: 1px solid ${props => props.theme.palette.divider};
   ${DESKTOP_MEDIA_QUERY} {
-    padding: 1.7rem 2.2rem;
+    padding: 1.5rem 2.2rem;
   }
 `;
 

--- a/packages/datatrak-web/src/views/LandingPage/ActivityFeedSection/ActivityFeedMarkdownItem.tsx
+++ b/packages/datatrak-web/src/views/LandingPage/ActivityFeedSection/ActivityFeedMarkdownItem.tsx
@@ -9,7 +9,6 @@ import { Typography } from '@material-ui/core';
 import Markdown from 'markdown-to-jsx';
 import { MarkdownFeedItem } from '../../../types';
 
-const Wrapper = styled.div``;
 const Heading = styled(Typography)`
   font-weight: ${({ theme }) => theme.typography.fontWeightMedium};
   margin-bottom: 0.4rem;
@@ -18,6 +17,7 @@ const Heading = styled(Typography)`
 const Image = styled.img`
   max-height: 10rem;
   border-radius: 0.625rem;
+  max-width: 100%;
 `;
 
 const Header = styled.div`
@@ -38,7 +38,7 @@ export const ActivityFeedMarkdownItem = ({ feedItem }: { feedItem: MarkdownFeedI
   const { templateVariables, creationDate } = feedItem;
   const formattedDate = creationDate ? new Date(creationDate as Date).toLocaleDateString() : '';
   return (
-    <Wrapper>
+    <div>
       <Header>
         <Logo />
         <div>
@@ -54,6 +54,6 @@ export const ActivityFeedMarkdownItem = ({ feedItem }: { feedItem: MarkdownFeedI
           alt={`Image for feed item ${templateVariables?.title}`}
         />
       )}
-    </Wrapper>
+    </div>
   );
 };

--- a/packages/datatrak-web/src/views/LandingPage/RecentSurveysSection.tsx
+++ b/packages/datatrak-web/src/views/LandingPage/RecentSurveysSection.tsx
@@ -7,8 +7,9 @@ import React from 'react';
 import styled from 'styled-components';
 import { useNavigate } from 'react-router';
 import { SectionHeading } from './SectionHeading';
-import { SurveyIcon, Tile } from '../../components';
 import { Typography } from '@material-ui/core';
+import { SpinningLoader } from '@tupaia/ui-components';
+import { SurveyIcon, Tile } from '../../components';
 import { useCurrentUserRecentSurveys } from '../../api/queries';
 import { useEditUser } from '../../api/mutations';
 
@@ -42,7 +43,7 @@ const ScrollBody = styled.div`
 `;
 
 export const RecentSurveysSection = () => {
-  const { data: recentSurveys = [], isSuccess } = useCurrentUserRecentSurveys();
+  const { data: recentSurveys = [], isSuccess, isLoading } = useCurrentUserRecentSurveys();
   const navigate = useNavigate();
   const { mutateAsync: editUser } = useEditUser();
 
@@ -57,30 +58,33 @@ export const RecentSurveysSection = () => {
   return (
     <RecentSurveys>
       <SectionHeading>My recent surveys</SectionHeading>
-      <ScrollBody>
-        {isSuccess && recentSurveys?.length ? (
-          recentSurveys.map(({ surveyName, surveyCode, countryName, countryId }) => (
-            <Tile
-              key={`${surveyCode}-${countryName}`}
-              title={surveyName}
-              text={countryName}
-              tooltip={
-                <>
-                  {surveyName}
-                  <br />
-                  {countryName}
-                </>
-              }
-              Icon={SurveyIcon}
-              onClick={() => handleSelectSurvey(surveyCode, countryId)}
-            />
-          ))
-        ) : (
-          <Typography variant="body2" color="textSecondary">
-            No recent surveys to display
-          </Typography>
-        )}
-      </ScrollBody>
+      {isLoading && <SpinningLoader />}
+      {isSuccess && (
+        <ScrollBody>
+          {recentSurveys?.length ? (
+            recentSurveys.map(({ surveyName, surveyCode, countryName, countryId }) => (
+              <Tile
+                key={`${surveyCode}-${countryName}`}
+                title={surveyName}
+                text={countryName}
+                tooltip={
+                  <>
+                    {surveyName}
+                    <br />
+                    {countryName}
+                  </>
+                }
+                Icon={SurveyIcon}
+                onClick={() => handleSelectSurvey(surveyCode, countryId)}
+              />
+            ))
+          ) : (
+            <Typography variant="body2" color="textSecondary">
+              No recent surveys to display
+            </Typography>
+          )}
+        </ScrollBody>
+      )}
     </RecentSurveys>
   );
 };

--- a/packages/datatrak-web/src/views/LandingPage/SurveyResponsesSection.tsx
+++ b/packages/datatrak-web/src/views/LandingPage/SurveyResponsesSection.tsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import { Typography } from '@material-ui/core';
 import styled from 'styled-components';
+import { SpinningLoader } from '@tupaia/ui-components';
 import { useCurrentUserSurveyResponses } from '../../api';
 import { SurveyTickIcon, Tile } from '../../components';
 import { shortDate } from '../../utils';
@@ -34,38 +35,41 @@ const ScrollBody = styled.div`
 `;
 
 export const SurveyResponsesSection = () => {
-  const { data: recentSurveyResponses, isSuccess } = useCurrentUserSurveyResponses();
+  const { data: recentSurveyResponses, isSuccess, isLoading } = useCurrentUserSurveyResponses();
   return (
     <Container>
       <SectionHeading>My recent responses</SectionHeading>
-      <ScrollBody>
-        {isSuccess && recentSurveyResponses?.length > 0 ? (
-          recentSurveyResponses.map(
-            ({ id, surveyName, surveyCode, dataTime, entityName, countryName }) => (
-              <Tile
-                key={id}
-                title={surveyName}
-                text={entityName}
-                to={`/survey/${surveyCode}/response/${id}`}
-                tooltip={
-                  <>
-                    {surveyName}
-                    <br />
-                    {entityName}
-                  </>
-                }
-                Icon={SurveyTickIcon}
-              >
-                {countryName}, {shortDate(dataTime)}
-              </Tile>
-            ),
-          )
-        ) : (
-          <Typography variant="body2" color="textSecondary">
-            No recent surveys responses to display
-          </Typography>
-        )}
-      </ScrollBody>
+      {isLoading && <SpinningLoader />}
+      {isSuccess && (
+        <ScrollBody>
+          {recentSurveyResponses?.length > 0 ? (
+            recentSurveyResponses.map(
+              ({ id, surveyName, surveyCode, dataTime, entityName, countryName }) => (
+                <Tile
+                  key={id}
+                  title={surveyName}
+                  text={entityName}
+                  to={`/survey/${surveyCode}/response/${id}`}
+                  tooltip={
+                    <>
+                      {surveyName}
+                      <br />
+                      {entityName}
+                    </>
+                  }
+                  Icon={SurveyTickIcon}
+                >
+                  {countryName}, {shortDate(dataTime)}
+                </Tile>
+              ),
+            )
+          ) : (
+            <Typography variant="body2" color="textSecondary">
+              No recent surveys responses to display
+            </Typography>
+          )}
+        </ScrollBody>
+      )}
     </Container>
   );
 };


### PR DESCRIPTION
### No issue: Leaderboard responsive styling

### Changes:
- Added loaders to dashboard sections (but not activity feed because is infinite scroll with own loader)
- Made leaderboard respond to height of viewport

---

### Screenshots:
13 inch laptop
![Dashboard laptop 13 inch](https://github.com/beyondessential/tupaia/assets/129009580/dca8eab6-3d2c-439a-ab12-73d724f0d045)

15 inch laptop
![Dashboard laptop 15 inch](https://github.com/beyondessential/tupaia/assets/129009580/aa24d319-8e86-4fcd-9e35-ca127b8318e3)

Desktop
![Dashboard larger desktop](https://github.com/beyondessential/tupaia/assets/129009580/9ffe7803-d9c4-4b6a-98c9-dddb99d5c683)


