### PR TITLE
WAITP-1496 Make questions optional in GETSurveys

### DIFF
--- a/packages/central-server/src/apiV2/surveys/GETSurveys.js
+++ b/packages/central-server/src/apiV2/surveys/GETSurveys.js
@@ -23,6 +23,9 @@ import { processColumns } from '../GETHandler/helpers';
  * - /countries/id/surveys
  */
 
+const SURVEY_QUESTIONS_COLUMN = 'surveyQuestions';
+const COUNTRY_NAMES_COLUMN = 'countryNames';
+
 export class GETSurveys extends GETHandler {
   permissionsFilteredInternally = true;
 
@@ -94,15 +97,19 @@ export class GETSurveys extends GETHandler {
       return super.getProcessedColumns();
     }
 
-    const unprocessedColumns =
-      columnsString &&
-      JSON.parse(columnsString).filter(col => !['surveyQuestions', 'countryNames'].includes(col));
+    const parsedColumns = columnsString && JSON.parse(columnsString);
+    this.includeQuestions = parsedColumns.includes(SURVEY_QUESTIONS_COLUMN);
+    this.includeCountryNames = parsedColumns.includes(COUNTRY_NAMES_COLUMN);
+
+    const unprocessedColumns = parsedColumns.filter(
+      col => ![SURVEY_QUESTIONS_COLUMN, COUNTRY_NAMES_COLUMN].includes(col),
+    );
     return processColumns(this.models, unprocessedColumns, this.recordType);
   }
 
   async getSurveyQuestionsValues(surveyIds) {
     // See README.md
-    if (surveyIds.length === 0) return {};
+    if (surveyIds.length === 0 || !this.includeQuestions) return {};
     const rows = await this.database.executeSql(
       `
     SELECT 
@@ -138,7 +145,7 @@ export class GETSurveys extends GETHandler {
   }
 
   async getSurveyCountryNames(surveyIds) {
-    if (surveyIds.length === 0) return {};
+    if (surveyIds.length === 0 || !this.includeCountryNames) return {};
     const rows = await this.database.executeSql(
       `
     SELECT survey.id, array_agg(country.name) as country_names

--- a/packages/central-server/src/apiV2/surveys/GETSurveys.js
+++ b/packages/central-server/src/apiV2/surveys/GETSurveys.js
@@ -94,10 +94,14 @@ export class GETSurveys extends GETHandler {
     const { columns: columnsString } = this.req.query;
 
     if (!columnsString) {
+      // Always include these by default
+      this.includeQuestions = true;
+      this.includeCountryNames = true;
       return super.getProcessedColumns();
     }
 
     const parsedColumns = columnsString && JSON.parse(columnsString);
+    // If we've requested specific columns, we allow skipping these fields by not requesting them
     this.includeQuestions = parsedColumns.includes(SURVEY_QUESTIONS_COLUMN);
     this.includeCountryNames = parsedColumns.includes(COUNTRY_NAMES_COLUMN);
 

--- a/packages/datatrak-web-server/src/routes/SurveyRoute.ts
+++ b/packages/datatrak-web-server/src/routes/SurveyRoute.ts
@@ -15,7 +15,7 @@ export type SurveyRequest = Request<
   DatatrakWebSurveyRequest.ReqQuery
 >;
 
-const DEFAULT_FIELDS = ['name', 'code', 'id', 'can_repeat', 'survey_group.name'];
+const DEFAULT_FIELDS = ['name', 'code', 'id', 'can_repeat', 'survey_group.name', 'surveyQuestions'];
 
 const parseOption = (option: string) => {
   try {

--- a/packages/datatrak-web/src/api/queries/useSurveys.ts
+++ b/packages/datatrak-web/src/api/queries/useSurveys.ts
@@ -14,7 +14,7 @@ export const useSurveys = (selectedCountryName?: Entity['name'], projectId?: Pro
     (): Promise<DatatrakWebSurveyRequest.ResBody[]> =>
       get('surveys', {
         params: {
-          fields: ['name', 'code', 'id', 'survey_group.name'],
+          fields: ['name', 'code', 'id', 'survey_group.name', 'countryNames'],
           projectId,
         },
       }),


### PR DESCRIPTION
### Issue #: WAITP-1496

### Changes:

- `surveyQuestions` and `countryNames` are now optional and controlled by the `columns` query parameter
  - They follow the same logic as any other column, they are included by default but filtered out if you are requesting specific columns only