### PR TITLE
no-issue: Fix `start-stack` help text

### DIFF
--- a/scripts/bash/pm2startInline.sh
+++ b/scripts/bash/pm2startInline.sh
@@ -2,22 +2,21 @@
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-
 if [ -z "$1" ]; then
-  echo "Usage: yarn start-dev <stack>"
-  echo ""
-  echo "All stacks:"
+  echo -e "Usage: \033[1myarn start-stack\033[0m \033[4mstack\033[0m"
+  echo    ""
+  echo -e "All \033[4mstack\033[0ms:"
   ls -1 ../../packages/devops/configs/pm2/ | sed 's|.config.js||g' | grep -v 'base' | awk '$0="  "$0'
-  echo ""
-  echo "Tips:"
-  echo "  - normal pm2 commands work e.g. yarn pm2 status"
-  echo "  - start multiple stacks by calling this cmd multiple times"
+  echo    ""
+  echo    "Tips:"
+  echo -e "  - Normal PM2 commands work e.g. \033[1myarn pm2 status\033[0m"
+  echo    "  - Start multiple stacks by calling this command multiple times"
   exit 1
 fi
 
 yarn pm2 start "../../packages/devops/configs/pm2/$1.config.js"
 
-# When user quits logs stop everything
-trap "echo Stopping... && yarn pm2 delete all" EXIT
+# When user quits logs, stop everything
+trap "echo -e '\n\033[1;41;97m  Stopping...  \033[0m' && yarn pm2 delete all" EXIT
 
 yarn pm2 logs --lines 0


### PR DESCRIPTION
### Changes:

- Changed legacy `start-dev` instruction to `start-stack`
- Set parameters with underline (GitHub sanitises `<u>` so no inline preview 🥲) and verbatim commands in **`bold`**

---

### Screenshots

Before:
![Screenshot 2024-02-09T125426](https://github.com/beyondessential/tupaia/assets/33956381/498df54b-5492-40d4-85d9-ce5d82cc8319)

After:
![Screenshot 2024-02-09T125439](https://github.com/beyondessential/tupaia/assets/33956381/83116803-9c79-4a31-96f9-e983864ed939)

