### PR TITLE
RN-1112: Bump `react-native-document-picker` to 9.1.1

### DIFF
--- a/packages/meditrak-app/package.json
+++ b/packages/meditrak-app/package.json
@@ -29,7 +29,7 @@
     "react-native-config": "^1.5.1",
     "react-native-database": "^0.3.3",
     "react-native-device-info": "^10.9.0",
-    "react-native-document-picker": "^9.0.1",
+    "react-native-document-picker": "^9.1.1",
     "react-native-fs": "^2.20.0",
     "react-native-gesture-handler": "^2.13.0",
     "react-native-image-picker": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12515,7 +12515,7 @@ __metadata:
     react-native-config: ^1.5.1
     react-native-database: ^0.3.3
     react-native-device-info: ^10.9.0
-    react-native-document-picker: ^9.0.1
+    react-native-document-picker: ^9.1.1
     react-native-fs: ^2.20.0
     react-native-gesture-handler: ^2.13.0
     react-native-image-picker: ^7.0.0
@@ -37235,9 +37235,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-document-picker@npm:^9.0.1":
-  version: 9.0.1
-  resolution: "react-native-document-picker@npm:9.0.1"
+"react-native-document-picker@npm:^9.1.1":
+  version: 9.1.1
+  resolution: "react-native-document-picker@npm:9.1.1"
   dependencies:
     invariant: ^2.2.4
   peerDependencies:
@@ -37247,7 +37247,7 @@ __metadata:
   peerDependenciesMeta:
     react-native-windows:
       optional: true
-  checksum: a8ad0bc2ed13290e8d7ff5f77aa7e35ffda9fa380a7d01d1286111e92656415985d61469a50567b8bcb67e42c41a36b89e879d0d08b40d3fdda171eaa08721e4
+  checksum: e29b9406dd77e16f461e64035a5f7056b1fcb0d05fb26b23f0073ff2211520a7ac9b57da7e58e61ff03bcbe1120d2e104fb1c90282412736feeb12abe96e2d3b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue RN-1112: Bump `react-native-document-picker` to 9.1.1

### Changes

This PR is identical to the #5490 Dependabot PR, which resolves [an alert of **moderate** severity](https://github.com/beyondessential/tupaia/security/dependabot/276).

The only reason for this PR because Dependabot’s feature branch names don’t pass our CI validation.