### PR TITLE
no-issue: Remove legacy `requestCountryAccess` endpoint

### DIFF
--- a/packages/central-server/src/apiV2/index.js
+++ b/packages/central-server/src/apiV2/index.js
@@ -156,14 +156,6 @@ apiV2.use(logApiRequest); // log every request to the api_request_log table
 apiV2.use(ensurePermissionCheck); // ensure permissions checking is handled by each endpoint
 
 /**
- * Legacy routes to be eventually removed
- */
-apiV2.post(
-  '/user/:userId/requestCountryAccess', // TODO not used from app version 1.7.93. Once usage stops, remove
-  allowAnyone(requestCountryAccess),
-);
-
-/**
  * /export and /import routes
  */
 apiV2.use('/export', exportRoutes);


### PR DESCRIPTION
### Changes

Removes legacy `/user/:userId/requestCountryAccess` endpoint from `central-server`, which was deprecated in favour of `/me/requestCountryAccess` with MediTrak 1.7.93 (March 2019). Based on [this September 2023 internal Slack thread](https://beyondessential.slack.com/archives/C02C43K1WN6/p1695601263228799), it seems the oldest actively used version in 2023 was 1.7.106.