### PR TITLE
WAITP-1214: Fix height issue of overlay selector on mobile

### DIFF
--- a/packages/tupaia-web/src/features/Map/MapOverlaySelector/MobileMapOverlaySelector.tsx
+++ b/packages/tupaia-web/src/features/Map/MapOverlaySelector/MobileMapOverlaySelector.tsx
@@ -66,7 +66,8 @@ const OverlayListWrapper = styled.div`
 const OverlayMenu = styled.div<{
   $expanded: boolean;
 }>`
-  height: ${({ $expanded }) => ($expanded ? `calc(100vh - ${getMobileTopBarHeight()})` : '0')};
+  // we use dvh here to make up for mobile viewports which have system ui bars (e.g. forward button, address bar etc) that are not accounted for in vh units. Support for this is widespread for modern browsers (https://caniuse.com/viewport-unit-variants), especially relative to usage.
+  height: ${({ $expanded }) => ($expanded ? `calc(100dvh - ${getMobileTopBarHeight()})` : '0')};
   transition: height 0.3s ease-in-out;
   width: 100%;
   position: fixed;


### PR DESCRIPTION
### Issue WAITP-1214: Fix height issue of overlay selector on mobile

### Changes:
- Use `dvh` instead of `vh` on mobile browser for height of overlay selector because of system specific infringements on the  useable viewport space on mobile devices