### PR TITLE
no-issue: Globally reset `<fieldset>` styling

### DIFF
--- a/packages/datatrak-web/src/features/Questions/GeolocateQuestion/GeolocateQuestion.tsx
+++ b/packages/datatrak-web/src/features/Questions/GeolocateQuestion/GeolocateQuestion.tsx
@@ -25,9 +25,6 @@ const Container = styled.div`
 `;
 
 const Wrapper = styled.fieldset`
-  margin: 0;
-  border: none;
-  padding: 0;
   legend {
     padding: 0;
   }

--- a/packages/datatrak-web/src/features/RequestProjectAccess/ProjectAccessForm.tsx
+++ b/packages/datatrak-web/src/features/RequestProjectAccess/ProjectAccessForm.tsx
@@ -4,12 +4,12 @@
  */
 import React from 'react';
 import styled from 'styled-components';
-import { useForm, SubmitHandler } from 'react-hook-form';
+import { SubmitHandler, useForm } from 'react-hook-form';
 import {
   DialogActions,
-  Typography,
-  FormGroup,
   FormControl as BaseFormControl,
+  FormGroup,
+  Typography,
 } from '@material-ui/core';
 import { CheckCircle } from '@material-ui/icons';
 import {
@@ -27,8 +27,6 @@ const FormControl = styled(BaseFormControl).attrs({
   component: 'fieldset',
   required: true,
 })`
-  border: none;
-  padding: 0;
   margin-bottom: 2rem;
 `;
 
@@ -62,7 +60,7 @@ const TextArea = styled(TextField).attrs({
     font-size: 0.875rem;
     padding: 0.875rem;
   }
-  // we have to override this here as there are selectors inside ui-components with higher specificity than we can achieve via the theme overrides 
+  // we have to override this here as there are selectors inside ui-components with higher specificity than we can achieve via the theme overrides
   .MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline {
     box-shadow: none;
     border-color: ${({ theme }) => theme.palette.primary.main};

--- a/packages/datatrak-web/src/features/Survey/Components/SurveyReviewSection.tsx
+++ b/packages/datatrak-web/src/features/Survey/Components/SurveyReviewSection.tsx
@@ -32,9 +32,6 @@ const SectionHeader = styled(Typography).attrs({
 const Fieldset = styled.fieldset.attrs({
   disabled: true,
 })`
-  border: none;
-  margin: 0;
-  padding: 0;
   input,
   label,
   button,

--- a/packages/datatrak-web/src/theme/theme.ts
+++ b/packages/datatrak-web/src/theme/theme.ts
@@ -73,6 +73,19 @@ export const theme = createMuiTheme({
     },
   },
   overrides: {
+    MuiCssBaseline: {
+      '@global': {
+        fieldset: {
+          border: 0,
+          margin: 0,
+          minWidth: 0,
+          padding: 0,
+        },
+        img: {
+          display: 'block;',
+        },
+      },
+    },
     MuiDialogActions: {
       root: {
         padding: '1.5rem 0 0 0',

--- a/packages/datatrak-web/src/theme/theme.ts
+++ b/packages/datatrak-web/src/theme/theme.ts
@@ -81,9 +81,6 @@ export const theme = createMuiTheme({
           minWidth: 0,
           padding: 0,
         },
-        img: {
-          display: 'block;',
-        },
       },
     },
     MuiDialogActions: {

--- a/packages/datatrak-web/src/views/AccountSettingsPage/ChangePasswordSection/ChangePasswordForm.tsx
+++ b/packages/datatrak-web/src/views/AccountSettingsPage/ChangePasswordSection/ChangePasswordForm.tsx
@@ -20,10 +20,6 @@ const StyledForm = styled(Form)`
 `;
 
 const StyledFieldset = styled.fieldset`
-  border: none;
-  margin: 0;
-  padding: 0;
-
   align-items: start;
   display: grid;
   gap: 1.56rem 1.25rem;


### PR DESCRIPTION
### Changes

- Use `CssBaseline` overrides to set sensible defaults for `<fieldset>`, rather than repeating the same CSS code for every use.
- Set `img` to use block display by default. This one’s slightly more opinionated—happy to discuss/remove.