### PR TITLE
RN-880: Make 'multiValue' visualisations exportable

### DIFF
--- a/packages/tupaia-web/src/features/DashboardItem/ExpandItemButton.tsx
+++ b/packages/tupaia-web/src/features/DashboardItem/ExpandItemButton.tsx
@@ -8,7 +8,7 @@ import styled from 'styled-components';
 import MuiZoomIcon from '@material-ui/icons/ZoomIn';
 import { useSearchParams } from 'react-router-dom';
 import { Button } from '@tupaia/ui-components';
-import { ViewReport } from '@tupaia/types';
+import { DashboardItemTypes, ViewReport, ViewTypes } from '@tupaia/types';
 import { MOBILE_BREAKPOINT, URL_SEARCH_PARAMS } from '../../constants';
 import { DashboardItemConfig } from '../../types';
 import { DashboardItemContext } from './DashboardItemContext';
@@ -58,7 +58,12 @@ const ZoomInIcon = styled(MuiZoomIcon)`
   }
 `;
 
-const EXPANDABLE_TYPES = ['chart', 'dataDownload', 'filesDownload'];
+const EXPANDABLE_TYPES = [
+  DashboardItemTypes.Chart,
+  ViewTypes.DataDownload,
+  ViewTypes.FilesDownload,
+  ViewTypes.MultiValue,
+];
 
 /**
  * ExpandItemButton handles the 'expand' button for the dashboard item in both mobile and desktop sizes
@@ -74,12 +79,12 @@ export const ExpandItemButton = () => {
   const getIsExpandable = () => {
     if (periodGranularity) return true;
     // always allow matrix to be expanded
-    else if (type === 'matrix') return true;
+    else if (type === DashboardItemTypes.Matrix) return true;
     // only expand expandable types if they have data, if they don't have periodGranularity set
     else if (EXPANDABLE_TYPES.includes(type) || (viewType && EXPANDABLE_TYPES.includes(viewType))) {
       const { data } = report as ViewReport;
       return data && data.length > 0;
-    } else if (viewType === 'qrCodeVisual') {
+    } else if (viewType === ViewTypes.QRCode) {
       const { data } = report as ViewReport;
       return data && data.length > 1;
     }
@@ -89,7 +94,7 @@ export const ExpandItemButton = () => {
   if (!getIsExpandable()) return null;
 
   const getText = () => {
-    if (viewType === 'dataDownload' || viewType === 'qrCodeVisual')
+    if (viewType && [ViewTypes.DataDownload, ViewTypes.FilesDownload].includes(viewType))
       return 'Expand to download data';
     return 'Expand chart';
   };

--- a/packages/tupaia-web/src/features/EnlargedDashboardItem/EnlargedDashboardItem.tsx
+++ b/packages/tupaia-web/src/features/EnlargedDashboardItem/EnlargedDashboardItem.tsx
@@ -43,17 +43,16 @@ const Wrapper = styled.div<{
  */
 export const EnlargedDashboardItem = ({ entityName }: { entityName?: Entity['name'] }) => {
   const [urlSearchParams, setUrlSearchParams] = useSearchParams();
-  const {
-    reportCode,
-    currentDashboardItem,
-    isLoadingDashboards,
-    reportData,
-  } = useEnlargedDashboardItem();
+  const { reportCode, currentDashboardItem, isLoadingDashboards, reportData } =
+    useEnlargedDashboardItem();
 
   const { type, presentationOptions } = currentDashboardItem?.config || {};
 
-  const { exportWithLabels = false, exportWithTable = true, exportWithTableDisabled = false } =
-    presentationOptions || {};
+  const {
+    exportWithLabels = false,
+    exportWithTable = true,
+    exportWithTableDisabled = false,
+  } = presentationOptions || {};
 
   const [exportConfig, dispatch] = useReducer(exportReducer, {
     isExporting: false,
@@ -77,7 +76,7 @@ export const EnlargedDashboardItem = ({ entityName }: { entityName?: Entity['nam
 
   const { isExportMode } = exportConfig;
   const isDataDownload =
-    ((currentDashboardItem?.config as unknown) as ViewConfig)?.viewType === 'dataDownload';
+    (currentDashboardItem?.config as unknown as ViewConfig)?.viewType === 'dataDownload';
 
   const getHasBigData = () => {
     if (isDataDownload || !reportData) return false;

--- a/packages/tupaia-web/src/features/EnlargedDashboardItem/ExportButton.tsx
+++ b/packages/tupaia-web/src/features/EnlargedDashboardItem/ExportButton.tsx
@@ -5,16 +5,17 @@
 
 import React, { useContext } from 'react';
 import styled from 'styled-components';
+import { useSearchParams } from 'react-router-dom';
 import { GetApp } from '@material-ui/icons';
+import { DashboardItemTypes, ViewTypes } from '@tupaia/types';
 import { IconButton } from '@tupaia/ui-components';
+import { URL_SEARCH_PARAMS } from '../../constants';
 import {
   ACTION_TYPES,
   ExportContext,
   ExportDispatchContext,
   useEnlargedDashboardItem,
 } from './utils';
-import { useSearchParams } from 'react-router-dom';
-import { URL_SEARCH_PARAMS } from '../../constants';
 
 const Button = styled(IconButton).attrs({
   color: 'default',
@@ -26,15 +27,25 @@ const Button = styled(IconButton).attrs({
   z-index: 1;
 `;
 
+const EXPORTABLE_TYPES = [
+  DashboardItemTypes.Chart,
+  DashboardItemTypes.Matrix,
+  ViewTypes.MultiValue,
+];
+
 export const ExportButton = () => {
   const [urlSearchParams] = useSearchParams();
   const { isExportMode } = useContext(ExportContext);
   const dispatch = useContext(ExportDispatchContext)!;
   const { currentDashboardItem } = useEnlargedDashboardItem();
-  const { type } = currentDashboardItem?.config || {};
+  const { type, viewType } = currentDashboardItem?.config || {};
+  const displayType = viewType || type;
+
+  // Only show export button if the current dashboard item is a chart, matrix or multi-value view AND it is not a drilldown
   const canExport =
-    (type === 'chart' || type === 'matrix') &&
+    EXPORTABLE_TYPES.includes(displayType) &&
     !urlSearchParams.get(URL_SEARCH_PARAMS.REPORT_DRILLDOWN_ID);
+
   const onClickExportButton = () => {
     dispatch({
       type: ACTION_TYPES.SET_IS_EXPORT_MODE,

--- a/packages/tupaia-web/src/features/EnlargedDashboardItem/ExportDashboardItem.tsx
+++ b/packages/tupaia-web/src/features/EnlargedDashboardItem/ExportDashboardItem.tsx
@@ -22,6 +22,7 @@ import {
 } from './utils';
 import { Entity } from '../../types';
 import { EnlargedDashboardVisual } from './EnlargedDashboardVisual';
+import { DashboardItemTypes, ViewTypes } from '@tupaia/types';
 
 const Wrapper = styled.div`
   flex-grow: 1;
@@ -143,7 +144,7 @@ const PreviewWrapper = styled.div<{
 
 const PreviewContainer = styled.div`
   min-width: 50rem; // the size of the a4 page
-  width: max-content;
+  width: 100%;
   padding: 1rem;
   h2 {
     color: ${({ theme }) => theme.palette.common.black};
@@ -221,10 +222,13 @@ export const ExportDashboardItem = ({ entityName }: { entityName?: Entity['name'
       value: EXPORT_FORMATS.XLSX,
     },
   ];
-  const { type } = currentDashboardItem?.config ?? {};
+
+  const { type, viewType } = currentDashboardItem?.config ?? {};
+  const isChart = type === DashboardItemTypes.Chart;
+
   // PNG export is not available for matrix reports
   const availableExportOptions =
-    type === 'chart'
+    isChart || viewType === ViewTypes.MultiValue
       ? exportOptions
       : exportOptions.filter(option => option.value !== EXPORT_FORMATS.PNG);
 
@@ -245,7 +249,7 @@ export const ExportDashboardItem = ({ entityName }: { entityName?: Entity['name'
                 name="exportFormat"
                 label="Export format"
               />
-              {exportFormat === EXPORT_FORMATS.PNG && (
+              {exportFormat === EXPORT_FORMATS.PNG && isChart && (
                 <FormGroup>
                   <Legend>Display options</Legend>
                   <Checkbox

--- a/packages/tupaia-web/src/features/Visuals/Chart.tsx
+++ b/packages/tupaia-web/src/features/Visuals/Chart.tsx
@@ -177,7 +177,7 @@ export const Chart = () => {
   const showTable = isEnlarged ? !isExport || config?.presentationOptions?.exportWithTable : false;
 
   const views = isExport ? EXPORT_DISPLAY_TYPE_VIEWS : DISPLAY_TYPE_VIEWS;
-  let availableDisplayTypes = showTable ? views : [views[0]];
+  const availableDisplayTypes = showTable ? views : [views[0]];
 
   const viewContent = {
     ...report,

--- a/packages/tupaia-web/src/features/Visuals/View/MultiValue.tsx
+++ b/packages/tupaia-web/src/features/Visuals/View/MultiValue.tsx
@@ -10,7 +10,17 @@ import { MultiValueViewConfig, ViewConfig, ViewReport, ViewDataItem } from '@tup
 
 const StyledTable = styled(Table)<{
   $isExport?: boolean;
+  $isEnlarged?: boolean;
 }>`
+  max-width: 30rem;
+  margin: ${({ $isEnlarged, $isExport }) => {
+    if (!$isEnlarged) return 0;
+    if ($isExport) {
+      return '1rem auto 0';
+    }
+    return '2rem auto 0';
+  }};
+  color: ${({ theme, $isExport }) => ($isExport ? theme.palette.common.black : 'inherit')};
   th.MuiTableCell-root,
   td.MuiTableCell-root {
     ${props => props.$isExport && 'color: currentColor;'}
@@ -47,6 +57,7 @@ interface MultiValueProps {
   report: ViewReport;
   config: ViewConfig;
   isExport?: boolean;
+  isEnlarged?: boolean;
 }
 
 const TableCell = styled(MuiTableCell)`
@@ -61,10 +72,10 @@ const TableCell = styled(MuiTableCell)`
   }
 `;
 
-export const MultiValue = ({ report: { data }, config, isExport }: MultiValueProps) => {
+export const MultiValue = ({ report: { data }, config, isExport, isEnlarged }: MultiValueProps) => {
   const { valueType } = config;
   return (
-    <StyledTable $isExport={isExport}>
+    <StyledTable $isExport={isExport} $isEnlarged={isEnlarged}>
       <TableBody>
         {data?.map((datum: ViewDataItem, i) => (
           <TableRow key={i}>

--- a/packages/tupaia-web/src/types/dashboard.d.ts
+++ b/packages/tupaia-web/src/types/dashboard.d.ts
@@ -8,9 +8,9 @@ import {
   MatrixConfig,
   MultiValueRowViewConfig,
   MultiValueViewConfig,
-  ViewConfig,
   DashboardItem as BaseDashboardItem,
   TupaiaWebDashboardsRequest,
+  ViewTypes,
 } from '@tupaia/types';
 import { KeysToCamelCase } from './helpers';
 
@@ -26,7 +26,7 @@ type BaseConfig = Omit<
 >;
 
 export type DashboardItemConfig = BaseConfig & {
-  viewType?: ViewConfig['viewType'];
+  viewType?: ViewTypes;
   presentationOptions?: DashboardItemConfigPresentationOptions;
   componentName?: ComponentConfig['componentName'];
 };

--- a/packages/types/src/types/index.ts
+++ b/packages/types/src/types/index.ts
@@ -57,6 +57,8 @@ export {
   SurveyResponseTemplateVariables,
   MarkdownTemplateVariables,
   FeedItemTypes,
+  DashboardItemTypes,
+  ViewTypes,
 } from './models-extra';
 export * from './requests';
 export * from './css';

--- a/packages/types/src/types/models-extra/dashboard-item/common.ts
+++ b/packages/types/src/types/models-extra/dashboard-item/common.ts
@@ -169,3 +169,10 @@ export type ExportPresentationOptions = {
   exportWithTable?: boolean;
   exportWithTableDisabled?: boolean;
 };
+
+export enum DashboardItemTypes {
+  Chart = 'chart',
+  Component = 'component',
+  Matrix = 'matrix',
+  View = 'view',
+}

--- a/packages/types/src/types/models-extra/dashboard-item/index.ts
+++ b/packages/types/src/types/models-extra/dashboard-item/index.ts
@@ -26,6 +26,7 @@ import type {
   SingleValueViewConfig,
   ViewConfig,
 } from './views';
+export { ViewTypes } from './views';
 
 export type {
   BarChartConfig,
@@ -42,7 +43,7 @@ export type {
  */
 export type DashboardItemConfig = ChartConfig | ComponentConfig | MatrixConfig | ViewConfig;
 
-export type { ValueType } from './common';
+export { DashboardItemTypes, ValueType } from './common';
 export type {
   MatrixConfig,
   PresentationOptionCondition,

--- a/packages/types/src/types/models-extra/dashboard-item/matricies.ts
+++ b/packages/types/src/types/models-extra/dashboard-item/matricies.ts
@@ -2,15 +2,19 @@
  * Tupaia
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
-
-import type { BaseConfig, ExportPresentationOptions, ValueType } from './common';
 import { CssColor } from '../../css';
+import type {
+  BaseConfig,
+  DashboardItemTypes,
+  ExportPresentationOptions,
+  ValueType,
+} from './common';
 
 /**
  * @description Matrix viz type
  */
 export type MatrixConfig = BaseConfig & {
-  type: 'matrix';
+  type: DashboardItemTypes.Matrix;
 
   /**
    * @description Matrix viz type can specify a column as the data element column.

--- a/packages/types/src/types/models-extra/dashboard-item/views.ts
+++ b/packages/types/src/types/models-extra/dashboard-item/views.ts
@@ -2,13 +2,12 @@
  * Tupaia
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
-
-import type { BaseConfig, ValueType } from './common';
 import { CssColor } from '../../css';
+import type { BaseConfig, DashboardItemTypes, ValueType } from './common';
 
 type BaseViewConfig = BaseConfig &
   Record<string, unknown> & {
-    type: 'view';
+    type: DashboardItemTypes.View;
     valueType?: ValueType;
     value_metadata?: Record<string, unknown>;
   };
@@ -17,8 +16,23 @@ type ColorOption = {
   color: CssColor;
 };
 
+export enum ViewTypes {
+  List = 'list',
+  SingleValue = 'singleValue',
+  MultiPhotograph = 'multiPhotograph',
+  MultiSingleValue = 'multiSingleValue',
+  SingleDownloadLink = 'singleDownloadLink',
+  MultiValueRow = 'multiValueRow',
+  DataDownload = 'dataDownload',
+  SingleDate = 'singleDate',
+  MultiValue = 'multiValue',
+  FilesDownload = 'filesDownload',
+  QRCode = 'qrCodeVisual',
+  ColorList = 'colorList',
+}
+
 export type ListViewConfig = BaseViewConfig & {
-  viewType: 'list';
+  viewType: ViewTypes.List;
   listConfig: {
     [key: string]: {
       color: CssColor;
@@ -36,25 +50,25 @@ export type ListViewConfig = BaseViewConfig & {
 };
 
 export type SingleValueViewConfig = BaseViewConfig & {
-  viewType: 'singleValue';
+  viewType: ViewTypes.SingleValue;
   dataColor: CssColor;
 };
 
 export type MultiPhotographViewConfig = BaseViewConfig & {
-  viewType: 'multiPhotograph';
+  viewType: ViewTypes.MultiPhotograph;
 };
 
 export type MultiSingleValueViewConfig = BaseViewConfig & {
-  viewType: 'multiSingleValue';
+  viewType: ViewTypes.MultiSingleValue;
 };
 
 export type SingleDownloadLinkViewConfig = BaseViewConfig & {
-  viewType: 'singleDownloadLink';
+  viewType: ViewTypes.SingleDownloadLink;
 };
 
 type MultiValueRowOption = ColorOption & { header: string };
 export type MultiValueRowViewConfig = BaseViewConfig & {
-  viewType: 'multiValueRow';
+  viewType: ViewTypes.MultiValueRow;
   presentationOptions?: MultiValueRowOption & {
     dataPairNames?: string[];
     rowHeader?: ColorOption & { name?: string };
@@ -65,22 +79,22 @@ export type MultiValueRowViewConfig = BaseViewConfig & {
 };
 
 export type ColorListViewConfig = BaseViewConfig & {
-  viewType: 'colorList';
+  viewType: ViewTypes.ColorList;
 };
 
 export type DataDownloadViewConfig = BaseViewConfig & {
-  viewType: 'dataDownload';
+  viewType: ViewTypes.DataDownload;
 };
 export type SingleDateViewConfig = BaseViewConfig & {
-  viewType: 'singleDate';
+  viewType: ViewTypes.SingleDate;
 };
 
 export type DownloadFilesViewConfig = BaseViewConfig & {
-  viewType: 'filesDownload';
+  viewType: ViewTypes.FilesDownload;
 };
 
 export type MultiValueViewConfig = BaseViewConfig & {
-  viewType: 'multiValue';
+  viewType: ViewTypes.MultiValue;
   presentationOptions?: Record<string, ColorOption> & {
     isTitleVisible?: boolean;
     valueFormat?: string;
@@ -88,7 +102,7 @@ export type MultiValueViewConfig = BaseViewConfig & {
 };
 
 export type QRCodeViewConfig = BaseViewConfig & {
-  viewType: 'qrCodeVisual';
+  viewType: ViewTypes.QRCode;
 };
 
 export type ViewConfig =

--- a/packages/types/src/types/models-extra/index.ts
+++ b/packages/types/src/types/models-extra/index.ts
@@ -14,7 +14,7 @@ export type {
   ViewDataItem,
   ViewReport,
 } from './report';
-export type {
+export {
   DashboardItemConfig,
   BarChartConfig,
   ComposedChartConfig,
@@ -42,6 +42,8 @@ export type {
   SingleDownloadLinkViewConfig,
   SingleValueViewConfig,
   ChartConfig,
+  DashboardItemTypes,
+  ViewTypes,
 } from './dashboard-item';
 export {
   MapOverlayConfig,


### PR DESCRIPTION
### Issue RN-880: Make 'multiValue' visualisations exportable

### Changes:
- Add dashboard type and view type enums to types package
- Make `multiValue` visualisations expandable when no period granularity defined
- Make `multiValue` visualisations exportable

---

### Screenshots:
![Screen Shot 2024-01-09 at 2 08 35 PM](https://github.com/beyondessential/tupaia/assets/129009580/88a91b11-ec62-4f52-bb94-f74297e50c67)
![Screen Shot 2024-01-09 at 2 08 40 PM](https://github.com/beyondessential/tupaia/assets/129009580/71914ca2-b141-4c1a-9def-53f028f31737)
