### PR TITLE
no-issue: Split DataBroker pullMetadata API per type

### DIFF
--- a/packages/aggregator/global.d.ts
+++ b/packages/aggregator/global.d.ts
@@ -1,0 +1,15 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ */
+
+import 'jest-extended';
+
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toHaveBeenCalledOnceWith<E extends unknown[]>(...params: E): R;
+      toBeRejectedWith(error?: string | Constructable | RegExp | Error): Promise<R>;
+    }
+  }
+}

--- a/packages/aggregator/global.d.ts
+++ b/packages/aggregator/global.d.ts
@@ -1,6 +1,6 @@
 /**
  * Tupaia
- * Copyright (c) 2017 - 2022 Beyond Essential Systems Pty Ltd
+ * Copyright (c) 2017 - 2024 Beyond Essential Systems Pty Ltd
  */
 
 import 'jest-extended';

--- a/packages/aggregator/src/Aggregator.js
+++ b/packages/aggregator/src/Aggregator.js
@@ -125,13 +125,11 @@ export class Aggregator {
   }
 
   async fetchDataElements(codes, fetchOptions) {
-    const dataSourceSpec = { code: codes, type: this.dataSourceTypes.DATA_ELEMENT };
-    return this.dataBroker.pullMetadata(dataSourceSpec, fetchOptions);
+    return this.dataBroker.pullDataElements(codes, fetchOptions);
   }
 
   async fetchDataGroup(code, fetchOptions) {
-    const dataSourceSpec = { code, type: this.dataSourceTypes.DATA_GROUP };
-    return this.dataBroker.pullMetadata(dataSourceSpec, fetchOptions);
+    return this.dataBroker.pullDataGroup(code, fetchOptions);
   }
 
   // TODO ultimately Aggregator should handle preaggregation internally - at that point this method

--- a/packages/aggregator/src/__tests__/Aggregator/Aggregator.test.js
+++ b/packages/aggregator/src/__tests__/Aggregator/Aggregator.test.js
@@ -12,6 +12,8 @@ import {
   RESPONSE_BY_SOURCE_TYPE,
   AGGREGATED_ANALYTICS,
   FILTERED_ANALYTICS,
+  DATA_ELEMENTS,
+  DATA_GROUPS,
 } from './fixtures';
 
 jest.mock('../../analytics/aggregateAnalytics/aggregateAnalytics');
@@ -26,16 +28,17 @@ const dataBroker = {
   getDataSourceTypes: jest.fn(() => DATA_SOURCE_TYPES),
   pullAnalytics: jest.fn(async () => RESPONSE_BY_SOURCE_TYPE[DATA_ELEMENT]),
   pullEvents: jest.fn(async () => RESPONSE_BY_SOURCE_TYPE[DATA_GROUP]),
+  pullDataElements: jest.fn(async codes =>
+    Object.values(DATA_ELEMENTS).filter(de => codes.includes(de.code)),
+  ),
+  pullDataGroup: jest.fn(async code => DATA_GROUPS[code]),
 };
 
+/**
+ * @type {Aggregator}
+ */
 let aggregator;
 
-const fetchOptions = {
-  organisationUnitCodes: ['TO'],
-  startDate: '20200214',
-  endDate: '20200215',
-  period: '20200214;20200215',
-};
 const aggregationOptions = {
   aggregations: [
     {
@@ -56,6 +59,13 @@ describe('Aggregator', () => {
   });
 
   describe('fetchAnalytics()', () => {
+    const fetchOptions = {
+      organisationUnitCodes: ['TO'],
+      startDate: '20200214',
+      endDate: '20200215',
+      period: '20200214;20200215',
+    };
+
     it('`aggregationOptions` parameter is optional', async () => {
       const assertErrorIsNotThrown = async emptyAggregationOptions =>
         expect(
@@ -170,7 +180,14 @@ describe('Aggregator', () => {
     });
   });
 
-  describe('fetch events', () => {
+  describe('fetchEvents()', () => {
+    const fetchOptions = {
+      organisationUnitCodes: ['TO'],
+      startDate: '20200214',
+      endDate: '20200215',
+      period: '20200214;20200215',
+    };
+
     it('fetches events', async () => {
       const code = 'PROGRAM_1';
 
@@ -203,6 +220,27 @@ describe('Aggregator', () => {
       });
       expect(dataBroker.pullEvents).toHaveBeenCalledTimes(0);
       return expect(response).toStrictEqual([]);
+    });
+  });
+
+  describe('fetchDataElements', () => {
+    it('fetches data elements', async () => {
+      const codes = ['POP01', 'POP02'];
+      const fetchOptions = { includeOptions: true };
+
+      const results = await aggregator.fetchDataElements(codes, fetchOptions);
+      expect(results).toStrictEqual([DATA_ELEMENTS.POP01, DATA_ELEMENTS.POP02]);
+      expect(dataBroker.pullDataElements).toHaveBeenCalledOnceWith(codes, fetchOptions);
+    });
+  });
+
+  describe('fetchDataGroup', () => {
+    it('fetches data groups', async () => {
+      const fetchOptions = { includeOptions: true };
+
+      const result = await aggregator.fetchDataGroup('POP', fetchOptions);
+      expect(result).toStrictEqual(DATA_GROUPS.POP);
+      expect(dataBroker.pullDataGroup).toHaveBeenCalledOnceWith('POP', fetchOptions);
     });
   });
 });

--- a/packages/aggregator/src/__tests__/Aggregator/fixtures.js
+++ b/packages/aggregator/src/__tests__/Aggregator/fixtures.js
@@ -28,3 +28,17 @@ export const AGGREGATED_ANALYTICS = [
   { dataElement: 'POP01', period: '20200214', value: 6 },
 ];
 export const FILTERED_ANALYTICS = [{ dataElement: 'POP01', period: '20200214', value: 3 }];
+
+export const DATA_ELEMENTS = {
+  POP01: { code: 'POP01', name: 'Population 1' },
+  POP02: { code: 'POP02', name: 'Population 2' },
+  DIFF: { code: 'Diff', name: 'Other' },
+};
+
+export const DATA_GROUPS = {
+  POP: {
+    code: 'POP',
+    name: 'Population Survey',
+    dataElements: [DATA_ELEMENTS.POP01, DATA_ELEMENTS.POP02],
+  },
+};

--- a/packages/data-broker/.env.example
+++ b/packages/data-broker/.env.example
@@ -1,0 +1,6 @@
+# Used in tests
+DB_NAME=
+DB_PASSWORD=
+DB_PORT=
+DB_URL=
+DB_USER=

--- a/packages/data-broker/README.md
+++ b/packages/data-broker/README.md
@@ -13,5 +13,8 @@ Centralised gateway which provides a common interface to external data sources.
 ### Interface
 
 - `push` - pushes data to an external data source
-- `pull` - pulls analytics or events data for requested data elements or data groups
-- `pullMetadata` - pull metadata around requested data elements, data groups, or sync groups
+- `pullAnalytics` - pulls analytics for requested data elements
+- `pullEvents` - pulls event data for requested data groups
+- `pullSyncGroupResults` - pulls data for requested sync groups
+- `pullDataElements` - pull metadata around requested data elements
+- `pullDataGroup` - pull metadata around requested data group

--- a/packages/data-broker/src/DataBroker/DataBroker.ts
+++ b/packages/data-broker/src/DataBroker/DataBroker.ts
@@ -44,10 +44,14 @@ type FetchConditions = { code: string | string[] };
 
 type Fetcher = (dataSourceSpec: FetchConditions) => Promise<DataSourceTypeInstance[]>;
 
-interface PullOptions {
+type PullOptions = Record<string, unknown> & {
   organisationUnitCode?: string;
   organisationUnitCodes?: string[];
-}
+};
+
+type PullMetadataOptions = Record<string, unknown> & {
+  organisationUnitCode?: string;
+};
 
 let modelRegistry: DataBrokerModelRegistry;
 
@@ -259,17 +263,26 @@ export class DataBroker {
     );
   }
 
-  public async pullMetadata(dataSourceSpec: DataSourceSpec, options?: Record<string, unknown>) {
-    const dataSources = await this.fetchDataSources(dataSourceSpec);
+  public async pullDataElements(codes: string[], options?: PullMetadataOptions) {
+    const dataElements = await fetchDataElements(this.models, codes);
     const { serviceType, dataServiceMapping } = await this.getSingleServiceAndMapping(
-      dataSources,
+      dataElements,
       options,
     );
 
     const service = this.createService(serviceType);
-    // `dataSourceSpec` is defined  for a single `type`
-    const { type } = dataSourceSpec;
-    return service.pullMetadata(dataSources, type, { dataServiceMapping, ...options });
+    return service.pullMetadata(dataElements, 'dataElement', { dataServiceMapping, ...options });
+  }
+
+  public async pullDataGroup(code: string, options?: PullMetadataOptions) {
+    const [dataGroup] = await fetchDataGroups(this.models, [code]);
+    const { serviceType, dataServiceMapping } = await this.getSingleServiceAndMapping(
+      [dataGroup],
+      options,
+    );
+
+    const service = this.createService(serviceType);
+    return service.pullMetadata([dataGroup], 'dataGroup', { dataServiceMapping, ...options });
   }
 
   /**
@@ -277,7 +290,7 @@ export class DataBroker {
    */
   private async getSingleServiceAndMapping(
     dataSources: DataSourceTypeInstance[],
-    options: { organisationUnitCode?: string } = {},
+    options: PullMetadataOptions = {},
   ): Promise<{ serviceType: ServiceType; dataServiceMapping: DataServiceMapping }> {
     const { organisationUnitCode } = options;
 

--- a/packages/data-broker/src/__tests__/DataBroker/DataBroker.stubs.ts
+++ b/packages/data-broker/src/__tests__/DataBroker/DataBroker.stubs.ts
@@ -8,6 +8,7 @@ import { reduceToDictionary } from '@tupaia/utils';
 import { createModelsStub as baseCreateModelsStub } from '@tupaia/database';
 import * as CreateService from '../../services/createService';
 import { Service } from '../../services/Service';
+import { DataBrokerModelRegistry, DataElement, DataGroup, DataServiceSyncGroup } from '../../types';
 import {
   DATA_ELEMENT_DATA_SERVICES,
   DATA_ELEMENTS,
@@ -16,7 +17,6 @@ import {
   MockServiceData,
   SYNC_GROUPS,
 } from './DataBroker.fixtures';
-import { DataBrokerModelRegistry, DataElement, DataGroup, DataServiceSyncGroup } from '../../types';
 
 export const stubCreateService = (services: Record<string, Service>) =>
   jest.spyOn(CreateService, 'createService').mockImplementation((_, type) => {

--- a/packages/data-broker/src/__tests__/DataBroker/DataBroker.test.ts
+++ b/packages/data-broker/src/__tests__/DataBroker/DataBroker.test.ts
@@ -7,12 +7,12 @@ import assert from 'assert';
 
 import { AccessPolicy } from '@tupaia/access-policy';
 import { DataBroker } from '../../DataBroker/DataBroker';
+import { DataServiceMapping } from '../../services/DataServiceMapping';
 import { Service } from '../../services/Service';
 import { DataBrokerModelRegistry, DataElement, ServiceType } from '../../types';
 import { DATA_SOURCE_TYPES } from '../../utils';
 import { DATA_BY_SERVICE, DATA_ELEMENTS, DATA_GROUPS, SYNC_GROUPS } from './DataBroker.fixtures';
 import { stubCreateService, createModelsStub, MockService } from './DataBroker.stubs';
-import { DataServiceMapping } from '../../services/DataServiceMapping';
 
 const mockModels = createModelsStub();
 
@@ -61,7 +61,13 @@ describe('DataBroker', () => {
   });
 
   describe('Data service resolution', () => {
-    type MethodUnderTest = 'push' | 'pullAnalytics' | 'pullEvents' | 'delete' | 'pullMetadata';
+    type MethodUnderTest =
+      | 'push'
+      | 'pullAnalytics'
+      | 'pullEvents'
+      | 'delete'
+      | 'pullDataElements'
+      | 'pullDataGroup';
 
     const TO_OPTIONS = { organisationUnitCode: 'TO_FACILITY_01' };
     const FJ_OPTIONS = { organisationUnitCode: 'FJ_FACILITY_01' };
@@ -81,8 +87,8 @@ describe('DataBroker', () => {
         ['delete', 2, [{ code: 'DHIS_PROGRAM_01', type: 'dataGroup' }, TO_OPTIONS], 'dhis'],
         ['pullAnalytics', 1, ['DHIS_01', TO_OPTIONS], 'dhis'],
         ['pullEvents', 2, ['DHIS_PROGRAM_01', TO_OPTIONS], 'dhis'],
-        ['pullMetadata', 1, [{ code: 'DHIS_01', type: 'dataElement' }, TO_OPTIONS], 'dhis'],
-        ['pullMetadata', 2, [{ code: 'DHIS_PROGRAM_01', type: 'dataGroup' }, TO_OPTIONS], 'dhis'],
+        ['pullDataElements', 1, [['DHIS_01'], TO_OPTIONS], 'dhis'],
+        ['pullDataGroup', 2, ['DHIS_PROGRAM_01', TO_OPTIONS], 'dhis'],
       ];
 
       testData.forEach(([methodUnderTest, testNum, inputArgs, expectedServiceNameUsed]) =>
@@ -115,9 +121,9 @@ describe('DataBroker', () => {
         ['delete', 1, [{ code: 'DHIS_01', type: 'dataElement' }, NO_OU_OPT], 'dhis'],
         ['delete', 2, [{ code: 'DHIS_PROGRAM_01', type: 'dataGroup' }, NO_OU_OPT], 'dhis'],
         ['pullAnalytics', 1, ['DHIS_01', NO_OU_OPT], 'dhis'],
-        ['pullEvents', 2, ['DHIS_PROGRAM_01', NO_OU_OPT], 'dhis'],
-        ['pullMetadata', 1, [{ code: 'DHIS_01', type: 'dataElement' }, NO_OU_OPT], 'dhis'],
-        ['pullMetadata', 2, [{ code: 'DHIS_PROGRAM_01', type: 'dataGroup' }, NO_OU_OPT], 'dhis'],
+        ['pullEvents', 1, ['DHIS_PROGRAM_01', NO_OU_OPT], 'dhis'],
+        ['pullDataElements', 1, [['DHIS_01'], NO_OU_OPT], 'dhis'],
+        ['pullDataGroup', 1, ['DHIS_PROGRAM_01'], 'dhis'],
       ];
 
       testData.forEach(([methodUnderTest, testNum, inputArgs, expectedServiceNameUsed]) =>
@@ -148,7 +154,7 @@ describe('DataBroker', () => {
           'tupaia',
         ],
         ['pullAnalytics', ['MAPPED_01', FJ_OPTIONS], 'tupaia'],
-        ['pullMetadata', [{ code: 'MAPPED_01', type: 'dataElement' }, FJ_OPTIONS], 'tupaia'],
+        ['pullDataElements', [['MAPPED_01'], FJ_OPTIONS], 'tupaia'],
       ];
 
       testData.forEach(([methodUnderTest, inputArgs, expectedServiceType]) =>
@@ -166,35 +172,71 @@ describe('DataBroker', () => {
 
     describe('passes mapping to service', () => {
       const dataBroker = new DataBroker();
-      const mapping = new DataServiceMapping([
-        { dataSource: DATA_ELEMENTS.DHIS_01, service_type: 'dhis', config: {} },
-      ]);
 
-      const testData: [MethodUnderTest, any[]][] = [
-        ['push', [{ code: 'DHIS_01', type: 'dataElement' }, [{ value: 2 }], TO_OPTIONS]],
-        ['delete', [{ code: 'DHIS_01', type: 'dataElement' }, { value: 2 }, TO_OPTIONS]],
-        ['pullMetadata', [{ code: 'DHIS_01', type: 'dataElement' }, TO_OPTIONS]],
-      ];
+      it('passes mapping to service: push', async () => {
+        const expectedMapping = new DataServiceMapping([
+          { dataSource: DATA_ELEMENTS.DHIS_01, service_type: 'dhis', config: {} },
+        ]);
 
-      testData.forEach(
-        ([methodUnderTest, inputArgs]) =>
-          it(`passes mapping to service: ${methodUnderTest}`, async () => {
-            await dataBroker[methodUnderTest](inputArgs[0], inputArgs[1], inputArgs[2]);
-            expect(SERVICES.dhis[methodUnderTest]).toHaveBeenCalledOnceWith(
-              expect.anything(),
-              expect.anything(),
-              expect.objectContaining({ dataServiceMapping: mapping }),
-            );
-          }),
+        await dataBroker.push({ code: 'DHIS_01', type: 'dataElement' }, [{ value: 2 }], TO_OPTIONS);
+        expect(SERVICES.dhis.push).toHaveBeenCalledOnceWith(
+          expect.anything(),
+          expect.anything(),
+          expect.objectContaining({ dataServiceMapping: expectedMapping }),
+        );
+      });
 
-        it('passes mapping to service: pullAnalytics', async () => {
-          await dataBroker.pullAnalytics(['DHIS_01'], TO_OPTIONS);
-          expect(SERVICES.dhis.pullAnalytics).toHaveBeenCalledOnceWith(
-            expect.anything(),
-            expect.objectContaining({ dataServiceMapping: mapping }),
-          );
-        }),
-      );
+      it('passes mapping to service: delete', async () => {
+        const expectedMapping = new DataServiceMapping([
+          { dataSource: DATA_ELEMENTS.DHIS_01, service_type: 'dhis', config: {} },
+        ]);
+
+        await dataBroker.delete({ code: 'DHIS_01', type: 'dataElement' }, { value: 2 }, TO_OPTIONS);
+        expect(SERVICES.dhis.delete).toHaveBeenCalledOnceWith(
+          expect.anything(),
+          expect.anything(),
+          expect.objectContaining({ dataServiceMapping: expectedMapping }),
+        );
+      });
+
+      it('passes mapping to service: pullAnalytics', async () => {
+        const expectedMapping = new DataServiceMapping([
+          { dataSource: DATA_ELEMENTS.DHIS_01, service_type: 'dhis', config: {} },
+        ]);
+
+        await dataBroker.pullAnalytics(['DHIS_01'], TO_OPTIONS);
+        expect(SERVICES.dhis.pullAnalytics).toHaveBeenCalledOnceWith(
+          expect.anything(),
+          expect.objectContaining({ dataServiceMapping: expectedMapping }),
+        );
+      });
+
+      it('passes mapping to service: pullDataElements', async () => {
+        const expectedMapping = new DataServiceMapping([
+          { dataSource: DATA_ELEMENTS.DHIS_01, service_type: 'dhis', config: {} },
+        ]);
+
+        await dataBroker.pullDataElements(['DHIS_01'], TO_OPTIONS);
+        expect(SERVICES.dhis.pullMetadata).toHaveBeenCalledOnceWith(
+          expect.anything(),
+          'dataElement',
+          expect.objectContaining({ dataServiceMapping: expectedMapping }),
+        );
+      });
+
+      it('passes mapping to service: pullDataGroup', async () => {
+        const expectedMapping = new DataServiceMapping(
+          [],
+          [{ dataSource: DATA_GROUPS.DHIS_PROGRAM_01, service_type: 'dhis', config: {} }],
+        );
+
+        await dataBroker.pullDataGroup('DHIS_PROGRAM_01', TO_OPTIONS);
+        expect(SERVICES.dhis.pullMetadata).toHaveBeenCalledOnceWith(
+          expect.anything(),
+          'dataGroup',
+          expect.objectContaining({ dataServiceMapping: expectedMapping }),
+        );
+      });
     });
 
     describe('multiple org units pull', () => {
@@ -543,29 +585,17 @@ describe('DataBroker', () => {
     });
   });
 
-  describe('pullMetadata()', () => {
-    it('throws if the data sources belong to multiple services', async () => {
+  describe('pullDataElements()', () => {
+    it('throws if the data elements belong to multiple services', async () => {
       const dataBroker = new DataBroker();
-      await expect(
-        dataBroker.pullMetadata({ code: ['DHIS_01', 'TUPAIA_01'], type: 'dataElement' }),
-      ).toBeRejectedWith('Multiple data service types found, only a single service type expected');
-    });
-
-    it('single data element', async () => {
-      const dataBroker = new DataBroker();
-      await dataBroker.pullMetadata({ code: 'DHIS_01', type: 'dataElement' }, options);
-
-      expect(createServiceMock).toHaveBeenCalledOnceWith(mockModels, 'dhis', dataBroker);
-      expect(SERVICES.dhis.pullMetadata).toHaveBeenCalledOnceWith(
-        [DATA_ELEMENTS.DHIS_01],
-        'dataElement',
-        expect.objectContaining(options),
+      await expect(dataBroker.pullDataElements(['DHIS_01', 'TUPAIA_01'])).toBeRejectedWith(
+        'Multiple data service types found, only a single service type expected',
       );
     });
 
-    it('multiple data elements', async () => {
+    it('pulls data elements', async () => {
       const dataBroker = new DataBroker();
-      await dataBroker.pullMetadata({ code: ['DHIS_01', 'DHIS_02'], type: 'dataElement' }, options);
+      await dataBroker.pullDataElements(['DHIS_01', 'DHIS_02'], options);
 
       expect(createServiceMock).toHaveBeenCalledOnceWith(mockModels, 'dhis', dataBroker);
       expect(SERVICES.dhis.pullMetadata).toHaveBeenCalledOnceWith(
@@ -574,20 +604,16 @@ describe('DataBroker', () => {
         expect.objectContaining(options),
       );
     });
+  });
 
-    it('multiple data groups', async () => {
+  describe('pullDataGroup()', () => {
+    it('pulls data group', async () => {
       const dataBroker = new DataBroker();
-      await dataBroker.pullMetadata(
-        {
-          code: ['DHIS_PROGRAM_01', 'DHIS_PROGRAM_02'],
-          type: 'dataGroup',
-        },
-        options,
-      );
+      await dataBroker.pullDataGroup('DHIS_PROGRAM_01', options);
 
       expect(createServiceMock).toHaveBeenCalledOnceWith(mockModels, 'dhis', dataBroker);
       expect(SERVICES.dhis.pullMetadata).toHaveBeenCalledOnceWith(
-        [DATA_GROUPS.DHIS_PROGRAM_01, DATA_GROUPS.DHIS_PROGRAM_02],
+        [DATA_GROUPS.DHIS_PROGRAM_01],
         'dataGroup',
         expect.objectContaining(options),
       );

--- a/packages/data-broker/src/services/Service.ts
+++ b/packages/data-broker/src/services/Service.ts
@@ -13,7 +13,6 @@ import {
   DataSourceType,
   Diagnostics,
   EventResults,
-  Metadata,
   SyncGroupResults,
 } from '../types';
 import { DATA_SOURCE_TYPES } from '../utils';
@@ -82,7 +81,7 @@ export abstract class Service {
     dataSources: DataSource[],
     type: DataSourceType,
     options: PullMetadataOptions,
-  ): Promise<Metadata[]> {
+  ): Promise<{ code: string }[]> {
     return dataSources.map(ds => ({ code: ds.code }));
   }
 }

--- a/packages/data-broker/src/types/results.ts
+++ b/packages/data-broker/src/types/results.ts
@@ -12,17 +12,19 @@ export interface Analytic {
 
 export interface DataElementMetadata {
   code: string;
-  name: string;
+  name?: string;
 }
 
-export interface DhisMetadataObject extends DataElementMetadata {
+export interface DhisMetadataObject {
   id: string;
+  code: string;
+  name: string;
   options?: Record<string, string>;
 }
 
 export interface DataGroupMetadata {
   code: string;
-  name: string;
+  name?: string;
   dataElements?: DataElementMetadata[];
 }
 
@@ -77,8 +79,3 @@ export interface Diagnostics {
   errors: string[];
   wasSuccessful: boolean;
 }
-
-export type Metadata = {
-  code: string;
-  [key: string]: any; // any metadata
-};


### PR DESCRIPTION
Splitting `DataBroker.pullMetadata` into two APIs, one for data elements and one for data group.

Splitting the Service APIs will be done in another PR