### PR TITLE
no-issue: Set the initial selection of a multi-value autocomplete input

### DIFF
--- a/packages/admin-panel/src/widgets/InputField/registerInputFields.jsx
+++ b/packages/admin-panel/src/widgets/InputField/registerInputFields.jsx
@@ -66,6 +66,7 @@ export const registerInputFields = () => {
     <ReduxAutocomplete
       id={props.id}
       placeholder={props.value}
+      initialValue={props.value}
       label={props.label}
       helperText={props.secondaryLabel}
       endpoint={props.optionsEndpoint}


### PR DESCRIPTION
### Issue https://beyondessential.slack.com/archives/C011G5L1J12/p1704949776764939:

This makes it easier for users to add/remove from the existing selection rather than needing to remember it