### PR TITLE
no-issue: Fix camel case keys type

### DIFF
--- a/packages/types/generate-schemas.ts
+++ b/packages/types/generate-schemas.ts
@@ -14,6 +14,18 @@ const settings: TJS.PartialArgs = {
   noExtraProps: true,
 };
 
+function getTsFiles(dir: string): string[] {
+  const dirContents = fs.readdirSync(dir);
+  const files = dirContents
+    .map(dirItem => {
+      const res = resolve(dir, dirItem);
+      return fs.statSync(res).isDirectory() ? getTsFiles(res) : res;
+    })
+    .flat();
+
+  return files.filter(fileName => fileName.endsWith('.ts'));
+}
+
 const HEADER = `/*
  * Tupaia
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
@@ -26,10 +38,13 @@ const HEADER = `/*
  */
 `;
 
+const rootDir = 'src/types';
+const filesToBuildSchemasFor = getTsFiles(rootDir);
+
 const { filename, typesPath } = config as any;
 
 const program = TJS.getProgramFromFiles([resolve(typesPath)]);
-const schemas = TJS.generateSchema(program, '*', settings);
+const schemas = TJS.generateSchema(program, '*', settings, filesToBuildSchemasFor);
 
 if (schemas?.definitions) {
   let fileContents = HEADER;

--- a/packages/types/src/schemas/schemas.ts
+++ b/packages/types/src/schemas/schemas.ts
@@ -26457,6 +26457,18 @@ export const IconKeySchema = {
 	"type": "string"
 } 
 
+export const ScaleTypeSchema = {
+	"enum": [
+		"gpi",
+		"neutral",
+		"neutralReverse",
+		"performance",
+		"performanceDesc",
+		"time"
+	],
+	"type": "string"
+} 
+
 export const MeasureTypeSchema = {
 	"enum": [
 		"color",
@@ -27771,6 +27783,36 @@ export const ClinicUpdateSchema = {
 		}
 	},
 	"additionalProperties": false
+} 
+
+export const CommentSchema = {
+	"type": "object",
+	"properties": {
+		"created_time": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"id": {
+			"type": "string"
+		},
+		"last_modified_time": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"text": {
+			"type": "string"
+		},
+		"user_id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"created_time",
+		"id",
+		"last_modified_time",
+		"text"
+	]
 } 
 
 export const CommentCreateSchema = {
@@ -59374,27 +59416,8 @@ export const DataTablePreviewRequestSchema = {
 	]
 } 
 
-export const CamelCaseSchema = {
+export const ParamsSchema = {
 	"description": "Tupaia\nCopyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd",
-	"type": "array",
-	"items": {
-		"type": "string"
-	}
-} 
-
-export const CamelCasePartSchema = {
-	"type": "array",
-	"items": {
-		"type": "string"
-	}
-} 
-
-export const ObjectToCamelSchema = {
-	"type": "object",
-	"additionalProperties": false
-} 
-
-export const KeysToCamelCaseSchema = {
 	"type": "object",
 	"additionalProperties": false
 } 

--- a/packages/types/src/utils/casing.ts
+++ b/packages/types/src/utils/casing.ts
@@ -16,14 +16,10 @@ type CamelCasePart<S extends string> = S extends `${infer First}_${infer Rest}`
 
 // Converts a type object to camel case, from snake case
 export type ObjectToCamel<T> = {
-  [K in keyof T as CamelCase<string & K>]: T[K] extends Record<string, any>
-    ? KeysToCamelCase<T[K]>
-    : T[K];
+  [K in keyof T as CamelCase<string & K>]: KeysToCamelCase<T[K]>;
 };
 
 // Converts type objects or arrays to camel case
-export type KeysToCamelCase<T> = {
-  [K in keyof T as CamelCase<string & K>]: T[K] extends Array<any>
-    ? KeysToCamelCase<T[K][number]>[]
-    : ObjectToCamel<T[K]>;
-};
+export type KeysToCamelCase<T> = T extends Array<infer ArrayElm>
+  ? KeysToCamelCase<ArrayElm>[] // If array, camel case items
+  : ObjectToCamel<T>; // If object, camel case keys;


### PR DESCRIPTION
The camel-case keys type wasn't working correctly when being passed an array with nested objects. Reworked it to handle this, but as part of that had to change how we build the schemas to not include the util types. This is a win since we don't want schemas for those util types anyway.