### PR TITLE
no-issue: Update UI component package READMEs

### DIFF
--- a/packages/ui-chart-components/README.md
+++ b/packages/ui-chart-components/README.md
@@ -2,29 +2,36 @@
 
 A library of chart interface components for the Tupaia project.
 
-## Available Scripts
+## Available scripts
 
-In the project directory, you can run:
+In the package directory, you can run:
 
-`yarn storybook`
+```sh
+yarn storybook
+```
 
-Runs the storybook app and pulls stories from the `src` directory which have a .stories.js suffix.<br />
+Or from the monorepo root:
 
-The page will reload if you make edits.<br />
+```sh
+yarn workspace @tupaia/ui-chart-components storybook
+```
 
-## Story Book
+This runs the Storybook app and pulls stories from the [`stories/`](stories/) directory which have a `.stories.js` suffix.
 
-Storybook is an open source tool for developing UI components.
-[https://github.com/storybookjs/storybook](https://github.com/storybookjs/storybook)
+The page will reload if you make edits.
+
+## Storybook
+
+[Storybook](https://storybook.js.org) is an open-source tool for developing UI components.
 
 ## Recharts
 
-The components are mostly built on top of components from the [ReCharts library](https://recharts.org).
+The components are mostly built on top of components from the [Recharts](https://recharts.org)  library.
 
-##### Notes on approach:
+## Notes on approach
 
-- Use [styled components](https://styled-components.com) to customise components
-- Import Material UI components with a Mui prefix to distinguish them from custom components. eg. `import MuiButton from '@material-ui/core/Button';`
+- Use [Styled Components](https://styled-components.com) to customise components.
+- Import Material UI components with a `Mui` prefix to when you need to disambiguate them from custom components. e.g. `import { Button as MuiButton } from '@material-ui/core'`
+- Avoid hard-coding children and allow them to be passed in as JSX as much as possible.
+- Export components using named exports.
 
-- Avoid hard coding children and allow them to be passed in as JSX as much as possible
-- Export components using named exports

--- a/packages/ui-components/README.md
+++ b/packages/ui-components/README.md
@@ -16,7 +16,7 @@ Or from the monorepo root:
 yarn workspace @tupaia/ui-components storybook
 ```
 
-This runs the Storybook app and pulls stories from the [`.storybook/`](.storybook/) directory which have a `.stories.js` suffix.
+This runs the Storybook app and pulls stories from the [`stories/`](stories/) directory which have a `.stories.js` suffix.
 
 The page will reload if you make edits.
 

--- a/packages/ui-components/README.md
+++ b/packages/ui-components/README.md
@@ -28,9 +28,9 @@ The page will reload if you make edits.
 
 The components are mostly built on top of components from the [Material UI (version 4)](https://v4.mui.com) library.
 
-## Notes on approach:
+## Notes on approach
 
 - Use [Styled Components](https://styled-components.com) to customise components.
-- Import Material UI components with a `Mui` prefix to when you need to disambiguate them from custom components. e.g. `import { Button as MuiButton } from '@material-ui/core'`
+- Import Material UI components with a `Mui` prefix to when you need to disambiguate them from custom components. e.g. `import { Button as MuiButton } from '@material-ui/core'`
 - Avoid hard-coding children and allow them to be passed in as JSX as much as possible.
 - Export components using named exports.

--- a/packages/ui-components/README.md
+++ b/packages/ui-components/README.md
@@ -2,29 +2,35 @@
 
 A library of user interface components for the Tupaia project.
 
-## Available Scripts
+## Available scripts
 
-In the project directory, you can run:
+In the package directory, you can run:
 
-`yarn storybook`
+```sh
+yarn storybook
+```
 
-Runs the storybook app and pulls stories from the `src` directory which have a .stories.js suffix.<br />
+Or from the monorepo root:
 
-The page will reload if you make edits.<br />
+```sh
+yarn workspace @tupaia/ui-components storybook
+```
 
-## Story Book
+This runs the Storybook app and pulls stories from the [`.storybook/`](.storybook/) directory which have a `.stories.js` suffix.
 
-Storybook is an open source tool for developing UI components.
-[https://github.com/storybookjs/storybook](https://github.com/storybookjs/storybook)
+The page will reload if you make edits.
+
+## Storybook
+
+[Storybook](https://storybook.js.org) is an open-source tool for developing UI components.
 
 ## Material UI
 
-The components are mostly built on top of components from the Material UI library. https://material-ui.com.
+The components are mostly built on top of components from the [Material UI (version 4)](https://v4.mui.com) library.
 
-##### Notes on approach:
+## Notes on approach:
 
-- Use [styled components](https://styled-components.com) to customise components
-- Import Material UI components with a Mui prefix to distinguish them from custom components. eg. `import MuiButton from '@material-ui/core/Button';`
-
-- Avoid hard coding children and allow them to be passed in as JSX as much as possible
-- Export components using named exports
+- Use [Styled Components](https://styled-components.com) to customise components.
+- Import Material UI components with a `Mui` prefix to when you need to disambiguate them from custom components. e.g. `import { Button as MuiButton } from '@material-ui/core'`
+- Avoid hard-coding children and allow them to be passed in as JSX as much as possible.
+- Export components using named exports.

--- a/packages/ui-map-components/README.md
+++ b/packages/ui-map-components/README.md
@@ -2,29 +2,35 @@
 
 A library of chart interface components for the Tupaia project.
 
-## Available Scripts
+## Available scripts
 
-In the project directory, you can run:
+In the package directory, you can run:
 
-`yarn storybook`
+```sh
+yarn storybook
+```
 
-Runs the storybook app and pulls stories from the `src` directory which have a .stories.js suffix.<br />
+Or from the monorepo root:
 
-The page will reload if you make edits.<br />
+```sh
+yarn workspace @tupaia/ui-chart-components storybook
+```
 
-## Story Book
+This runs the Storybook app and pulls stories from the [`stories/`](stories/) directory which have a `.stories.js` suffix.
 
-Storybook is an open source tool for developing UI components.
-[https://github.com/storybookjs/storybook](https://github.com/storybookjs/storybook)
+The page will reload if you make edits.
+
+## Storybook
+
+[Storybook](https://storybook.js.org) is an open-source tool for developing UI components.
 
 ## Leaflet
 
 The components are mostly built on top of components from the [Leaflet JS library](https://leafletjs.com).
 
-##### Notes on approach:
+## Notes on approach
 
-- Use [styled components](https://styled-components.com) to customise components
-- Import Material UI components with a Mui prefix to distinguish them from custom components. eg. `import MuiButton from '@material-ui/core/Button';`
-
-- Avoid hard coding children and allow them to be passed in as JSX as much as possible
-- Export components using named exports
+- Use [Styled Components](https://styled-components.com) to customise components.
+- Import Material UI components with a `Mui` prefix to when you need to disambiguate them from custom components. e.g. `import { Button as MuiButton } from '@material-ui/core'`
+- Avoid hard-coding children and allow them to be passed in as JSX as much as possible.
+- Export components using named exports.

--- a/packages/ui-map-components/README.md
+++ b/packages/ui-map-components/README.md
@@ -26,7 +26,7 @@ The page will reload if you make edits.
 
 ## Leaflet
 
-The components are mostly built on top of components from the [Leaflet JS library](https://leafletjs.com).
+The components are mostly built on top of components from the [Leaflet](https://leafletjs.com) library.
 
 ## Notes on approach
 

--- a/packages/ui-map-components/README.md
+++ b/packages/ui-map-components/README.md
@@ -1,6 +1,6 @@
-# @tupaia/ui-chart-components
+# @tupaia/ui-map-components
 
-A library of chart interface components for the Tupaia project.
+A library of map interface components for the Tupaia project.
 
 ## Available scripts
 
@@ -13,7 +13,7 @@ yarn storybook
 Or from the monorepo root:
 
 ```sh
-yarn workspace @tupaia/ui-chart-components storybook
+yarn workspace @tupaia/ui-map-components storybook
 ```
 
 This runs the Storybook app and pulls stories from the [`stories/`](stories/) directory which have a `.stories.js` suffix.


### PR DESCRIPTION
### Changes:

- `ui-map-components` README actually talked about `ui-chart-components`. Fixed.
- The updated READMEs referenced the wrong directory when describing where Storybooks looks. Fixed.
- Various minuscule quality-of-life and readability improvements.