### PR TITLE
RN-1073: Permissions for dashboard emailing

### DIFF
--- a/packages/admin-panel/src/pages/resources/DashboardMailingListsPage.jsx
+++ b/packages/admin-panel/src/pages/resources/DashboardMailingListsPage.jsx
@@ -6,6 +6,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { ResourcePage } from './ResourcePage';
+import { ArrayFilter } from '../../table/columnTypes/columnFilters';
+import { prettyArray } from '../../utilities';
 
 const DASHBOARD_MAILING_LIST_FIELDS = {
   project: {
@@ -50,6 +52,21 @@ const DASHBOARD_MAILING_LIST_FIELDS = {
       secondaryLabel: 'Select the entity this dashboard mailing list should be for',
     },
   },
+  email_admin_permission_groups: {
+    Header: 'Email admin permission groups',
+    source: 'email_admin_permission_groups',
+    Filter: ArrayFilter,
+    Cell: ({ value }) => prettyArray(value),
+    editConfig: {
+      optionsEndpoint: 'permissionGroups',
+      optionLabelKey: 'name',
+      optionValueKey: 'name',
+      sourceKey: 'email_admin_permission_groups',
+      allowMultipleValues: true,
+      secondaryLabel:
+        'Users with any of these permissions can send out the dashboard to the mailing list',
+    },
+  },
 };
 
 const DASHBOARD_MAILING_LIST_COLUMNS = [
@@ -65,6 +82,7 @@ const DASHBOARD_MAILING_LIST_COLUMNS = [
         DASHBOARD_MAILING_LIST_FIELDS.project,
         DASHBOARD_MAILING_LIST_FIELDS.dashboard_code,
         DASHBOARD_MAILING_LIST_FIELDS.entity_name,
+        DASHBOARD_MAILING_LIST_FIELDS.email_admin_permission_groups,
       ],
     },
   },
@@ -85,6 +103,7 @@ const CREATE_CONFIG = {
       DASHBOARD_MAILING_LIST_FIELDS.project,
       DASHBOARD_MAILING_LIST_FIELDS.dashboard_code,
       DASHBOARD_MAILING_LIST_FIELDS.entity_name,
+      DASHBOARD_MAILING_LIST_FIELDS.email_admin_permission_groups,
     ],
     title: 'New dashboard mailing list',
   },

--- a/packages/admin-panel/src/pages/resources/DashboardMailingListsPage.jsx
+++ b/packages/admin-panel/src/pages/resources/DashboardMailingListsPage.jsx
@@ -52,16 +52,16 @@ const DASHBOARD_MAILING_LIST_FIELDS = {
       secondaryLabel: 'Select the entity this dashboard mailing list should be for',
     },
   },
-  email_admin_permission_groups: {
-    Header: 'Email admin permission groups',
-    source: 'email_admin_permission_groups',
+  admin_permission_groups: {
+    Header: 'Admin permission groups',
+    source: 'admin_permission_groups',
     Filter: ArrayFilter,
     Cell: ({ value }) => prettyArray(value),
     editConfig: {
       optionsEndpoint: 'permissionGroups',
       optionLabelKey: 'name',
       optionValueKey: 'name',
-      sourceKey: 'email_admin_permission_groups',
+      sourceKey: 'admin_permission_groups',
       allowMultipleValues: true,
       secondaryLabel:
         'Users with any of these permissions can send out the dashboard to the mailing list',
@@ -82,7 +82,7 @@ const DASHBOARD_MAILING_LIST_COLUMNS = [
         DASHBOARD_MAILING_LIST_FIELDS.project,
         DASHBOARD_MAILING_LIST_FIELDS.dashboard_code,
         DASHBOARD_MAILING_LIST_FIELDS.entity_name,
-        DASHBOARD_MAILING_LIST_FIELDS.email_admin_permission_groups,
+        DASHBOARD_MAILING_LIST_FIELDS.admin_permission_groups,
       ],
     },
   },
@@ -103,7 +103,7 @@ const CREATE_CONFIG = {
       DASHBOARD_MAILING_LIST_FIELDS.project,
       DASHBOARD_MAILING_LIST_FIELDS.dashboard_code,
       DASHBOARD_MAILING_LIST_FIELDS.entity_name,
-      DASHBOARD_MAILING_LIST_FIELDS.email_admin_permission_groups,
+      DASHBOARD_MAILING_LIST_FIELDS.admin_permission_groups,
     ],
     title: 'New dashboard mailing list',
   },

--- a/packages/database/src/migrations/20231123022242-AddEmailAdminPermissionGroupsToDashboardMailingList-modifies-schema.js
+++ b/packages/database/src/migrations/20231123022242-AddEmailAdminPermissionGroupsToDashboardMailingList-modifies-schema.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = async function (db) {
+  await db.runSql(`
+    ALTER TABLE dashboard_mailing_list ADD COLUMN email_admin_permission_groups TEXT[] NOT NULL DEFAULT '{}';
+  `);
+};
+
+exports.down = async function (db) {
+  await db.runSql(`
+  ALTER TABLE survey DROP COLUMN email_admin_permission_groups;
+`);
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/packages/database/src/migrations/20231123022242-AddEmailAdminPermissionGroupsToDashboardMailingList-modifies-schema.js
+++ b/packages/database/src/migrations/20231123022242-AddEmailAdminPermissionGroupsToDashboardMailingList-modifies-schema.js
@@ -16,13 +16,13 @@ exports.setup = function (options, seedLink) {
 
 exports.up = async function (db) {
   await db.runSql(`
-    ALTER TABLE dashboard_mailing_list ADD COLUMN email_admin_permission_groups TEXT[] NOT NULL DEFAULT '{}';
+    ALTER TABLE dashboard_mailing_list ADD COLUMN admin_permission_groups TEXT[] NOT NULL DEFAULT '{}';
   `);
 };
 
 exports.down = async function (db) {
   await db.runSql(`
-  ALTER TABLE survey DROP COLUMN email_admin_permission_groups;
+  ALTER TABLE survey DROP COLUMN admin_permission_groups;
 `);
 };
 

--- a/packages/tsutils/src/typeGuards.ts
+++ b/packages/tsutils/src/typeGuards.ts
@@ -8,5 +8,13 @@ export const isDefined = <T>(value: T): value is Exclude<T, undefined> => value 
 export const isNotNullish = <T>(val: T): val is Exclude<T, undefined | null> =>
   val !== undefined && val !== null;
 
+export const ensure = <T>(val: T) => {
+  if (isNotNullish(val)) {
+    return val;
+  }
+
+  throw new Error(`Unexpected null or undefined value`);
+};
+
 export const isObject = (val: unknown): val is Record<string, unknown> =>
   typeof val === 'object' && val !== null && !Array.isArray(val);

--- a/packages/tsutils/src/typeGuards.ts
+++ b/packages/tsutils/src/typeGuards.ts
@@ -5,15 +5,17 @@
 
 export const isDefined = <T>(value: T): value is Exclude<T, undefined> => value !== undefined;
 
-export const isNotNullish = <T>(val: T): val is Exclude<T, undefined | null> =>
-  val !== undefined && val !== null;
+export const isNotNullish = <T>(val: T): val is NonNullable<T> => val !== undefined && val !== null;
+
+export function assertIsNotNullish<T>(val: T): asserts val is NonNullable<T> {
+  if (!isNotNullish(val)) {
+    throw new Error('Unexpected null or undefined value');
+  }
+}
 
 export const ensure = <T>(val: T) => {
-  if (isNotNullish(val)) {
-    return val;
-  }
-
-  throw new Error(`Unexpected null or undefined value`);
+  assertIsNotNullish(val);
+  return val;
 };
 
 export const isObject = (val: unknown): val is Record<string, unknown> =>

--- a/packages/tupaia-web-server/src/routes/DashboardsRoute.ts
+++ b/packages/tupaia-web-server/src/routes/DashboardsRoute.ts
@@ -182,6 +182,11 @@ export class DashboardsRoute extends Route<DashboardsRequest> {
               entry.subscribed,
           )
         : false,
+      isEmailAdmin: session
+        ? list.email_admin_permission_groups.some(permissionGroup =>
+            rootEntityPermissions.includes(permissionGroup),
+          )
+        : false,
     }));
 
     const dashboardsWithMetadata = dashboards.map(rawDashboard => {
@@ -197,9 +202,10 @@ export class DashboardsRoute extends Route<DashboardsRequest> {
           })),
         mailingLists: mailingLists
           .filter(list => list.dashboardId === dashboard.id)
-          .map(({ entityCode: mailingListEntityCode, isSubscribed }) => ({
+          .map(({ entityCode: mailingListEntityCode, isSubscribed, isEmailAdmin }) => ({
             entityCode: mailingListEntityCode,
             isSubscribed,
+            isEmailAdmin,
           })),
       };
     });

--- a/packages/tupaia-web-server/src/routes/DashboardsRoute.ts
+++ b/packages/tupaia-web-server/src/routes/DashboardsRoute.ts
@@ -153,7 +153,7 @@ export class DashboardsRoute extends Route<DashboardsRequest> {
             comparisonValue: dashboards.map(d => d.id),
           },
         },
-        columns: ['id', 'entity.code', 'dashboard_id', 'email_admin_permission_groups'],
+        columns: ['id', 'entity.code', 'dashboard_id', 'admin_permission_groups'],
         // Override the default limit of 100 records
         pageSize: DEFAULT_PAGE_SIZE,
       });
@@ -182,8 +182,8 @@ export class DashboardsRoute extends Route<DashboardsRequest> {
               entry.subscribed,
           )
         : false,
-      isEmailAdmin: session
-        ? list.email_admin_permission_groups.some(permissionGroup =>
+      isAdmin: session
+        ? list.admin_permission_groups.some(permissionGroup =>
             rootEntityPermissions.includes(permissionGroup),
           )
         : false,
@@ -202,10 +202,10 @@ export class DashboardsRoute extends Route<DashboardsRequest> {
           })),
         mailingLists: mailingLists
           .filter(list => list.dashboardId === dashboard.id)
-          .map(({ entityCode: mailingListEntityCode, isSubscribed, isEmailAdmin }) => ({
+          .map(({ entityCode: mailingListEntityCode, isSubscribed, isAdmin }) => ({
             entityCode: mailingListEntityCode,
             isSubscribed,
-            isEmailAdmin,
+            isAdmin,
           })),
       };
     });

--- a/packages/tupaia-web-server/src/routes/EmailDashboardRoute.ts
+++ b/packages/tupaia-web-server/src/routes/EmailDashboardRoute.ts
@@ -70,9 +70,9 @@ export class EmailDashboardRoute extends Route<EmailDashboardRequest> {
           project_id: project.id,
           entity_id: entity.id,
         },
-        columns: ['id', 'email_admin_permission_groups'],
+        columns: ['id', 'admin_permission_groups'],
       },
-    )) as Pick<DashboardMailingList, 'id' | 'email_admin_permission_groups'>[];
+    )) as Pick<DashboardMailingList, 'id' | 'admin_permission_groups'>[];
 
     if (!mailingList) {
       throw new Error(
@@ -81,7 +81,7 @@ export class EmailDashboardRoute extends Route<EmailDashboardRequest> {
     }
 
     if (
-      !mailingList.email_admin_permission_groups.some(permissionGroup =>
+      !mailingList.admin_permission_groups.some(permissionGroup =>
         entityPermissions.includes(permissionGroup),
       )
     ) {

--- a/packages/tupaia-web-server/src/routes/MapOverlaysRoute.ts
+++ b/packages/tupaia-web-server/src/routes/MapOverlaysRoute.ts
@@ -56,9 +56,11 @@ const integrateMapOverlayItemsReference = (children: OverlayChild[]) => {
   }
 
   // Delete all the same references
-  const noReferenceMapOverlayItems = children.map(mapOverlayItem => {
+  const noReferenceMapOverlayItems: OverlayChild[] = children.map(mapOverlayItem => {
     const { info, ...restValues } = mapOverlayItem;
-    delete info!.reference;
+    if (info) {
+      info.reference = undefined;
+    }
     return { ...restValues, info };
   });
 
@@ -112,11 +114,12 @@ export class MapOverlaysRoute extends Route<MapOverlaysRequest> {
     }
 
     // Breaking orchestration server convention and accessing the db directly
-    const mapOverlayRelations = await this.req.models.mapOverlayGroupRelation.findParentRelationTree(
-      mapOverlays
-        .filter((overlay: MapOverlay) => !overlay.config?.hideFromMenu)
-        .map((overlay: MapOverlay) => overlay.id),
-    );
+    const mapOverlayRelations =
+      await this.req.models.mapOverlayGroupRelation.findParentRelationTree(
+        mapOverlays
+          .filter((overlay: MapOverlay) => !overlay.config?.hideFromMenu)
+          .map((overlay: MapOverlay) => overlay.id),
+      );
 
     // Fetch all the groups we've used
     const overlayGroupIds: string[] = mapOverlayRelations.map(
@@ -167,10 +170,10 @@ export class MapOverlaysRoute extends Route<MapOverlaysRequest> {
         name: parentEntry.name,
         info,
         children: orderBy(children, [
-          (child: OverlayChild) => (child.sortOrder === null ? 1 : 0), // Puts null values last
+          child => (child.sortOrder === null ? 1 : 0), // Puts null values last
           'sortOrder',
           'name',
-        ]).map((child: OverlayChild) => {
+        ]).map(child => {
           // We only needed the sortOrder for sorting, strip it before we return
           const { sortOrder, ...restOfChild } = child;
           return restOfChild;

--- a/packages/tupaia-web/src/features/Dashboard/ExportDashboard/ExportSettings.tsx
+++ b/packages/tupaia-web/src/features/Dashboard/ExportDashboard/ExportSettings.tsx
@@ -14,9 +14,9 @@ import { useDashboards, useEntity, useProject } from '../../../api/queries';
 import { useExportDashboard } from '../../../api/mutations';
 import { PDFExport } from '../../../views';
 import { MOBILE_BREAKPOINT } from '../../../constants';
+import { useDashboardMailingList } from '../../../utils';
 import { ExportSettingLabel } from './ExportSettingLabel';
 import { ExportSettingsInstructions } from './ExportSettingsInstructions';
-import { useDashboardMailingList } from '../../../utils';
 import { MailingListButton } from './MailingListButton';
 
 const ButtonGroup = styled.div`
@@ -167,6 +167,7 @@ export const ExportSettings = ({ onClose, selectedDashboardItems = [] }: ExportD
   const { data: entity } = useEntity(projectCode, entityCode);
   const { activeDashboard } = useDashboards(projectCode, entityCode, dashboardName);
   const mailingList = useDashboardMailingList();
+  const showMailingListButton = mailingList && mailingList.isEmailAdmin;
   const [page, setPage] = useState(1);
   const onPageChange = (_: unknown, newPage: number) => setPage(newPage);
   const visualisationToPreview = selectedDashboardItems[page - 1];
@@ -233,8 +234,8 @@ export const ExportSettings = ({ onClose, selectedDashboardItems = [] }: ExportD
                   />
                 </fieldset>
               </FormGroup>
-              {mailingList ? <Divider /> : null}
-              {mailingList ? (
+              {showMailingListButton ? <Divider /> : null}
+              {showMailingListButton ? (
                 <MailingListButton selectedDashboardItems={selectedDashboardItems} />
               ) : null}
             </ExportSetting>

--- a/packages/tupaia-web/src/features/Dashboard/ExportDashboard/ExportSettings.tsx
+++ b/packages/tupaia-web/src/features/Dashboard/ExportDashboard/ExportSettings.tsx
@@ -167,7 +167,7 @@ export const ExportSettings = ({ onClose, selectedDashboardItems = [] }: ExportD
   const { data: entity } = useEntity(projectCode, entityCode);
   const { activeDashboard } = useDashboards(projectCode, entityCode, dashboardName);
   const mailingList = useDashboardMailingList();
-  const showMailingListButton = mailingList && mailingList.isEmailAdmin;
+  const showMailingListButton = mailingList && mailingList.isAdmin;
   const [page, setPage] = useState(1);
   const onPageChange = (_: unknown, newPage: number) => setPage(newPage);
   const visualisationToPreview = selectedDashboardItems[page - 1];

--- a/packages/tupaia-web/src/features/Dashboard/ExportDashboard/MailingListButton.tsx
+++ b/packages/tupaia-web/src/features/Dashboard/ExportDashboard/MailingListButton.tsx
@@ -85,7 +85,11 @@ export const MailingListButton = ({ selectedDashboardItems = [] }: ExportDashboa
     setSuccessMessage(result.message);
   };
 
-  const { mutate: requestEmailDashboard, isLoading, error } = useEmailDashboard({
+  const {
+    mutate: requestEmailDashboard,
+    isLoading,
+    error,
+  } = useEmailDashboard({
     onSuccess: handleEmailSuccess,
   });
 

--- a/packages/types/src/schemas/schemas.ts
+++ b/packages/types/src/schemas/schemas.ts
@@ -52024,6 +52024,12 @@ export const DashboardMailingListSchema = {
 		"dashboard_id": {
 			"type": "string"
 		},
+		"email_admin_permission_groups": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
 		"entity_id": {
 			"type": "string"
 		},
@@ -52037,6 +52043,7 @@ export const DashboardMailingListSchema = {
 	"additionalProperties": false,
 	"required": [
 		"dashboard_id",
+		"email_admin_permission_groups",
 		"entity_id",
 		"id",
 		"project_id"
@@ -52048,6 +52055,12 @@ export const DashboardMailingListCreateSchema = {
 	"properties": {
 		"dashboard_id": {
 			"type": "string"
+		},
+		"email_admin_permission_groups": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
 		},
 		"entity_id": {
 			"type": "string"
@@ -52069,6 +52082,12 @@ export const DashboardMailingListUpdateSchema = {
 	"properties": {
 		"dashboard_id": {
 			"type": "string"
+		},
+		"email_admin_permission_groups": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
 		},
 		"entity_id": {
 			"type": "string"

--- a/packages/types/src/schemas/schemas.ts
+++ b/packages/types/src/schemas/schemas.ts
@@ -60210,11 +60210,15 @@ export const MailingListSchema = {
 		},
 		"isSubscribed": {
 			"type": "boolean"
+		},
+		"isEmailAdmin": {
+			"type": "boolean"
 		}
 	},
 	"additionalProperties": false,
 	"required": [
 		"entityCode",
+		"isEmailAdmin",
 		"isSubscribed"
 	]
 } 
@@ -68247,11 +68251,15 @@ export const DashboardWithMetadataSchema = {
 					},
 					"isSubscribed": {
 						"type": "boolean"
+					},
+					"isEmailAdmin": {
+						"type": "boolean"
 					}
 				},
 				"additionalProperties": false,
 				"required": [
 					"entityCode",
+					"isEmailAdmin",
 					"isSubscribed"
 				]
 			}

--- a/packages/types/src/schemas/schemas.ts
+++ b/packages/types/src/schemas/schemas.ts
@@ -26156,10 +26156,7 @@ export const MapOverlayConfigSchema = {
 					"additionalProperties": false
 				}
 			},
-			"additionalProperties": false,
-			"required": [
-				"reference"
-			]
+			"additionalProperties": false
 		},
 		"isTimePeriodEditable": {
 			"type": "boolean"
@@ -54821,10 +54818,7 @@ export const MapOverlaySchema = {
 							"additionalProperties": false
 						}
 					},
-					"additionalProperties": false,
-					"required": [
-						"reference"
-					]
+					"additionalProperties": false
 				},
 				"isTimePeriodEditable": {
 					"type": "boolean"
@@ -55329,10 +55323,7 @@ export const MapOverlayCreateSchema = {
 							"additionalProperties": false
 						}
 					},
-					"additionalProperties": false,
-					"required": [
-						"reference"
-					]
+					"additionalProperties": false
 				},
 				"isTimePeriodEditable": {
 					"type": "boolean"
@@ -55831,10 +55822,7 @@ export const MapOverlayUpdateSchema = {
 							"additionalProperties": false
 						}
 					},
-					"additionalProperties": false,
-					"required": [
-						"reference"
-					]
+					"additionalProperties": false
 				},
 				"isTimePeriodEditable": {
 					"type": "boolean"
@@ -68543,10 +68531,7 @@ export const TranslatedMapOverlaySchema = {
 					"additionalProperties": false
 				}
 			},
-			"additionalProperties": false,
-			"required": [
-				"reference"
-			]
+			"additionalProperties": false
 		},
 		"isTimePeriodEditable": {
 			"type": "boolean"

--- a/packages/types/src/schemas/schemas.ts
+++ b/packages/types/src/schemas/schemas.ts
@@ -52018,14 +52018,14 @@ export const DashboardItemUpdateSchema = {
 export const DashboardMailingListSchema = {
 	"type": "object",
 	"properties": {
-		"dashboard_id": {
-			"type": "string"
-		},
-		"email_admin_permission_groups": {
+		"admin_permission_groups": {
 			"type": "array",
 			"items": {
 				"type": "string"
 			}
+		},
+		"dashboard_id": {
+			"type": "string"
 		},
 		"entity_id": {
 			"type": "string"
@@ -52039,8 +52039,8 @@ export const DashboardMailingListSchema = {
 	},
 	"additionalProperties": false,
 	"required": [
+		"admin_permission_groups",
 		"dashboard_id",
-		"email_admin_permission_groups",
 		"entity_id",
 		"id",
 		"project_id"
@@ -52050,14 +52050,14 @@ export const DashboardMailingListSchema = {
 export const DashboardMailingListCreateSchema = {
 	"type": "object",
 	"properties": {
-		"dashboard_id": {
-			"type": "string"
-		},
-		"email_admin_permission_groups": {
+		"admin_permission_groups": {
 			"type": "array",
 			"items": {
 				"type": "string"
 			}
+		},
+		"dashboard_id": {
+			"type": "string"
 		},
 		"entity_id": {
 			"type": "string"
@@ -52077,14 +52077,14 @@ export const DashboardMailingListCreateSchema = {
 export const DashboardMailingListUpdateSchema = {
 	"type": "object",
 	"properties": {
-		"dashboard_id": {
-			"type": "string"
-		},
-		"email_admin_permission_groups": {
+		"admin_permission_groups": {
 			"type": "array",
 			"items": {
 				"type": "string"
 			}
+		},
+		"dashboard_id": {
+			"type": "string"
 		},
 		"entity_id": {
 			"type": "string"
@@ -60211,14 +60211,14 @@ export const MailingListSchema = {
 		"isSubscribed": {
 			"type": "boolean"
 		},
-		"isEmailAdmin": {
+		"isAdmin": {
 			"type": "boolean"
 		}
 	},
 	"additionalProperties": false,
 	"required": [
 		"entityCode",
-		"isEmailAdmin",
+		"isAdmin",
 		"isSubscribed"
 	]
 } 
@@ -68252,14 +68252,14 @@ export const DashboardWithMetadataSchema = {
 					"isSubscribed": {
 						"type": "boolean"
 					},
-					"isEmailAdmin": {
+					"isAdmin": {
 						"type": "boolean"
 					}
 				},
 				"additionalProperties": false,
 				"required": [
 					"entityCode",
-					"isEmailAdmin",
+					"isAdmin",
 					"isSubscribed"
 				]
 			}

--- a/packages/types/src/types/models-extra/mapOverlay.ts
+++ b/packages/types/src/types/models-extra/mapOverlay.ts
@@ -24,7 +24,7 @@ export type MapOverlayConfig = {
   hideFromPopup?: boolean;
   icon?: IconKey;
   info?: {
-    reference: {
+    reference?: {
       link?: string;
       name?: string;
       text?: string;

--- a/packages/types/src/types/models.ts
+++ b/packages/types/src/types/models.ts
@@ -314,17 +314,20 @@ export interface DashboardItemUpdate {
 }
 export interface DashboardMailingList {
   'dashboard_id': string;
+  'email_admin_permission_groups': string[];
   'entity_id': string;
   'id': string;
   'project_id': string;
 }
 export interface DashboardMailingListCreate {
   'dashboard_id': string;
+  'email_admin_permission_groups'?: string[];
   'entity_id': string;
   'project_id': string;
 }
 export interface DashboardMailingListUpdate {
   'dashboard_id'?: string;
+  'email_admin_permission_groups'?: string[];
   'entity_id'?: string;
   'id'?: string;
   'project_id'?: string;

--- a/packages/types/src/types/models.ts
+++ b/packages/types/src/types/models.ts
@@ -313,21 +313,21 @@ export interface DashboardItemUpdate {
   'report_code'?: string | null;
 }
 export interface DashboardMailingList {
+  'admin_permission_groups': string[];
   'dashboard_id': string;
-  'email_admin_permission_groups': string[];
   'entity_id': string;
   'id': string;
   'project_id': string;
 }
 export interface DashboardMailingListCreate {
+  'admin_permission_groups'?: string[];
   'dashboard_id': string;
-  'email_admin_permission_groups'?: string[];
   'entity_id': string;
   'project_id': string;
 }
 export interface DashboardMailingListUpdate {
+  'admin_permission_groups'?: string[];
   'dashboard_id'?: string;
-  'email_admin_permission_groups'?: string[];
   'entity_id'?: string;
   'id'?: string;
   'project_id'?: string;

--- a/packages/types/src/types/requests/tupaia-web-server/DashboardsRequest.ts
+++ b/packages/types/src/types/requests/tupaia-web-server/DashboardsRequest.ts
@@ -13,6 +13,7 @@ export interface Params {
 interface MailingList {
   entityCode: string;
   isSubscribed: boolean;
+  isEmailAdmin: boolean;
 }
 
 interface DashboardWithMetadata extends Dashboard {

--- a/packages/types/src/types/requests/tupaia-web-server/DashboardsRequest.ts
+++ b/packages/types/src/types/requests/tupaia-web-server/DashboardsRequest.ts
@@ -13,7 +13,7 @@ export interface Params {
 interface MailingList {
   entityCode: string;
   isSubscribed: boolean;
-  isEmailAdmin: boolean;
+  isAdmin: boolean;
 }
 
 interface DashboardWithMetadata extends Dashboard {

--- a/packages/utils/src/object.js
+++ b/packages/utils/src/object.js
@@ -39,6 +39,13 @@ export function getSortByKey(key, options) {
   return getSortByExtractedValue(o => o[key], options);
 }
 
+/**
+ * @template T
+ * @param {T[]} array
+ * @param { (string | (value: T) => unknown)[] } valueMappers
+ * @param {*} orders
+ * @returns {T[]}
+ */
 export const orderBy = (array, valueMappers, orders = []) => {
   const comparators = valueMappers.map((valueMapper, i) => {
     const mapValue =


### PR DESCRIPTION
### Issue RN-1073:

Added a `email_admins_permission_groups` column to the `dashboard_mailing_list` table.

A user must have permissions to the country they're in to be able to see the Mailing list button and to send the email export.