### PR TITLE
WAITP-1519: Show/hide “Account settings” from menu

### DIFF
--- a/packages/datatrak-web/src/layout/UserMenu/MenuList.tsx
+++ b/packages/datatrak-web/src/layout/UserMenu/MenuList.tsx
@@ -11,6 +11,15 @@ import { useCurrentUser } from '../../api';
 import { useLogout } from '../../api/mutations';
 import { ROUTES } from '../../constants';
 
+interface MenuItem {
+  label: string;
+  to?: string;
+  href?: string;
+  isExternal?: boolean;
+  onClick?: () => void;
+  component?: ComponentType<any> | string;
+}
+
 const Menu = styled.ul`
   list-style: none;
   padding-inline-start: 0;
@@ -37,7 +46,8 @@ export const MenuButton = styled(Button).attrs({
 `;
 
 /**
- * This is the menu list that appears in both the drawer and popover menus. It shows different options depending on whether the user is logged in or not.
+ * The menu list that appears in both the drawer and popover menus. It shows different options depending on whether the
+ * user is logged in or not.
  */
 export const MenuList = ({
   children,
@@ -46,69 +56,63 @@ export const MenuList = ({
   children?: ReactNode;
   onCloseMenu: () => void;
 }) => {
-  const { isLoggedIn } = useCurrentUser();
+  const { isLoggedIn, projectId } = useCurrentUser();
   const { mutate: logout } = useLogout();
 
-  // The help centre link is the same for both logged in and logged out users
-  const helpCentre = {
+  const accountSettingsItem = {
+    label: 'Account settings',
+    to: ROUTES.ACCOUNT_SETTINGS,
+  };
+
+  // The help centre link is the same for both logged-in and logged-out users
+  const helpCentreItem = {
     label: 'Help centre',
     href: 'https://beyond-essential.slab.com/posts/tupaia-instruction-manuals-05nke1dm',
     isExternal: true,
     component: Link,
   };
-  const onClickLogout = () => {
-    logout();
-    onCloseMenu();
+
+  const logOutItem = {
+    label: 'Log out',
+    onClick: () => {
+      logout();
+      onCloseMenu();
+    },
+    component: 'button',
   };
 
-  const menuItems = isLoggedIn
-    ? [
-        {
-          label: 'Account settings',
-          to: ROUTES.ACCOUNT_SETTINGS,
-        },
-        helpCentre,
-        {
-          label: 'Log out',
-          onClick: onClickLogout,
-          component: 'button',
-        },
-      ]
-    : [helpCentre];
+  const menuItems = () => {
+    const hasProjectSelected = !!projectId;
+    const items: MenuItem[] = [];
+
+    if (isLoggedIn && hasProjectSelected) {
+      items.push(accountSettingsItem);
+    }
+    items.push(helpCentreItem);
+    if (isLoggedIn) {
+      items.push(logOutItem);
+    }
+
+    return items;
+  };
 
   return (
     <Menu>
       {children}
-      {menuItems.map(
-        ({
-          label,
-          to,
-          href,
-          isExternal,
-          onClick,
-          component,
-        }: {
-          label: string;
-          to?: string;
-          href?: string;
-          isExternal?: boolean;
-          onClick?: () => void;
-          component?: ComponentType<any> | string;
-        }) => (
-          <MenuListItem key={label} button>
-            <MenuButton
-              component={component || RouterLink}
-              underline="none"
-              target={isExternal ? '_blank' : null}
-              onClick={onClick || onCloseMenu}
-              to={to}
-              href={href}
-            >
-              {label}
-            </MenuButton>
-          </MenuListItem>
-        ),
-      )}
+      {menuItems().map(({ label, to, href, isExternal, onClick, component }) => (
+        <MenuListItem key={label} button>
+          <MenuButton
+            component={component || RouterLink}
+            underline="none"
+            target={isExternal ? '_blank' : null}
+            onClick={onClick || onCloseMenu}
+            to={to}
+            href={href}
+          >
+            {label}
+          </MenuButton>
+        </MenuListItem>
+      ))}
     </Menu>
   );
 };

--- a/packages/datatrak-web/src/layout/UserMenu/MenuList.tsx
+++ b/packages/datatrak-web/src/layout/UserMenu/MenuList.tsx
@@ -63,7 +63,6 @@ export const MenuList = ({
     label: 'Account settings',
     to: ROUTES.ACCOUNT_SETTINGS,
   };
-
   // The help centre link is the same for both logged-in and logged-out users
   const helpCentreItem = {
     label: 'Help centre',
@@ -71,7 +70,6 @@ export const MenuList = ({
     isExternal: true,
     component: Link,
   };
-
   const logOutItem = {
     label: 'Log out',
     onClick: () => {
@@ -81,25 +79,21 @@ export const MenuList = ({
     component: 'button',
   };
 
-  const menuItems = () => {
-    const hasProjectSelected = !!projectId;
-    const items: MenuItem[] = [];
+  const hasProjectSelected = !!projectId;
 
-    if (isLoggedIn && hasProjectSelected) {
-      items.push(accountSettingsItem);
-    }
-    items.push(helpCentreItem);
-    if (isLoggedIn) {
-      items.push(logOutItem);
-    }
-
-    return items;
-  };
+  const menuItems: MenuItem[] = [];
+  if (isLoggedIn && hasProjectSelected) {
+    menuItems.push(accountSettingsItem);
+  }
+  menuItems.push(helpCentreItem);
+  if (isLoggedIn) {
+    menuItems.push(logOutItem);
+  }
 
   return (
     <Menu>
       {children}
-      {menuItems().map(({ label, to, href, isExternal, onClick, component }) => (
+      {menuItems.map(({ label, to, href, isExternal, onClick, component }) => (
         <MenuListItem key={label} button>
           <MenuButton
             component={component || RouterLink}


### PR DESCRIPTION
### Issue WAITP-1519: Hide Account Settings button from the menu on project page for DataTrak

### Changes

Previously, on the **Select project** page, **Account settings** appears in the hamburger popover/drawer menu in the navbar. If the user has not yet selected a project, this link does nothing.

This PR prevents that by showing **Account settings** only when the currently logged-in user has a project selected.

---

### Screenshots

| | Logged-in | Logged-out |
|---|---|---|
| No project selected | ![Screenshot 2023-12-11T214513](https://github.com/beyondessential/tupaia/assets/33956381/20f55b32-02a1-4ce2-9c2b-ce2f3f75bfd0) | ![Screenshot 2023-12-11T215114](https://github.com/beyondessential/tupaia/assets/33956381/71172948-cc82-4a62-9bac-df1ae1edaff0) |
| Project selected | ![Screenshot 2023-12-11T214556](https://github.com/beyondessential/tupaia/assets/33956381/a3aed56e-f7d3-4078-a022-cd834ab7d965) | ![Screenshot 2023-12-11T215114](https://github.com/beyondessential/tupaia/assets/33956381/71172948-cc82-4a62-9bac-df1ae1edaff0) |
