### PR TITLE
RN-1223: Update clearTestData to remove all test database data

### DIFF
--- a/packages/central-server/src/tests/scaffolding.test.js
+++ b/packages/central-server/src/tests/scaffolding.test.js
@@ -6,7 +6,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import winston from 'winston';
 
-import { clearAllTestData } from '@tupaia/database';
+import { clearTestData } from '@tupaia/database';
 import { getIsProductionEnvironment } from '@tupaia/utils';
 import * as ServerUtils from '@tupaia/server-utils';
 import { getModels, resetTestData } from './testUtilities';
@@ -41,6 +41,6 @@ before(async () => {
 after(async () => {
   const models = getModels();
   sendEmailStub.restore();
-  await clearAllTestData(models.database);
+  await clearTestData(models.database);
   await models.database.closeConnections();
 });

--- a/packages/central-server/src/tests/testUtilities/database/resetTestData.js
+++ b/packages/central-server/src/tests/testUtilities/database/resetTestData.js
@@ -2,12 +2,12 @@
  * Tupaia MediTrak
  * Copyright (c) 2019 Beyond Essential Systems Pty Ltd
  */
-import { clearAllTestData } from '@tupaia/database';
+import { clearTestData } from '@tupaia/database';
 import { addBaselineTestData } from './addBaselineTestData';
 import { getModels } from './getModels';
 
 export async function resetTestData() {
   const models = getModels();
-  await clearAllTestData(models.database);
+  await clearTestData(models.database);
   await addBaselineTestData();
 }

--- a/packages/data-broker/jest.setup.ts
+++ b/packages/data-broker/jest.setup.ts
@@ -3,10 +3,10 @@
  * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
  */
 
-import { getTestDatabase, clearAllTestData } from '@tupaia/database';
+import { getTestDatabase, clearTestData } from '@tupaia/database';
 
 afterAll(async () => {
   const database = getTestDatabase();
-  await clearAllTestData(database);
+  await clearTestData(database);
   await database.closeConnections();
 });

--- a/packages/database/src/testUtilities/clearTestData.js
+++ b/packages/database/src/testUtilities/clearTestData.js
@@ -62,38 +62,38 @@ const TABLES_TO_CLEAR = [
   'map_overlay',
 ];
 
-export async function clearTestData(db, testStartTime = moment().format('YYYY-MM-DD HH:mm:ss')) {
-  const extraConditions = {
-    api_request_log: [`request_time >= '${testStartTime}'`],
-    api_client: [`id ${COMPARISON}`, `user_account_id ${COMPARISON}`],
-    answer: [`question_id ${COMPARISON}`, `survey_response_id ${COMPARISON}`],
-    survey_response: [`survey_id ${COMPARISON}`, `entity_id ${COMPARISON}`],
-    survey_screen_component: [`question_id ${COMPARISON}`],
-    survey: [`code LIKE 'test%'`, `name ${COMPARISON}`], // name comparison is for clearing test data when importing new surveys using excel files
-    user_entity_permission: [`permission_group_id ${COMPARISON}`],
-    user_account: [`email = 'test.user@tupaia.org'`, `first_name = 'Automated test'`],
-    clinic: [`country_id ${COMPARISON}`],
-    dashboard_relation: [`child_id ${COMPARISON}`, `dashboard_id ${COMPARISON}`],
-    map_overlay_group_relation: [`child_id ${COMPARISON}`, `map_overlay_group_id ${COMPARISON}`],
-    entity: [`code LIKE 'test%'`, `code ${COMPARISON}`, `parent_id ${COMPARISON}`],
-    entity_relation: [`child_id ${COMPARISON}`, `parent_id ${COMPARISON}`],
-    meditrak_sync_queue: [`record_id ${COMPARISON}`],
-  };
-  const sql = TABLES_TO_CLEAR.reduce(
-    (acc, table) => `${acc}\n${getDeleteStatement(table, extraConditions[table])}`,
-    '',
-  );
-  await db.executeSql(sql);
-  await AnalyticsRefresher.refreshAnalytics(db);
-}
+// export async function clearTestData(db, testStartTime = moment().format('YYYY-MM-DD HH:mm:ss')) {
+//   const extraConditions = {
+//     api_request_log: [`request_time >= '${testStartTime}'`],
+//     api_client: [`id ${COMPARISON}`, `user_account_id ${COMPARISON}`],
+//     answer: [`question_id ${COMPARISON}`, `survey_response_id ${COMPARISON}`],
+//     survey_response: [`survey_id ${COMPARISON}`, `entity_id ${COMPARISON}`],
+//     survey_screen_component: [`question_id ${COMPARISON}`],
+//     survey: [`code LIKE 'test%'`, `name ${COMPARISON}`], // name comparison is for clearing test data when importing new surveys using excel files
+//     user_entity_permission: [`permission_group_id ${COMPARISON}`],
+//     user_account: [`email = 'test.user@tupaia.org'`, `first_name = 'Automated test'`],
+//     clinic: [`country_id ${COMPARISON}`],
+//     dashboard_relation: [`child_id ${COMPARISON}`, `dashboard_id ${COMPARISON}`],
+//     map_overlay_group_relation: [`child_id ${COMPARISON}`, `map_overlay_group_id ${COMPARISON}`],
+//     entity: [`code LIKE 'test%'`, `code ${COMPARISON}`, `parent_id ${COMPARISON}`],
+//     entity_relation: [`child_id ${COMPARISON}`, `parent_id ${COMPARISON}`],
+//     meditrak_sync_queue: [`record_id ${COMPARISON}`],
+//   };
+//   const sql = TABLES_TO_CLEAR.reduce(
+//     (acc, table) => `${acc}\n${getDeleteStatement(table, extraConditions[table])}`,
+//     '',
+//   );
+//   await db.executeSql(sql);
+//   await AnalyticsRefresher.refreshAnalytics(db);
+// }
 
-export async function clearAllTestData(db) {
+export async function clearTestData(db) {
   // Safety check
   const [row] = await db.executeSql(`SELECT current_database();`);
   const { current_database } = row;
   if (current_database !== 'tupaia_test') {
     throw new Error(
-      `Safety check failed: clearAllTestData can only be run against a database named tupaia_test, found ${current_database}.`,
+      `Safety check failed: clearTestData can only be run against a database named tupaia_test, found ${current_database}.`,
     );
   }
 

--- a/packages/database/src/testUtilities/clearTestData.js
+++ b/packages/database/src/testUtilities/clearTestData.js
@@ -1,16 +1,9 @@
 /**
  * Tupaia
- * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
+ * Copyright (c) 2017 - 2024 Beyond Essential Systems Pty Ltd
  */
 
-import moment from 'moment';
 import { AnalyticsRefresher } from '..';
-
-const COMPARISON = `LIKE '%_test%'`;
-const getDeleteStatement = (table, extraConditions = []) => {
-  const conditions = [`id ${COMPARISON}`, ...extraConditions];
-  return `DELETE FROM "${table}" WHERE ${conditions.join(' OR ')};`;
-};
 
 // tables are in a significant order, ensuring any foreign keys are cleaned up correctly
 const TABLES_TO_CLEAR = [
@@ -61,31 +54,6 @@ const TABLES_TO_CLEAR = [
   'map_overlay_group',
   'map_overlay',
 ];
-
-// export async function clearTestData(db, testStartTime = moment().format('YYYY-MM-DD HH:mm:ss')) {
-//   const extraConditions = {
-//     api_request_log: [`request_time >= '${testStartTime}'`],
-//     api_client: [`id ${COMPARISON}`, `user_account_id ${COMPARISON}`],
-//     answer: [`question_id ${COMPARISON}`, `survey_response_id ${COMPARISON}`],
-//     survey_response: [`survey_id ${COMPARISON}`, `entity_id ${COMPARISON}`],
-//     survey_screen_component: [`question_id ${COMPARISON}`],
-//     survey: [`code LIKE 'test%'`, `name ${COMPARISON}`], // name comparison is for clearing test data when importing new surveys using excel files
-//     user_entity_permission: [`permission_group_id ${COMPARISON}`],
-//     user_account: [`email = 'test.user@tupaia.org'`, `first_name = 'Automated test'`],
-//     clinic: [`country_id ${COMPARISON}`],
-//     dashboard_relation: [`child_id ${COMPARISON}`, `dashboard_id ${COMPARISON}`],
-//     map_overlay_group_relation: [`child_id ${COMPARISON}`, `map_overlay_group_id ${COMPARISON}`],
-//     entity: [`code LIKE 'test%'`, `code ${COMPARISON}`, `parent_id ${COMPARISON}`],
-//     entity_relation: [`child_id ${COMPARISON}`, `parent_id ${COMPARISON}`],
-//     meditrak_sync_queue: [`record_id ${COMPARISON}`],
-//   };
-//   const sql = TABLES_TO_CLEAR.reduce(
-//     (acc, table) => `${acc}\n${getDeleteStatement(table, extraConditions[table])}`,
-//     '',
-//   );
-//   await db.executeSql(sql);
-//   await AnalyticsRefresher.refreshAnalytics(db);
-// }
 
 export async function clearTestData(db) {
   // Safety check

--- a/packages/database/src/testUtilities/index.js
+++ b/packages/database/src/testUtilities/index.js
@@ -6,7 +6,7 @@
 export { buildAndInsertSurvey, buildAndInsertSurveys } from './buildAndInsertSurveys';
 export { buildAndInsertSurveyResponses } from './buildAndInsertSurveyResponses';
 export { buildAndInsertProjectsAndHierarchies } from './buildAndInsertProjectsAndHierarchies';
-export { clearTestData, clearAllTestData } from './clearTestData';
+export { clearTestData } from './clearTestData';
 export { generateTestId } from './generateTestId';
 export { generateValueOfType } from './generateValueOfType';
 export { getTestDatabase, getTestModels } from './getTestDatabase';

--- a/packages/tupaia-web-server/package.json
+++ b/packages/tupaia-web-server/package.json
@@ -23,7 +23,7 @@
     "start-dev": "LOG_LEVEL=debug yarn package:start:backend-start-dev 9998 -ts",
     "start-verbose": "LOG_LEVEL=debug yarn start-dev",
     "setup-test": "yarn workspace @tupaia/database setup-test-database",
-    "test": "yarn package:test"
+    "test": "yarn package:test:withdb"
   },
   "dependencies": {
     "@tupaia/access-policy": "workspace:*",


### PR DESCRIPTION
### Issue RN-1223: Update clearTestData to remove all test database data

### Changes:
- Removed old `clearTestData` util
- Updated `clearAllTestData` to be called `clearTestData`
- Updated `tupaia-web-server` to test with test db instead of real db