### PR TITLE
no-issue: Fix persistent DataTrak sidebar

### DIFF
--- a/packages/datatrak-web/src/layout/UserMenu/MenuList.tsx
+++ b/packages/datatrak-web/src/layout/UserMenu/MenuList.tsx
@@ -8,8 +8,7 @@ import styled from 'styled-components';
 import { useMatch } from 'react-router';
 import { Link, ListItem } from '@material-ui/core';
 import { Button, RouterLink } from '@tupaia/ui-components';
-import { useCurrentUser } from '../../api';
-import { useLogout } from '../../api/mutations';
+import { useCurrentUser, useLogout } from '../../api';
 import { ROUTES } from '../../constants';
 import { CancelConfirmModal } from '../../components';
 
@@ -18,7 +17,7 @@ interface MenuItem {
   to?: string | null;
   href?: string;
   isExternal?: boolean;
-  onClick?: (e: any) => void;
+  onClick?: (e?: Event) => void;
   component?: ComponentType<any> | string;
 }
 
@@ -64,14 +63,14 @@ export const MenuList = ({
   const { isLoggedIn, projectId } = useCurrentUser();
   const { mutate: logout } = useLogout();
 
-  const onClickInternalLink = e => {
-    if (isSurveyScreen && !isSuccessScreen) {
+  const shouldShowCancelModal = isSurveyScreen && !isSuccessScreen;
+
+  const onClickInternalLink = (e: Event) => {
+    if (shouldShowCancelModal) {
       e.preventDefault();
       setIsOpen(true);
     }
   };
-
-  const shouldShowCancelModal = isSurveyScreen && !isSuccessScreen;
 
   const accountSettingsItem = {
     label: 'Account settings',

--- a/packages/datatrak-web/src/layout/UserMenu/MenuList.tsx
+++ b/packages/datatrak-web/src/layout/UserMenu/MenuList.tsx
@@ -75,7 +75,10 @@ export const MenuList = ({
 
   const accountSettingsItem = {
     label: 'Account settings',
-    onClick: onClickInternalLink,
+    onClick: e => {
+      onClickInternalLink(e);
+      onCloseMenu();
+    },
     to: shouldShowCancelModal ? null : ROUTES.ACCOUNT_SETTINGS,
     component: shouldShowCancelModal ? 'button' : RouterLink,
   };

--- a/packages/datatrak-web/src/layout/UserMenu/MenuList.tsx
+++ b/packages/datatrak-web/src/layout/UserMenu/MenuList.tsx
@@ -96,9 +96,9 @@ export const MenuList = ({
     },
   };
 
-  const hasProjectSelected = !!projectId;
-
   const getMenuItems = () => {
+    const hasProjectSelected = !!projectId;
+
     const items: MenuItem[] = [];
     if (isLoggedIn && hasProjectSelected) items.push(accountSettingsItem);
     items.push(helpCentreItem);


### PR DESCRIPTION
### Changes

In medium and smaller size classes (where the hamburger menu appears as a drawer/sidebar) it would not dismiss when you clicked **Account settings**. This PR fixes that.

---

### Screenshots

![Screenshot 2024-01-09T091607](https://github.com/beyondessential/tupaia/assets/33956381/afbabfbc-bdef-46f2-8bc2-4aa715f3d752)
