### PR TITLE
no-issue: Bump monorepo to using TS 5.2.2 globally

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@babel/types": "^7.23.0",
     "@beyondessential/eslint-config-jest": "^1.0.0",
     "@beyondessential/eslint-config-js": "^1.1.1",
-    "@beyondessential/eslint-config-ts": "^1.3.2",
+    "@beyondessential/eslint-config-ts": "^2.0.0",
     "@vitejs/plugin-react": "^4.0.4",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^27.0.6",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "npm-package-json-lint": "5.1.0",
     "ts-jest": "^27.1.3",
     "ts-node": "^10.7.0",
-    "typescript": "^4.2.0",
+    "typescript": "^5.2.2",
     "vite": "^4.4.8",
     "vite-plugin-ejs": "^1.6.4",
     "yargs": "15.4.1"

--- a/packages/admin-panel/package.json
+++ b/packages/admin-panel/package.json
@@ -56,7 +56,7 @@
     "lodash.groupby": "^4.6.0",
     "lodash.keyby": "^4.6.0",
     "lodash.throttle": "^4.1.1",
-    "moment": "^2.22.2",
+    "moment": "^2.24.0",
     "parse-link-header": "^2.0.0",
     "prop-types": "^15.6.0",
     "qrcode": "^1.5.3",

--- a/packages/datatrak-web/package.json
+++ b/packages/datatrak-web/package.json
@@ -45,7 +45,6 @@
     "@vitejs/plugin-react": "^4.0.0",
     "msw": "^1.3.1",
     "npm-run-all": "^4.1.5",
-    "typescript": "^5.0.2",
     "vite": "^4.3.2"
   },
   "scripts": {

--- a/packages/datatrak-web/package.json
+++ b/packages/datatrak-web/package.json
@@ -48,7 +48,7 @@
     "vite": "^4.3.2"
   },
   "scripts": {
-    "build": "tsc && npm run --prefix ../../ package:build:vite",
+    "build": "yarn package:build:types && yarn package:build:vite",
     "lint": "yarn package:lint",
     "lint:fix": "yarn lint --fix",
     "preview": "vite preview",

--- a/packages/dhis-api/package.json
+++ b/packages/dhis-api/package.json
@@ -28,7 +28,7 @@
     "chai-as-promised": "^7.1.1",
     "lodash.groupby": "^4.6.0",
     "lodash.keyby": "^4.6.0",
-    "moment": "^2.22.2",
+    "moment": "^2.24.0",
     "simple-oauth2": "^1.5.0",
     "urlencode": "^1.1.0",
     "winston": "^3.3.3"

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -31,7 +31,7 @@
     "js-beautify": "^1.13.0",
     "lodash": "^4.17.4",
     "markdown-to-jsx": "^6.4.1",
-    "moment": "^2.21.0",
+    "moment": "^2.24.0",
     "moment-timezone": "^0.5.14",
     "node-fetch": "^1.7.3",
     "npm-run-all": "^4.1.5",

--- a/packages/entity-server/src/routes/hierarchy/middleware/filter.ts
+++ b/packages/entity-server/src/routes/hierarchy/middleware/filter.ts
@@ -178,7 +178,8 @@ export const extractFilterFromQuery = (
   }
 
   const filterClauses = queryFilter.split(CLAUSE_DELIMITER).map(toFilterClause);
-  const filter: Writable<NotNullValues<Record<string, unknown>>> = {};
+  //TODO: Stop using any here in favour of validating against the entity filter schema
+  const filter: Writable<NotNullValues<Record<string, any>>> = {};
 
   filterClauses.forEach(([field, operator, value]) => {
     const formattedField = isNestedField(field) ? toJsonBKey(field) : field;

--- a/packages/indicators/src/Builder/AnalyticArithmeticBuilder/config/aggregation.ts
+++ b/packages/indicators/src/Builder/AnalyticArithmeticBuilder/config/aggregation.ts
@@ -69,7 +69,7 @@ const validateAggregationArray = (aggregation: Array<unknown>) => {
     try {
       validateAggregationDescriptor(descriptor);
     } catch (error) {
-      throw new Error(`Error in item #${i + 1}: ${error.message}`);
+      throw new Error(`Error in item #${i + 1}: ${(error as Error).message}`);
     }
   });
 };
@@ -97,7 +97,7 @@ const validateAggregationDictionary = (
         validateAggregationDescriptor(aggregationSpecs);
       }
     } catch (error) {
-      throw new Error(`Error in key '${code}': ${error.message}`);
+      throw new Error(`Error in key '${code}': ${(error as Error).message}`);
     }
   });
 };

--- a/packages/lesmis/package.json
+++ b/packages/lesmis/package.json
@@ -47,7 +47,7 @@
     "leaflet": "^1.7.1",
     "lodash.debounce": "^4.0.8",
     "lodash.keyby": "^4.6.0",
-    "moment": "^2.22.2",
+    "moment": "^2.24.0",
     "prop-types": "^15.7.2",
     "query-string": "^5.1.1",
     "react": "^16.13.1",

--- a/packages/meditrak-app/package.json
+++ b/packages/meditrak-app/package.json
@@ -22,7 +22,7 @@
     "appcenter": "^5.0.0",
     "appcenter-analytics": "^5.0.0",
     "bson-objectid": "^2.0.4",
-    "moment": "^2.29.4",
+    "moment": "^2.24.0",
     "nanoid": "^2.0.3",
     "react": "18.2.0",
     "react-native": "0.72.5",

--- a/packages/report-server/src/reportBuilder/transform/transform.ts
+++ b/packages/report-server/src/reportBuilder/transform/transform.ts
@@ -49,7 +49,7 @@ const transform = async (table: TransformTable, transformSteps: BuiltTransformPa
       }
       const titlePart = transformStep.title ? ` (${transformStep.title})` : '';
       const errorMessagePrefix = `Error in transform[${i + 1}]${titlePart}: `;
-      e.message = `${errorMessagePrefix}${(e as Error).message}`;
+      (e as Error).message = `${errorMessagePrefix}${(e as Error).message}`;
       throw e;
     }
   }

--- a/packages/report-server/src/routes/FetchTransformSchemaRoute.ts
+++ b/packages/report-server/src/routes/FetchTransformSchemaRoute.ts
@@ -42,7 +42,7 @@ const formatYupSchema = (yupSchema: yup.AnyObjectSchema) => {
     Object.entries(fields).map(([field, description]) => {
       const formattedDescription = removeRedundantConfigs(description);
       // 'getDefault' is not supported on lazy schemas
-      if (yupSchema.fields[field].getDefault) {
+      if (!Array.isArray(formattedDescription) && yupSchema.fields[field].getDefault) {
         formattedDescription.defaultValue = yupSchema.fields[field].getDefault();
       }
       return [field, formattedDescription];

--- a/packages/tsutils/src/camelcaseKeys.ts
+++ b/packages/tsutils/src/camelcaseKeys.ts
@@ -5,17 +5,15 @@
 
 import baseCamelFunction, { Options } from 'camelcase-keys';
 import { KeysToCamelCase } from '@tupaia/types';
+import { isObject } from './typeGuards';
 
 /**
  * Wrapper for camelcaseKeys library function to add correct type interpretation
  *  @returns Input object with keys in camelcase
  */
-export function camelcaseKeys<
-  InputType,
-  ReturnType = InputType extends Array<infer Item>
-    ? KeysToCamelCase<Item>[]
-    : KeysToCamelCase<InputType>
->(input: InputType, options?: Options): ReturnType {
-  // Cast through unknown to satisfy typescript, we know it will work correctly
-  return (baseCamelFunction(input, options) as unknown) as ReturnType;
+export function camelcaseKeys<InputType>(input: InputType, options?: Options) {
+  if (isObject(input) || Array.isArray(input)) {
+    return baseCamelFunction(input, options) as KeysToCamelCase<InputType>;
+  }
+  return input as KeysToCamelCase<InputType>;
 }

--- a/packages/tsutils/src/typeGuards.ts
+++ b/packages/tsutils/src/typeGuards.ts
@@ -7,3 +7,6 @@ export const isDefined = <T>(value: T): value is Exclude<T, undefined> => value 
 
 export const isNotNullish = <T>(val: T): val is Exclude<T, undefined | null> =>
   val !== undefined && val !== null;
+
+export const isObject = (val: unknown): val is Record<string, unknown> =>
+  typeof val === 'object' && val !== null && !Array.isArray(val);

--- a/packages/tupaia-web-server/src/app/createApp.ts
+++ b/packages/tupaia-web-server/src/app/createApp.ts
@@ -12,9 +12,9 @@ import {
   SessionSwitchingAuthHandler,
   forwardRequest,
 } from '@tupaia/server-boilerplate';
-import { attachAccessPolicy } from './middleware';
 import { TupaiaWebSessionModel } from '../models';
 import * as routes from '../routes';
+import { attachAccessPolicy } from './middleware';
 
 const {
   WEB_CONFIG_API_URL = 'http://localhost:8000/api/v1',

--- a/packages/tupaia-web/package.json
+++ b/packages/tupaia-web/package.json
@@ -42,7 +42,7 @@
     "axios": "^1.4.0",
     "dom-to-image": "2.6.0",
     "downloadjs": "1.4.7",
-    "moment": "^2.29.1",
+    "moment": "^2.24.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-hook-form": "^6.15.1",

--- a/packages/tupaia-web/package.json
+++ b/packages/tupaia-web/package.json
@@ -72,7 +72,6 @@
     "@vitejs/plugin-react": "^4.0.0",
     "npm-run-all": "^4.1.5",
     "storybook": "^7.0.18",
-    "typescript": "^5.0.2",
     "vite": "^4.3.2",
     "vite-plugin-html": "^3.2.0"
   }

--- a/packages/tupaia-web/package.json
+++ b/packages/tupaia-web/package.json
@@ -11,7 +11,7 @@
   },
   "author": "Beyond Essential Systems <admin@tupaia.org> (https://beyondessential.com.au)",
   "scripts": {
-    "build": "tsc && npm run --prefix ../../ package:build:vite",
+    "build": "yarn package:build:types && yarn package:build:vite",
     "lint": "yarn package:lint",
     "lint:fix": "yarn lint --fix",
     "preview": "vite preview",

--- a/packages/tupaia-web/stories/components/dateRangePicker.stories.tsx
+++ b/packages/tupaia-web/stories/components/dateRangePicker.stories.tsx
@@ -7,7 +7,7 @@ import { Moment } from 'moment';
 import { GRANULARITIES, displayStringToMoment } from '@tupaia/utils';
 import type { Meta } from '@storybook/react';
 import { DateRangePicker } from '../../src/components/DateRangePicker';
-import { ValueOf } from '../types';
+import { ValueOf } from '../../src/types';
 
 const meta: Meta<typeof DateRangePicker> = {
   title: 'components/DateRangePicker',

--- a/packages/ui-chart-components/package.json
+++ b/packages/ui-chart-components/package.json
@@ -1,45 +1,45 @@
 {
-    "name": "@tupaia/ui-chart-components",
-    "version": "1.0.0",
-    "private": true,
-    "description": "A library of chart components for the monorepo",
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/beyondessential/tupaia",
-        "directory": "packages/ui-chart-components"
-    },
-    "author": "Beyond Essential Systems <admin@tupaia.org> (https://beyondessential.com.au)",
-    "source": "src/index.js",
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "scripts": {
-        "build": "rm -rf dist && yarn package:build:ts",
-        "build-dev": "npm run build",
-        "lint": "yarn package:lint:js",
-        "lint:fix": "yarn lint --fix",
-        "storybook": "start-storybook -s public -p 6006",
-        "test": "yarn package:test --env=jsdom",
-        "test:coverage": "yarn test --coverage",
-        "test:watch": "yarn test --watch"
-    },
-    "dependencies": {
-        "@material-ui/core": "^4.9.8",
-        "@tupaia/ui-components": "1.0.0",
-        "@tupaia/utils": "1.0.0",
-        "lodash.get": "^4.4.2",
-        "moment": "^2.29.1",
-        "prop-types": "^15.7.2",
-        "react": "^16.13.1",
-        "react-dom": "^16.13.1",
-        "react-table": "^7.7.0",
-        "recharts": "^1.8.5",
-        "styled-components": "^5.0.1"
-    },
-    "devDependencies": {
-        "@material-ui/styles": "^4.9.10",
-        "@storybook/react": "^6.3.9",
-        "@tupaia/types": "1.0.0",
-        "@types/lodash.get": "^4.4.7",
-        "@types/recharts": "^1.8.24"
-    }
+  "name": "@tupaia/ui-chart-components",
+  "version": "1.0.0",
+  "private": true,
+  "description": "A library of chart components for the monorepo",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/beyondessential/tupaia",
+    "directory": "packages/ui-chart-components"
+  },
+  "author": "Beyond Essential Systems <admin@tupaia.org> (https://beyondessential.com.au)",
+  "source": "src/index.js",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "rm -rf dist && yarn package:build:ts",
+    "build-dev": "npm run build",
+    "lint": "yarn package:lint:js",
+    "lint:fix": "yarn lint --fix",
+    "storybook": "start-storybook -s public -p 6006",
+    "test": "yarn package:test --env=jsdom",
+    "test:coverage": "yarn test --coverage",
+    "test:watch": "yarn test --watch"
+  },
+  "dependencies": {
+    "@material-ui/core": "^4.9.8",
+    "@tupaia/ui-components": "1.0.0",
+    "@tupaia/utils": "1.0.0",
+    "lodash.get": "^4.4.2",
+    "moment": "^2.24.0",
+    "prop-types": "^15.7.2",
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1",
+    "react-table": "^7.7.0",
+    "recharts": "^1.8.5",
+    "styled-components": "^5.0.1"
+  },
+  "devDependencies": {
+    "@material-ui/styles": "^4.9.10",
+    "@storybook/react": "^6.3.9",
+    "@tupaia/types": "1.0.0",
+    "@types/lodash.get": "^4.4.7",
+    "@types/recharts": "^1.8.24"
+  }
 }

--- a/packages/ui-chart-components/src/components/Charts/PieChart.tsx
+++ b/packages/ui-chart-components/src/components/Charts/PieChart.tsx
@@ -16,12 +16,12 @@ import {
   TooltipProps,
   LegendProps,
 } from 'recharts';
+import { PieChartConfig } from '@tupaia/types';
 import { OFF_WHITE, CHART_COLOR_PALETTE } from '../../constants';
 import { getPieLegend } from '../Reference/Legend';
 import { isMobile } from '../../utils';
 import { TooltipContainer } from '../Reference';
 import { ViewContent, LegendPosition, PresentationOptions } from '../../types';
-import { PieChartConfig } from '@tupaia/types';
 
 const Heading = styled(Typography)`
   font-weight: 500;
@@ -119,7 +119,7 @@ export const PieChart = ({
   const [activeIndex, setActiveIndex] = useState(-1);
   const { presentationOptions, data } = viewContent;
   // eslint-disable-next-line no-unused-vars
-  const [_, setLoaded] = useState(false);
+  const [, setLoaded] = useState(false);
 
   const isMobileSize = isMobile(isExporting);
 
@@ -146,7 +146,10 @@ export const PieChart = ({
 
   const getValidData = () =>
     data
-      .filter(element => element.value > 0)
+      .filter(({ value }) => {
+        if (typeof value === 'number') return value > 0;
+        return parseFloat(value) > 0;
+      })
       .map(item => {
         const { name, ...otherKeyValues } = item;
         // Map names to labels if available

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -63,7 +63,6 @@
     "faker": "^4.1.0",
     "fast-glob": "^3.2.5",
     "react-docgen-typescript-plugin": "^1.0.5",
-    "react-password-strength-bar": "^0.3.3",
-    "typescript": "^5.0.4"
+    "react-password-strength-bar": "^0.3.3"
   }
 }

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -35,7 +35,7 @@
     "jszip": "^3.10.1",
     "lodash.throttle": "^4.1.1",
     "markdown-to-jsx": "^6.4.1",
-    "moment": "^2.29.1",
+    "moment": "^2.24.0",
     "prop-types": "^15.7.2",
     "qrcode": "^1.5.3",
     "react": "^16.13.1",

--- a/packages/ui-map-components/package.json
+++ b/packages/ui-map-components/package.json
@@ -28,7 +28,7 @@
     "@tupaia/ui-components": "1.0.0",
     "@tupaia/utils": "1.0.0",
     "leaflet": "^1.7.1",
-    "moment": "^2.29.1",
+    "moment": "^2.24.0",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/packages/web-config-server/package.json
+++ b/packages/web-config-server/package.json
@@ -59,7 +59,7 @@
     "lodash.sumby": "^4.6.0",
     "lodash.tail": "^4.1.1",
     "lodash.zipobject": "^4.1.3",
-    "moment": "^2.22.2",
+    "moment": "^2.24.0",
     "morgan": "^1.9.0",
     "nodemailer": "^4.6.7",
     "promise": "^7.3.1",

--- a/packages/web-frontend/package.json
+++ b/packages/web-frontend/package.json
@@ -56,7 +56,7 @@
     "markdown-to-jsx": "^6.4.1",
     "material-ui": "^0.18.3",
     "material-ui-datetimepicker": "^1.0.7",
-    "moment": "^2.21.0",
+    "moment": "^2.24.0",
     "numeral": "^2.0.6",
     "polished": "^3.0.0",
     "prop-types": "^15.6.2",

--- a/tupaia-packages.code-workspace
+++ b/tupaia-packages.code-workspace
@@ -249,7 +249,8 @@
       "**/lib": true,
       "**/logfile*.log": true,
       "**/yarn-1.18.0.js": true
-    }
+    },
+    "typescript.tsdk": "root/node_modules/typescript/lib"
   },
   "extensions": {
     "recommendations": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -12323,7 +12323,6 @@ __metadata:
     react-router: 6.3.0
     react-router-dom: 6.3.0
     styled-components: ^5.1.0
-    typescript: ^5.0.2
     vite: ^4.3.2
     yup: ^1.3.2
   languageName: unknown
@@ -12825,7 +12824,6 @@ __metadata:
     react-router-dom: 6.3.0
     storybook: ^7.0.18
     styled-components: ^5.1.0
-    typescript: ^5.0.2
     vite: ^4.3.2
     vite-plugin-ejs: ^1.6.4
     vite-plugin-env-compatible: ^1.1.1
@@ -12910,7 +12908,6 @@ __metadata:
     react-router-dom: ^5.1.2
     react-table: ^7.7.0
     styled-components: ^5.0.1
-    typescript: ^5.0.4
     xlsx: ^0.17.0
   languageName: unknown
   linkType: soft
@@ -14730,19 +14727,19 @@ __metadata:
   linkType: hard
 
 "@typescript-eslint/parser@npm:^4.18.0, @typescript-eslint/parser@npm:^4.4.1":
-  version: 4.19.0
-  resolution: "@typescript-eslint/parser@npm:4.19.0"
+  version: 4.33.0
+  resolution: "@typescript-eslint/parser@npm:4.33.0"
   dependencies:
-    "@typescript-eslint/scope-manager": 4.19.0
-    "@typescript-eslint/types": 4.19.0
-    "@typescript-eslint/typescript-estree": 4.19.0
-    debug: ^4.1.1
+    "@typescript-eslint/scope-manager": 4.33.0
+    "@typescript-eslint/types": 4.33.0
+    "@typescript-eslint/typescript-estree": 4.33.0
+    debug: ^4.3.1
   peerDependencies:
     eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: ea5dae1492477861ba71b201bc0917b7b9a4364fb0981d2c7184687bf292ce5e05b824d2797e1a64ec0a6eee42dd8e5fea17878983574b7355320117d5f27850
+  checksum: 102457eae1acd516211098fea081c8a2ed728522bbda7f5a557b6ef23d88970514f9a0f6285d53fca134d3d4d7d17822b5d5e12438d5918df4d1f89cc9e67d57
   languageName: node
   linkType: hard
 
@@ -14800,16 +14797,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:4.19.0":
-  version: 4.19.0
-  resolution: "@typescript-eslint/scope-manager@npm:4.19.0"
-  dependencies:
-    "@typescript-eslint/types": 4.19.0
-    "@typescript-eslint/visitor-keys": 4.19.0
-  checksum: e55946ea064bad5228c96c2624825c292d5fdb19b7813f2dc9a22a6574a70e63fcc059360980eed85c97565bf52c615b0bbd3c40a177ece10456ea40ea5ddb9d
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/scope-manager@npm:4.31.1":
   version: 4.31.1
   resolution: "@typescript-eslint/scope-manager@npm:4.31.1"
@@ -14817,6 +14804,16 @@ __metadata:
     "@typescript-eslint/types": 4.31.1
     "@typescript-eslint/visitor-keys": 4.31.1
   checksum: 386442e7713df96cf32565e0f3caff173a9206630f385c1cfa09f11d8b4479a9f51572a4b795e4b68b2740bacebd1bb3a3de5a69bee564bc28dbce4b035ed3fb
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/scope-manager@npm:4.33.0":
+  version: 4.33.0
+  resolution: "@typescript-eslint/scope-manager@npm:4.33.0"
+  dependencies:
+    "@typescript-eslint/types": 4.33.0
+    "@typescript-eslint/visitor-keys": 4.33.0
+  checksum: 9a25fb7ba7c725ea7227a24d315b0f6aacbad002e2549a049edf723c1d3615c22f5c301f0d7d615b377f2cdf2f3519d97e79af0c459de6ef8d2aaf0906dff13e
   languageName: node
   linkType: hard
 
@@ -14851,17 +14848,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:4.19.0":
-  version: 4.19.0
-  resolution: "@typescript-eslint/types@npm:4.19.0"
-  checksum: e745fb8f9fd335e2e822c97ec332fc8b70e95bb4dff7e650e1851c5550116ede9ac54fb6f5d4375ae0ce2d9155eeef532a870f09a04bd9491f6eafccd8c13e4c
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/types@npm:4.31.1":
   version: 4.31.1
   resolution: "@typescript-eslint/types@npm:4.31.1"
   checksum: 08b5cf0d02fbf946a4b10e93279e3253287e4826ee744e7d3f38d7da241aaa6fce2743e448f9cdf36d93c20259e17248e50b9fffdff59e1c878289acca0c2d65
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/types@npm:4.33.0":
+  version: 4.33.0
+  resolution: "@typescript-eslint/types@npm:4.33.0"
+  checksum: 3baae1ca35872421b4eb60f5d3f3f32dc1d513f2ae0a67dee28c7d159fd7a43ed0d11a8a5a0f0c2d38507ffa036fc7c511cb0f18a5e8ac524b3ebde77390ec53
   languageName: node
   linkType: hard
 
@@ -14928,24 +14925,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:4.19.0":
-  version: 4.19.0
-  resolution: "@typescript-eslint/typescript-estree@npm:4.19.0"
-  dependencies:
-    "@typescript-eslint/types": 4.19.0
-    "@typescript-eslint/visitor-keys": 4.19.0
-    debug: ^4.1.1
-    globby: ^11.0.1
-    is-glob: ^4.0.1
-    semver: ^7.3.2
-    tsutils: ^3.17.1
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: e28563086ea38dd058403edf83b22723945b3f08feb00e92b2bcb646e2b2d3073f036150f99be2123ec94e9d74c28016c9862912bbc1cef9872446fb8360b03b
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/typescript-estree@npm:4.31.1":
   version: 4.31.1
   resolution: "@typescript-eslint/typescript-estree@npm:4.31.1"
@@ -14961,6 +14940,24 @@ __metadata:
     typescript:
       optional: true
   checksum: 1780223f52fde98fcfef4e7d9a59fc811232f608800e6a69b73789aad34ddf43fc9d4041707baa88b25cf88c223a7f2a749cf084dc45d89de44a803b29e19eb3
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/typescript-estree@npm:4.33.0":
+  version: 4.33.0
+  resolution: "@typescript-eslint/typescript-estree@npm:4.33.0"
+  dependencies:
+    "@typescript-eslint/types": 4.33.0
+    "@typescript-eslint/visitor-keys": 4.33.0
+    debug: ^4.3.1
+    globby: ^11.0.3
+    is-glob: ^4.0.1
+    semver: ^7.3.5
+    tsutils: ^3.21.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 2566984390c76bd95f43240057215c068c69769e406e27aba41e9f21fd300074d6772e4983fa58fe61e80eb5550af1548d2e31e80550d92ba1d051bb00fe6f5c
   languageName: node
   linkType: hard
 
@@ -15029,16 +15026,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:4.19.0":
-  version: 4.19.0
-  resolution: "@typescript-eslint/visitor-keys@npm:4.19.0"
-  dependencies:
-    "@typescript-eslint/types": 4.19.0
-    eslint-visitor-keys: ^2.0.0
-  checksum: 32f5b5315d54d05a16cd97f70577d79c93d3d4608cd9418a868eba769d4c4d81fce6d73b26ed616375716c7e51d180fb6d08a897166b29cbd1a420d55d621bb8
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/visitor-keys@npm:4.31.1":
   version: 4.31.1
   resolution: "@typescript-eslint/visitor-keys@npm:4.31.1"
@@ -15046,6 +15033,16 @@ __metadata:
     "@typescript-eslint/types": 4.31.1
     eslint-visitor-keys: ^2.0.0
   checksum: 14a86bf96a41a81feba32f5acbb72539345a33f250b2f17968dc7b9f4ae9eca00209a11dd208b9c6305f5a841a9f809713027c0ed969465e2d62a042d116bdc9
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:4.33.0":
+  version: 4.33.0
+  resolution: "@typescript-eslint/visitor-keys@npm:4.33.0"
+  dependencies:
+    "@typescript-eslint/types": 4.33.0
+    eslint-visitor-keys: ^2.0.0
+  checksum: 59953e474ad4610c1aa23b2b1a964445e2c6201521da6367752f37939d854352bbfced5c04ea539274065e012b1337ba3ffa49c2647a240a4e87155378ba9873
   languageName: node
   linkType: hard
 
@@ -23652,18 +23649,18 @@ __metadata:
   linkType: hard
 
 "eslint-import-resolver-typescript@npm:^2.4.0":
-  version: 2.4.0
-  resolution: "eslint-import-resolver-typescript@npm:2.4.0"
+  version: 2.7.1
+  resolution: "eslint-import-resolver-typescript@npm:2.7.1"
   dependencies:
-    debug: ^4.1.1
-    glob: ^7.1.6
-    is-glob: ^4.0.1
-    resolve: ^1.17.0
-    tsconfig-paths: ^3.9.0
+    debug: ^4.3.4
+    glob: ^7.2.0
+    is-glob: ^4.0.3
+    resolve: ^1.22.0
+    tsconfig-paths: ^3.14.1
   peerDependencies:
     eslint: "*"
     eslint-plugin-import: "*"
-  checksum: 2db0de33531f563bbbeecbdb080e3ff7ac0dbdd01f82ed690ccc9b29f746e431bf639322b1f1384f5c67055104c722cf70d9bf837d3ef70d6f3cf4ec2ba6562d
+  checksum: 1d81b657b1f73bf95b8f0b745c0305574b91630c1db340318f3ca8918e206fce20a933b95e7c419338cc4452cb80bb2b2d92acaf01b6aa315c78a332d832545c
   languageName: node
   linkType: hard
 
@@ -31814,6 +31811,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json5@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "json5@npm:1.0.2"
+  dependencies:
+    minimist: ^1.2.0
+  bin:
+    json5: lib/cli.js
+  checksum: 866458a8c58a95a49bef3adba929c625e82532bcff1fe93f01d29cb02cac7c3fe1f4b79951b7792c2da9de0b32871a8401a6e3c5b36778ad852bf5b8a61165d7
+  languageName: node
+  linkType: hard
+
 "json5@npm:^2.1.2":
   version: 2.1.3
   resolution: "json5@npm:2.1.3"
@@ -34643,7 +34651,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimist@npm:^1.2.3":
+"minimist@npm:^1.2.3, minimist@npm:^1.2.6":
   version: 1.2.8
   resolution: "minimist@npm:1.2.8"
   checksum: 75a6d645fb122dad29c06a7597bddea977258957ed88d7a6df59b5cd3fe4a527e253e9bbf2e783e4b73657f9098b96a5fe96ab8a113655d4109108577ecf85b0
@@ -42293,6 +42301,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"resolve@npm:^1.22.0":
+  version: 1.22.8
+  resolution: "resolve@npm:1.22.8"
+  dependencies:
+    is-core-module: ^2.13.0
+    path-parse: ^1.0.7
+    supports-preserve-symlinks-flag: ^1.0.0
+  bin:
+    resolve: bin/resolve
+  checksum: f8a26958aa572c9b064562750b52131a37c29d072478ea32e129063e2da7f83e31f7f11e7087a18225a8561cfe8d2f0df9dbea7c9d331a897571c0a2527dbb4c
+  languageName: node
+  linkType: hard
+
 "resolve@npm:^2.0.0-next.4":
   version: 2.0.0-next.5
   resolution: "resolve@npm:2.0.0-next.5"
@@ -42354,6 +42375,19 @@ __metadata:
   dependencies:
     path-parse: ^1.0.6
   checksum: 6fd799f282ddf078c4bc20ce863e3af01fa8cb218f0658d9162c57161a2dbafe092b13015b9a4c58d0e1e801cf7aa7a4f13115fea9db98c3f9a0c43e429bad6f
+  languageName: node
+  linkType: hard
+
+"resolve@patch:resolve@^1.22.0#~builtin<compat/resolve>":
+  version: 1.22.8
+  resolution: "resolve@patch:resolve@npm%3A1.22.8#~builtin<compat/resolve>::version=1.22.8&hash=07638b"
+  dependencies:
+    is-core-module: ^2.13.0
+    path-parse: ^1.0.7
+    supports-preserve-symlinks-flag: ^1.0.0
+  bin:
+    resolve: bin/resolve
+  checksum: 5479b7d431cacd5185f8db64bfcb7286ae5e31eb299f4c4f404ad8aa6098b77599563ac4257cb2c37a42f59dfc06a1bec2bcf283bb448f319e37f0feb9a09847
   languageName: node
   linkType: hard
 
@@ -45976,6 +46010,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tsconfig-paths@npm:^3.14.1":
+  version: 3.14.2
+  resolution: "tsconfig-paths@npm:3.14.2"
+  dependencies:
+    "@types/json5": ^0.0.29
+    json5: ^1.0.2
+    minimist: ^1.2.6
+    strip-bom: ^3.0.0
+  checksum: a6162eaa1aed680537f93621b82399c7856afd10ec299867b13a0675e981acac4e0ec00896860480efc59fc10fd0b16fdc928c0b885865b52be62cadac692447
+  languageName: node
+  linkType: hard
+
 "tsconfig-paths@npm:^3.9.0":
   version: 3.9.0
   resolution: "tsconfig-paths@npm:3.9.0"
@@ -46143,7 +46189,7 @@ __metadata:
     npm-package-json-lint: 5.1.0
     ts-jest: ^27.1.3
     ts-node: ^10.7.0
-    typescript: ^4.2.0
+    typescript: ^5.2.2
     vite: ^4.4.8
     vite-plugin-ejs: ^1.6.4
     yargs: 15.4.1
@@ -46420,23 +46466,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.2.0":
-  version: 4.2.3
-  resolution: "typescript@npm:4.2.3"
+"typescript@npm:^5.2.2":
+  version: 5.3.2
+  resolution: "typescript@npm:5.3.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: b4a2020c021211184ac15caf59936b2089c13e79685f340a31aaa839c9de2f73b44a5e3757292de6cdad2ed967aef80d4592161b814cc29c0570f261850c4bca
-  languageName: node
-  linkType: hard
-
-"typescript@npm:^5.0.2, typescript@npm:^5.0.4":
-  version: 5.1.6
-  resolution: "typescript@npm:5.1.6"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: b2f2c35096035fe1f5facd1e38922ccb8558996331405eb00a5111cc948b2e733163cc22fab5db46992aba7dd520fff637f2c1df4996ff0e134e77d3249a7350
+  checksum: d92534dda639eb825db013203404c1fabca8ac630564283c9e7dc9e64fd9c9346c2de95ecebdf3e6e8c1c32941bca1cfe0da37877611feb9daf8feeaea58d230
   languageName: node
   linkType: hard
 
@@ -46450,23 +46486,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.2.0#~builtin<compat/typescript>":
-  version: 4.2.3
-  resolution: "typescript@patch:typescript@npm%3A4.2.3#~builtin<compat/typescript>::version=4.2.3&hash=7ad353"
+"typescript@patch:typescript@^5.2.2#~builtin<compat/typescript>":
+  version: 5.3.2
+  resolution: "typescript@patch:typescript@npm%3A5.3.2#~builtin<compat/typescript>::version=5.3.2&hash=7ad353"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: f00e6e6e72c950865979d5beb66916c75d92eda09514eb2953828b95505cfd2ef3ae9ac776fdac9f841a9ce67744999b70d23779726e0072656a1841c8080860
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@^5.0.2#~builtin<compat/typescript>, typescript@patch:typescript@^5.0.4#~builtin<compat/typescript>":
-  version: 5.1.6
-  resolution: "typescript@patch:typescript@npm%3A5.1.6#~builtin<compat/typescript>::version=5.1.6&hash=7ad353"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 21e88b0a0c0226f9cb9fd25b9626fb05b4c0f3fddac521844a13e1f30beb8f14e90bd409a9ac43c812c5946d714d6e0dee12d5d02dfc1c562c5aacfa1f49b606
+  checksum: c034461079fbfde3cb584ddee52afccb15b6e32a0ce186d0b2719968786f7ca73e1b07f71fac4163088790b16811c6ccf79680de190664ef66ff0ba9c1fe4a23
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12008,7 +12008,7 @@ __metadata:
     lodash.groupby: ^4.6.0
     lodash.keyby: ^4.6.0
     lodash.throttle: ^4.1.1
-    moment: ^2.22.2
+    moment: ^2.24.0
     npm-run-all: ^4.1.5
     parse-link-header: ^2.0.0
     prop-types: ^15.6.0
@@ -12344,7 +12344,7 @@ __metadata:
     chai-as-promised: ^7.1.1
     lodash.groupby: ^4.6.0
     lodash.keyby: ^4.6.0
-    moment: ^2.22.2
+    moment: ^2.24.0
     npm-run-all: ^4.1.5
     simple-oauth2: ^1.5.0
     urlencode: ^1.1.0
@@ -12369,7 +12369,7 @@ __metadata:
     js-beautify: ^1.13.0
     lodash: ^4.17.4
     markdown-to-jsx: ^6.4.1
-    moment: ^2.21.0
+    moment: ^2.24.0
     moment-timezone: ^0.5.14
     node-fetch: ^1.7.3
     npm-run-all: ^4.1.5
@@ -12470,7 +12470,7 @@ __metadata:
     leaflet: ^1.7.1
     lodash.debounce: ^4.0.8
     lodash.keyby: ^4.6.0
-    moment: ^2.22.2
+    moment: ^2.24.0
     npm-run-all: ^4.1.5
     prop-types: ^15.7.2
     query-string: ^5.1.1
@@ -12541,7 +12541,7 @@ __metadata:
     eslint: ^8.19.0
     jest: ^29.2.1
     metro-react-native-babel-preset: 0.76.8
-    moment: ^2.29.4
+    moment: ^2.24.0
     nanoid: ^2.0.3
     prettier: ^2.4.1
     prop-types: ^15.8.1
@@ -12814,7 +12814,7 @@ __metadata:
     axios: ^1.4.0
     dom-to-image: 2.6.0
     downloadjs: 1.4.7
-    moment: ^2.29.1
+    moment: ^2.24.0
     npm-run-all: ^4.1.5
     react: ^16.13.1
     react-dom: ^16.13.1
@@ -12856,7 +12856,7 @@ __metadata:
     "@types/lodash.get": ^4.4.7
     "@types/recharts": ^1.8.24
     lodash.get: ^4.4.2
-    moment: ^2.29.1
+    moment: ^2.24.0
     prop-types: ^15.7.2
     react: ^16.13.1
     react-dom: ^16.13.1
@@ -12897,7 +12897,7 @@ __metadata:
     jszip: ^3.10.1
     lodash.throttle: ^4.1.1
     markdown-to-jsx: ^6.4.1
-    moment: ^2.29.1
+    moment: ^2.24.0
     prop-types: ^15.7.2
     qrcode: ^1.5.3
     react: ^16.13.1
@@ -12929,7 +12929,7 @@ __metadata:
     "@types/react-dom": ^16.9.18
     "@types/styled-components": ^5.1.26
     leaflet: ^1.7.1
-    moment: ^2.29.1
+    moment: ^2.24.0
     prop-types: ^15.7.2
     react: ^16.13.1
     react-docgen-typescript-plugin: ^1.0.5
@@ -13019,7 +13019,7 @@ __metadata:
     lodash.sumby: ^4.6.0
     lodash.tail: ^4.1.1
     lodash.zipobject: ^4.1.3
-    moment: ^2.22.2
+    moment: ^2.24.0
     morgan: ^1.9.0
     nodemailer: ^4.6.7
     promise: ^7.3.1
@@ -13066,7 +13066,7 @@ __metadata:
     material-ui: ^0.18.3
     material-ui-datetimepicker: ^1.0.7
     mockdate: ^3.0.5
-    moment: ^2.21.0
+    moment: ^2.24.0
     npm-run-all: ^4.1.5
     numeral: ^2.0.6
     object-assign: 4.1.1
@@ -34947,7 +34947,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"moment@npm:2.x.x, moment@npm:>= 2.9.0, moment@npm:^2.21.0, moment@npm:^2.22.2, moment@npm:^2.24.0":
+"moment@npm:2.x.x, moment@npm:>= 2.9.0, moment@npm:^2.24.0":
   version: 2.24.0
   resolution: "moment@npm:2.24.0"
   checksum: 9cd93a251a2b33cb1b532eade0e496a2a7547faa6cfe37a283ee7bf69e202cd7c8ab0673d66883b5b29aed051353176dc0e6684f04073a75b0a155c500be1580

--- a/yarn.lock
+++ b/yarn.lock
@@ -6515,15 +6515,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@beyondessential/eslint-config-ts@npm:^1.3.2":
-  version: 1.3.2
-  resolution: "@beyondessential/eslint-config-ts@npm:1.3.2"
+"@beyondessential/eslint-config-ts@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@beyondessential/eslint-config-ts@npm:2.0.0"
   dependencies:
-    "@typescript-eslint/eslint-plugin": ^4.18.0
-    "@typescript-eslint/parser": ^4.18.0
-    eslint-config-airbnb-typescript: ^12.3.1
+    "@typescript-eslint/eslint-plugin": ^5.62.0
+    "@typescript-eslint/parser": ^5.62.0
+    eslint-config-airbnb-typescript: ^17.1.0
     eslint-config-prettier: ^8.1.0
-    eslint-import-resolver-typescript: ^2.4.0
+    eslint-import-resolver-typescript: ^3.6.1
     eslint-plugin-import: ^2.22.0
     eslint-plugin-jsx-a11y: ^6.3.1
     eslint-plugin-prettier: ^3.3.1
@@ -6536,8 +6536,8 @@ __metadata:
     prettier: ">= 2.2.1"
     prop-types: ^15.0
     react: ">=16.8"
-    typescript: ">=4.2.0"
-  checksum: f408e20bb0da39f3e040fa50769f162f7caebcc5a747976c26aa0d1f25a2b60f9b0ebd1ef9b4da2d156c0cfc291842e0fd73598d33d32eb0b9f1e2dbcf371f69
+    typescript: ">=5.2.2"
+  checksum: 83aa2eefc37cf305a621416fe2f92758a65d4d4573d77b46484fa553b6ba8d54a759b9c120b3a2fc3341b02507d327b8148e47a30076907cc6c53a922dfe23c4
   languageName: node
   linkType: hard
 
@@ -14726,23 +14726,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:^4.18.0, @typescript-eslint/parser@npm:^4.4.1":
-  version: 4.33.0
-  resolution: "@typescript-eslint/parser@npm:4.33.0"
-  dependencies:
-    "@typescript-eslint/scope-manager": 4.33.0
-    "@typescript-eslint/types": 4.33.0
-    "@typescript-eslint/typescript-estree": 4.33.0
-    debug: ^4.3.1
-  peerDependencies:
-    eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 102457eae1acd516211098fea081c8a2ed728522bbda7f5a557b6ef23d88970514f9a0f6285d53fca134d3d4d7d17822b5d5e12438d5918df4d1f89cc9e67d57
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/parser@npm:^4.5.0":
   version: 4.31.1
   resolution: "@typescript-eslint/parser@npm:4.31.1"
@@ -14760,7 +14743,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:^5.30.5":
+"@typescript-eslint/parser@npm:^5.30.5, @typescript-eslint/parser@npm:^5.62.0":
   version: 5.62.0
   resolution: "@typescript-eslint/parser@npm:5.62.0"
   dependencies:
@@ -14807,16 +14790,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:4.33.0":
-  version: 4.33.0
-  resolution: "@typescript-eslint/scope-manager@npm:4.33.0"
-  dependencies:
-    "@typescript-eslint/types": 4.33.0
-    "@typescript-eslint/visitor-keys": 4.33.0
-  checksum: 9a25fb7ba7c725ea7227a24d315b0f6aacbad002e2549a049edf723c1d3615c22f5c301f0d7d615b377f2cdf2f3519d97e79af0c459de6ef8d2aaf0906dff13e
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/scope-manager@npm:5.62.0":
   version: 5.62.0
   resolution: "@typescript-eslint/scope-manager@npm:5.62.0"
@@ -14852,13 +14825,6 @@ __metadata:
   version: 4.31.1
   resolution: "@typescript-eslint/types@npm:4.31.1"
   checksum: 08b5cf0d02fbf946a4b10e93279e3253287e4826ee744e7d3f38d7da241aaa6fce2743e448f9cdf36d93c20259e17248e50b9fffdff59e1c878289acca0c2d65
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/types@npm:4.33.0":
-  version: 4.33.0
-  resolution: "@typescript-eslint/types@npm:4.33.0"
-  checksum: 3baae1ca35872421b4eb60f5d3f3f32dc1d513f2ae0a67dee28c7d159fd7a43ed0d11a8a5a0f0c2d38507ffa036fc7c511cb0f18a5e8ac524b3ebde77390ec53
   languageName: node
   linkType: hard
 
@@ -14943,24 +14909,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:4.33.0":
-  version: 4.33.0
-  resolution: "@typescript-eslint/typescript-estree@npm:4.33.0"
-  dependencies:
-    "@typescript-eslint/types": 4.33.0
-    "@typescript-eslint/visitor-keys": 4.33.0
-    debug: ^4.3.1
-    globby: ^11.0.3
-    is-glob: ^4.0.1
-    semver: ^7.3.5
-    tsutils: ^3.21.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 2566984390c76bd95f43240057215c068c69769e406e27aba41e9f21fd300074d6772e4983fa58fe61e80eb5550af1548d2e31e80550d92ba1d051bb00fe6f5c
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/typescript-estree@npm:5.62.0":
   version: 5.62.0
   resolution: "@typescript-eslint/typescript-estree@npm:5.62.0"
@@ -15033,16 +14981,6 @@ __metadata:
     "@typescript-eslint/types": 4.31.1
     eslint-visitor-keys: ^2.0.0
   checksum: 14a86bf96a41a81feba32f5acbb72539345a33f250b2f17968dc7b9f4ae9eca00209a11dd208b9c6305f5a841a9f809713027c0ed969465e2d62a042d116bdc9
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/visitor-keys@npm:4.33.0":
-  version: 4.33.0
-  resolution: "@typescript-eslint/visitor-keys@npm:4.33.0"
-  dependencies:
-    "@typescript-eslint/types": 4.33.0
-    eslint-visitor-keys: ^2.0.0
-  checksum: 59953e474ad4610c1aa23b2b1a964445e2c6201521da6367752f37939d854352bbfced5c04ea539274065e012b1337ba3ffa49c2647a240a4e87155378ba9873
   languageName: node
   linkType: hard
 
@@ -22936,6 +22874,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"enhanced-resolve@npm:^5.12.0":
+  version: 5.15.0
+  resolution: "enhanced-resolve@npm:5.15.0"
+  dependencies:
+    graceful-fs: ^4.2.4
+    tapable: ^2.2.0
+  checksum: fbd8cdc9263be71cc737aa8a7d6c57b43d6aa38f6cc75dde6fcd3598a130cc465f979d2f4d01bb3bf475acb43817749c79f8eef9be048683602ca91ab52e4f11
+  languageName: node
+  linkType: hard
+
 "enquirer@npm:^2.3.5":
   version: 2.3.5
   resolution: "enquirer@npm:2.3.5"
@@ -23539,14 +23487,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-config-airbnb-typescript@npm:^12.3.1":
-  version: 12.3.1
-  resolution: "eslint-config-airbnb-typescript@npm:12.3.1"
+"eslint-config-airbnb-base@npm:^15.0.0":
+  version: 15.0.0
+  resolution: "eslint-config-airbnb-base@npm:15.0.0"
   dependencies:
-    "@typescript-eslint/parser": ^4.4.1
-    eslint-config-airbnb: ^18.2.0
-    eslint-config-airbnb-base: ^14.2.0
-  checksum: 2aac9d736c0bcb778a8b6894aa7e061f2454895e0e4cc7bc1247074c4c54d777212f9523539b57b49c2e09abe64f0b95d8571196f04e471db9d764f88aff697a
+    confusing-browser-globals: ^1.0.10
+    object.assign: ^4.1.2
+    object.entries: ^1.1.5
+    semver: ^6.3.0
+  peerDependencies:
+    eslint: ^7.32.0 || ^8.2.0
+    eslint-plugin-import: ^2.25.2
+  checksum: 38626bad2ce2859fccac86b30cd2b86c9b7d8d71d458331860861dc05290a5b198bded2f4fb89efcb9046ec48f8ab4c4fb00365ba8916f27b172671da28b93ea
+  languageName: node
+  linkType: hard
+
+"eslint-config-airbnb-typescript@npm:^17.1.0":
+  version: 17.1.0
+  resolution: "eslint-config-airbnb-typescript@npm:17.1.0"
+  dependencies:
+    eslint-config-airbnb-base: ^15.0.0
+  peerDependencies:
+    "@typescript-eslint/eslint-plugin": ^5.13.0 || ^6.0.0
+    "@typescript-eslint/parser": ^5.0.0 || ^6.0.0
+    eslint: ^7.32.0 || ^8.2.0
+    eslint-plugin-import: ^2.25.3
+  checksum: cfd26a2782e322ebfdfbf9a64262332c7653f297c4a32d7b951079eb18bb9502a83d67b3f7ef2cc1c5374ae06098eb454ed010784b3416e7274839083022a08c
   languageName: node
   linkType: hard
 
@@ -23648,19 +23614,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-import-resolver-typescript@npm:^2.4.0":
-  version: 2.7.1
-  resolution: "eslint-import-resolver-typescript@npm:2.7.1"
+"eslint-import-resolver-typescript@npm:^3.6.1":
+  version: 3.6.1
+  resolution: "eslint-import-resolver-typescript@npm:3.6.1"
   dependencies:
     debug: ^4.3.4
-    glob: ^7.2.0
+    enhanced-resolve: ^5.12.0
+    eslint-module-utils: ^2.7.4
+    fast-glob: ^3.3.1
+    get-tsconfig: ^4.5.0
+    is-core-module: ^2.11.0
     is-glob: ^4.0.3
-    resolve: ^1.22.0
-    tsconfig-paths: ^3.14.1
   peerDependencies:
     eslint: "*"
     eslint-plugin-import: "*"
-  checksum: 1d81b657b1f73bf95b8f0b745c0305574b91630c1db340318f3ca8918e206fce20a933b95e7c419338cc4452cb80bb2b2d92acaf01b6aa315c78a332d832545c
+  checksum: 454fa0646533050fb57f13d27daf8c71f51b0bb9156d6a461290ccb8576d892209fcc6702a89553f3f5ea8e5b407395ca2e5de169a952c953685f1f7c46b4496
   languageName: node
   linkType: hard
 
@@ -23681,6 +23649,18 @@ __metadata:
     debug: ^3.2.7
     pkg-dir: ^2.0.0
   checksum: 814591f494e4f4b04c1af0fde2a679e7a7664a5feb51175e02ba96d671e34ec60cb1835d174508eb81c07a6c92c243f84c6349f4169b3bec1a8dbdd36a0934f3
+  languageName: node
+  linkType: hard
+
+"eslint-module-utils@npm:^2.7.4":
+  version: 2.8.0
+  resolution: "eslint-module-utils@npm:2.8.0"
+  dependencies:
+    debug: ^3.2.7
+  peerDependenciesMeta:
+    eslint:
+      optional: true
+  checksum: 74c6dfea7641ebcfe174be61168541a11a14aa8d72e515f5f09af55cd0d0862686104b0524aa4b8e0ce66418a44aa38a94d2588743db5fd07a6b49ffd16921d2
   languageName: node
   linkType: hard
 
@@ -24990,6 +24970,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-glob@npm:^3.3.1":
+  version: 3.3.2
+  resolution: "fast-glob@npm:3.3.2"
+  dependencies:
+    "@nodelib/fs.stat": ^2.0.2
+    "@nodelib/fs.walk": ^1.2.3
+    glob-parent: ^5.1.2
+    merge2: ^1.3.0
+    micromatch: ^4.0.4
+  checksum: 900e4979f4dbc3313840078419245621259f349950411ca2fa445a2f9a1a6d98c3b5e7e0660c5ccd563aa61abe133a21765c6c0dec8e57da1ba71d8000b05ec1
+  languageName: node
+  linkType: hard
+
 "fast-json-parse@npm:^1.0.3":
   version: 1.0.3
   resolution: "fast-json-parse@npm:1.0.3"
@@ -26239,6 +26232,15 @@ __metadata:
     call-bind: ^1.0.2
     get-intrinsic: ^1.1.1
   checksum: 9ceff8fe968f9270a37a1f73bf3f1f7bda69ca80f4f80850670e0e7b9444ff99323f7ac52f96567f8b5f5fbe7ac717a0d81d3407c7313e82810c6199446a5247
+  languageName: node
+  linkType: hard
+
+"get-tsconfig@npm:^4.5.0":
+  version: 4.7.2
+  resolution: "get-tsconfig@npm:4.7.2"
+  dependencies:
+    resolve-pkg-maps: ^1.0.0
+  checksum: 172358903250eff0103943f816e8a4e51d29b8e5449058bdf7266714a908a48239f6884308bd3a6ff28b09f692b9533dbebfd183ab63e4e14f073cda91f1bca9
   languageName: node
   linkType: hard
 
@@ -28571,7 +28573,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-core-module@npm:^2.13.0":
+"is-core-module@npm:^2.11.0, is-core-module@npm:^2.13.0":
   version: 2.13.1
   resolution: "is-core-module@npm:2.13.1"
   dependencies:
@@ -31811,17 +31813,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json5@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "json5@npm:1.0.2"
-  dependencies:
-    minimist: ^1.2.0
-  bin:
-    json5: lib/cli.js
-  checksum: 866458a8c58a95a49bef3adba929c625e82532bcff1fe93f01d29cb02cac7c3fe1f4b79951b7792c2da9de0b32871a8401a6e3c5b36778ad852bf5b8a61165d7
-  languageName: node
-  linkType: hard
-
 "json5@npm:^2.1.2":
   version: 2.1.3
   resolution: "json5@npm:2.1.3"
@@ -34651,7 +34642,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimist@npm:^1.2.3, minimist@npm:^1.2.6":
+"minimist@npm:^1.2.3":
   version: 1.2.8
   resolution: "minimist@npm:1.2.8"
   checksum: 75a6d645fb122dad29c06a7597bddea977258957ed88d7a6df59b5cd3fe4a527e253e9bbf2e783e4b73657f9098b96a5fe96ab8a113655d4109108577ecf85b0
@@ -36261,7 +36252,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object.entries@npm:^1.1.6":
+"object.entries@npm:^1.1.5, object.entries@npm:^1.1.6":
   version: 1.1.7
   resolution: "object.entries@npm:1.1.7"
   dependencies:
@@ -42218,6 +42209,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"resolve-pkg-maps@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "resolve-pkg-maps@npm:1.0.0"
+  checksum: 1012afc566b3fdb190a6309cc37ef3b2dcc35dff5fa6683a9d00cd25c3247edfbc4691b91078c97adc82a29b77a2660c30d791d65dab4fc78bfc473f60289977
+  languageName: node
+  linkType: hard
+
 "resolve-url-loader@npm:^3.1.2":
   version: 3.1.4
   resolution: "resolve-url-loader@npm:3.1.4"
@@ -42301,19 +42299,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.22.0":
-  version: 1.22.8
-  resolution: "resolve@npm:1.22.8"
-  dependencies:
-    is-core-module: ^2.13.0
-    path-parse: ^1.0.7
-    supports-preserve-symlinks-flag: ^1.0.0
-  bin:
-    resolve: bin/resolve
-  checksum: f8a26958aa572c9b064562750b52131a37c29d072478ea32e129063e2da7f83e31f7f11e7087a18225a8561cfe8d2f0df9dbea7c9d331a897571c0a2527dbb4c
-  languageName: node
-  linkType: hard
-
 "resolve@npm:^2.0.0-next.4":
   version: 2.0.0-next.5
   resolution: "resolve@npm:2.0.0-next.5"
@@ -42375,19 +42360,6 @@ __metadata:
   dependencies:
     path-parse: ^1.0.6
   checksum: 6fd799f282ddf078c4bc20ce863e3af01fa8cb218f0658d9162c57161a2dbafe092b13015b9a4c58d0e1e801cf7aa7a4f13115fea9db98c3f9a0c43e429bad6f
-  languageName: node
-  linkType: hard
-
-"resolve@patch:resolve@^1.22.0#~builtin<compat/resolve>":
-  version: 1.22.8
-  resolution: "resolve@patch:resolve@npm%3A1.22.8#~builtin<compat/resolve>::version=1.22.8&hash=07638b"
-  dependencies:
-    is-core-module: ^2.13.0
-    path-parse: ^1.0.7
-    supports-preserve-symlinks-flag: ^1.0.0
-  bin:
-    resolve: bin/resolve
-  checksum: 5479b7d431cacd5185f8db64bfcb7286ae5e31eb299f4c4f404ad8aa6098b77599563ac4257cb2c37a42f59dfc06a1bec2bcf283bb448f319e37f0feb9a09847
   languageName: node
   linkType: hard
 
@@ -45116,6 +45088,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tapable@npm:^2.2.0":
+  version: 2.2.1
+  resolution: "tapable@npm:2.2.1"
+  checksum: 3b7a1b4d86fa940aad46d9e73d1e8739335efd4c48322cb37d073eb6f80f5281889bf0320c6d8ffcfa1a0dd5bfdbd0f9d037e252ef972aca595330538aac4d51
+  languageName: node
+  linkType: hard
+
 "tar-fs@npm:2.1.1, tar-fs@npm:^2.0.0, tar-fs@npm:^2.1.1":
   version: 2.1.1
   resolution: "tar-fs@npm:2.1.1"
@@ -46010,18 +45989,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsconfig-paths@npm:^3.14.1":
-  version: 3.14.2
-  resolution: "tsconfig-paths@npm:3.14.2"
-  dependencies:
-    "@types/json5": ^0.0.29
-    json5: ^1.0.2
-    minimist: ^1.2.6
-    strip-bom: ^3.0.0
-  checksum: a6162eaa1aed680537f93621b82399c7856afd10ec299867b13a0675e981acac4e0ec00896860480efc59fc10fd0b16fdc928c0b885865b52be62cadac692447
-  languageName: node
-  linkType: hard
-
 "tsconfig-paths@npm:^3.9.0":
   version: 3.9.0
   resolution: "tsconfig-paths@npm:3.9.0"
@@ -46171,7 +46138,7 @@ __metadata:
     "@babel/types": ^7.23.0
     "@beyondessential/eslint-config-jest": ^1.0.0
     "@beyondessential/eslint-config-js": ^1.1.1
-    "@beyondessential/eslint-config-ts": ^1.3.2
+    "@beyondessential/eslint-config-ts": ^2.0.0
     "@vitejs/plugin-react": ^4.0.4
     babel-eslint: ^10.1.0
     babel-jest: ^27.0.6


### PR DESCRIPTION
It'd be good to get everything in the monorepo on the same version of typescript. Keeps things simpler.