### PR TITLE
RN-1179: Calculate centroids for regions for weather service

### DIFF
--- a/packages/data-broker/src/services/weather/WeatherService.ts
+++ b/packages/data-broker/src/services/weather/WeatherService.ts
@@ -188,7 +188,7 @@ export class WeatherService extends Service {
     }
   }
 
-  private getEntityPoint(entity: EntityType) {
+  private async getEntityPoint(entity: EntityType) {
     try {
       return entity.pointLatLon();
     } catch (error) {
@@ -224,7 +224,7 @@ export class WeatherService extends Service {
 
     // Run requests in parallel for performance
     const getDataForEntity = async (entity: EntityType) => {
-      const { lat, lon } = this.getEntityPoint(entity);
+      const { lat, lon } = await this.getEntityPoint(entity);
 
       // Maximum forecast is 16 days, we request all of it and filter it down to the dates we need.
       // Performance looks fine requesting 16 days.
@@ -265,7 +265,7 @@ export class WeatherService extends Service {
 
     // Run requests in parallel for performance
     const getDataForEntity = async (entity: EntityType) => {
-      const { lat, lon } = this.getEntityPoint(entity);
+      const { lat, lon } = await this.getEntityPoint(entity);
 
       if (sanitisedStartDate === null || sanitisedEndDate === null) {
         return {

--- a/packages/database/src/modelClasses/Entity.js
+++ b/packages/database/src/modelClasses/Entity.js
@@ -291,12 +291,32 @@ export class EntityType extends DatabaseType {
     );
   }
 
-  pointLatLon() {
-    const pointJson = JSON.parse(this.point);
+  async calculateCentroid() {
+    const result = await this.database.executeSql(
+      `SELECT ST_AsGeoJSON(ST_Centroid(ST_AsGeoJSON(region))) as centroid from entity where id = ?;`,
+      [this.id],
+    );
+    const parsedPoint = JSON.parse(result[0].centroid);
     return {
-      lat: pointJson.coordinates[1],
-      lon: pointJson.coordinates[0],
+      lat: parsedPoint.coordinates[1],
+      lon: parsedPoint.coordinates[0],
     };
+  }
+
+  async pointLatLon() {
+    const { point } = this;
+    if (point) {
+      const pointJson = JSON.parse(point);
+      return {
+        lat: pointJson.coordinates[1],
+        lon: pointJson.coordinates[0],
+      };
+    }
+    const region = this.getRegion();
+    if (!region) return null;
+
+    // calculate centroid of region
+    return this.calculateCentroid();
   }
 }
 


### PR DESCRIPTION
### Issue RN-1179: Calculate centroids for regions for weather service

### Changes:
- If an entity does not have a `point` on it, calculate the centroid from the `region` when fetching the `pointLatLon`