### PR TITLE
no-issue: Explicitly name `useContext` wrappers

### DIFF
--- a/packages/admin-panel/src/VizBuilderApp/components/DashboardItem/DashboardItemMetadataForm.jsx
+++ b/packages/admin-panel/src/VizBuilderApp/components/DashboardItem/DashboardItemMetadataForm.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import { useForm } from 'react-hook-form';
 import { Autocomplete, TextField } from '@tupaia/ui-components';
 import { useSearchPermissionGroups } from '../../api/queries';
-import { useVizConfig } from '../../context';
+import { useVizConfigContext } from '../../context';
 import { useDebounce } from '../../../utilities';
 import { DASHBOARD_ITEM_VIZ_TYPES } from '../../constants';
 
@@ -20,7 +20,7 @@ export const DashboardItemMetadataForm = ({ Header, Body, Footer, onSubmit }) =>
   const [
     { visualisation, vizType },
     { setVisualisationValue, setVizType, setPresentation, setPresentationValue },
-  ] = useVizConfig();
+  ] = useVizConfigContext();
 
   // Save the default values here so that they are frozen from the store when the component first mounts
   const [defaults] = useState(visualisation);

--- a/packages/admin-panel/src/VizBuilderApp/components/ExportButton.jsx
+++ b/packages/admin-panel/src/VizBuilderApp/components/ExportButton.jsx
@@ -13,7 +13,7 @@ import {
   useExportDashboardVisualisation,
   useExportMapOverlayVisualisation,
 } from '../api/mutations';
-import { useVisualisationContext, useVizConfigError } from '../context';
+import { useVisualisationContext, useVizConfigErrorContext } from '../context';
 import { DASHBOARD_ITEM_OR_MAP_OVERLAY_PARAM } from '../constants';
 
 export const ExportButton = () => {
@@ -31,7 +31,7 @@ export const ExportButton = () => {
     throw new Error('Unknown viz type');
   };
 
-  const { hasError: vizConfigHasError } = useVizConfigError();
+  const { hasError: vizConfigHasError } = useVizConfigErrorContext();
   const { mutateAsync: exportVisualisation } = useExportViz();
 
   return (

--- a/packages/admin-panel/src/VizBuilderApp/components/ExportButton.jsx
+++ b/packages/admin-panel/src/VizBuilderApp/components/ExportButton.jsx
@@ -13,11 +13,11 @@ import {
   useExportDashboardVisualisation,
   useExportMapOverlayVisualisation,
 } from '../api/mutations';
-import { useVisualisation, useVizConfigError } from '../context';
+import { useVisualisationContext, useVizConfigError } from '../context';
 import { DASHBOARD_ITEM_OR_MAP_OVERLAY_PARAM } from '../constants';
 
 export const ExportButton = () => {
-  const { visualisation } = useVisualisation();
+  const { visualisation } = useVisualisationContext();
 
   const { dashboardItemOrMapOverlay } = useParams();
 

--- a/packages/admin-panel/src/VizBuilderApp/components/JsonToggleButton.jsx
+++ b/packages/admin-panel/src/VizBuilderApp/components/JsonToggleButton.jsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { FormControlLabel, Switch } from '@material-ui/core';
-import { usePreviewData } from '../context';
+import { usePreviewDataContext } from '../context';
 
 const ControlLabel = styled(FormControlLabel)`
   color: ${props => (props.$jsonToggleEnabled ? props.theme.palette.primary.main : 'grey')};
@@ -17,7 +17,7 @@ const ControlLabel = styled(FormControlLabel)`
 `;
 
 export const JsonToggleButton = () => {
-  const { jsonToggleEnabled, setJsonToggleEnabled } = usePreviewData();
+  const { jsonToggleEnabled, setJsonToggleEnabled } = usePreviewDataContext();
 
   const handleClick = () => {
     setJsonToggleEnabled(!jsonToggleEnabled);

--- a/packages/admin-panel/src/VizBuilderApp/components/MapOverlay/MapOverlayMetadataForm.jsx
+++ b/packages/admin-panel/src/VizBuilderApp/components/MapOverlay/MapOverlayMetadataForm.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import { useForm } from 'react-hook-form';
 import { Autocomplete, TextField } from '@tupaia/ui-components';
 import Chip from '@material-ui/core/Chip';
-import { useCountries, useSearchPermissionGroups, useProjects } from '../../api/queries';
+import { useCountries, useProjects, useSearchPermissionGroups } from '../../api/queries';
 import { useVizConfig } from '../../context';
 import { useDebounce } from '../../../utilities';
 import { MAP_OVERLAY_VIZ_TYPES } from '../../constants';

--- a/packages/admin-panel/src/VizBuilderApp/components/MapOverlay/MapOverlayMetadataForm.jsx
+++ b/packages/admin-panel/src/VizBuilderApp/components/MapOverlay/MapOverlayMetadataForm.jsx
@@ -8,7 +8,7 @@ import { useForm } from 'react-hook-form';
 import { Autocomplete, TextField } from '@tupaia/ui-components';
 import Chip from '@material-ui/core/Chip';
 import { useCountries, useProjects, useSearchPermissionGroups } from '../../api/queries';
-import { useVizConfig } from '../../context';
+import { useVizConfigContext } from '../../context';
 import { useDebounce } from '../../../utilities';
 import { MAP_OVERLAY_VIZ_TYPES } from '../../constants';
 
@@ -20,7 +20,7 @@ export const MapOverlayMetadataForm = ({ Header, Body, Footer, onSubmit }) => {
 
   const { handleSubmit, register, errors } = useForm();
   const [{ visualisation, vizType }, { setVisualisationValue, setVizType, setPresentation }] =
-    useVizConfig();
+    useVizConfigContext();
   const { data: allProjects = [], isLoading: isLoadingAllProjects } = useProjects();
   const { data: allCountries = [], isLoading: isLoadingAllCountries } = useCountries();
 

--- a/packages/admin-panel/src/VizBuilderApp/components/Modal/SaveVisualisationModal.jsx
+++ b/packages/admin-panel/src/VizBuilderApp/components/Modal/SaveVisualisationModal.jsx
@@ -21,7 +21,7 @@ import {
 } from '@tupaia/ui-components';
 
 import { DASHBOARD_ITEM_OR_MAP_OVERLAY_PARAM, MODAL_STATUS } from '../../constants';
-import { useVisualisationContext, useVizConfig } from '../../context';
+import { useVisualisationContext, useVizConfigContext } from '../../context';
 import { useSaveDashboardVisualisation, useSaveMapOverlayVisualisation } from '../../api';
 import { useVizBuilderBasePath } from '../../utils';
 
@@ -39,7 +39,7 @@ const SuccessText = styled(Typography)`
 export const SaveVisualisationModal = ({ isOpen, onClose }) => {
   const [status, setStatus] = useState(MODAL_STATUS.INITIAL);
   // eslint-disable-next-line no-unused-vars
-  const [_, { setVisualisationValue }] = useVizConfig();
+  const [_, { setVisualisationValue }] = useVizConfigContext();
   const { visualisation } = useVisualisationContext();
 
   const basePath = useVizBuilderBasePath();

--- a/packages/admin-panel/src/VizBuilderApp/components/Modal/SaveVisualisationModal.jsx
+++ b/packages/admin-panel/src/VizBuilderApp/components/Modal/SaveVisualisationModal.jsx
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
  */
 
-import React, { useState, useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Link as RouterLink, useParams } from 'react-router-dom';
@@ -12,16 +12,16 @@ import Typography from '@material-ui/core/Typography';
 
 import {
   Button,
-  OutlinedButton,
+  ConfirmModal,
   Dialog,
   DialogContent,
   DialogFooter,
   DialogHeader,
-  ConfirmModal,
+  OutlinedButton,
 } from '@tupaia/ui-components';
 
-import { MODAL_STATUS, DASHBOARD_ITEM_OR_MAP_OVERLAY_PARAM } from '../../constants';
-import { useVizConfig, useVisualisation } from '../../context';
+import { DASHBOARD_ITEM_OR_MAP_OVERLAY_PARAM, MODAL_STATUS } from '../../constants';
+import { useVisualisationContext, useVizConfig } from '../../context';
 import { useSaveDashboardVisualisation, useSaveMapOverlayVisualisation } from '../../api';
 import { useVizBuilderBasePath } from '../../utils';
 
@@ -40,7 +40,7 @@ export const SaveVisualisationModal = ({ isOpen, onClose }) => {
   const [status, setStatus] = useState(MODAL_STATUS.INITIAL);
   // eslint-disable-next-line no-unused-vars
   const [_, { setVisualisationValue }] = useVizConfig();
-  const { visualisation } = useVisualisation();
+  const { visualisation } = useVisualisationContext();
 
   const basePath = useVizBuilderBasePath();
   const { dashboardItemOrMapOverlay } = useParams();

--- a/packages/admin-panel/src/VizBuilderApp/components/Panel.jsx
+++ b/packages/admin-panel/src/VizBuilderApp/components/Panel.jsx
@@ -13,7 +13,7 @@ import {
   usePreviewDataContext,
   useVisualisationContext,
   useVizConfigContext,
-  useVizConfigError,
+  useVizConfigErrorContext,
 } from '../context';
 import { TransformDataLibrary } from './DataLibrary';
 
@@ -47,7 +47,7 @@ const PanelTabPanel = styled.div`
 `;
 
 export const Panel = () => {
-  const { setDataError } = useVizConfigError();
+  const { setDataError } = useVizConfigErrorContext();
   const { jsonToggleEnabled } = usePreviewDataContext();
   const [
     {

--- a/packages/admin-panel/src/VizBuilderApp/components/Panel.jsx
+++ b/packages/admin-panel/src/VizBuilderApp/components/Panel.jsx
@@ -9,7 +9,12 @@ import { JsonEditor } from '../../widgets';
 import { TabPanel } from './TabPanel';
 import { PlayButton } from './PlayButton';
 import { JsonToggleButton } from './JsonToggleButton';
-import { useVizConfig, useVisualisation, useVizConfigError, usePreviewData } from '../context';
+import {
+  usePreviewData,
+  useVisualisationContext,
+  useVizConfig,
+  useVizConfigError,
+} from '../context';
 import { TransformDataLibrary } from './DataLibrary';
 
 const Container = styled(FlexColumn)`
@@ -53,7 +58,7 @@ export const Panel = () => {
 
   const {
     visualisation: { data: vizData },
-  } = useVisualisation();
+  } = useVisualisationContext();
 
   const handleInvalidChange = errMsg => {
     setDataError(errMsg);

--- a/packages/admin-panel/src/VizBuilderApp/components/Panel.jsx
+++ b/packages/admin-panel/src/VizBuilderApp/components/Panel.jsx
@@ -10,7 +10,7 @@ import { TabPanel } from './TabPanel';
 import { PlayButton } from './PlayButton';
 import { JsonToggleButton } from './JsonToggleButton';
 import {
-  usePreviewData,
+  usePreviewDataContext,
   useVisualisationContext,
   useVizConfigContext,
   useVizConfigError,
@@ -48,7 +48,7 @@ const PanelTabPanel = styled.div`
 
 export const Panel = () => {
   const { setDataError } = useVizConfigError();
-  const { jsonToggleEnabled } = usePreviewData();
+  const { jsonToggleEnabled } = usePreviewDataContext();
   const [
     {
       visualisation: { data: dataWithConfig },

--- a/packages/admin-panel/src/VizBuilderApp/components/Panel.jsx
+++ b/packages/admin-panel/src/VizBuilderApp/components/Panel.jsx
@@ -12,7 +12,7 @@ import { JsonToggleButton } from './JsonToggleButton';
 import {
   usePreviewData,
   useVisualisationContext,
-  useVizConfig,
+  useVizConfigContext,
   useVizConfigError,
 } from '../context';
 import { TransformDataLibrary } from './DataLibrary';
@@ -54,7 +54,7 @@ export const Panel = () => {
       visualisation: { data: dataWithConfig },
     },
     { setDataConfig },
-  ] = useVizConfig();
+  ] = useVizConfigContext();
 
   const {
     visualisation: { data: vizData },

--- a/packages/admin-panel/src/VizBuilderApp/components/PlayButton.jsx
+++ b/packages/admin-panel/src/VizBuilderApp/components/PlayButton.jsx
@@ -7,7 +7,7 @@ import styled from 'styled-components';
 import MuiIconButton from '@material-ui/core/IconButton';
 import PlayIcon from '@material-ui/icons/PlayCircleFilled';
 
-import { usePreviewData, useVizConfigError } from '../context';
+import { usePreviewDataContext, useVizConfigError } from '../context';
 
 const IconButton = styled(MuiIconButton)`
   border: 1px solid ${({ theme }) => theme.palette.grey['400']};
@@ -22,7 +22,7 @@ const IconButton = styled(MuiIconButton)`
 `;
 
 export const PlayButton = () => {
-  const { setFetchEnabled, setShowData } = usePreviewData();
+  const { setFetchEnabled, setShowData } = usePreviewDataContext();
   const { hasError: vizConfigHasError } = useVizConfigError();
 
   const handleClick = () => {

--- a/packages/admin-panel/src/VizBuilderApp/components/PlayButton.jsx
+++ b/packages/admin-panel/src/VizBuilderApp/components/PlayButton.jsx
@@ -7,7 +7,7 @@ import styled from 'styled-components';
 import MuiIconButton from '@material-ui/core/IconButton';
 import PlayIcon from '@material-ui/icons/PlayCircleFilled';
 
-import { usePreviewDataContext, useVizConfigError } from '../context';
+import { usePreviewDataContext, useVizConfigErrorContext } from '../context';
 
 const IconButton = styled(MuiIconButton)`
   border: 1px solid ${({ theme }) => theme.palette.grey['400']};
@@ -23,7 +23,7 @@ const IconButton = styled(MuiIconButton)`
 
 export const PlayButton = () => {
   const { setFetchEnabled, setShowData } = usePreviewDataContext();
-  const { hasError: vizConfigHasError } = useVizConfigError();
+  const { hasError: vizConfigHasError } = useVizConfigErrorContext();
 
   const handleClick = () => {
     setFetchEnabled(true);

--- a/packages/admin-panel/src/VizBuilderApp/components/PreviewOptions.jsx
+++ b/packages/admin-panel/src/VizBuilderApp/components/PreviewOptions.jsx
@@ -17,7 +17,7 @@ import {
   ImportModal,
 } from '@tupaia/ui-components';
 import { useLocations, useProjects } from '../api/queries';
-import { usePreviewData, useVizConfig } from '../context';
+import { usePreviewData, useVizConfigContext } from '../context';
 import { LinkButton } from './LinkButton';
 import { useUploadTestData } from '../api';
 
@@ -152,7 +152,7 @@ export const PreviewOptions = () => {
   const [
     { project, location },
     { setProject, setLocation, setStartDate, setEndDate, setTestData },
-  ] = useVizConfig();
+  ] = useVizConfigContext();
   const { mutateAsync: uploadTestData } = useUploadTestData();
 
   const handleSelectProject = (event, value) => {

--- a/packages/admin-panel/src/VizBuilderApp/components/PreviewOptions.jsx
+++ b/packages/admin-panel/src/VizBuilderApp/components/PreviewOptions.jsx
@@ -17,7 +17,7 @@ import {
   ImportModal,
 } from '@tupaia/ui-components';
 import { useLocations, useProjects } from '../api/queries';
-import { usePreviewData, useVizConfigContext } from '../context';
+import { usePreviewDataContext, useVizConfigContext } from '../context';
 import { LinkButton } from './LinkButton';
 import { useUploadTestData } from '../api';
 
@@ -141,7 +141,7 @@ const UploadDataModal = ({ isOpen, onSubmit, onClose }) => (
 );
 
 export const PreviewOptions = () => {
-  const { setShowData } = usePreviewData();
+  const { setShowData } = usePreviewDataContext();
   const [locationSearch, setLocationSearch] = useState('');
   const [selectedProjectOption, setSelectedProjectOption] = useState(null);
   const [selectedLocationOption, setSelectedLocationOption] = useState(null);

--- a/packages/admin-panel/src/VizBuilderApp/components/PreviewSection.jsx
+++ b/packages/admin-panel/src/VizBuilderApp/components/PreviewSection.jsx
@@ -16,7 +16,7 @@ import {
   usePreviewDataContext,
   useVisualisationContext,
   useVizConfigContext,
-  useVizConfigError,
+  useVizConfigErrorContext,
 } from '../context';
 import { IdleMessage } from './IdleMessage';
 import { getColumns, getRows } from '../../utilities';
@@ -110,7 +110,7 @@ export const PreviewSection = () => {
 
   const { dashboardItemOrMapOverlay } = useParams();
   const { fetchEnabled, setFetchEnabled, showData, jsonToggleEnabled } = usePreviewDataContext();
-  const { hasPresentationError, setPresentationError } = useVizConfigError();
+  const { hasPresentationError, setPresentationError } = useVizConfigErrorContext();
 
   const [
     { vizType, project, location, startDate, endDate, testData, visualisation },

--- a/packages/admin-panel/src/VizBuilderApp/components/PreviewSection.jsx
+++ b/packages/admin-panel/src/VizBuilderApp/components/PreviewSection.jsx
@@ -15,7 +15,7 @@ import { useReportPreview } from '../api';
 import {
   usePreviewData,
   useVisualisationContext,
-  useVizConfig,
+  useVizConfigContext,
   useVizConfigError,
 } from '../context';
 import { IdleMessage } from './IdleMessage';
@@ -115,7 +115,7 @@ export const PreviewSection = () => {
   const [
     { vizType, project, location, startDate, endDate, testData, visualisation },
     { setPresentation },
-  ] = useVizConfig();
+  ] = useVizConfigContext();
   const { visualisationForFetchingData } = useVisualisationContext();
 
   const presentationSchema =

--- a/packages/admin-panel/src/VizBuilderApp/components/PreviewSection.jsx
+++ b/packages/admin-panel/src/VizBuilderApp/components/PreviewSection.jsx
@@ -13,7 +13,7 @@ import { JsonEditor, JsonTreeEditor } from '../../widgets';
 import { TabPanel } from './TabPanel';
 import { useReportPreview } from '../api';
 import {
-  usePreviewData,
+  usePreviewDataContext,
   useVisualisationContext,
   useVizConfigContext,
   useVizConfigError,
@@ -109,7 +109,7 @@ export const PreviewSection = () => {
   const [tab, setTab] = useState(0);
 
   const { dashboardItemOrMapOverlay } = useParams();
-  const { fetchEnabled, setFetchEnabled, showData, jsonToggleEnabled } = usePreviewData();
+  const { fetchEnabled, setFetchEnabled, showData, jsonToggleEnabled } = usePreviewDataContext();
   const { hasPresentationError, setPresentationError } = useVizConfigError();
 
   const [

--- a/packages/admin-panel/src/VizBuilderApp/components/PreviewSection.jsx
+++ b/packages/admin-panel/src/VizBuilderApp/components/PreviewSection.jsx
@@ -2,17 +2,22 @@
  * Tupaia
  *  Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
  */
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import MuiTab from '@material-ui/core/Tab';
 import MuiTabs from '@material-ui/core/Tabs';
-import { FlexSpaceBetween, FetchLoader, DataGrid } from '@tupaia/ui-components';
+import { DataGrid, FetchLoader, FlexSpaceBetween } from '@tupaia/ui-components';
 import { Chart } from '@tupaia/ui-chart-components';
 import { JsonEditor, JsonTreeEditor } from '../../widgets';
 import { TabPanel } from './TabPanel';
 import { useReportPreview } from '../api';
-import { usePreviewData, useVisualisation, useVizConfig, useVizConfigError } from '../context';
+import {
+  usePreviewData,
+  useVisualisationContext,
+  useVizConfig,
+  useVizConfigError,
+} from '../context';
 import { IdleMessage } from './IdleMessage';
 import { getColumns, getRows } from '../../utilities';
 import {
@@ -111,7 +116,7 @@ export const PreviewSection = () => {
     { vizType, project, location, startDate, endDate, testData, visualisation },
     { setPresentation },
   ] = useVizConfig();
-  const { visualisationForFetchingData } = useVisualisation();
+  const { visualisationForFetchingData } = useVisualisationContext();
 
   const presentationSchema =
     dashboardItemOrMapOverlay === DASHBOARD_ITEM_OR_MAP_OVERLAY_PARAM.DASHBOARD_ITEM

--- a/packages/admin-panel/src/VizBuilderApp/components/SaveButton.jsx
+++ b/packages/admin-panel/src/VizBuilderApp/components/SaveButton.jsx
@@ -3,14 +3,14 @@
  *  Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
  */
 
-import React, { useState, useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import { Button } from '@tupaia/ui-components';
-import { useVizConfigError } from '../context';
+import { useVizConfigErrorContext } from '../context';
 
 import { SaveVisualisationModal } from './Modal';
 
 export const SaveButton = () => {
-  const { hasError: vizConfigHasError } = useVizConfigError();
+  const { hasError: vizConfigHasError } = useVizConfigErrorContext();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const handleCloseModal = useCallback(() => {
     setIsModalOpen(false);

--- a/packages/admin-panel/src/VizBuilderApp/components/Toolbar.jsx
+++ b/packages/admin-panel/src/VizBuilderApp/components/Toolbar.jsx
@@ -8,7 +8,7 @@ import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import Typography from '@material-ui/core/Typography';
 import MuiBox from '@material-ui/core/Box';
-import { FlexStart, FlexEnd, FlexSpaceBetween } from '@tupaia/ui-components';
+import { FlexEnd, FlexSpaceBetween, FlexStart } from '@tupaia/ui-components';
 import { ExportButton } from './ExportButton';
 import { SaveButton } from './SaveButton';
 import { DocumentIcon } from './DocumentIcon';

--- a/packages/admin-panel/src/VizBuilderApp/components/Toolbar.jsx
+++ b/packages/admin-panel/src/VizBuilderApp/components/Toolbar.jsx
@@ -13,7 +13,7 @@ import { ExportButton } from './ExportButton';
 import { SaveButton } from './SaveButton';
 import { DocumentIcon } from './DocumentIcon';
 import { EditModal } from './Modal';
-import { useVizConfig } from '../context';
+import { useVizConfigContext } from '../context';
 import { DASHBOARD_ITEM_OR_MAP_OVERLAY_PARAM } from '../constants';
 
 const Wrapper = styled.div`
@@ -54,7 +54,7 @@ const ButtonContainer = styled(FlexSpaceBetween)`
 `;
 
 export const Toolbar = () => {
-  const [{ project, visualisation }] = useVizConfig();
+  const [{ project, visualisation }] = useVizConfigContext();
   const { dashboardItemOrMapOverlay } = useParams();
 
   const permissionGroup = visualisation.permissionGroup ?? visualisation.mapOverlayPermissionGroup;

--- a/packages/admin-panel/src/VizBuilderApp/context/PreviewData.jsx
+++ b/packages/admin-panel/src/VizBuilderApp/context/PreviewData.jsx
@@ -29,7 +29,7 @@ export const PreviewDataProvider = ({ children }) => {
   );
 };
 
-export const usePreviewData = () => useContext(PreviewDataContext);
+export const usePreviewDataContext = () => useContext(PreviewDataContext);
 
 PreviewDataProvider.propTypes = {
   children: PropTypes.node.isRequired,

--- a/packages/admin-panel/src/VizBuilderApp/context/VizConfig.jsx
+++ b/packages/admin-panel/src/VizBuilderApp/context/VizConfig.jsx
@@ -225,10 +225,10 @@ const useVisualisationContext = () => {
   return useContext(VisualisationContext);
 };
 
-const useVizConfig = () => {
+const useVizConfigContext = () => {
   return useContext(VizBuilderConfigContext);
 };
 
 // Note: the store can be debugged in dev tools using a chrome plugin.
 // https://chrome.google.com/webstore/detail/react-context-devtool/oddhnidmicpefilikhgeagedibnefkcf?hl=en
-export { useVisualisationContext, useVizConfig, VizConfigProvider };
+export { useVisualisationContext, useVizConfigContext, VizConfigProvider };

--- a/packages/admin-panel/src/VizBuilderApp/context/VizConfig.jsx
+++ b/packages/admin-panel/src/VizBuilderApp/context/VizConfig.jsx
@@ -2,7 +2,7 @@
  * Tupaia
  * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
  */
-import React, { useReducer, createContext, useContext } from 'react';
+import React, { createContext, useContext, useReducer } from 'react';
 
 /**
  * This store is designed to hold the state for the vizBuilderConfig
@@ -221,7 +221,7 @@ const VizConfigProvider = ({ children }) => {
   );
 };
 
-const useVisualisation = () => {
+const useVisualisationContext = () => {
   return useContext(VisualisationContext);
 };
 
@@ -231,4 +231,4 @@ const useVizConfig = () => {
 
 // Note: the store can be debugged in dev tools using a chrome plugin.
 // https://chrome.google.com/webstore/detail/react-context-devtool/oddhnidmicpefilikhgeagedibnefkcf?hl=en
-export { useVisualisation, useVizConfig, VizConfigProvider };
+export { useVisualisationContext, useVizConfig, VizConfigProvider };

--- a/packages/admin-panel/src/VizBuilderApp/context/VizConfig.jsx
+++ b/packages/admin-panel/src/VizBuilderApp/context/VizConfig.jsx
@@ -221,13 +221,9 @@ const VizConfigProvider = ({ children }) => {
   );
 };
 
-const useVisualisationContext = () => {
-  return useContext(VisualisationContext);
-};
+const useVisualisationContext = () => useContext(VisualisationContext);
 
-const useVizConfigContext = () => {
-  return useContext(VizBuilderConfigContext);
-};
+const useVizConfigContext = () => useContext(VizBuilderConfigContext);
 
 // Note: the store can be debugged in dev tools using a chrome plugin.
 // https://chrome.google.com/webstore/detail/react-context-devtool/oddhnidmicpefilikhgeagedibnefkcf?hl=en

--- a/packages/admin-panel/src/VizBuilderApp/context/VizConfigError.jsx
+++ b/packages/admin-panel/src/VizBuilderApp/context/VizConfigError.jsx
@@ -30,7 +30,7 @@ export const VizConfigErrorProvider = ({ children }) => {
   );
 };
 
-export const useVizConfigError = () => useContext(VizConfigErrorContext);
+export const useVizConfigErrorContext = () => useContext(VizConfigErrorContext);
 
 VizConfigErrorProvider.propTypes = {
   children: PropTypes.node.isRequired,

--- a/packages/admin-panel/src/VizBuilderApp/views/Main.jsx
+++ b/packages/admin-panel/src/VizBuilderApp/views/Main.jsx
@@ -12,7 +12,7 @@ import CircularProgress from '@material-ui/core/CircularProgress';
 import { FlexColumn, SmallAlert } from '@tupaia/ui-components';
 import { useDashboardVisualisation } from '../api';
 import { Panel, PreviewOptions, PreviewSection, Toolbar } from '../components';
-import { PreviewDataProvider, VizConfigErrorProvider, useVizConfig } from '../context';
+import { PreviewDataProvider, useVizConfig, VizConfigErrorProvider } from '../context';
 import { useMapOverlayVisualisation } from '../api/queries/useMapOverlayVisualisation';
 import {
   DASHBOARD_ITEM_OR_MAP_OVERLAY_PARAM,

--- a/packages/admin-panel/src/VizBuilderApp/views/Main.jsx
+++ b/packages/admin-panel/src/VizBuilderApp/views/Main.jsx
@@ -12,7 +12,7 @@ import CircularProgress from '@material-ui/core/CircularProgress';
 import { FlexColumn, SmallAlert } from '@tupaia/ui-components';
 import { useDashboardVisualisation } from '../api';
 import { Panel, PreviewOptions, PreviewSection, Toolbar } from '../components';
-import { PreviewDataProvider, useVizConfig, VizConfigErrorProvider } from '../context';
+import { PreviewDataProvider, useVizConfigContext, VizConfigErrorProvider } from '../context';
 import { useMapOverlayVisualisation } from '../api/queries/useMapOverlayVisualisation';
 import {
   DASHBOARD_ITEM_OR_MAP_OVERLAY_PARAM,
@@ -58,7 +58,7 @@ export const Main = () => {
   };
 
   // eslint-disable-next-line no-unused-vars
-  const [_, { setVisualisation, setVizType }] = useVizConfig();
+  const [_, { setVisualisation, setVizType }] = useVizConfigContext();
   const [visualisationLoaded, setVisualisationLoaded] = useState(false);
   const { data = {}, error } = useViz();
   const { visualisation } = data;

--- a/packages/admin-panel/src/api/mutations/useResubmitSurveyResponse.js
+++ b/packages/admin-panel/src/api/mutations/useResubmitSurveyResponse.js
@@ -4,14 +4,14 @@
  *
  */
 import { useMutation } from 'react-query';
-import { useApi } from '../../utilities/ApiProvider';
+import { useApiContext } from '../../utilities/ApiProvider';
 
 export const useResubmitSurveyResponse = (
   surveyResponseId,
   updatedSurveyResponse,
   filesByQuestionCode,
 ) => {
-  const api = useApi();
+  const api = useApiContext();
   return useMutation(
     [`surveyResubmit`, surveyResponseId, updatedSurveyResponse],
     () => {

--- a/packages/admin-panel/src/importExport/ExportButton.jsx
+++ b/packages/admin-panel/src/importExport/ExportButton.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import ExportIcon from '@material-ui/icons/GetApp';
 import { IconButton } from '../widgets';
 import { makeSubstitutionsInString } from '../utilities';
-import { useApi } from '../utilities/ApiProvider';
+import { useApiContext } from '../utilities/ApiProvider';
 
 const buildExportQueryParameters = (rowIdQueryParameter, rowData, filterQueryParameters) => {
   if (!rowIdQueryParameter && !filterQueryParameters) return null;
@@ -20,18 +20,14 @@ const buildExportQueryParameters = (rowIdQueryParameter, rowData, filterQueryPar
 };
 
 export const ExportButton = ({ actionConfig, row }) => {
-  const api = useApi();
+  const api = useApiContext();
 
   return (
     <IconButton
       className="export-button"
       onClick={async () => {
-        const {
-          exportEndpoint,
-          rowIdQueryParameter,
-          extraQueryParameters,
-          fileName,
-        } = actionConfig;
+        const { exportEndpoint, rowIdQueryParameter, extraQueryParameters, fileName } =
+          actionConfig;
         const queryParameters = buildExportQueryParameters(rowIdQueryParameter, row);
         const endpoint = `export/${exportEndpoint}${
           !queryParameters && row.id ? `/${row.id}` : ''

--- a/packages/admin-panel/src/importExport/ExportModal.jsx
+++ b/packages/admin-panel/src/importExport/ExportModal.jsx
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
  */
 
-import React, { useState, useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
 import ExportIcon from '@material-ui/icons/GetApp';
 import {
@@ -15,7 +15,7 @@ import {
   OutlinedButton,
 } from '@tupaia/ui-components';
 import { ModalContentProvider } from '../widgets';
-import { useApi } from '../utilities/ApiProvider';
+import { useApiContext } from '../utilities/ApiProvider';
 
 const STATUS = {
   IDLE: 'idle',
@@ -35,7 +35,7 @@ export const ExportModal = React.memo(
     cancelButtonText,
     isExportingMessage,
   }) => {
-    const api = useApi();
+    const api = useApiContext();
     const [status, setStatus] = useState(STATUS.IDLE);
     const [errorMessage, setErrorMessage] = useState(null);
     const [isOpen, setIsOpen] = useState(false);

--- a/packages/admin-panel/src/importExport/ImportModal.jsx
+++ b/packages/admin-panel/src/importExport/ImportModal.jsx
@@ -3,7 +3,7 @@
  * Copyright (c) 2018 Beyond Essential Systems Pty Ltd
  */
 
-import React, { useState, useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import ImportIcon from '@material-ui/icons/Publish';
@@ -16,9 +16,9 @@ import {
   LightOutlinedButton,
   OutlinedButton,
 } from '@tupaia/ui-components';
-import { ModalContentProvider, InputField } from '../widgets';
-import { useApi } from '../utilities/ApiProvider';
-import { DATA_CHANGE_REQUEST, DATA_CHANGE_SUCCESS, DATA_CHANGE_ERROR } from '../table/constants';
+import { InputField, ModalContentProvider } from '../widgets';
+import { useApiContext } from '../utilities/ApiProvider';
+import { DATA_CHANGE_ERROR, DATA_CHANGE_REQUEST, DATA_CHANGE_SUCCESS } from '../table/constants';
 import { checkVisibilityCriteriaAreMet, labelToId } from '../utilities';
 
 const STATUS = {
@@ -46,7 +46,7 @@ export const ImportModalComponent = React.memo(
     uploadButtonText,
     noFileMessage,
   }) => {
-    const api = useApi();
+    const api = useApiContext();
     const [status, setStatus] = useState(STATUS.IDLE);
     const [finishedMessage, setFinishedMessage] = useState(null);
     const [errorMessage, setErrorMessage] = useState(null);

--- a/packages/admin-panel/src/library.js
+++ b/packages/admin-panel/src/library.js
@@ -11,6 +11,6 @@ export { ReduxAutocomplete } from './autocomplete';
 export { ExportModal } from './importExport';
 export { IconButton } from './widgets';
 export { AdminPanelDataProviders } from './utilities/AdminPanelProviders';
-export { useApi } from './utilities/ApiProvider';
+export { useApiContext } from './utilities/ApiProvider';
 export { DataChangeAction } from './editor';
 export { App as VizBuilderApp } from './VizBuilderApp/App';

--- a/packages/admin-panel/src/surveyResponse/FileQuestionField.jsx
+++ b/packages/admin-panel/src/surveyResponse/FileQuestionField.jsx
@@ -14,7 +14,7 @@ import DeleteIcon from '@material-ui/icons/Delete';
 import ExportIcon from '@material-ui/icons/GetApp';
 import { FileUploadField } from '../widgets/InputField/FileUploadField';
 import { IconButton, ModalContentProvider } from '../widgets';
-import { useApi } from '../utilities/ApiProvider';
+import { useApiContext } from '../utilities/ApiProvider';
 
 const Container = styled.div`
   padding-bottom: 1.2rem;
@@ -113,7 +113,7 @@ export const FileQuestionField = ({ value: uniqueFileName, onChange, label, maxS
     });
   };
 
-  const api = useApi();
+  const api = useApiContext();
   const downloadFile = async () => {
     await api.download(`downloadFiles`, { uniqueFileNames: uniqueFileName }, fileName);
   };

--- a/packages/admin-panel/src/surveys/SurveyEditFields.jsx
+++ b/packages/admin-panel/src/surveys/SurveyEditFields.jsx
@@ -7,7 +7,7 @@ import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Editor } from '../editor/Editor';
 import { useSuggestSurveyCode } from './useSuggestSurveyCode';
-import { useApi } from '../utilities/ApiProvider';
+import { useApiContext } from '../utilities/ApiProvider';
 import { useDebounce } from '../utilities';
 
 export const SurveyEditFields = ({ fields, recordData, onEditField, ...restOfProps }) => {
@@ -15,7 +15,7 @@ export const SurveyEditFields = ({ fields, recordData, onEditField, ...restOfPro
   const debouncedName = useDebounce(name);
 
   const [codeTouched, setCodeTouched] = useState(false);
-  const api = useApi();
+  const api = useApiContext();
   const { data } = useSuggestSurveyCode(api, debouncedName);
   const suggestedCode = data;
 

--- a/packages/admin-panel/src/sync/SyncStatus.jsx
+++ b/packages/admin-panel/src/sync/SyncStatus.jsx
@@ -3,7 +3,7 @@
  * Copyright (c) 2018 Beyond Essential Systems Pty Ltd
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { formatDistance } from 'date-fns';
 import SyncIcon from '@material-ui/icons/Sync';
@@ -11,7 +11,7 @@ import ErrorIcon from '@material-ui/icons/Error';
 import CheckCircleIcon from '@material-ui/icons/CheckCircle';
 import { Tooltip } from '@material-ui/core';
 import styled, { keyframes } from 'styled-components';
-import { useApi } from '../utilities/ApiProvider';
+import { useApiContext } from '../utilities/ApiProvider';
 import { IconButton } from '../widgets';
 import { makeSubstitutionsInString } from '../utilities';
 
@@ -97,7 +97,7 @@ const formatLog = ({ timestamp, message }) =>
 
 export const SyncStatus = props => {
   const { actionConfig, original } = props;
-  const api = useApi();
+  const api = useApiContext();
   const [status, setStatus] = useExternalState(`${original.id}.status`, original.sync_status);
   const [logMessage, setLogMessage] = useExternalState(`${original.id}.logMessage`, '');
   const [errorMessage, setErrorMessage] = useState(null);

--- a/packages/admin-panel/src/table/columnTypes/TestDatabaseConnectionButton.jsx
+++ b/packages/admin-panel/src/table/columnTypes/TestDatabaseConnectionButton.jsx
@@ -10,7 +10,7 @@ import ErrorIcon from '@material-ui/icons/Error';
 import CheckCircleIcon from '@material-ui/icons/CheckCircle';
 import { Tooltip } from '@material-ui/core';
 import styled from 'styled-components';
-import { useApi } from '../../utilities/ApiProvider';
+import { useApiContext } from '../../utilities/ApiProvider';
 import { IconButton } from '../../widgets';
 import { makeSubstitutionsInString } from '../../utilities';
 
@@ -43,7 +43,7 @@ const TestConnectionIconButton = styled(IconButton)`
 `;
 
 export const TestDatabaseConnectionButton = ({ row }) => {
-  const api = useApi();
+  const api = useApiContext();
   const [buttonState, setButtonState] = useState(BUTTON_STATES.IDLE);
   const [toolTip, setTooltip] = useState(null);
 

--- a/packages/admin-panel/src/utilities/ApiProvider.jsx
+++ b/packages/admin-panel/src/utilities/ApiProvider.jsx
@@ -1,7 +1,8 @@
 /*
  * Tupaia
- *  Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ * Copyright (c) 2017 - 2024 Beyond Essential Systems Pty Ltd
  */
+
 import React, { createContext, useContext } from 'react';
 
 const APIContext = createContext(null);
@@ -11,4 +12,4 @@ export const ApiProvider = ({ children, api }) => (
   <APIContext.Provider value={api}>{children}</APIContext.Provider>
 );
 
-export const useApi = () => useContext(APIContext);
+export const useApiContext = () => useContext(APIContext);

--- a/packages/datatrak-web/src/api/CurrentUserContext.tsx
+++ b/packages/datatrak-web/src/api/CurrentUserContext.tsx
@@ -15,7 +15,7 @@ const CurrentUserContext = createContext<CurrentUserContextType | null>(null);
 export const useCurrentUserContext = (): CurrentUserContextType => {
   const currentUser = useContext(CurrentUserContext);
   if (!currentUser) {
-    throw new Error('useCurrentUser must be used within a CurrentUserContextProvider');
+    throw new Error('useCurrentUserContext must be used within a CurrentUserContextProvider');
   }
   return currentUser;
 };

--- a/packages/datatrak-web/src/api/CurrentUserContext.tsx
+++ b/packages/datatrak-web/src/api/CurrentUserContext.tsx
@@ -12,7 +12,7 @@ export type CurrentUserContextType = DatatrakWebUserRequest.ResBody & { isLogged
 
 const CurrentUserContext = createContext<CurrentUserContextType | null>(null);
 
-export const useCurrentUser = (): CurrentUserContextType => {
+export const useCurrentUserContext = (): CurrentUserContextType => {
   const currentUser = useContext(CurrentUserContext);
   if (!currentUser) {
     throw new Error('useCurrentUser must be used within a CurrentUserContextProvider');

--- a/packages/datatrak-web/src/api/mutations/useSubmitSurvey.ts
+++ b/packages/datatrak-web/src/api/mutations/useSubmitSurvey.ts
@@ -7,7 +7,7 @@ import { useMutation, useQueryClient } from 'react-query';
 import { generatePath, useNavigate, useParams } from 'react-router';
 import { getBrowserTimeZone } from '@tupaia/utils';
 import { Coconut } from '../../components';
-import { post, useCurrentUser, useEntityByCode } from '../../api';
+import { post, useCurrentUserContext, useEntityByCode } from '../../api';
 import { ROUTES } from '../../constants';
 import { getAllSurveyComponents, useSurveyForm } from '../../features';
 import { useSurvey } from '../queries';
@@ -19,7 +19,7 @@ export type AnswersT = Record<string, Answer>;
 
 // utility hook for getting survey response data
 export const useSurveyResponseData = () => {
-  const user = useCurrentUser();
+  const user = useCurrentUserContext();
   const { surveyCode, countryCode } = useParams();
   const { surveyStartTime, surveyScreens } = useSurveyForm();
   const { data: survey } = useSurvey(surveyCode);
@@ -40,7 +40,7 @@ export const useSubmitSurvey = () => {
   const navigate = useNavigate();
   const params = useParams();
   const { resetForm } = useSurveyForm();
-  const user = useCurrentUser();
+  const user = useCurrentUserContext();
   const { data: survey } = useSurvey(params.surveyCode);
 
   const surveyResponseData = useSurveyResponseData();

--- a/packages/datatrak-web/src/api/mutations/useTupaiaRedirect.ts
+++ b/packages/datatrak-web/src/api/mutations/useTupaiaRedirect.ts
@@ -4,13 +4,13 @@
  */
 
 import { useMutation } from 'react-query';
-import { useCurrentUser } from '../CurrentUserContext';
+import { useCurrentUserContext } from '../CurrentUserContext';
 import { post } from '../api';
 
-const TUPAIA_REDIRECT_URL = process.env.REACT_APP_TUPAIA_REDIRECT_URL || 'https://tupaia.org'
+const TUPAIA_REDIRECT_URL = process.env.REACT_APP_TUPAIA_REDIRECT_URL || 'https://tupaia.org';
 
 export const useTupaiaRedirect = () => {
-  const user = useCurrentUser();
+  const user = useCurrentUserContext();
 
   return useMutation<any, Error, Record<never, any>, unknown>(
     () => {
@@ -18,8 +18,11 @@ export const useTupaiaRedirect = () => {
     },
     {
       onSuccess: ({ token }) => {
-        window.open(`${TUPAIA_REDIRECT_URL}/${user.project?.code}/${user.project?.homeEntityCode}?loginToken=${token}`, '_blank');
+        window.open(
+          `${TUPAIA_REDIRECT_URL}/${user.project?.code}/${user.project?.homeEntityCode}?loginToken=${token}`,
+          '_blank',
+        );
       },
-    }
+    },
   );
 };

--- a/packages/datatrak-web/src/api/queries/useRecentSurveys.ts
+++ b/packages/datatrak-web/src/api/queries/useRecentSurveys.ts
@@ -5,7 +5,7 @@
 import { useQuery } from 'react-query';
 import { DatatrakWebRecentSurveysRequest, Project, UserAccount } from '@tupaia/types';
 import { get } from '../api';
-import { useCurrentUser } from '../CurrentUserContext';
+import { useCurrentUserContext } from '../CurrentUserContext';
 
 export const useRecentSurveys = (userId?: UserAccount['id'], projectId?: Project['id']) => {
   return useQuery(
@@ -17,6 +17,6 @@ export const useRecentSurveys = (userId?: UserAccount['id'], projectId?: Project
 };
 
 export const useCurrentUserRecentSurveys = () => {
-  const { id, projectId } = useCurrentUser();
+  const { id, projectId } = useCurrentUserContext();
   return useRecentSurveys(id, projectId);
 };

--- a/packages/datatrak-web/src/api/queries/useSurveyResponses.ts
+++ b/packages/datatrak-web/src/api/queries/useSurveyResponses.ts
@@ -4,7 +4,7 @@
  */
 import { useQuery } from 'react-query';
 import { DatatrakWebSurveyResponsesRequest, UserAccount, Project } from '@tupaia/types';
-import { useCurrentUser } from '../CurrentUserContext';
+import { useCurrentUserContext } from '../CurrentUserContext';
 import { get } from '../api';
 
 export const useSurveyResponses = (userId?: UserAccount['id'], projectId?: Project['id']) => {
@@ -17,6 +17,6 @@ export const useSurveyResponses = (userId?: UserAccount['id'], projectId?: Proje
 };
 
 export const useCurrentUserSurveyResponses = () => {
-  const user = useCurrentUser();
+  const user = useCurrentUserContext();
   return useSurveyResponses(user.id, user.projectId);
 };

--- a/packages/datatrak-web/src/api/queries/useUserRewards.ts
+++ b/packages/datatrak-web/src/api/queries/useUserRewards.ts
@@ -6,7 +6,7 @@ import { useQuery } from 'react-query';
 import { Project } from '@tupaia/types';
 import { get } from '../api';
 import { UserRewards } from '../../types';
-import { useCurrentUser } from '../CurrentUserContext';
+import { useCurrentUserContext } from '../CurrentUserContext';
 
 const useRewards = (projectId?: Project['id']) => {
   return useQuery(
@@ -24,6 +24,6 @@ const useRewards = (projectId?: Project['id']) => {
 };
 
 export const useUserRewards = () => {
-  const user = useCurrentUser();
+  const user = useCurrentUserContext();
   return useRewards(user.projectId);
 };

--- a/packages/datatrak-web/src/features/Leaderboard/Leaderboard.tsx
+++ b/packages/datatrak-web/src/features/Leaderboard/Leaderboard.tsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import styled from 'styled-components';
-import { useCurrentUser } from '../../api';
+import { useCurrentUserContext } from '../../api';
 import { useLeaderboard, useUserRewards } from '../../api/queries';
 import { UserRewardsSection } from './UserRewardsSection';
 import { LeaderboardTable } from './LeaderboardTable';
@@ -24,7 +24,7 @@ const ScrollBody = styled.div`
 `;
 
 export const Leaderboard = () => {
-  const user = useCurrentUser();
+  const user = useCurrentUserContext();
   const { data: userRewards, isSuccess } = useUserRewards();
   const { data: leaderboard } = useLeaderboard(user.projectId);
 

--- a/packages/datatrak-web/src/features/MobileAppPrompt.tsx
+++ b/packages/datatrak-web/src/features/MobileAppPrompt.tsx
@@ -8,7 +8,7 @@ import styled from 'styled-components';
 import { SwipeableDrawer, Typography } from '@material-ui/core';
 import { Button } from '@tupaia/ui-components';
 import { BROWSERS, getBrowser, getIsMobileDevice } from '../utils';
-import { useCurrentUser } from '../api';
+import { useCurrentUserContext } from '../api';
 
 const Container = styled.div`
   padding: 2.2rem 1.25rem 3.4rem 1.25rem;
@@ -121,7 +121,7 @@ const getAppStoreLink = () => {
 };
 
 export const MobileAppPrompt = () => {
-  const user = useCurrentUser();
+  const user = useCurrentUserContext();
   const [showPrompt, setShowPrompt] = useState(true);
   const isMobile = getIsMobileDevice();
   const { prompted, setHasBeenPrompted } = usePromptCookie();

--- a/packages/datatrak-web/src/features/Survey/Screens/SurveySuccessScreen.tsx
+++ b/packages/datatrak-web/src/features/Survey/Screens/SurveySuccessScreen.tsx
@@ -12,7 +12,7 @@ import { useSurveyForm } from '../SurveyContext';
 import { ROUTES } from '../../../constants';
 import { useSurvey } from '../../../api/queries';
 import { SurveyQRCode } from '../SurveyQRCode';
-import { useCurrentUser } from '../../../api';
+import { useCurrentUserContext } from '../../../api';
 
 const Wrapper = styled.div`
   display: flex;
@@ -70,7 +70,7 @@ const Button = styled(BaseButton)`
 `;
 
 export const SurveySuccessScreen = () => {
-  const { isLoggedIn } = useCurrentUser();
+  const { isLoggedIn } = useCurrentUserContext();
   const params = useParams();
   const navigate = useNavigate();
   const { resetForm } = useSurveyForm();

--- a/packages/datatrak-web/src/layout/UserMenu/DrawerMenu.tsx
+++ b/packages/datatrak-web/src/layout/UserMenu/DrawerMenu.tsx
@@ -8,7 +8,7 @@ import { Drawer as MuiDrawer, Paper as MuiPaper, Typography } from '@material-ui
 import CloseIcon from '@material-ui/icons/Close';
 import { IconButton, RouterLink } from '@tupaia/ui-components';
 import { MOBILE_BREAKPOINT, ROUTES } from '../../constants';
-import { useCurrentUser } from '../../api';
+import { useCurrentUserContext } from '../../api';
 import { Button } from '../../components';
 import { MenuButton, MenuList } from './MenuList';
 
@@ -76,7 +76,7 @@ interface DrawerMenuProps {
   openProjectModal: () => void;
 }
 export const DrawerMenu = ({ menuOpen, onCloseMenu, openProjectModal }: DrawerMenuProps) => {
-  const user = useCurrentUser();
+  const user = useCurrentUserContext();
   // When not logged in, show the login and register buttons in the drawer menu
 
   const getAdditionalMenuItems = () => {

--- a/packages/datatrak-web/src/layout/UserMenu/MenuList.tsx
+++ b/packages/datatrak-web/src/layout/UserMenu/MenuList.tsx
@@ -8,7 +8,7 @@ import styled from 'styled-components';
 import { useMatch } from 'react-router';
 import { Link, ListItem } from '@material-ui/core';
 import { Button, RouterLink } from '@tupaia/ui-components';
-import { useCurrentUser, useLogout } from '../../api';
+import { useCurrentUserContext, useLogout } from '../../api';
 import { ROUTES } from '../../constants';
 import { CancelConfirmModal } from '../../components';
 
@@ -58,7 +58,7 @@ export const MenuList = ({
   onCloseMenu: () => void;
 }) => {
   const [confirmModalLink, setConfirmModalLink] = useState('');
-  const { isLoggedIn, projectId, hasAdminPanelAccess } = useCurrentUser();
+  const { isLoggedIn, projectId, hasAdminPanelAccess } = useCurrentUserContext();
   const [surveyCancelModalIsOpen, setIsOpen] = useState(false);
   const isSurveyScreen = !!useMatch(ROUTES.SURVEY_SCREEN);
   const isSuccessScreen = !!useMatch(ROUTES.SURVEY_SUCCESS);

--- a/packages/datatrak-web/src/layout/UserMenu/ProjectSelectModal.tsx
+++ b/packages/datatrak-web/src/layout/UserMenu/ProjectSelectModal.tsx
@@ -6,7 +6,7 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { Paper } from '@material-ui/core';
 import { ProjectSelectForm, RequestProjectAccess } from '../../features';
-import { useCurrentUser } from '../../api';
+import { useCurrentUserContext } from '../../api';
 import { Modal } from '../../components';
 
 const Wrapper = styled(Paper)`
@@ -24,7 +24,7 @@ interface ModalProps {
 }
 
 export const ProjectSelectModal = ({ onClose }: ModalProps) => {
-  const { projectId } = useCurrentUser();
+  const { projectId } = useCurrentUserContext();
   const [requestAccessProjectCode, setRequestAccessProjectCode] = useState<string | null>(null);
 
   return (

--- a/packages/datatrak-web/src/layout/UserMenu/UserInfo.tsx
+++ b/packages/datatrak-web/src/layout/UserMenu/UserInfo.tsx
@@ -8,7 +8,7 @@ import styled from 'styled-components';
 import { Typography } from '@material-ui/core';
 import { RouterLink } from '@tupaia/ui-components';
 import { Button } from '../../components';
-import { useCurrentUser } from '../../api';
+import { useCurrentUserContext } from '../../api';
 import { ROUTES } from '../../constants';
 
 const Wrapper = styled.div`
@@ -84,7 +84,7 @@ const AuthButtons = styled.div`
  * This is the displayed user name OR the login/register buttons on desktop
  */
 export const UserInfo = ({ openProjectModal }: { openProjectModal: () => void }) => {
-  const user = useCurrentUser();
+  const user = useCurrentUserContext();
 
   return (
     <Wrapper>

--- a/packages/datatrak-web/src/routes/PrivateRoute.tsx
+++ b/packages/datatrak-web/src/routes/PrivateRoute.tsx
@@ -5,12 +5,12 @@
 
 import React, { ReactElement } from 'react';
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
-import { useCurrentUser } from '../api';
+import { useCurrentUserContext } from '../api';
 import { ADMIN_ONLY_ROUTES, ROUTES } from '../constants';
 
 // Reusable wrapper to handle redirecting to login if user is not logged in and the route is private
 export const PrivateRoute = ({ children }: { children?: ReactElement }): ReactElement => {
-  const { isLoggedIn, hasAdminPanelAccess, ...user } = useCurrentUser();
+  const { isLoggedIn, hasAdminPanelAccess, ...user } = useCurrentUserContext();
   const location = useLocation();
   if (!isLoggedIn)
     return (

--- a/packages/datatrak-web/src/routes/Routes.tsx
+++ b/packages/datatrak-web/src/routes/Routes.tsx
@@ -20,7 +20,7 @@ import {
   AccountSettingsPage,
   ReportsPage,
 } from '../views';
-import { useCurrentUser } from '../api';
+import { useCurrentUserContext } from '../api';
 import { ROUTES } from '../constants';
 import { useFromLocation } from '../utils';
 import { CentredLayout, BackgroundPageLayout, MainPageLayout } from '../layout';
@@ -31,7 +31,7 @@ import { SurveyRoutes } from './SurveyRoutes';
  * If the user is logged in and tries to access the auth pages, redirect to the home page or project select pages
  */
 const AuthViewLoggedInRedirect = ({ children }) => {
-  const { isLoggedIn, ...user } = useCurrentUser();
+  const { isLoggedIn, ...user } = useCurrentUserContext();
   const from = useFromLocation();
 
   if (!isLoggedIn) {

--- a/packages/datatrak-web/src/routes/SurveyRoutes.tsx
+++ b/packages/datatrak-web/src/routes/SurveyRoutes.tsx
@@ -15,7 +15,7 @@ import {
   SurveySuccessScreen,
 } from '../views';
 import { SurveyLayout, useSurveyForm } from '../features';
-import { useCurrentUser, useSurvey } from '../api';
+import { useCurrentUserContext, useSurvey } from '../api';
 
 // Redirect to the start of the survey if no screen number is provided
 const SurveyStartRedirect = () => {
@@ -36,7 +36,7 @@ const SurveyPageRedirect = ({ children }) => {
 };
 
 const SurveyRoute = ({ children }) => {
-  const { isLoggedIn } = useCurrentUser();
+  const { isLoggedIn } = useCurrentUserContext();
   const { surveyCode } = useParams();
   const { isError, error, isLoading } = useSurvey(surveyCode);
 

--- a/packages/datatrak-web/src/views/AccountSettingsPage/DeleteAccountSection/DeleteAccountSection.tsx
+++ b/packages/datatrak-web/src/views/AccountSettingsPage/DeleteAccountSection/DeleteAccountSection.tsx
@@ -9,7 +9,7 @@ import styled from 'styled-components';
 import { AccountSettingsSection } from '../AccountSettingsSection';
 import { UserDetails } from './UserDetails';
 import { ConfirmDeleteModal } from './ConfirmDeleteModal';
-import { useCurrentUser } from '../../../api';
+import { useCurrentUserContext } from '../../../api';
 import { AccountSettingsColumn } from '../AccountSettingsColumn';
 import { Button } from '../../../components';
 
@@ -22,7 +22,7 @@ const RequestPendingText = styled(Typography)`
 
 export const DeleteAccountSection = () => {
   const [confirmationDialogOpen, setConfirmationDialogOpen] = useState(false);
-  const { deleteAccountRequested } = useCurrentUser();
+  const { deleteAccountRequested } = useCurrentUserContext();
   const toggleConfirmationDialog = () => {
     setConfirmationDialogOpen(!confirmationDialogOpen);
   };

--- a/packages/datatrak-web/src/views/AccountSettingsPage/DeleteAccountSection/UserDetails.tsx
+++ b/packages/datatrak-web/src/views/AccountSettingsPage/DeleteAccountSection/UserDetails.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Typography } from '@material-ui/core';
-import { useCurrentUser, useUserRewards } from '../../../api';
+import { useCurrentUserContext, useUserRewards } from '../../../api';
 import { Coconut, Pig } from '../../../components';
 
 const UserContent = styled.div<{
@@ -59,7 +59,7 @@ const UserRewardsItem = styled(Typography)`
 `;
 
 export const UserDetails = () => {
-  const user = useCurrentUser();
+  const user = useCurrentUserContext();
   const { data: userRewards } = useUserRewards();
   return (
     <UserContent $appearsDisabled={user.deleteAccountRequested}>

--- a/packages/datatrak-web/src/views/AccountSettingsPage/PersonalDetailsSection/PersonalDetailsForm.tsx
+++ b/packages/datatrak-web/src/views/AccountSettingsPage/PersonalDetailsSection/PersonalDetailsForm.tsx
@@ -11,7 +11,7 @@ import { Form, FormInput, TextField } from '@tupaia/ui-components';
 import { Button } from '../../../components';
 import { UserAccountDetails } from '../../../types';
 import { successToast } from '../../../utils';
-import { CurrentUserContextType, useCurrentUser, useEditUser } from '../../../api';
+import { CurrentUserContextType, useCurrentUserContext, useEditUser } from '../../../api';
 
 type PersonalDetailsFormFields = Pick<
   UserAccountDetails,
@@ -60,7 +60,7 @@ const StyledFieldset = styled.fieldset`
 `;
 
 export const PersonalDetailsForm = () => {
-  const user: CurrentUserContextType = useCurrentUser();
+  const user: CurrentUserContextType = useCurrentUserContext();
 
   const formContext = useForm<PersonalDetailsFormFields>({
     defaultValues: {

--- a/packages/datatrak-web/src/views/LandingPage/SurveyResponsesSection.tsx
+++ b/packages/datatrak-web/src/views/LandingPage/SurveyResponsesSection.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import { Typography } from '@material-ui/core';
 import styled from 'styled-components';
-import { useCurrentUser, useCurrentUserSurveyResponses } from '../../api';
+import { useCurrentUserContext, useCurrentUserSurveyResponses } from '../../api';
 import { displayDate } from '../../utils';
 import { LoadingTile, SurveyTickIcon, Tile } from '../../components';
 import { SectionHeading } from './SectionHeading';
@@ -35,7 +35,7 @@ const ScrollBody = styled.div`
 
 export const SurveyResponsesSection = () => {
   const { data: recentSurveyResponses, isSuccess, isLoading } = useCurrentUserSurveyResponses();
-  const { project } = useCurrentUser();
+  const { project } = useCurrentUserContext();
 
   return (
     <Container>

--- a/packages/datatrak-web/src/views/SurveyPage.tsx
+++ b/packages/datatrak-web/src/views/SurveyPage.tsx
@@ -6,7 +6,7 @@ import React, { useEffect } from 'react';
 import { useParams, Outlet } from 'react-router-dom';
 import styled from 'styled-components';
 import { useForm, FormProvider } from 'react-hook-form';
-import { useCurrentUser, useEditUser, useEntityByCode, useSurvey } from '../api';
+import { useCurrentUserContext, useEditUser, useEntityByCode, useSurvey } from '../api';
 import { CancelConfirmModal } from '../components';
 import { SurveyToolbar, useSurveyForm, useValidationResolver, SurveyContext } from '../features';
 import { SurveyParams } from '../types';
@@ -72,7 +72,7 @@ const SurveyPageInner = () => {
 export const SurveyPage = () => {
   const { countryCode, surveyCode } = useParams<SurveyParams>();
   const { mutateAsync: editUser } = useEditUser();
-  const user = useCurrentUser();
+  const user = useCurrentUserContext();
   const { data: survey } = useSurvey(surveyCode);
   const { data: surveyCountry } = useEntityByCode(countryCode!);
 

--- a/packages/datatrak-web/src/views/SurveySelectPage/SurveySelectPage.tsx
+++ b/packages/datatrak-web/src/views/SurveySelectPage/SurveySelectPage.tsx
@@ -10,7 +10,7 @@ import { SpinningLoader } from '@tupaia/ui-components';
 import { useEditUser } from '../../api/mutations';
 import { SelectList, ListItemType, Button, SurveyFolderIcon, SurveyIcon } from '../../components';
 import { Survey } from '../../types';
-import { useCurrentUser, useProjectSurveys } from '../../api';
+import { useCurrentUserContext, useProjectSurveys } from '../../api';
 import { HEADER_HEIGHT } from '../../constants';
 import { SurveyCountrySelector } from './SurveyCountrySelector';
 import { useUserCountries } from './useUserCountries';
@@ -113,7 +113,7 @@ export const SurveySelectPage = () => {
     navigate(`/survey/${selectedCountry?.code}/${selectedSurvey?.value}`);
   };
   const { mutate: updateUser, isLoading: isUpdatingUser } = useEditUser(navigateToSurvey);
-  const user = useCurrentUser();
+  const user = useCurrentUserContext();
 
   const { data: surveys, isLoading } = useProjectSurveys(user.projectId, selectedCountry?.name);
 

--- a/packages/datatrak-web/src/views/SurveySelectPage/useUserCountries.ts
+++ b/packages/datatrak-web/src/views/SurveySelectPage/useUserCountries.ts
@@ -3,11 +3,11 @@
  *  Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
  */
 import { useState } from 'react';
-import { useProjectEntities, useCurrentUser } from '../../api';
+import { useProjectEntities, useCurrentUserContext } from '../../api';
 import { Entity } from '../../types';
 
 export const useUserCountries = () => {
-  const user = useCurrentUser();
+  const user = useCurrentUserContext();
   const [newSelectedCountry, setSelectedCountry] = useState<Entity | null>(null);
   const { data: countries, isLoading: isLoadingCountries } = useProjectEntities(
     user.project?.code,


### PR DESCRIPTION
### Changes

Renames custom hooks which simply wrap `useContext` to have the `Context` suffix, in light of internal dev chat from 9 February 2024.
