### PR TITLE
no-issue: Bump `validator` to 13.11.0

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -38,7 +38,7 @@
     "numeral": "^2.0.6",
     "prop-types": "^15.6.2",
     "sanitize-filename": "^1.6.3",
-    "validator": "^13.7.0",
+    "validator": "^13.11.0",
     "winston": "^3.3.3",
     "xlsx": "^0.10.9",
     "yup": "^0.32.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12931,7 +12931,7 @@ __metadata:
     numeral: ^2.0.6
     prop-types: ^15.6.2
     sanitize-filename: ^1.6.3
-    validator: ^13.7.0
+    validator: ^13.11.0
     winston: ^3.3.3
     xlsx: ^0.10.9
     yup: ^0.32.9
@@ -43544,10 +43544,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"validator@npm:^13.7.0":
-  version: 13.9.0
-  resolution: "validator@npm:13.9.0"
-  checksum: e2c936f041f61faa42bafd17c6faddf939498666cd82e88d733621c286893730b008959f4cb12ab3e236148a4f3805c30b85e3dcf5e0efd8b0cbcd36c02bfc0c
+"validator@npm:^13.11.0":
+  version: 13.11.0
+  resolution: "validator@npm:13.11.0"
+  checksum: d1e0c27022681420756da25bc03eb08d5f0c66fb008f8ff02ebc95812b77c6be6e03d3bd05cf80ca702e23eeb73dadd66b4b3683173ea2a0bc7cc72820bee131
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Changes

- Was originally going to do this as part of ticket RN 1112, but but turns out #4665 already addressed the vulnerability (hence not linking the ticket)
- [validator’s changelog](https://github.com/validatorjs/validator.js/blob/master/CHANGELOG.md) has only had two releases since 13.7 and seems to have only minor improvements with no breaking changes, so may as well go ahead