### PR TITLE
RN-1112: Bump `nodemailer` to ≥6.9.9

### DIFF
--- a/packages/server-utils/package.json
+++ b/packages/server-utils/package.json
@@ -25,7 +25,7 @@
     "@aws-sdk/lib-storage": "^3.348.0",
     "@tupaia/utils": "workspace:*",
     "cookie": "^0.5.0",
-    "nodemailer": "^6.9.7",
+    "nodemailer": "^6.9.12",
     "puppeteer": "^15.4.0",
     "sha256": "^0.2.0"
   },

--- a/packages/web-config-server/package.json
+++ b/packages/web-config-server/package.json
@@ -61,7 +61,7 @@
     "lodash.zipobject": "^4.1.3",
     "moment": "^2.24.0",
     "morgan": "^1.9.0",
-    "nodemailer": "^4.6.7",
+    "nodemailer": "^6.9.12",
     "promise": "^7.3.1",
     "react-autobind": "^1.0.6",
     "request": "^2.81.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12689,7 +12689,7 @@ __metadata:
     "@types/nodemailer": ^6.4.13
     "@types/sha256": ^0.2.2
     cookie: ^0.5.0
-    nodemailer: ^6.9.7
+    nodemailer: ^6.9.12
     puppeteer: ^15.4.0
     sha256: ^0.2.0
   languageName: unknown
@@ -12992,7 +12992,7 @@ __metadata:
     lodash.zipobject: ^4.1.3
     moment: ^2.24.0
     morgan: ^1.9.0
-    nodemailer: ^4.6.7
+    nodemailer: ^6.9.12
     promise: ^7.3.1
     react-autobind: ^1.0.6
     request: ^2.81.0
@@ -33554,17 +33554,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nodemailer@npm:^4.6.7":
-  version: 4.7.0
-  resolution: "nodemailer@npm:4.7.0"
-  checksum: 33f8774cd1883c693b4cafe66eb599e2351c3e0dfa29f4d37dcfcc26ad789490e9cede64784f4cd79db8ee7675381aafb9e52243859977a5c1ecd2fff6607d97
-  languageName: node
-  linkType: hard
-
-"nodemailer@npm:^6.9.7":
-  version: 6.9.7
-  resolution: "nodemailer@npm:6.9.7"
-  checksum: 0cf66d27aed3bd2cbdff9939402cec3d2119c31b2b9ff4af3bcd59f48287ea75b90c0ce2cd9eb0df838164972cd25581b4b723c91fd673e2608bcb28445ccb1b
+"nodemailer@npm:^6.9.12":
+  version: 6.9.12
+  resolution: "nodemailer@npm:6.9.12"
+  checksum: 061f4c785b5362903078ef2434d1e5a50901439caa0102435cfdb33efa993ac5d03ae26780c1baef5adb90909793e40ba36d853273294fe83dc4dffb9719dfd0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue RN-1112: Bump `nodemailer` to ≥6.9.9

### Changes

This supersedes the #5488 Dependabot PR, which addresses [an alert of **critical** severity](https://github.com/beyondessential/tupaia/security/dependabot/36).

According to the [changelog](https://github.com/nodemailer/nodemailer/blob/master/CHANGELOG.md) `server-utils` should see only bug fixes.

`web-config-server` is coming from 4.6, so _may_ see a few more changes, but I didn’t see anything drastic in the [changelog](https://github.com/nodemailer/nodemailer/blob/master/CHANGELOG.md).