### PR TITLE
WAITP-1511: map overlay error handling

### DIFF
--- a/packages/tupaia-web/src/components/FetchErrorAlert.tsx
+++ b/packages/tupaia-web/src/components/FetchErrorAlert.tsx
@@ -38,27 +38,26 @@ const Alert = styled(BaseAlert)`
   }
 `;
 
-interface DashboardItemErrorProps {
+interface FetchErrorAlertProps {
   error: UseQueryResult['error'] | null;
   refetch: UseQueryResult['refetch'];
-  isExport?: boolean;
 }
 /**
  * DashboardItemError handles error displays for dashboard items in both enlarged and collapsed states
  */
-export const DashboardItemError = ({ error, refetch, isExport }: DashboardItemErrorProps) => {
+export const FetchErrorAlert = ({ error, refetch }: FetchErrorAlertProps) => {
   return (
     <Alert severity="error">
       <Typography>{error.message}</Typography>
       <Typography>
-        {isExport ? (
-          <>
-            Contact <ErrorLink href="mailto:support@tupaia.org">support@tupaia.org</ErrorLink>
-          </>
-        ) : (
+        {refetch ? (
           <>
             <RetryButton onClick={refetch}>Retry loading data</RetryButton> or contact{' '}
             <ErrorLink href="mailto:support@tupaia.org">support@tupaia.org</ErrorLink>
+          </>
+        ) : (
+          <>
+            Contact <ErrorLink href="mailto:support@tupaia.org">support@tupaia.org</ErrorLink>
           </>
         )}
       </Typography>

--- a/packages/tupaia-web/src/components/index.ts
+++ b/packages/tupaia-web/src/components/index.ts
@@ -11,4 +11,5 @@ export { CheckboxList } from './CheckboxList';
 export { RouterButton, RouterLink } from './RouterButton';
 export { Form } from './Form';
 export { DateRangePicker } from './DateRangePicker';
-export * from './ModalTypography'
+export * from './ModalTypography';
+export { FetchErrorAlert } from './FetchErrorAlert';

--- a/packages/tupaia-web/src/features/DashboardItem/DashboardItemContent.tsx
+++ b/packages/tupaia-web/src/features/DashboardItem/DashboardItemContent.tsx
@@ -6,7 +6,8 @@
 import React, { useContext } from 'react';
 import { NoData } from '@tupaia/ui-components';
 import { BaseReport } from '@tupaia/types';
-import { ExpandItemButton } from './ExpandItemButton';
+import { FetchErrorAlert } from '../../components';
+import { DashboardItemReport, DashboardItemConfig } from '../../types';
 import {
   View,
   Chart,
@@ -15,9 +16,8 @@ import {
   NoAccessDashboard,
   NoDataAtLevelDashboard,
 } from '../Visuals';
-import { DashboardItemReport, DashboardItemConfig } from '../../types';
+import { ExpandItemButton } from './ExpandItemButton';
 import { DashboardItemContext } from './DashboardItemContext';
-import { DashboardItemError } from './DashboardItemError';
 import { DashboardItemLoader } from './DashboardItemLoader';
 import { DashboardItemDateDisplay } from './DashboardItemDateDisplay';
 
@@ -52,7 +52,7 @@ export const DashboardItemContent = () => {
 
   if (!DisplayComponent) return null;
 
-  if (error) return <DashboardItemError error={error} refetch={refetch} isExport={isExport} />;
+  if (error) return <FetchErrorAlert error={error} refetch={isExport ? undefined : refetch} />;
   // there will be no report returned if type is component, so don't show the loader for that type
   if (isLoading || (!report && config?.type !== 'component'))
     return <DashboardItemLoader name={config?.name} isExport={isExport} />;

--- a/packages/tupaia-web/src/features/Map/MapOverlaySelector/MapOverlayList.tsx
+++ b/packages/tupaia-web/src/features/Map/MapOverlaySelector/MapOverlayList.tsx
@@ -192,14 +192,15 @@ const useSavedMapOverlayDates = () => {
 /**
  * This is the parent list of all the map overlays available to pick from
  */
-export const MapOverlayList = ({ toggleOverlayLibrary }: { toggleOverlayLibrary?: Function }) => {
+export const MapOverlayList = ({ toggleOverlayLibrary }: { toggleOverlayLibrary?: () => void }) => {
   const [urlSearchParams, setUrlParams] = useSearchParams();
   const { projectCode, entityCode } = useParams();
   const { getSavedMapOverlayDateRange } = useSavedMapOverlayDates();
-  const { mapOverlayGroups = [], selectedOverlayCode, isLoadingMapOverlays } = useMapOverlays(
-    projectCode,
-    entityCode,
-  );
+  const {
+    mapOverlayGroups = [],
+    selectedOverlayCode,
+    isLoadingMapOverlays,
+  } = useMapOverlays(projectCode, entityCode);
 
   const onChangeMapOverlay = (e: ChangeEvent<HTMLInputElement>) => {
     const selectedCode = e.target.value;

--- a/packages/tupaia-web/src/features/Map/MapOverlaySelector/MapOverlaySelectorTitle.tsx
+++ b/packages/tupaia-web/src/features/Map/MapOverlaySelector/MapOverlaySelectorTitle.tsx
@@ -11,11 +11,27 @@ import { useParams } from 'react-router';
 import { useEntity, useMapOverlays } from '../../../api/queries';
 import { MOBILE_BREAKPOINT } from '../../../constants';
 import { useMapOverlayMapData } from '../utils';
+import { FetchErrorAlert } from '../../../components';
 
 const Wrapper = styled.div<{
   $hasMapOverlays: boolean;
 }>`
   border-radius: ${({ $hasMapOverlays }) => ($hasMapOverlays ? '0' : '0 0 5px 5px')};
+  .MuiAlert-root {
+    padding: 0.6rem 0.8rem;
+    margin-top: 1rem;
+    p {
+      font-size: 0.875rem;
+    }
+    .MuiAlert-message {
+      padding: 0;
+    }
+    @media screen and (max-width: ${MOBILE_BREAKPOINT}) {
+      p {
+        font-size: 0.75rem;
+      }
+    }
+  }
 `;
 
 const MapOverlayName = styled.span`
@@ -54,11 +70,12 @@ export const MapOverlaySelectorTitle = () => {
     projectCode,
     entityCode,
   );
-  const { isLoading: isLoadingOverlayData } = useMapOverlayMapData();
+  const { isLoading: isLoadingOverlayData, error, refetch } = useMapOverlayMapData();
 
   const { data: entity } = useEntity(projectCode, entityCode);
   const isLoading =
     isLoadingMapOverlays || isLoadingOverlayData || (hasMapOverlays && !selectedOverlay?.name);
+
   return (
     <Wrapper $hasMapOverlays={hasMapOverlays}>
       {isLoading ? (
@@ -76,6 +93,7 @@ export const MapOverlaySelectorTitle = () => {
           )}
         </Typography>
       )}
+      {error && <FetchErrorAlert error={error} refetch={refetch} />}
     </Wrapper>
   );
 };

--- a/packages/tupaia-web/src/features/Map/MapOverlaySelector/MobileMapOverlaySelector.tsx
+++ b/packages/tupaia-web/src/features/Map/MapOverlaySelector/MobileMapOverlaySelector.tsx
@@ -4,15 +4,16 @@
  */
 import React from 'react';
 import styled from 'styled-components';
+import { useParams } from 'react-router';
+import { Typography } from '@material-ui/core';
 import { ArrowBack, ArrowForwardIos } from '@material-ui/icons';
 import { Button } from '@tupaia/ui-components';
 import { MOBILE_BREAKPOINT } from '../../../constants';
+import { getMobileTopBarHeight } from '../../../utils';
+import { useMapOverlays } from '../../../api/queries';
 import { MapOverlayList } from './MapOverlayList';
 import { MapOverlaySelectorTitle } from './MapOverlaySelectorTitle';
 import { MapOverlayDatePicker } from './MapOverlayDatePicker';
-import { getMobileTopBarHeight } from '../../../utils/getTopBarHeight';
-import { useMapOverlays } from '../../../api/queries';
-import { useParams } from 'react-router';
 
 const Wrapper = styled.div`
   width: 100%;
@@ -25,23 +26,17 @@ const Wrapper = styled.div`
 `;
 
 const ExpandButton = styled(Button)`
-  width: 100%;
   display: flex;
   justify-content: space-between;
   text-transform: none;
   align-items: center;
-  font-size: 0.875rem;
   border-radius: 0;
   padding: 1rem;
-  text-align: left;
   background-color: ${({ theme }) => theme.overlaySelector.menuBackground};
   position: relative;
   &:hover,
   &:focus {
     background-color: ${({ theme }) => theme.overlaySelector.menuBackground};
-  }
-  p {
-    margin-left: 1rem;
   }
 `;
 
@@ -53,6 +48,7 @@ const OverlayLibraryHeaderButton = styled(ExpandButton)`
   font-size: 1.125rem;
   text-align: center;
   padding: 1rem;
+  width: 100%;
 `;
 
 const OverlayLibraryHeader = styled.span`
@@ -73,9 +69,7 @@ const OverlayMenu = styled.div<{
   position: fixed;
   bottom: 0;
   background-color: ${({ theme }) => theme.mobile.background};
-
   overflow: auto;
-
   ${OverlayLibraryHeaderButton} {
     display: ${({ $expanded }) => ($expanded ? 'flex' : 'none')};
   }
@@ -84,11 +78,22 @@ const OverlayMenu = styled.div<{
   }
 `;
 
-const ExpandButtonLabel = styled.div`
+const MapOverlayTitle = styled(Typography).attrs({
+  variant: 'h2',
+})`
   padding-bottom: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: ${({ theme }) => theme.typography.fontWeightMedium};
+`;
+
+const TitleWrapper = styled.div`
+  width: 100%;
+  background-color: ${({ theme }) => theme.overlaySelector.menuBackground};
+  padding: 1rem;
 `;
 
 const ButtonWrapper = styled.div`
+  display: flex;
   // add padding around the date picker when present
   > div {
     padding: 1rem;
@@ -109,25 +114,24 @@ export const MobileMapOverlaySelector = ({
 
   return (
     <Wrapper>
-      {!overlayLibraryOpen && (
-        <ButtonWrapper>
-          <MapOverlayDatePicker />
+      <ButtonWrapper>
+        <MapOverlayDatePicker />
+        <TitleWrapper>
+          <MapOverlayTitle>Map Overlay</MapOverlayTitle>
+          <MapOverlaySelectorTitle />
+        </TitleWrapper>
+        {hasMapOverlays && (
           <ExpandButton
-            onClick={hasMapOverlays ? toggleOverlayLibrary : undefined}
+            onClick={toggleOverlayLibrary}
             aria-controls="overlay-selector"
+            title={`${overlayLibraryOpen ? 'Hide' : 'Show'} overlay library`}
           >
-            <span>
-              <ExpandButtonLabel>Map Overlay</ExpandButtonLabel>
-              <MapOverlaySelectorTitle />
-            </span>
-            {hasMapOverlays && (
-              <ArrowWrapper>
-                <ArrowForwardIos />
-              </ArrowWrapper>
-            )}
+            <ArrowWrapper>
+              <ArrowForwardIos />
+            </ArrowWrapper>
           </ExpandButton>
-        </ButtonWrapper>
-      )}
+        )}
+      </ButtonWrapper>
       <OverlayMenu
         $expanded={overlayLibraryOpen}
         aria-expanded={overlayLibraryOpen}

--- a/packages/tupaia-web/src/features/Map/MapOverlaysLayer/MapOverlaysLayer.tsx
+++ b/packages/tupaia-web/src/features/Map/MapOverlaysLayer/MapOverlaysLayer.tsx
@@ -48,10 +48,11 @@ export const MapOverlaysLayer = ({
 }: {
   hiddenValues: LegendProps['hiddenValues'];
 }) => {
-  const { serieses, measureData, isLoading, isLoadingDifferentMeasureLevel } =
+  const { serieses, measureData, isLoading, isLoadingDifferentMeasureLevel, error } =
     useMapOverlayMapData(hiddenValues);
   useZoomToEntity();
 
+  if (error) return null;
   return (
     <>
       <PolygonLayer measureData={measureData} serieses={serieses} isLoading={isLoading} />

--- a/packages/tupaia-web/src/features/Map/utils/useMapOverlayTableData.ts
+++ b/packages/tupaia-web/src/features/Map/utils/useMapOverlayTableData.ts
@@ -81,7 +81,11 @@ export const useMapOverlayTableData = ({
     selectedOverlay?.measureLevel?.includes('Country') &&
     entity?.type !== 'project';
 
-  const { data: entities } = useMapOverlayEntities(
+  const {
+    data: entities,
+    error: mapOverlayEntitiesError,
+    refetch: refetchMapOverlayEntities,
+  } = useMapOverlayEntities(
     projectCode,
     rootEntityCode,
     includeRootEntity,
@@ -89,7 +93,16 @@ export const useMapOverlayTableData = ({
     keepPreviousData,
   );
 
-  const { data, isLoading, isFetched, isFetching, isIdle, isPreviousData } = useMapOverlayReport(
+  const {
+    data,
+    isLoading,
+    isFetched,
+    isFetching,
+    isIdle,
+    isPreviousData,
+    error: mapOverlayReportError,
+    refetch: refetchMapOverlayReport,
+  } = useMapOverlayReport(
     projectCode,
     rootEntityCode,
     selectedOverlay,
@@ -124,5 +137,7 @@ export const useMapOverlayTableData = ({
     activeEntity: entity,
     startDate,
     endDate,
+    error: mapOverlayEntitiesError || mapOverlayReportError,
+    refetch: mapOverlayEntitiesError ? refetchMapOverlayEntities : refetchMapOverlayReport,
   };
 };

--- a/packages/tupaia-web/src/utils/index.ts
+++ b/packages/tupaia-web/src/utils/index.ts
@@ -14,3 +14,4 @@ export { transformDownloadLink } from './transformDownloadLink';
 export { useDebounce } from './useDebounce';
 export { getDefaultDashboard } from './getDefaultDashboard';
 export { useGAEffect } from './useGAEffect';
+export { getTopBarHeight, getMobileTopBarHeight } from './getTopBarHeight';


### PR DESCRIPTION
### Issue WAITP-1511: map overlay error handling

### Changes:
- Show an error message and option to refetch when an error is caught for map overlay data\
- Don't show blank map overlay data when an error is caught
- Fix issue with map overlays reloading on open/close of the library

---

### Screenshots:
![Screenshot 2023-12-21 at 3 04 54 pm](https://github.com/beyondessential/tupaia/assets/129009580/5ea4275e-91ec-46f1-82e4-9994120d6c4e)
![Screenshot 2023-12-21 at 3 05 09 pm](https://github.com/beyondessential/tupaia/assets/129009580/4bb5213f-3cfd-4b33-a276-444250f7f704)
