### PR TITLE
no-issue: PR template for releases

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_template.md
@@ -8,10 +8,6 @@
 
 
 
-## Visualisations 📊 
-
-
-
 ## Bug fixes 🐛
 
 

--- a/.github/PULL_REQUEST_TEMPLATE/release_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_template.md
@@ -20,9 +20,9 @@
 
 # Instructions
 
-Name this PR `Release <year>-<week number>`, e.g. `Release 2023-50`. See https://www.calendar-365.com/week-number.html for the current week number.
+Name this PR `Release <year>-<week number>` (e.g. `Release 2023-50`). See https://www.calendar-365.com/week-number.html for the current week number.
 
-Release Process page on Slab: https://beyond-essential.slab.com/posts/release-process-j4ersmrg
+Release process documentation: https://beyond-essential.slab.com/posts/release-process-j4ersmrg
 
 # Example entries
 

--- a/.github/PULL_REQUEST_TEMPLATE/release_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_template.md
@@ -1,4 +1,4 @@
-### Manual Release Steps
+## Manual release steps
 
 ## Features ⭐
 

--- a/.github/PULL_REQUEST_TEMPLATE/release_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_template.md
@@ -1,5 +1,7 @@
 ## Manual release steps
 
+
+
 ## Features ⭐
 
 

--- a/.github/PULL_REQUEST_TEMPLATE/release_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_template.md
@@ -22,7 +22,7 @@
 
 # Instructions
 
-Name this PR `Release <year>-<iso week number>` (e.g. `Release 2023-7`). See https://www.calendar-365.com/week-number.html for the current week number.
+Name this PR `Release <year>-<week number>` (e.g. `Release 2023-7`). See https://www.calendar-365.com/week-number.html for the current week number.
 
 Release process documentation: https://beyond-essential.slab.com/posts/release-process-j4ersmrg
 

--- a/.github/PULL_REQUEST_TEMPLATE/release_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_template.md
@@ -16,7 +16,15 @@
 
 
 
-<!-- EXAMPLE ENTRIES
+<!--
+
+# Instructions
+
+Name this PR `Release <year>-<week number>`, e.g. `Release 2023-50`. See https://www.calendar-365.com/week-number.html for the current week number.
+
+Release Process page on Slab: https://beyond-essential.slab.com/posts/release-process-j4ersmrg
+
+# Example entries
 
 - RN-977: Allow downloading the generated QR code in Meditrak App
 - (no issue) #4695

--- a/.github/PULL_REQUEST_TEMPLATE/release_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_template.md
@@ -1,0 +1,24 @@
+### Manual Release Steps
+
+## Features ⭐
+
+
+
+## Visualisations 📊 
+
+
+
+## Bug fixes 🐛
+
+
+
+## Infrastructure and maintenance 🛠️
+
+
+
+<!-- EXAMPLE ENTRIES
+
+- RN-977: Allow downloading the generated QR code in Meditrak App
+- (no issue) #4695
+
+-->

--- a/.github/PULL_REQUEST_TEMPLATE/release_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_template.md
@@ -22,7 +22,7 @@
 
 # Instructions
 
-Name this PR `Release <year>-<week number>` (e.g. `Release 2023-50`). See https://www.calendar-365.com/week-number.html for the current week number.
+Name this PR `Release <year>-<iso week number>` (e.g. `Release 2023-7`). See https://www.calendar-365.com/week-number.html for the current week number.
 
 Release process documentation: https://beyond-essential.slab.com/posts/release-process-j4ersmrg
 

--- a/.github/PULL_REQUEST_TEMPLATE/release_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_template.md
@@ -28,7 +28,7 @@ Release process documentation: https://beyond-essential.slab.com/posts/release-p
 
 # Example entries
 
-- RN-977: Allow downloading the generated QR code in Meditrak App
+- RN-977: Allow downloading the generated QR code in MediTrak app
 - (no issue) #4695
 
 -->

--- a/.github/PULL_REQUEST_TEMPLATE/release_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_template.md
@@ -4,6 +4,10 @@
 
 
 
+## Tweaks ⚖️
+
+
+
 ## Visualisations 📊 
 
 


### PR DESCRIPTION
### Changes

Created a PR template for releases. After merging, this can (in theory) be invoked using https://github.com/beyondessential/tupaia/compare/master...dev?quick_pull=1&title=Release+20yy-w&labels=release&template=release_template.md, which will also automatically add the **release** tag.

If an open `master` ← `dev` PR already exists, GitHub will prompt you to view that one instead of creating a new one.

The [existing pull request template](https://github.com/beyondessential/tupaia/blob/dev/.github/pull_request_template.md) remains the default. Unfortunately, this needs to stay at the top level of the `./github` folder; moving it into the new `./github/PULL_REQUEST_TEMPLATE` folder makes it accessible only via a link with a `template` [query parameter](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request) (like the one above).

### Testing

This can’t be comprehensively tested until it’s merged into the default branch. Instead, I replicated this template setup in a private repo on my own account, and it seems to work there

---

### Screenshots

None.