### PR TITLE
No Issue: Fix UI-Components Storybook

### DIFF
--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -60,6 +60,7 @@
     "@types/react-router-dom": "^5.3.3",
     "@types/react-table": "^7.7.14",
     "@types/styled-components": "^5.0.0",
+    "babel-loader": "8.1.0",
     "faker": "^4.1.0",
     "fast-glob": "^3.2.5",
     "react-docgen-typescript-plugin": "^1.0.5",

--- a/packages/ui-components/src/components/HorizontalTree/ColumnFilter.jsx
+++ b/packages/ui-components/src/components/HorizontalTree/ColumnFilter.jsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useCallback, useState } from 'react';
-import { TextField } from '@tupaia/ui-components';
+import { TextField } from '../Inputs';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 

--- a/packages/ui-components/stories/passwordStrengthBar.stories.js
+++ b/packages/ui-components/stories/passwordStrengthBar.stories.js
@@ -6,9 +6,8 @@
 import React, { lazy, useState } from 'react';
 import styled from 'styled-components';
 import MuiBox from '@material-ui/core/Box';
-import { PasswordStrengthBar } from '../src/components';
+import { TextField, PasswordStrengthBar } from '../src/components';
 import * as COLORS from './story-utils/theme/colors';
-import { TextField } from '..';
 
 // Lazy load the password strength library as it uses zxcvbn which is a large dependency.
 // For more about lazy loading components @see: https://reactjs.org/docs/code-splitting.html#reactlazy

--- a/yarn.lock
+++ b/yarn.lock
@@ -12890,6 +12890,7 @@ __metadata:
     "@types/react-router-dom": ^5.3.3
     "@types/react-table": ^7.7.14
     "@types/styled-components": ^5.0.0
+    babel-loader: 8.1.0
     date-fns: ^2.12.0
     downloadjs: ^1.4.7
     faker: ^4.1.0


### PR DESCRIPTION
### Issue #: No Issue: Fix Storybook

### Changes:
In this recent change (here) we removed react-scripts from the mono-repo. It turns out that storybook was relying on the babel-loader module that came with react-scripts and so storybook broke. This change is to explicitly add babel-loader to ui-components to fill the gap.