### PR TITLE
no-issue: Nitpicky GUI tweaks and tidy-ups

### DIFF
--- a/packages/database/src/modelClasses/SurveyResponse.js
+++ b/packages/database/src/modelClasses/SurveyResponse.js
@@ -37,7 +37,8 @@ export class SurveyResponseModel extends MaterializedViewLogDatabaseModel {
     return this.database.executeSql(
       `SELECT r.user_id, user_account.first_name, user_account.last_name, r.coconuts, r.pigs
         FROM (
-          SELECT user_id, COUNT(*) as coconuts, FLOOR(COUNT(*) / 100) as pigs
+          SELECT user_id, FLOOR(COUNT(*)) as coconuts, FLOOR(COUNT(*) / 100) as pigs
+          --              ^~~~~~~~~~~~~~~ FLOOR to force result to be returned as int, not string
           FROM survey_response
           JOIN survey on survey.id=survey_id
           ${projectId ? 'WHERE (survey.project_id = ? OR survey.project_id IS NULL)' : ''}

--- a/packages/datatrak-web/src/features/Leaderboard/LeaderboardTable.tsx
+++ b/packages/datatrak-web/src/features/Leaderboard/LeaderboardTable.tsx
@@ -66,8 +66,7 @@ const FooterRow = styled(Row)`
 const Cell = styled(TableCell)<{
   $isActiveUser?: boolean;
 }>`
-  padding-top: 0.3rem;
-  padding-bottom: 0.3rem;
+  padding-block: 0.3rem;
   border: none;
   font-weight: ${({ $isActiveUser, theme }) =>
     $isActiveUser ? theme.typography.fontWeightMedium : theme.typography.fontWeightRegular};
@@ -86,8 +85,7 @@ const Cell = styled(TableCell)<{
 `;
 
 const HeaderCell = styled(Cell)`
-  padding-top: 0;
-  padding-bottom: 0;
+  padding-block: 0;
   line-height: 1.4;
   font-weight: ${({ theme }) => theme.typography.fontWeightMedium};
 `;
@@ -131,7 +129,7 @@ export const LeaderboardTable = ({ userRewards, user, leaderboard }: Leaderboard
         </Body>
         <TableFooter>
           <FooterRow>
-            <FooterCell>-</FooterCell>
+            <FooterCell>&mdash;</FooterCell>
             <FooterCell>{user?.userName}</FooterCell>
             <FooterCell>{userRewards?.coconuts}</FooterCell>
           </FooterRow>

--- a/packages/datatrak-web/src/features/Leaderboard/LeaderboardTable.tsx
+++ b/packages/datatrak-web/src/features/Leaderboard/LeaderboardTable.tsx
@@ -122,7 +122,7 @@ export const LeaderboardTable = ({ userRewards, user, leaderboard }: Leaderboard
                 <Cell $isActiveUser={isActiveUser}>
                   {firstName} {lastName}
                 </Cell>
-                <Cell $isActiveUser={isActiveUser}>{coconuts}</Cell>
+                <Cell $isActiveUser={isActiveUser}>{coconuts.toLocaleString()}</Cell>
               </Row>
             );
           })}

--- a/packages/datatrak-web/src/features/Leaderboard/LeaderboardTable.tsx
+++ b/packages/datatrak-web/src/features/Leaderboard/LeaderboardTable.tsx
@@ -11,81 +11,67 @@ import {
   TableBody,
   TableCell,
   TableContainer as MuiTableContainer,
+  TableFooter,
   TableHead,
   TableRow,
-  TableFooter,
 } from '@material-ui/core';
 import { UserRewards } from '../../types';
 
 const TableContainer = styled(MuiTableContainer)`
-  padding: 0.2rem 1.6rem;
-  flex: 1;
-  display: flex;
-  flex-direction: column;
+  font-variant-numeric: tabular-nums;
+  height: 100%;
+  padding: 1rem 1.6rem;
+
   table {
-    display: flex;
-    flex-direction: column;
-    flex: 1;
+    height: 100%;
   }
-  thead,
-  tfoot {
-    display: flex;
+
+  table thead,
+  table tfoot {
+    font-weight: ${({ theme }) => theme.typography.fontWeightMedium};
+  }
+
+  table tr {
+    height: 8.33333333%;
+    min-height: fit-content;
+    vertical-align: baseline;
+  }
+
+  table th,
+  table td {
+    padding: 0.5rem 1rem;
   }
 `;
 
-const Row = styled(TableRow)`
-  display: flex;
-  width: 100%;
-`;
-
-const HeaderRow = styled(Row)`
+const HeaderRow = styled(TableRow)`
   border-bottom: 1px solid ${({ theme }) => theme.palette.divider};
-  padding: 0.4rem 0;
-  margin-bottom: 0.5rem;
-  @media screen and (min-height: 900px) {
-    padding: 0.6rem 0;
-  }
 `;
 
-const Body = styled(TableBody)<{
-  $rowCount?: number;
-}>`
-  display: flex;
-  flex-direction: column;
-  justify-content: ${({ $rowCount = 0 }) => ($rowCount < 10 ? 'flex-start' : 'space-between')};
-  width: 100%;
-  flex: 1;
-`;
-
-const FooterRow = styled(Row)`
+const FooterRow = styled(TableRow)`
   border-top: 1px solid ${({ theme }) => theme.palette.divider};
-  padding: 0.3rem 0;
-  margin-top: 0.3rem;
 `;
 
 const Cell = styled(TableCell)<{
   $isActiveUser?: boolean;
 }>`
-  padding-block: 0.3rem;
   border: none;
+  color: ${({ theme }) => theme.palette.text.primary};
+  font-size: 0.875rem;
   font-weight: ${({ $isActiveUser, theme }) =>
     $isActiveUser ? theme.typography.fontWeightMedium : theme.typography.fontWeightRegular};
-  font-size: 0.875rem;
-  color: ${({ theme }) => theme.palette.text.primary};
-  width: 55%;
-  text-align: left;
+  text-align: start;
+
   &:first-child {
     font-weight: ${({ theme }) => theme.typography.fontWeightMedium};
-    width: 20%;
+    text-align: end;
   }
+
   &:last-child {
-    text-align: right;
-    width: 25%;
+    text-align: end;
   }
 `;
 
 const HeaderCell = styled(Cell)`
-  padding-block: 0;
   line-height: 1.4;
   font-weight: ${({ theme }) => theme.typography.fontWeightMedium};
 `;
@@ -113,20 +99,20 @@ export const LeaderboardTable = ({ userRewards, user, leaderboard }: Leaderboard
             <HeaderCell>Score</HeaderCell>
           </HeaderRow>
         </TableHead>
-        <Body $rowCount={leaderboard?.length}>
+        <TableBody>
           {leaderboard?.map(({ userId, firstName, lastName, coconuts }, i) => {
             const isActiveUser = user && user.id === userId;
             return (
-              <Row key={userId}>
+              <TableRow key={userId}>
                 <Cell>{i + 1}</Cell>
                 <Cell $isActiveUser={isActiveUser}>
                   {firstName} {lastName}
                 </Cell>
                 <Cell $isActiveUser={isActiveUser}>{coconuts.toLocaleString()}</Cell>
-              </Row>
+              </TableRow>
             );
           })}
-        </Body>
+        </TableBody>
         <TableFooter>
           <FooterRow>
             <FooterCell>&mdash;</FooterCell>

--- a/packages/datatrak-web/src/features/Leaderboard/UserRewardsSection.tsx
+++ b/packages/datatrak-web/src/features/Leaderboard/UserRewardsSection.tsx
@@ -43,11 +43,11 @@ export const UserRewardsSection = ({ pigs, coconuts }: UserRewards) => {
     <Wrapper>
       <UserRewardItem>
         <Pig />
-        <UserRewardCount>{pigs} Pigs</UserRewardCount>
+        <UserRewardCount>{pigs}&nbsp;pigs</UserRewardCount>
       </UserRewardItem>
       <UserRewardItem>
         <Coconut />
-        <UserRewardCount>{coconuts} Coconuts</UserRewardCount>
+        <UserRewardCount>{coconuts}&nbsp;coconuts</UserRewardCount>
       </UserRewardItem>
     </Wrapper>
   );

--- a/packages/datatrak-web/src/layout/UserMenu/MenuList.tsx
+++ b/packages/datatrak-web/src/layout/UserMenu/MenuList.tsx
@@ -69,7 +69,7 @@ export const MenuList = ({
         },
         helpCentre,
         {
-          label: 'Logout',
+          label: 'Log out',
           onClick: onClickLogout,
           component: 'button',
         },

--- a/packages/datatrak-web/src/layout/UserMenu/MenuList.tsx
+++ b/packages/datatrak-web/src/layout/UserMenu/MenuList.tsx
@@ -13,8 +13,6 @@ import { ROUTES } from '../../constants';
 
 const Menu = styled.ul`
   list-style: none;
-  margin-block-start: 0;
-  margin-block-end: 0;
   padding-inline-start: 0;
   margin: 0.5rem 0;
 `;

--- a/packages/datatrak-web/src/layout/UserMenu/UserInfo.tsx
+++ b/packages/datatrak-web/src/layout/UserMenu/UserInfo.tsx
@@ -104,7 +104,7 @@ export const UserInfo = ({ openProjectModal }: { openProjectModal: () => void })
           <AuthLink variant="text" to={ROUTES.REGISTER}>
             Register
           </AuthLink>
-          <LoginLink to={ROUTES.LOGIN}>Login</LoginLink>
+          <LoginLink to={ROUTES.LOGIN}>Log in</LoginLink>
         </AuthButtons>
       )}
     </Wrapper>

--- a/packages/datatrak-web/src/layout/UserMenu/UserInfo.tsx
+++ b/packages/datatrak-web/src/layout/UserMenu/UserInfo.tsx
@@ -48,6 +48,7 @@ const ProjectButton = styled(Button).attrs({
   }
   color: ${props => props.theme.palette.text.secondary};
   &:hover {
+    background: none;
     color: ${props => props.theme.palette.action.hover};
     text-decoration: underline;
   }

--- a/packages/datatrak-web/src/layout/UserMenu/UserInfo.tsx
+++ b/packages/datatrak-web/src/layout/UserMenu/UserInfo.tsx
@@ -19,14 +19,13 @@ const Wrapper = styled.div`
 `;
 
 const Details = styled.div`
-  display: flex;
   align-items: center;
+  display: flex;
+  gap: 0.5rem;
+  padding-inline: 0.5rem;
   > span {
     color: ${props => props.theme.palette.text.primary};
-    position: relative;
-    top: -1px;
     font-size: 1.2em;
-    margin-left: 0.5rem;
   }
   ${({ theme }) => theme.breakpoints.down('sm')} {
     display: none;
@@ -36,12 +35,9 @@ const Details = styled.div`
 const ProjectButton = styled(Button).attrs({
   variant: 'text',
 })`
-  margin-left: 0.5rem;
-  padding-left: 0;
-  padding-right: 0.5rem;
+  padding-inline: 0;
   justify-content: center;
   .MuiButton-label {
-    padding-left: 0.5rem;
     font-size: 1rem;
     line-height: 1.4;
     font-weight: ${({ theme }) => theme.typography.fontWeightRegular};
@@ -57,6 +53,7 @@ const ProjectButton = styled(Button).attrs({
     content: '';
     border-left: 1px solid ${props => props.theme.palette.text.secondary};
     height: 1.2rem;
+    margin-inline-end: 0.5rem;
   }
 `;
 

--- a/packages/datatrak-web/src/views/AccountSettingsPage/DeleteAccountSection/UserDetails.tsx
+++ b/packages/datatrak-web/src/views/AccountSettingsPage/DeleteAccountSection/UserDetails.tsx
@@ -69,10 +69,10 @@ export const UserDetails = () => {
       </div>
       <UserRewards>
         <UserRewardsItem>
-          <Pig /> {userRewards?.pigs} Pigs
+          <Pig /> {userRewards?.pigs}&nbsp;pigs
         </UserRewardsItem>
         <UserRewardsItem>
-          <Coconut /> {userRewards?.coconuts} Coconuts
+          <Coconut /> {userRewards?.coconuts}&nbsp;coconuts
         </UserRewardsItem>
       </UserRewards>
     </UserContent>

--- a/packages/datatrak-web/src/views/LandingPage/SurveySelectSection.tsx
+++ b/packages/datatrak-web/src/views/LandingPage/SurveySelectSection.tsx
@@ -129,7 +129,7 @@ export const SurveySelectSection = () => (
           <DesktopText>
             You can use Tupaia DataTrak to complete surveys (and collect coconuts!), share news,
             stories and information with the Tupaia community. To collect data offline, please
-            download our mobile app, Tupaia MediTrak from Google Play or the Apple App Store.
+            download our mobile app, Tupaia MediTrak, from Google Play or the Apple App Store.
           </DesktopText>
         </Text>
       </TextWrapper>

--- a/packages/tupaia-web/src/views/ForgotPasswordModal.tsx
+++ b/packages/tupaia-web/src/views/ForgotPasswordModal.tsx
@@ -46,8 +46,8 @@ const CheckEmailMessage = styled.p`
 `;
 
 const LinkText = styled(Typography)`
-  font-size: 11px;
-  line-height: 15px;
+  font-size: 0.6875rem;
+  line-height: 1.4;
   color: white;
 
   a {

--- a/packages/tupaia-web/src/views/ForgotPasswordModal.tsx
+++ b/packages/tupaia-web/src/views/ForgotPasswordModal.tsx
@@ -96,9 +96,9 @@ export const ForgotPasswordModal = () => {
           <AuthModalButton type="submit" isLoading={isLoading}>
             Reset password
           </AuthModalButton>
-          <CancelButton modal={MODAL_ROUTES.LOGIN}>Back to log in</CancelButton>
+          <CancelButton modal={MODAL_ROUTES.LOGIN}>Back to login</CancelButton>
           <LinkText align="center">
-            Don't have an account?{' '}
+            Don&rsquo;t have an account?{' '}
             <RouterLink modal={MODAL_ROUTES.REGISTER}>Register here</RouterLink>
           </LinkText>
         </StyledForm>

--- a/packages/tupaia-web/src/views/LoginModal.tsx
+++ b/packages/tupaia-web/src/views/LoginModal.tsx
@@ -68,7 +68,7 @@ export const LoginModal = () => {
           Log in
         </AuthModalButton>
         <LinkText align="center">
-          Don't have an account?{' '}
+          Don&rsquo;t have an account?{' '}
           <RouterLink modal={MODAL_ROUTES.REGISTER}>Register here</RouterLink>
         </LinkText>
       </StyledForm>

--- a/packages/tupaia-web/src/views/LoginModal.tsx
+++ b/packages/tupaia-web/src/views/LoginModal.tsx
@@ -23,8 +23,8 @@ const StyledForm = styled(Form)`
 
 const LinkText = styled(Typography)`
   font-weight: 400;
-  font-size: 11px;
-  line-height: 15px;
+  font-size: 0.6875rem;
+  line-height: 1.4;
   color: white;
 
   a {

--- a/packages/tupaia-web/src/views/ProjectsModal.tsx
+++ b/packages/tupaia-web/src/views/ProjectsModal.tsx
@@ -125,7 +125,7 @@ export const ProjectsModal = () => {
       <div>
         <Logo src={TUPAIA_LIGHT_LOGO_SRC} alt="Tupaia logo" />
         <TagLine>
-          Data aggregation, analysis, and visualisation for the most remote settings in the world.
+          Data aggregation, analysis, and visualisation for the most remote settings in the world
         </TagLine>
       </div>
       <div>

--- a/packages/ui-components/src/features/Auth/ForgotPasswordForm.tsx
+++ b/packages/ui-components/src/features/Auth/ForgotPasswordForm.tsx
@@ -83,7 +83,7 @@ export const ForgotPasswordForm = ({
             Back to log in
           </AuthSubmitButton>
           <AuthLink align="center">
-            Don't have an account? <RouterLink to={registerLink}>Register here</RouterLink>
+            Don&rsquo;t have an account? <RouterLink to={registerLink}>Register here</RouterLink>
           </AuthLink>
         </StyledForm>
       )}

--- a/packages/ui-components/src/features/Auth/LoginForm.tsx
+++ b/packages/ui-components/src/features/Auth/LoginForm.tsx
@@ -90,7 +90,7 @@ export const LoginForm = ({
           Log in
         </AuthSubmitButton>
         <AuthLink>
-          Don't have an account? <RouterLink to={registerLink}>Register here</RouterLink>
+          Don&rsquo;t have an account? <RouterLink to={registerLink}>Register here</RouterLink>
         </AuthLink>
       </StyledForm>
     </Wrapper>

--- a/packages/ui-components/src/features/Auth/ResetPasswordForm/ResetPasswordSuccess.tsx
+++ b/packages/ui-components/src/features/Auth/ResetPasswordForm/ResetPasswordSuccess.tsx
@@ -46,7 +46,7 @@ export const ResetPasswordSuccess = ({ loginLink }: PasswordResetSuccessProps) =
     <Wrapper>
       <CheckIcon />
       <Title>Password reset!</Title>
-      <Description>Your password has been successfully reset.</Description>
+      <Description>Your password has been successfully reset</Description>
       <AuthSubmitButton to={loginLink} component={RouterLink}>
         Back to login
       </AuthSubmitButton>

--- a/packages/web-frontend/src/containers/SearchBar/index.js
+++ b/packages/web-frontend/src/containers/SearchBar/index.js
@@ -195,7 +195,7 @@ export class SearchBar extends PureComponent {
           onControlBlur={() => onSearchBlur(isExpanded, isSafeToCloseResults)}
           isExpanded={isExpanded}
           onExpandClick={() => onExpandClick()}
-          hintText="Search Location"
+          hintText="Search location"
         >
           <div
             onMouseLeave={() => this.setState({ isSafeToCloseResults: true })}


### PR DESCRIPTION
### Changes

Various minor tweaks to Tupaia.org and DataTrak GUIs.

- Remove `background-color` hover effect on project button in navbar (at request of Felicity in internal communications).
- `getLeaderboard()` now returns `coconuts` count as a number, rather than a string. (Probably safe to assume this was the original intention anyway. This seems to be a quirk of Knex.js.)
- Fixed some misalignment in navbar.
- Correct some uses of “log in” vs “login” (ditto “log out” vs “logout”).
- More consistent casing (specifically sentence case) and punctuation in accordance with [Material UI style guide](https://m3.material.io/foundations/content-design/style-guide/ux-writing-best-practices).
- Non-breaking spaces between values and units.
- Refactor CSS styling of DataTrak leaderboard to improve readability. (Visually basically the same—a refactor in the truest sense.)