### PR TITLE
RN-998: Logo on export

### DIFF
--- a/packages/tupaia-web/src/features/PDFExportDashboardItem/PDFExportDashboardItem.tsx
+++ b/packages/tupaia-web/src/features/PDFExportDashboardItem/PDFExportDashboardItem.tsx
@@ -29,15 +29,15 @@ const StyledA4Page = styled(A4Page)<{
     $isPreview ? `width: 100%; zoom: ${$previewZoom};` : ''};
 `;
 
-const Wrapper = styled.div`
-  margin: 0 7.8rem;
+const PDFExportBody = styled.main`
+  margin-block: 36pt;
 `;
+
 const Title = styled.h3`
   font-size: 1.25rem;
   font-weight: ${({ theme }) => theme.typography.fontWeightMedium};
+  margin-block: 1rem 1.5rem;
   text-align: center;
-  padding: 1rem 1.5rem;
-  margin-bottom: 1.5rem;
 `;
 
 const ExportPeriod = styled(Typography)`
@@ -146,8 +146,8 @@ export const PDFExportDashboardItem = ({
       $previewZoom={previewZoom}
     >
       <PDFExportHeader>{entityName}</PDFExportHeader>
-      <DashboardName>{activeDashboard?.name}</DashboardName>
-      <Wrapper>
+      <PDFExportBody>
+        <DashboardName>{activeDashboard?.name}</DashboardName>
         <Title>{title}</Title>
         {reference && <ReferenceTooltip reference={reference} />}
         {period && <ExportPeriod>{period}</ExportPeriod>}
@@ -172,7 +172,7 @@ export const PDFExportDashboardItem = ({
             <DashboardItemContent />
           </DashboardItemContext.Provider>
         </ExportContent>
-      </Wrapper>
+      </PDFExportBody>
     </StyledA4Page>
   );
 };

--- a/packages/tupaia-web/src/features/PDFExportDashboardItem/PDFExportDashboardItem.tsx
+++ b/packages/tupaia-web/src/features/PDFExportDashboardItem/PDFExportDashboardItem.tsx
@@ -15,7 +15,7 @@ import {
   momentToDateDisplayString,
 } from '@tupaia/utils';
 import { BaseReport } from '@tupaia/types';
-import { A4_PAGE_WIDTH_PX, A4Page, A4PageContent, ReferenceTooltip } from '@tupaia/ui-components';
+import { A4_PAGE_WIDTH_PX, A4Page, ReferenceTooltip } from '@tupaia/ui-components';
 import { Dashboard, DashboardItem, DashboardItemConfig, Entity } from '../../types';
 import { useReport } from '../../api/queries';
 import { DashboardItemContent, DashboardItemContext } from '../DashboardItem';
@@ -146,35 +146,33 @@ export const PDFExportDashboardItem = ({
       $previewZoom={previewZoom}
     >
       <PDFExportHeader>{entityName}</PDFExportHeader>
-      <A4PageContent>
-        <DashboardName>{activeDashboard?.name}</DashboardName>
-        <Wrapper>
-          <Title>{title}</Title>
-          {reference && <ReferenceTooltip reference={reference} />}
-          {period && <ExportPeriod>{period}</ExportPeriod>}
-          <ExportContent $hasData={data && data?.length > 0}>
-            <DashboardItemContext.Provider
-              value={{
-                config: {
-                  ...config,
-                  presentationOptions: {
-                    ...config.presentationOptions,
-                    exportWithTable: true,
-                  },
+      <DashboardName>{activeDashboard?.name}</DashboardName>
+      <Wrapper>
+        <Title>{title}</Title>
+        {reference && <ReferenceTooltip reference={reference} />}
+        {period && <ExportPeriod>{period}</ExportPeriod>}
+        <ExportContent $hasData={data && data?.length > 0}>
+          <DashboardItemContext.Provider
+            value={{
+              config: {
+                ...config,
+                presentationOptions: {
+                  ...config.presentationOptions,
+                  exportWithTable: true,
                 },
-                report,
-                reportCode,
-                isLoading,
-                error,
-                isEnlarged: true,
-                isExport: true,
-              }}
-            >
-              <DashboardItemContent />
-            </DashboardItemContext.Provider>
-          </ExportContent>
-        </Wrapper>
-      </A4PageContent>
+              },
+              report,
+              reportCode,
+              isLoading,
+              error,
+              isEnlarged: true,
+              isExport: true,
+            }}
+          >
+            <DashboardItemContent />
+          </DashboardItemContext.Provider>
+        </ExportContent>
+      </Wrapper>
     </StyledA4Page>
   );
 };

--- a/packages/tupaia-web/src/features/PDFExportDashboardItem/PDFExportDashboardItem.tsx
+++ b/packages/tupaia-web/src/features/PDFExportDashboardItem/PDFExportDashboardItem.tsx
@@ -17,7 +17,7 @@ import {
 import { BaseReport } from '@tupaia/types';
 import { A4_PAGE_WIDTH_PX, A4Page, ReferenceTooltip } from '@tupaia/ui-components';
 import { Dashboard, DashboardItem, DashboardItemConfig, Entity } from '../../types';
-import { useReport } from '../../api/queries';
+import { useProject, useReport } from '../../api/queries';
 import { DashboardItemContent, DashboardItemContext } from '../DashboardItem';
 import { PDFExportHeader } from './PDFExportHeader';
 
@@ -134,6 +134,10 @@ export const PDFExportDashboardItem = ({
   } as DashboardItemConfig;
   const { reference, name, entityHeader, periodGranularity } = dashboardItemConfig;
 
+  const { data: project } = useProject(projectCode);
+  const projectLogoUrl = project?.logoUrl ?? undefined;
+  const projectLogoDescription = project ? `${project.name} logo` : undefined;
+
   const title = entityHeader ? `${name}, ${entityHeader}` : name;
   const period = getDatesAsString(periodGranularity, startDate, endDate);
 
@@ -145,7 +149,9 @@ export const PDFExportDashboardItem = ({
       $isPreview={isPreview}
       $previewZoom={previewZoom}
     >
-      <PDFExportHeader>{entityName}</PDFExportHeader>
+      <PDFExportHeader imageUrl={projectLogoUrl} imageDescription={projectLogoDescription}>
+        {entityName}
+      </PDFExportHeader>
       <PDFExportBody>
         <DashboardName>{activeDashboard?.name}</DashboardName>
         <Title>{title}</Title>

--- a/packages/tupaia-web/src/features/PDFExportDashboardItem/PDFExportDashboardItem.tsx
+++ b/packages/tupaia-web/src/features/PDFExportDashboardItem/PDFExportDashboardItem.tsx
@@ -86,7 +86,7 @@ export const getDatesAsString = (
   );
   const formattedEndDate = momentToDateDisplayString(endDate, granularity, rangeFormat, undefined);
 
-  return isSingleDate ? formattedEndDate : `${formattedStartDate} - ${formattedEndDate}`;
+  return isSingleDate ? formattedEndDate : `${formattedStartDate} – ${formattedEndDate}`; // En dash
 };
 
 /**

--- a/packages/tupaia-web/src/features/PDFExportDashboardItem/PDFExportDashboardItem.tsx
+++ b/packages/tupaia-web/src/features/PDFExportDashboardItem/PDFExportDashboardItem.tsx
@@ -6,7 +6,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { Moment } from 'moment';
 import styled from 'styled-components';
 import { useParams } from 'react-router';
-import { Typography, Divider as BaseDivider } from '@material-ui/core';
+import { Typography } from '@material-ui/core';
 import {
   GRANULARITIES,
   GRANULARITIES_WITH_ONE_DATE,
@@ -15,7 +15,7 @@ import {
   momentToDateDisplayString,
 } from '@tupaia/utils';
 import { BaseReport } from '@tupaia/types';
-import { A4Page, A4PageContent, A4_PAGE_WIDTH_PX, ReferenceTooltip } from '@tupaia/ui-components';
+import { A4_PAGE_WIDTH_PX, A4Page, A4PageContent, ReferenceTooltip } from '@tupaia/ui-components';
 import { Dashboard, DashboardItem, DashboardItemConfig, Entity } from '../../types';
 import { useReport } from '../../api/queries';
 import { DashboardItemContent, DashboardItemContext } from '../DashboardItem';
@@ -52,21 +52,12 @@ const ExportContent = styled.div<{
   padding-top: ${({ $hasData }) => ($hasData ? '0' : '1.5rem')};
 `;
 
-const DashboardTitleContainer = styled.div`
-  text-align: start;
-  margin-bottom: 1.125rem;
-`;
-
-const DashboardNameText = styled.h2`
-  font-weight: ${({ theme }) => theme.typography.fontWeightMedium};
+const DashboardName = styled.h2`
+  border-block-end: 0.18rem solid black;
   font-size: 1.25rem;
+  font-weight: ${({ theme }) => theme.typography.fontWeightMedium};
   line-height: 1.4;
-  margin: 0;
-`;
-
-const Divider = styled(BaseDivider)`
-  background-color: black;
-  height: 0.18rem;
+  margin-block-end: 1.125rem;
 `;
 
 export const getDatesAsString = (
@@ -118,7 +109,11 @@ export const PDFExportDashboardItem = ({
     endDate?: Moment;
   };
 
-  const { data: report, isLoading, error } = useReport(reportCode, {
+  const {
+    data: report,
+    isLoading,
+    error,
+  } = useReport(reportCode, {
     dashboardCode: activeDashboard?.code,
     projectCode,
     entityCode,
@@ -156,10 +151,7 @@ export const PDFExportDashboardItem = ({
     >
       <PDFExportHeader>{entityName}</PDFExportHeader>
       <A4PageContent>
-        <DashboardTitleContainer>
-          <DashboardNameText>{activeDashboard?.name}</DashboardNameText>
-          <Divider />
-        </DashboardTitleContainer>
+        <DashboardName>{activeDashboard?.name}</DashboardName>
         <Wrapper>
           <Title>{title}</Title>
           {reference && <ReferenceTooltip reference={reference} />}

--- a/packages/tupaia-web/src/features/PDFExportDashboardItem/PDFExportDashboardItem.tsx
+++ b/packages/tupaia-web/src/features/PDFExportDashboardItem/PDFExportDashboardItem.tsx
@@ -8,10 +8,10 @@ import styled from 'styled-components';
 import { useParams } from 'react-router';
 import { Typography } from '@material-ui/core';
 import {
+  getDefaultDates,
   GRANULARITIES,
   GRANULARITIES_WITH_ONE_DATE,
   GRANULARITY_CONFIG,
-  getDefaultDates,
   momentToDateDisplayString,
 } from '@tupaia/utils';
 import { BaseReport } from '@tupaia/types';
@@ -53,7 +53,7 @@ const ExportContent = styled.div<{
 `;
 
 const DashboardName = styled.h2`
-  border-block-end: 0.18rem solid black;
+  border-block-end: 0.18rem solid ${({ theme }) => theme.palette.common.black};
   font-size: 1.25rem;
   font-weight: ${({ theme }) => theme.typography.fontWeightMedium};
   line-height: 1.4;
@@ -81,7 +81,8 @@ export const getDatesAsString = (
 };
 
 /**
- * This is the dashboard item that gets generated when generating a PDF. It is only present when puppeteer hits this view.
+ * This is the dashboard item that gets generated when generating a PDF. It is only present when
+ * puppeteer hits this view.
  */
 export const PDFExportDashboardItem = ({
   dashboardItem,
@@ -133,12 +134,7 @@ export const PDFExportDashboardItem = ({
   } as DashboardItemConfig;
   const { reference, name, entityHeader, periodGranularity } = dashboardItemConfig;
 
-  const getTitle = () => {
-    if (entityHeader) return `${name}, ${entityHeader}`;
-    return name;
-  };
-
-  const title = getTitle();
+  const title = entityHeader ? `${name}, ${entityHeader}` : name;
   const period = getDatesAsString(periodGranularity, startDate, endDate);
 
   const data = isLoading ? undefined : (report as BaseReport)?.data;

--- a/packages/tupaia-web/src/features/PDFExportDashboardItem/PDFExportHeader.tsx
+++ b/packages/tupaia-web/src/features/PDFExportDashboardItem/PDFExportHeader.tsx
@@ -20,7 +20,6 @@ const HeaderImage = styled.img`
 `;
 
 const Heading = styled.h1`
-  block-size: 100%;
   font-size: 1.625rem;
   font-weight: ${({ theme }) => theme.typography.fontWeightBold};
   inline-size: 100%;

--- a/packages/tupaia-web/src/features/PDFExportDashboardItem/PDFExportHeader.tsx
+++ b/packages/tupaia-web/src/features/PDFExportDashboardItem/PDFExportHeader.tsx
@@ -5,39 +5,42 @@
 
 import React, { ReactNode } from 'react';
 import styled from 'styled-components';
-import { FlexCenter as BaseFlexCenter, FlexColumn as BaseFlexColumn } from '@tupaia/ui-components';
 
-const FlexCenter = styled(BaseFlexCenter)`
-  position: relative;
-  padding: 50px;
-`;
-
-const FlexColumn = styled(BaseFlexColumn)`
-  text-align: center;
+const Container = styled.div`
+  display: grid;
+  gap: 5mm;
+  grid-template-columns: 1fr 2fr 1fr;
+  vertical-align: center;
+  width: 100%;
 `;
 
 const Heading = styled.h1`
-  font-weight: ${({ theme }) => theme.typography.fontWeightBold};
-  line-height: 1.4;
+  text-align: center;
+  block-size: 100%;
   font-size: 1.625rem;
+  font-weight: ${({ theme }) => theme.typography.fontWeightBold};
+  inline-size: 100%;
+  line-height: 1.4;
   margin: 0;
 `;
 
-const Logo = styled.img.attrs({
-  src: '/tupaia-logo-dark.svg',
-})`
-  top: 1.875rem;
-  left: 1.2rem;
-  position: absolute;
+const Logo = styled.img.attrs({})`
+  max-width: 3.5cm;
 `;
 
-export const PDFExportHeader = ({ children }: { children: ReactNode }) => {
+export const PDFExportHeader = ({
+  headerImageUrl = '/tupaia-logo-dark.svg',
+  headerImageDescription = 'Tupaia logotype',
+  children,
+}: {
+  headerImageUrl?: string;
+  headerImageDescription?: string;
+  children: ReactNode;
+}) => {
   return (
-    <FlexCenter>
-      <Logo alt="Tupaia logo" width="74" height="30" />
-      <FlexColumn>
-        <Heading>{children}</Heading>
-      </FlexColumn>
-    </FlexCenter>
+    <Container>
+      <Logo alt={headerImageDescription} src={headerImageUrl} />
+      <Heading>{children}</Heading>
+    </Container>
   );
 };

--- a/packages/tupaia-web/src/features/PDFExportDashboardItem/PDFExportHeader.tsx
+++ b/packages/tupaia-web/src/features/PDFExportDashboardItem/PDFExportHeader.tsx
@@ -14,18 +14,18 @@ const Container = styled.div`
   width: 100%;
 `;
 
+const HeaderImage = styled.img.attrs({})`
+  max-width: 3.5cm;
+`;
+
 const Heading = styled.h1`
-  text-align: center;
   block-size: 100%;
   font-size: 1.625rem;
   font-weight: ${({ theme }) => theme.typography.fontWeightBold};
   inline-size: 100%;
   line-height: 1.4;
   margin: 0;
-`;
-
-const Logo = styled.img.attrs({})`
-  max-width: 3.5cm;
+  text-align: center;
 `;
 
 export const PDFExportHeader = ({
@@ -39,7 +39,7 @@ export const PDFExportHeader = ({
 }) => {
   return (
     <Container>
-      <Logo alt={headerImageDescription} src={headerImageUrl} />
+      <HeaderImage alt={headerImageDescription} src={headerImageUrl} />
       <Heading>{children}</Heading>
     </Container>
   );

--- a/packages/tupaia-web/src/features/PDFExportDashboardItem/PDFExportHeader.tsx
+++ b/packages/tupaia-web/src/features/PDFExportDashboardItem/PDFExportHeader.tsx
@@ -15,8 +15,9 @@ const Container = styled.div`
 `;
 
 const HeaderImage = styled.img`
-  max-height: 3cm;
-  max-width: 3.5cm;
+  aspect-ratio: 1;
+  height: 3.5cm; // equivalent to 132px
+  object-fit: contain;
 `;
 
 const Heading = styled.h1`
@@ -41,7 +42,7 @@ export const PDFExportHeader = ({
 }: PDFExportHeaderProps) => {
   return (
     <Container>
-      <HeaderImage alt={imageDescription} src={imageUrl} />
+      <HeaderImage alt={imageDescription} src={imageUrl} width="132" height="132" />
       <Heading>{children}</Heading>
     </Container>
   );

--- a/packages/tupaia-web/src/features/PDFExportDashboardItem/PDFExportHeader.tsx
+++ b/packages/tupaia-web/src/features/PDFExportDashboardItem/PDFExportHeader.tsx
@@ -30,7 +30,7 @@ const Heading = styled.h1`
 
 export const PDFExportHeader = ({
   imageUrl = '/tupaia-logo-dark.svg',
-  imageDescription = 'Tupaia logotype',
+  imageDescription = 'Tupaia logo',
   children,
 }: {
   imageUrl?: string;

--- a/packages/tupaia-web/src/features/PDFExportDashboardItem/PDFExportHeader.tsx
+++ b/packages/tupaia-web/src/features/PDFExportDashboardItem/PDFExportHeader.tsx
@@ -28,15 +28,17 @@ const Heading = styled.h1`
   text-align: center;
 `;
 
+interface PDFExportHeaderProps {
+  imageUrl?: string;
+  imageDescription?: string;
+  children: ReactNode;
+}
+
 export const PDFExportHeader = ({
   imageUrl = '/tupaia-logo-dark.svg',
   imageDescription = 'Tupaia logo',
   children,
-}: {
-  imageUrl?: string;
-  imageDescription?: string;
-  children: ReactNode;
-}) => {
+}: PDFExportHeaderProps) => {
   return (
     <Container>
       <HeaderImage alt={imageDescription} src={imageUrl} />

--- a/packages/tupaia-web/src/features/PDFExportDashboardItem/PDFExportHeader.tsx
+++ b/packages/tupaia-web/src/features/PDFExportDashboardItem/PDFExportHeader.tsx
@@ -7,14 +7,14 @@ import React, { ReactNode } from 'react';
 import styled from 'styled-components';
 
 const Container = styled.div`
+  align-items: center;
   display: grid;
   gap: 5mm;
   grid-template-columns: 1fr 2fr 1fr;
-  vertical-align: center;
   width: 100%;
 `;
 
-const HeaderImage = styled.img.attrs({})`
+const HeaderImage = styled.img`
   max-width: 3.5cm;
 `;
 

--- a/packages/tupaia-web/src/features/PDFExportDashboardItem/PDFExportHeader.tsx
+++ b/packages/tupaia-web/src/features/PDFExportDashboardItem/PDFExportHeader.tsx
@@ -20,7 +20,6 @@ const Heading = styled.h1`
   font-weight: ${({ theme }) => theme.typography.fontWeightBold};
   line-height: 1.4;
   font-size: 1.625rem;
-  text-transform: capitalize;
   margin: 0;
 `;
 

--- a/packages/tupaia-web/src/features/PDFExportDashboardItem/PDFExportHeader.tsx
+++ b/packages/tupaia-web/src/features/PDFExportDashboardItem/PDFExportHeader.tsx
@@ -15,6 +15,7 @@ const Container = styled.div`
 `;
 
 const HeaderImage = styled.img`
+  max-height: 3cm;
   max-width: 3.5cm;
 `;
 
@@ -29,17 +30,17 @@ const Heading = styled.h1`
 `;
 
 export const PDFExportHeader = ({
-  headerImageUrl = '/tupaia-logo-dark.svg',
-  headerImageDescription = 'Tupaia logotype',
+  imageUrl = '/tupaia-logo-dark.svg',
+  imageDescription = 'Tupaia logotype',
   children,
 }: {
-  headerImageUrl?: string;
-  headerImageDescription?: string;
+  imageUrl?: string;
+  imageDescription?: string;
   children: ReactNode;
 }) => {
   return (
     <Container>
-      <HeaderImage alt={headerImageDescription} src={headerImageUrl} />
+      <HeaderImage alt={imageDescription} src={imageUrl} />
       <Heading>{children}</Heading>
     </Container>
   );

--- a/packages/ui-components/src/__tests__/components/DateRangePicker/DateRangePicker.test.js
+++ b/packages/ui-components/src/__tests__/components/DateRangePicker/DateRangePicker.test.js
@@ -78,7 +78,7 @@ describe('dateRangePicker', () => {
       if (GRANULARITIES_WITH_ONE_DATE.includes(key)) {
         expect(labelText).toHaveTextContent(endDate);
       } else {
-        expect(labelText).toHaveTextContent(`${startDate} - ${endDate}`);
+        expect(labelText).toHaveTextContent(`${startDate} – ${endDate}`); // En dash
       }
     });
   });
@@ -94,7 +94,7 @@ describe('dateRangePicker', () => {
       if (GRANULARITIES_WITH_ONE_DATE.includes(key)) {
         expect(labelText).toHaveTextContent(endDate);
       } else {
-        expect(labelText).toHaveTextContent(`${startDate} - ${endDate}`);
+        expect(labelText).toHaveTextContent(`${startDate} – ${endDate}`); // En dash
       }
     });
   });

--- a/packages/ui-components/src/components/DateRangePicker/useDateRangePicker.tsx
+++ b/packages/ui-components/src/components/DateRangePicker/useDateRangePicker.tsx
@@ -6,17 +6,17 @@
 import { useEffect } from 'react';
 import moment, { Moment } from 'moment';
 import {
-  getDefaultDates,
   DEFAULT_MIN_DATE,
+  getDefaultDates,
   GRANULARITIES,
   GRANULARITIES_WITH_ONE_DATE,
   GRANULARITY_CONFIG,
-  WEEK_DISPLAY_CONFIG,
   momentToDateDisplayString,
-  roundStartEndDates,
-  roundStartDate,
   roundEndDate,
+  roundStartDate,
+  roundStartEndDates,
   toStandardDateString,
+  WEEK_DISPLAY_CONFIG,
 } from '@tupaia/utils';
 import { GranularityType, ModifierType } from '../../types';
 
@@ -30,9 +30,11 @@ const getDatesAsString = (
   weekDisplayFormat?: string | number,
 ) => {
   const isWeek = granularity === GRANULARITIES.WEEK || granularity === GRANULARITIES.SINGLE_WEEK;
-  const { rangeFormat, modifier } = (isWeek && weekDisplayFormat
-    ? WEEK_DISPLAY_CONFIG[weekDisplayFormat]
-    : GRANULARITY_CONFIG[granularity as keyof typeof GRANULARITY_CONFIG]) as {
+  const { rangeFormat, modifier } = (
+    isWeek && weekDisplayFormat
+      ? WEEK_DISPLAY_CONFIG[weekDisplayFormat]
+      : GRANULARITY_CONFIG[granularity as keyof typeof GRANULARITY_CONFIG]
+  ) as {
     rangeFormat: string;
     modifier?: ModifierType;
   };
@@ -45,7 +47,7 @@ const getDatesAsString = (
   );
   const formattedEndDate = momentToDateDisplayString(endDate, granularity, rangeFormat, modifier!);
 
-  return isSingleDate ? formattedEndDate : `${formattedStartDate} - ${formattedEndDate}`;
+  return isSingleDate ? formattedEndDate : `${formattedStartDate} – ${formattedEndDate}`; // En dash
 };
 
 /**

--- a/packages/ui-components/src/components/PDFExportComponent.tsx
+++ b/packages/ui-components/src/components/PDFExportComponent.tsx
@@ -1,13 +1,9 @@
 import styled from 'styled-components';
-import { FlexColumn } from './Layout/Flexbox';
 
 export const A4_PAGE_WIDTH_PX = 1192;
 
 export const A4Page = styled.div`
-  width: ${A4_PAGE_WIDTH_PX}px;
+  padding: 0px 70px;
   page-break-after: always;
-`;
-
-export const A4PageContent = styled(FlexColumn)`
-  margin: 0px 70px;
+  width: ${A4_PAGE_WIDTH_PX}px;
 `;

--- a/packages/ui-components/src/components/PDFExportComponent.tsx
+++ b/packages/ui-components/src/components/PDFExportComponent.tsx
@@ -16,5 +16,5 @@ export const A4Page = styled.div`
   height: ${A4_PAGE_HEIGHT_MM}px;
 
   break-after: page;
-  padding: 4cm 4.5cm 4.5cm; // Bottom slightly taller top for *optical* vertical center alignment
+  padding: 4cm 4.5cm 4.5cm; // Bottom slightly taller than top for *optical* alignment
 `;

--- a/packages/ui-components/src/components/PDFExportComponent.tsx
+++ b/packages/ui-components/src/components/PDFExportComponent.tsx
@@ -1,9 +1,20 @@
 import styled from 'styled-components';
 
-export const A4_PAGE_WIDTH_PX = 1192;
+export const A4_PAGE_WIDTH_MM = 210;
+export const A4_PAGE_HEIGHT_MM = 297;
+
+/*
+ * The px values below are not actually equivalent to the mm values above when interpreted as CSS
+ * units, because CSS takes 1px to be 1/96 of an inch. The intention is to refactor PDF exports to
+ * use absolute length units (like cm and pt) and remove these constants at some point.
+ */
+export const A4_PAGE_WIDTH_PX = 1191; // at 144ppi
+export const A4_PAGE_HEIGHT_PX = 1684; // at 144ppi
 
 export const A4Page = styled.div`
-  break-after: page;
-  padding: 0px 70px;
   width: ${A4_PAGE_WIDTH_PX}px;
+  height: ${A4_PAGE_HEIGHT_MM}px;
+
+  break-after: page;
+  padding: 4cm 4.5cm 4.5cm; // Bottom slightly taller top for *optical* vertical center alignment
 `;

--- a/packages/ui-components/src/components/PDFExportComponent.tsx
+++ b/packages/ui-components/src/components/PDFExportComponent.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 export const A4_PAGE_WIDTH_PX = 1192;
 
 export const A4Page = styled.div`
+  break-after: page;
   padding: 0px 70px;
-  page-break-after: always;
   width: ${A4_PAGE_WIDTH_PX}px;
 `;

--- a/packages/web-frontend/src/tests/components/dateRangePicker.test.js
+++ b/packages/web-frontend/src/tests/components/dateRangePicker.test.js
@@ -86,7 +86,7 @@ describe('dateRangePicker', () => {
       if (GRANULARITIES_WITH_ONE_DATE.includes(key)) {
         expect(labelText).toHaveTextContent(endDate);
       } else {
-        expect(labelText).toHaveTextContent(`${startDate} - ${endDate}`);
+        expect(labelText).toHaveTextContent(`${startDate} – ${endDate}`); // En dash
       }
     });
   });
@@ -102,7 +102,7 @@ describe('dateRangePicker', () => {
       if (GRANULARITIES_WITH_ONE_DATE.includes(key)) {
         expect(labelText).toHaveTextContent(endDate);
       } else {
-        expect(labelText).toHaveTextContent(`${startDate} - ${endDate}`);
+        expect(labelText).toHaveTextContent(`${startDate} – ${endDate}`); // En dash
       }
     });
   });


### PR DESCRIPTION
### Issue RN-998: Logo on export

### Changes

- PDF exports from Tupaia dashboard now show project logo that instead of the Tupaia logotype. (If no project logo is applicable and available, Tupaia logotype is shown as fallback.)
- Also refactored some the PDF layouts with some minor design tweaks.

### Screenshots

![Screenshot 2024-01-15T163948](https://github.com/beyondessential/tupaia/assets/33956381/fdd98bb4-4645-49c3-80b4-8c75c8cd371f)

### Side note

While working on this one I found that the `px` values we use to define the A4 page sizes are incorrect, but correcting it will have ripple effects which I felt was too much to tack onto this PR.