### PR TITLE
RN-1171: Tweak Tupaia `UserMenu`

### DIFF
--- a/packages/tupaia-web/src/layout/UserMenu/MenuList.tsx
+++ b/packages/tupaia-web/src/layout/UserMenu/MenuList.tsx
@@ -5,7 +5,7 @@
 
 import React, { ReactNode } from 'react';
 import styled, { css } from 'styled-components';
-import { Button, ListItem, Link, ListItemProps } from '@material-ui/core';
+import { Button, Link, ListItem, ListItemProps } from '@material-ui/core';
 import { RouterLink } from '../../components';
 import { MOBILE_BREAKPOINT } from '../../constants';
 
@@ -97,7 +97,7 @@ export const MenuItem = ({
   if (externalLink) {
     return (
       <MenuListItem $secondaryColor={secondaryColor}>
-        <MenuItemLink href={href} onClick={handleClickMenuItem}>
+        <MenuItemLink href={href} onClick={handleClickMenuItem} target="_blank">
           {children}
         </MenuItemLink>
       </MenuListItem>

--- a/packages/tupaia-web/src/layout/UserMenu/UserMenu.tsx
+++ b/packages/tupaia-web/src/layout/UserMenu/UserMenu.tsx
@@ -55,7 +55,7 @@ export const UserMenu = () => {
   const { data: user, isLoggedIn } = useUser();
 
   // Create the menu items
-  const BaseMenuItem = ({ children, ...props }: any) => (
+  const BaseMenuItem = ({ children, isExternal, ...props }: any) => (
     <MenuItem onCloseMenu={onCloseMenu} {...props} secondaryColor={secondaryHexcode}>
       {children}
     </MenuItem>
@@ -88,9 +88,9 @@ export const UserMenu = () => {
 
   const HelpCentre = (
     <BaseMenuItem
-      key="help"
       externalLink
       href="https://beyond-essential.slab.com/topics/support-and-resources-g6piq0i1"
+      key="help"
     >
       Help centre
     </BaseMenuItem>
@@ -114,8 +114,8 @@ export const UserMenu = () => {
     : [VisitMainSite, HelpCentre];
 
   const baseMenuItems = isLoggedIn
-    ? [SubmitData, ViewProjects, HelpCentre, ChangePassword, RequestCountryAccess, Logout]
-    : [SubmitData, ViewProjects, HelpCentre];
+    ? [ViewProjects, SubmitData, HelpCentre, ChangePassword, RequestCountryAccess, Logout]
+    : [ViewProjects, SubmitData, HelpCentre];
 
   const menuItems = isLandingPage ? customLandingPageMenuItems : baseMenuItems;
 

--- a/packages/tupaia-web/src/layout/UserMenu/UserMenu.tsx
+++ b/packages/tupaia-web/src/layout/UserMenu/UserMenu.tsx
@@ -55,7 +55,7 @@ export const UserMenu = () => {
   const { data: user, isLoggedIn } = useUser();
 
   // Create the menu items
-  const BaseMenuItem = ({ children, isExternal, ...props }: any) => (
+  const BaseMenuItem = ({ children, ...props }: any) => (
     <MenuItem onCloseMenu={onCloseMenu} {...props} secondaryColor={secondaryHexcode}>
       {children}
     </MenuItem>


### PR DESCRIPTION
### Issue RN-1171: Tweak Tupaia `UserMenu`

### Changes

- Bump <kbd>Submit data</kbd> below <kbd>View projects</kbd> to un-break muscle memory
- Make external links (namely <kbd>Submit data</kbd> and <kbd>Help centre</kbd>) open in a new tab

### Remark

The props for `BaseMenuItem` probably shouldn’t be any, but the typing around here is a little fragile. Would be nice if we could tighten things up at some point, but I decided against refactoring this time around.
