### PR TITLE
no-issue: Update setupGoldMaster.sh to correctly install on ubuntu 22+

### DIFF
--- a/packages/devops/scripts/deployment/setupGoldMaster.sh
+++ b/packages/devops/scripts/deployment/setupGoldMaster.sh
@@ -25,7 +25,7 @@ sudo apt-get --no-install-recommends -yqq install \
   libssl-dev  \
   libxml2 \
   libxml2-dev  \
-  libssl1.1 \
+  libssl3 \
   pkg-config \
   ca-certificates \
   xclip


### PR DESCRIPTION
We need to bump our base image to a newer version of ubuntu in order to run Node 20.