### PR TITLE
no-issue: Make entity.type NOT NULL

### DIFF
--- a/packages/database/src/migrations/20231204032614-MakeEntityTypeNotNull-modifies-schema.js
+++ b/packages/database/src/migrations/20231204032614-MakeEntityTypeNotNull-modifies-schema.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function (db) {
+  return db.runSql(`ALTER TABLE entity ALTER COLUMN type SET NOT NULL;`);
+};
+
+exports.down = function (db) {
+  return db.runSql(`ALTER TABLE entity ALTER COLUMN type DROP NOT NULL;`);
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/packages/datatrak-web-server/src/__tests__/processSurveyResponse.test.ts
+++ b/packages/datatrak-web-server/src/__tests__/processSurveyResponse.test.ts
@@ -2,7 +2,7 @@
  * Tupaia
  *  Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
  */
-import { QuestionType } from '@tupaia/types';
+import { EntityType, QuestionType } from '@tupaia/types';
 import { getBrowserTimeZone, getUniqueSurveyQuestionFileName } from '@tupaia/utils';
 import { generateId } from '@tupaia/database';
 import { processSurveyResponse } from '../routes/SubmitSurvey/processSurveyResponse';
@@ -19,6 +19,7 @@ const mockFindEntityById = async (id: string) => ({
   id: 'theEntityId',
   code: 'theEntityCode',
   name: 'The Entity Name',
+  type: 'facility' as EntityType,
 });
 
 jest.mock('@tupaia/database', () => ({

--- a/packages/datatrak-web/src/views/SurveySelectPage/SurveyCountrySelector.tsx
+++ b/packages/datatrak-web/src/views/SurveySelectPage/SurveyCountrySelector.tsx
@@ -5,6 +5,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Select as BaseSelect } from '@tupaia/ui-components';
+import { Country } from '@tupaia/types';
 import { Entity } from '../../types';
 
 const Select = styled(BaseSelect)`
@@ -40,7 +41,7 @@ const CountrySelectWrapper = styled.div`
 
 interface SurveyCountrySelectorProps {
   countries: Entity[];
-  selectedCountry?: Entity | null;
+  selectedCountry?: Country | null;
   onChangeCountry: (country: Entity | null) => void;
 }
 
@@ -55,11 +56,8 @@ export const SurveyCountrySelector = ({
   return (
     <CountrySelectWrapper>
       <Pin />
-      {/** @ts-ignore - TS is complaining about the type of the options, because we are creating them from Entities */}
       <Select
-        options={
-          countries?.map((country: Entity) => ({ value: country.code, label: country.name })) || []
-        }
+        options={countries?.map(country => ({ value: country.code, label: country.name })) || []}
         value={selectedCountry?.code}
         onChange={updateSelectedCountry}
         inputProps={{ 'aria-label': 'Select a country' }}

--- a/packages/datatrak-web/src/views/SurveySelectPage/SurveySelectPage.tsx
+++ b/packages/datatrak-web/src/views/SurveySelectPage/SurveySelectPage.tsx
@@ -11,9 +11,9 @@ import { useEditUser } from '../../api/mutations';
 import { SelectList, ListItemType, Button, SurveyFolderIcon, SurveyIcon } from '../../components';
 import { Survey } from '../../types';
 import { useSurveys, useCurrentUser } from '../../api';
+import { HEADER_HEIGHT } from '../../constants';
 import { SurveyCountrySelector } from './SurveyCountrySelector';
 import { useUserCountries } from './useUserCountries';
-import { HEADER_HEIGHT } from '../../constants';
 
 const Container = styled(Paper).attrs({
   variant: 'outlined',
@@ -77,7 +77,7 @@ const HeaderWrapper = styled.div`
     > div {
       width: auto;
     }
-  } ;
+  }
 `;
 
 const Subheader = styled(Typography).attrs({

--- a/packages/types/src/schemas/schemas.ts
+++ b/packages/types/src/schemas/schemas.ts
@@ -53541,7 +53541,8 @@ export const EntitySchema = {
 	"required": [
 		"code",
 		"id",
-		"name"
+		"name",
+		"type"
 	]
 } 
 
@@ -53613,7 +53614,8 @@ export const EntityCreateSchema = {
 	"additionalProperties": false,
 	"required": [
 		"code",
-		"name"
+		"name",
+		"type"
 	]
 } 
 
@@ -59327,7 +59329,8 @@ export const MeditrakSurveyResponseRequestSchema = {
 				"required": [
 					"code",
 					"id",
-					"name"
+					"name",
+					"type"
 				]
 			}
 		},
@@ -59566,7 +59569,8 @@ export const ResBodySchema = {
 		"required": [
 			"code",
 			"id",
-			"name"
+			"name",
+			"type"
 		]
 	}
 } 

--- a/packages/types/src/types/models.ts
+++ b/packages/types/src/types/models.ts
@@ -671,7 +671,7 @@ export interface Entity {
   'parent_id'?: string | null;
   'point'?: any | null;
   'region'?: any | null;
-  'type'?: EntityType | null;
+  'type': EntityType;
 }
 export interface EntityCreate {
   'attributes'?: any | null;
@@ -684,7 +684,7 @@ export interface EntityCreate {
   'parent_id'?: string | null;
   'point'?: any | null;
   'region'?: any | null;
-  'type'?: EntityType | null;
+  'type': EntityType;
 }
 export interface EntityUpdate {
   'attributes'?: any | null;
@@ -698,7 +698,7 @@ export interface EntityUpdate {
   'parent_id'?: string | null;
   'point'?: any | null;
   'region'?: any | null;
-  'type'?: EntityType | null;
+  'type'?: EntityType;
 }
 export interface EntityHierarchy {
   'canonical_types'?: string[] | null;

--- a/packages/types/src/types/requests/datatrak-web-server/UserRequest.ts
+++ b/packages/types/src/types/requests/datatrak-web-server/UserRequest.ts
@@ -4,9 +4,7 @@
  */
 
 import { ProjectResponse } from '../web-server';
-import { Entity } from '../../models';
-
-type Country = Pick<Entity, 'id' | 'name' | 'code'>;
+import { Country } from '../../models';
 
 export type Params = Record<string, never>;
 export interface ResBody {


### PR DESCRIPTION
The `type` column of the `entity` table being nullable makes typescript a bit more tricky in a few situations.
Having a `NULL` type is an invalid state, so ensuring this doesn't happen at the database level if useful.