### PR TITLE
WAITP-1467: Account Settings – Change Password 2 (Error Feedback)

### DIFF
--- a/packages/central-server/src/apiV2/changePassword.js
+++ b/packages/central-server/src/apiV2/changePassword.js
@@ -2,7 +2,7 @@
  * Tupaia MediTrak
  * Copyright (c) 2017 Beyond Essential Systems Pty Ltd
  */
-import { respond, FormValidationError, DatabaseError, isValidPassword } from '@tupaia/utils';
+import { DatabaseError, FormValidationError, isValidPassword, respond } from '@tupaia/utils';
 import { hashAndSaltPassword } from '@tupaia/auth';
 import { allowNoPermissions } from '../permissions';
 
@@ -57,5 +57,5 @@ export async function changePassword(req, res, next) {
     ...hashAndSaltPassword(passwordParam),
   });
 
-  respond(res, { message: 'Successfully updated password' });
+  respond(res, { message: 'Password successfully updated' });
 }

--- a/packages/central-server/src/apiV2/changePassword.js
+++ b/packages/central-server/src/apiV2/changePassword.js
@@ -40,11 +40,11 @@ export async function changePassword(req, res, next) {
       throw new FormValidationError('One time login is invalid');
     }
   } else if (!user.checkPassword(oldPassword)) {
-    throw new FormValidationError('Incorrect current password.', ['oldPassword']);
+    throw new FormValidationError('Incorrect current password', ['oldPassword']);
   }
 
   if (passwordParam !== passwordConfirmParam) {
-    throw new FormValidationError('Passwords do not match.', ['password', 'passwordConfirm']);
+    throw new FormValidationError('Passwords do not match', ['password', 'passwordConfirm']);
   }
 
   try {

--- a/packages/datatrak-web/src/api/mutations/useResetPassword.ts
+++ b/packages/datatrak-web/src/api/mutations/useResetPassword.ts
@@ -17,7 +17,7 @@ export type ResetPasswordParams = {
 export const useResetPassword = (options?: {
   onError?: (error?: Error) => void;
   onSettled?: () => void;
-  onSuccess?: () => void;
+  onSuccess?: (response: { message: string }) => void;
 }) => {
   const [urlSearchParams] = useSearchParams();
   const navigate = useNavigate();
@@ -37,7 +37,7 @@ export const useResetPassword = (options?: {
       onSettled: () => {
         if (options?.onSettled) options.onSettled();
       },
-      onSuccess: () => {
+      onSuccess: (response?) => {
         // manually navigate to the removed token - using setUrlParams seems to remove the hash as well in this one case
         urlSearchParams.delete(PASSWORD_RESET_TOKEN_PARAM);
         navigate({
@@ -45,7 +45,7 @@ export const useResetPassword = (options?: {
           search: urlSearchParams.toString(),
         });
 
-        if (options?.onSuccess) options.onSuccess();
+        if (options?.onSuccess) options.onSuccess(response);
       },
       meta: {
         applyCustomErrorHandling: true,

--- a/packages/datatrak-web/src/api/mutations/useResetPassword.ts
+++ b/packages/datatrak-web/src/api/mutations/useResetPassword.ts
@@ -35,10 +35,10 @@ export const useResetPassword = (options?: {
       });
     },
     {
-      onError: (error: Error): void => {
+      onError: (error: Error) => {
         if (options?.onError) options.onError(error);
       },
-      onSettled: (): void => {
+      onSettled: () => {
         if (options?.onSettled) options.onSettled();
       },
       onSuccess: (response: ResBody) => {

--- a/packages/datatrak-web/src/api/mutations/useResetPassword.ts
+++ b/packages/datatrak-web/src/api/mutations/useResetPassword.ts
@@ -8,16 +8,20 @@ import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { post } from '../api';
 import { PASSWORD_RESET_TOKEN_PARAM } from '../../constants';
 
-export type ResetPasswordParams = {
+export interface ResetPasswordParams {
   oldPassword: string;
   newPassword: string;
   newPasswordConfirm: string;
-};
+}
+
+interface ResBody {
+  message: string;
+}
 
 export const useResetPassword = (options?: {
-  onError?: (error?: Error) => void;
+  onError?: (error: Error) => void;
   onSettled?: () => void;
-  onSuccess?: (response: { message: string }) => void;
+  onSuccess?: (response: ResBody) => void;
 }) => {
   const [urlSearchParams] = useSearchParams();
   const navigate = useNavigate();
@@ -31,13 +35,13 @@ export const useResetPassword = (options?: {
       });
     },
     {
-      onError: (error?) => {
+      onError: (error: Error): void => {
         if (options?.onError) options.onError(error);
       },
-      onSettled: () => {
+      onSettled: (): void => {
         if (options?.onSettled) options.onSettled();
       },
-      onSuccess: (response?) => {
+      onSuccess: (response: ResBody) => {
         // manually navigate to the removed token - using setUrlParams seems to remove the hash as well in this one case
         urlSearchParams.delete(PASSWORD_RESET_TOKEN_PARAM);
         navigate({

--- a/packages/datatrak-web/src/api/mutations/useResetPassword.ts
+++ b/packages/datatrak-web/src/api/mutations/useResetPassword.ts
@@ -15,7 +15,7 @@ export type ResetPasswordParams = {
 };
 
 export const useResetPassword = (options?: {
-  onError?: () => void;
+  onError?: (error?: Error) => void;
   onSettled?: () => void;
   onSuccess?: () => void;
 }) => {
@@ -31,8 +31,8 @@ export const useResetPassword = (options?: {
       });
     },
     {
-      onError: () => {
-        if (options?.onError) options.onError();
+      onError: (error?) => {
+        if (options?.onError) options.onError(error);
       },
       onSettled: () => {
         if (options?.onSettled) options.onSettled();

--- a/packages/datatrak-web/src/views/AccountSettingsPage/ChangePasswordSection/ChangePasswordForm.tsx
+++ b/packages/datatrak-web/src/views/AccountSettingsPage/ChangePasswordSection/ChangePasswordForm.tsx
@@ -86,7 +86,8 @@ export const ChangePasswordForm = () => {
   } = formContext;
 
   const { mutate: attemptPasswordChange } = useResetPassword({
-    onError: () => errorToast('Sorry, couldn’t update your password. Please try again'),
+    onError: error =>
+      errorToast(error?.message ?? 'Sorry, couldn’t update your password. Please try again'),
     onSettled: () => reset(emptyFormState),
     onSuccess: () => successToast('Your password has been successfully updated'),
   });

--- a/packages/datatrak-web/src/views/AccountSettingsPage/ChangePasswordSection/ChangePasswordForm.tsx
+++ b/packages/datatrak-web/src/views/AccountSettingsPage/ChangePasswordSection/ChangePasswordForm.tsx
@@ -89,7 +89,7 @@ export const ChangePasswordForm = () => {
     onError: error =>
       errorToast(error?.message ?? 'Sorry, couldn’t update your password. Please try again'),
     onSettled: () => reset(emptyFormState),
-    onSuccess: () => successToast('Your password has been successfully updated'),
+    onSuccess: response => successToast(response.message),
   });
 
   const submissionShouldBeDisabled = isValidating || !isValid || isSubmitting;


### PR DESCRIPTION
### Issue WAITP-1467: Change Password

This PR is a small add-on to #5240. (Separate PR just to make reviewing easier.)

### Changes:

- When password change fails instead of simply saying “couldn’t update password”, show the server-supplied error message as a toast.
- Ditto with success message in API response.

---

### Screenshots

![Screenshot 2023-12-08T102506](https://github.com/beyondessential/tupaia/assets/33956381/e694b6c4-c30a-4d6c-a6c6-9c46fab88603)
