### PR TITLE
WAITP-1460: Add Zendesk bot to Datatrak Web

### DIFF
--- a/packages/datatrak-web/index.html
+++ b/packages/datatrak-web/index.html
@@ -21,6 +21,10 @@
           gtag('config', 'G-P5KF6SLGKR');
         </script>
       <!-- End Google Analytics -->
+
+      <!-- Start of bes-support Zendesk Widget script -->
+      <script id="ze-snippet" src="https://static.zdassets.com/ekr/snippet.js?key=4719227f-a493-431d-a920-41ebcafbcccb"> </script>
+      <!-- End of bes-support Zendesk Widget script -->
     <% } %>
     <link rel="icon" type="image/png" href="/favicon.ico" />
     <link
@@ -42,5 +46,6 @@
     </noscript>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
+
   </body>
 </html>


### PR DESCRIPTION
### Issue WAITP-1460: Add Zendesk bot to Datatrak Web

### Changes:
- Add Zendesk bot to datatrak when in production

---

### Screenshots:

Confirmation of mobile appearance
![Screenshot 2023-12-08 at 1 08 04 pm](https://github.com/beyondessential/tupaia/assets/129009580/7743538b-d703-4539-9edd-4b098be8cc5c)
