### PR TITLE
WAITP-1536: Require confirmation to leave account settings

### DIFF
--- a/packages/datatrak-web/src/layout/Header/LogoButton.tsx
+++ b/packages/datatrak-web/src/layout/Header/LogoButton.tsx
@@ -52,7 +52,7 @@ export const LogoButton = () => {
   return (
     <>
       <Logo component={RouterLink} onClick={onClickLogo} to="/" title="Home">
-        <img src="/datatrak-logo-black.svg" alt="Tupaia Datatrak logo" width="100%" height="100%" />
+        <img src="/datatrak-logo-black.svg" alt="Tupaia DataTrak logo" width="100%" height="100%" />
       </Logo>
       <CancelConfirmModal isOpen={leaveSurveyModalIsOpen} onClose={closeLeaveSurveyModal} />
       <CancelConfirmModal

--- a/packages/datatrak-web/src/layout/Header/LogoButton.tsx
+++ b/packages/datatrak-web/src/layout/Header/LogoButton.tsx
@@ -28,19 +28,25 @@ const Logo = styled(Button)`
 `;
 
 export const LogoButton = () => {
-  const [surveyCancelModalIsOpen, setIsOpen] = useState(false);
+  const [leaveSurveyModalIsOpen, setLeaveSurveyModalOpen] = useState(false);
+  const openLeaveSurveyModal = () => setLeaveSurveyModalOpen(true);
+  const closeLeaveSurveyModal = () => setLeaveSurveyModalOpen(false);
+
+  const [leaveSettingsModalIsOpen, setLeaveSettingsModalIsOpen] = useState(false);
+  const openLeaveSettingsModal = () => setLeaveSettingsModalIsOpen(true);
+  const closeLeaveSettingsModal = () => setLeaveSettingsModalIsOpen(false);
+
   const isSurveyScreen = !!useMatch(ROUTES.SURVEY_SCREEN);
   const isSuccessScreen = !!useMatch(ROUTES.SURVEY_SUCCESS);
+  const isAccountSettings = !!useMatch(ROUTES.ACCOUNT_SETTINGS);
 
   const onClickLogo = e => {
+    e.preventDefault();
     if (isSurveyScreen && !isSuccessScreen) {
-      e.preventDefault();
-      setIsOpen(true);
+      openLeaveSurveyModal();
+    } else if (isAccountSettings) {
+      openLeaveSettingsModal();
     }
-  };
-
-  const onClose = () => {
-    setIsOpen(false);
   };
 
   return (
@@ -48,7 +54,15 @@ export const LogoButton = () => {
       <Logo component={RouterLink} onClick={onClickLogo} to="/" title="Home">
         <img src="/datatrak-logo-black.svg" alt="Tupaia Datatrak logo" width="100%" height="100%" />
       </Logo>
-      <CancelConfirmModal isOpen={surveyCancelModalIsOpen} onClose={onClose} />
+      <CancelConfirmModal isOpen={leaveSurveyModalIsOpen} onClose={closeLeaveSurveyModal} />
+      <CancelConfirmModal
+        isOpen={leaveSettingsModalIsOpen}
+        onClose={closeLeaveSettingsModal}
+        headingText="Leave this page?"
+        bodyText="Your changes will not be saved"
+        confirmText="Leave page"
+        cancelText="Back to editing"
+      />
     </>
   );
 };

--- a/packages/datatrak-web/src/layout/Header/LogoButton.tsx
+++ b/packages/datatrak-web/src/layout/Header/LogoButton.tsx
@@ -32,9 +32,9 @@ export const LogoButton = () => {
   const openLeaveSurveyModal = () => setLeaveSurveyModalOpen(true);
   const closeLeaveSurveyModal = () => setLeaveSurveyModalOpen(false);
 
-  const [leaveSettingsModalIsOpen, setLeaveSettingsModalIsOpen] = useState(false);
-  const openLeaveSettingsModal = () => setLeaveSettingsModalIsOpen(true);
-  const closeLeaveSettingsModal = () => setLeaveSettingsModalIsOpen(false);
+  const [leaveSettingsModalIsOpen, setLeaveSettingsModalOpen] = useState(false);
+  const openLeaveSettingsModal = () => setLeaveSettingsModalOpen(true);
+  const closeLeaveSettingsModal = () => setLeaveSettingsModalOpen(false);
 
   const isSurveyScreen = !!useMatch(ROUTES.SURVEY_SCREEN);
   const isSuccessScreen = !!useMatch(ROUTES.SURVEY_SUCCESS);


### PR DESCRIPTION
### Issue WAITP-1536: Require confirmation to leave account settings

### Changes

Confirmation modal is now shown when clicking the logo in the navbar or when logging out.

### Remark

- Modal appears regardless of whether you actually have unsaved changes input into any of the form fields on this page. This would require some gymnastics because of how React wants data to flow. **Is this something we want to pursue regardless?** Confirmation for abandoning a survey currently has the same behaviour.
- The primary and secondary buttons are reversed from the Figma design, but match those of the existing confirmation model for leaving a survey.

---

### Screenshots