### PR TITLE
no-issue: Undo fix persistent DataTrak sidebar

### DIFF
--- a/packages/datatrak-web/src/layout/UserMenu/MenuList.tsx
+++ b/packages/datatrak-web/src/layout/UserMenu/MenuList.tsx
@@ -74,10 +74,7 @@ export const MenuList = ({
 
   const accountSettingsItem = {
     label: 'Account settings',
-    onClick: e => {
-      onClickInternalLink(e);
-      onCloseMenu();
-    },
+    onClick: onClickInternalLink,
     to: shouldShowCancelModal ? null : ROUTES.ACCOUNT_SETTINGS,
     component: shouldShowCancelModal ? 'button' : RouterLink,
   };

--- a/packages/datatrak-web/src/layout/UserMenu/MenuList.tsx
+++ b/packages/datatrak-web/src/layout/UserMenu/MenuList.tsx
@@ -17,7 +17,7 @@ interface MenuItem {
   to?: string | null;
   href?: string;
   isExternal?: boolean;
-  onClick?: (e?: Event) => void;
+  onClick?: (e: Event) => void;
   component?: ComponentType<any> | string;
 }
 


### PR DESCRIPTION
### Changes

#5314 fixed the sidebar remaining after navigating to Account Settings, but introduced a new (worse!) fault where navigating to Account Settings from an in-progress survey becomes impossible because the confirmation modal to leave the survey is a child of the menu that #5314 programatically closed.
