### PR TITLE
WAITP-1527: GZIP JS files and json responses on tupaia and datatrak

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "ts-node": "^10.7.0",
     "typescript": "^5.2.2",
     "vite": "^4.4.8",
+    "vite-plugin-compression": "^0.5.1",
     "vite-plugin-ejs": "^1.6.4",
     "yargs": "15.4.1"
   },

--- a/packages/devops/configs/servers.conf
+++ b/packages/devops/configs/servers.conf
@@ -65,6 +65,8 @@ server {
   server_name  ~^.*datatrak\.tupaia\.org$;
   root         /home/ubuntu/tupaia/packages/datatrak-web/dist;
 
+  gzip_static on;
+
   # Redirect to HTTPs when behind a proxy
   if ($http_x_forwarded_proto = "http") {
     return 301 https://$host$request_uri;
@@ -417,12 +419,6 @@ server {
 }
 
 server {
-
-  gzip on;
-  gzip_types      text/plain application/xml application/javascript application/json;
-  gzip_proxied    no-cache no-store private expired auth;
-  gzip_min_length 100;
-
   listen       80;
   listen       [::]:80;
   server_name  ~^.*tupaia-web-api\.tupaia\.org$;
@@ -591,6 +587,13 @@ server {
   listen       [::]:80;
   server_name  tupaia.org www.tupaia.org ~^(?<subdomain>((?!^www).)+)\.tupaia\.org$ ~^.*mobile\.tupaia\.org$;
   root         /home/ubuntu/tupaia/packages/tupaia-web/dist;
+
+  #gzip on;
+  #gzip_types      text/plain application/xml application/javascript;
+  #gzip_proxied    no-cache no-store private expired auth;
+  #gzip_min_length 1000;
+  gzip_static on;
+
 
   # Redirect to HTTPs when behind a proxy
   if ($http_x_forwarded_proto = "http") {

--- a/packages/devops/configs/servers.conf
+++ b/packages/devops/configs/servers.conf
@@ -428,7 +428,7 @@ server {
   gzip on;
   gzip_types text/plain application/json;
   gzip_proxied no-cache no-store private expired auth;
-  gzip_min_length 1000;
+  gzip_min_length 10000;
 
   # Redirect to HTTPs when behind a proxy
   if ($http_x_forwarded_proto = "http") {
@@ -472,7 +472,7 @@ server {
   gzip on;
   gzip_types text/plain application/json;
   gzip_proxied no-cache no-store private expired auth;
-  gzip_min_length 1000;
+  gzip_min_length 10000;
 
   # Redirect to HTTPs when behind a proxy
   if ($http_x_forwarded_proto = "http") {

--- a/packages/devops/configs/servers.conf
+++ b/packages/devops/configs/servers.conf
@@ -65,10 +65,7 @@ server {
   server_name  ~^.*datatrak\.tupaia\.org$;
   root         /home/ubuntu/tupaia/packages/datatrak-web/dist;
 
-  gzip on;
-  gzip_types      text/plain application/xml application/javascript;
-  gzip_proxied    no-cache no-store private expired auth;
-  gzip_min_length 1000;
+  # serve gzip files if they are available
   gzip_static on;
 
   # Redirect to HTTPs when behind a proxy
@@ -428,6 +425,11 @@ server {
   server_name  ~^.*tupaia-web-api\.tupaia\.org$;
   root         /usr/share/nginx/html;
 
+  gzip on;
+  gzip_types text/plain application/json;
+  gzip_proxied no-cache no-store private expired auth;
+  gzip_min_length 1000;
+
   # Redirect to HTTPs when behind a proxy
   if ($http_x_forwarded_proto = "http") {
     return 301 https://$host$request_uri;
@@ -466,6 +468,11 @@ server {
   listen       [::]:80;
   server_name  ~^.*datatrak-web-api\.tupaia\.org$;
   root         /usr/share/nginx/html;
+
+  gzip on;
+  gzip_types text/plain application/json;
+  gzip_proxied no-cache no-store private expired auth;
+  gzip_min_length 1000;
 
   # Redirect to HTTPs when behind a proxy
   if ($http_x_forwarded_proto = "http") {
@@ -592,10 +599,7 @@ server {
   server_name  tupaia.org www.tupaia.org ~^(?<subdomain>((?!^www).)+)\.tupaia\.org$ ~^.*mobile\.tupaia\.org$;
   root         /home/ubuntu/tupaia/packages/tupaia-web/dist;
 
-  gzip on;
-  gzip_types      text/plain application/xml application/javascript;
-  gzip_proxied    no-cache no-store private expired auth;
-  gzip_min_length 1000;
+  # serve gzip files if they are available
   gzip_static on;
 
 

--- a/packages/devops/configs/servers.conf
+++ b/packages/devops/configs/servers.conf
@@ -65,6 +65,10 @@ server {
   server_name  ~^.*datatrak\.tupaia\.org$;
   root         /home/ubuntu/tupaia/packages/datatrak-web/dist;
 
+  gzip on;
+  gzip_types      text/plain application/xml application/javascript;
+  gzip_proxied    no-cache no-store private expired auth;
+  gzip_min_length 1000;
   gzip_static on;
 
   # Redirect to HTTPs when behind a proxy
@@ -588,10 +592,10 @@ server {
   server_name  tupaia.org www.tupaia.org ~^(?<subdomain>((?!^www).)+)\.tupaia\.org$ ~^.*mobile\.tupaia\.org$;
   root         /home/ubuntu/tupaia/packages/tupaia-web/dist;
 
-  #gzip on;
-  #gzip_types      text/plain application/xml application/javascript;
-  #gzip_proxied    no-cache no-store private expired auth;
-  #gzip_min_length 1000;
+  gzip on;
+  gzip_types      text/plain application/xml application/javascript;
+  gzip_proxied    no-cache no-store private expired auth;
+  gzip_min_length 1000;
   gzip_static on;
 
 

--- a/packages/devops/configs/servers.conf
+++ b/packages/devops/configs/servers.conf
@@ -418,6 +418,11 @@ server {
 
 server {
 
+  gzip on;
+  gzip_types      text/plain application/xml application/javascript application/json;
+  gzip_proxied    no-cache no-store private expired auth;
+  gzip_min_length 100;
+
   listen       80;
   listen       [::]:80;
   server_name  ~^.*tupaia-web-api\.tupaia\.org$;

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,6 +5,7 @@
 
 import { defineConfig, loadEnv } from 'vite';
 import { ViteEjsPlugin } from 'vite-plugin-ejs';
+import viteCompression from 'vite-plugin-compression';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 import dns from 'dns';
@@ -39,6 +40,7 @@ export default defineConfig(({ command, mode }) => {
     // ViteEjsPlugin is used to allow the use of EJS templates in the index.html file, for analytics scripts etc
     plugins: [
       ViteEjsPlugin(),
+      viteCompression(),
       react({
         jsxRuntime: 'classic',
       }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -26221,7 +26221,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:^10.0.1":
+"fs-extra@npm:^10.0.0, fs-extra@npm:^10.0.1":
   version: 10.1.0
   resolution: "fs-extra@npm:10.1.0"
   dependencies:
@@ -46964,6 +46964,7 @@ __metadata:
     ts-node: ^10.7.0
     typescript: ^5.2.2
     vite: ^4.4.8
+    vite-plugin-compression: ^0.5.1
     vite-plugin-ejs: ^1.6.4
     yargs: 15.4.1
   languageName: unknown
@@ -48263,6 +48264,19 @@ __metadata:
     unist-util-stringify-position: ^2.0.0
     vfile-message: ^2.0.0
   checksum: 4a1b62d12ce7cc6684cb4d0dbae3dd6e22f8abfa7e332752320bfe8f76e96d22db76e7256a015068d30a4cdd4ed3362c20aa094013c4d29ad3bf43c4e4f7b00c
+  languageName: node
+  linkType: hard
+
+"vite-plugin-compression@npm:^0.5.1":
+  version: 0.5.1
+  resolution: "vite-plugin-compression@npm:0.5.1"
+  dependencies:
+    chalk: ^4.1.2
+    debug: ^4.3.3
+    fs-extra: ^10.0.0
+  peerDependencies:
+    vite: ">=2.0.0"
+  checksum: 55f01e7d6c9203776245614d30fa14df995bdf3cdb12ea4e2c0b9120741b74bd010b3aa5c467316f008aceaea6e2fd18fb394143cce06d22da9787d722da5223
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue #: WAITP-1527: GZIP JS files and json responses on tupaia and datatrak

These changes reduce the amount of data transferred over the network on landing page from 10MB to 3MB

### Changes:
- Pre-compress JS files in vite build
- Configure NGINX to server zip JS files if they exist
- Add GZIP compression for json responses in NGINX config

---

### Screenshots:
![image](https://github.com/beyondessential/tupaia/assets/12807916/70b583e5-fc55-4537-b81d-8f6c241c495c)

