### PR TITLE
RN-952: Switch to bitwarden for pulling .env vars

### DIFF
--- a/packages/devops/scripts/deployment/buildDeployablePackages.sh
+++ b/packages/devops/scripts/deployment/buildDeployablePackages.sh
@@ -20,9 +20,9 @@ yarn install --immutable
 yarn build:internal-dependencies
 
 # Inject environment variables from LastPass
-LASTPASS_EMAIL=$($DIR/fetchParameterStoreValue.sh LASTPASS_EMAIL)
-LASTPASS_PASSWORD=$($DIR/fetchParameterStoreValue.sh LASTPASS_PASSWORD)
-LASTPASS_EMAIL=$LASTPASS_EMAIL LASTPASS_PASSWORD=$LASTPASS_PASSWORD yarn download-env-vars $DEPLOYMENT_NAME
+BITWARDEN_EMAIL=$($DIR/fetchParameterStoreValue.sh BITWARDEN_EMAIL)
+BITWARDEN_PASSWORD=$($DIR/fetchParameterStoreValue.sh BITWARDEN_PASSWORD)
+BITWARDEN_EMAIL=$BITWARDEN_EMAIL BITWARDEN_PASSWORD=$BITWARDEN_PASSWORD yarn download-env-vars $DEPLOYMENT_NAME
 
 # Build each package
 for PACKAGE in ${PACKAGES[@]}; do

--- a/packages/devops/scripts/deployment/setupGoldMaster.sh
+++ b/packages/devops/scripts/deployment/setupGoldMaster.sh
@@ -15,7 +15,7 @@ rm -rf server-configs-nginx
 # install psql for use when installing mv refresh in the db
 sudo apt-get install -yqq postgresql-client
 
-# install lastpass
+# install base dependencies
 sudo apt-get --no-install-recommends -yqq install \
   bash-completion \
   build-essential \
@@ -28,15 +28,8 @@ sudo apt-get --no-install-recommends -yqq install \
   libssl3 \
   pkg-config \
   ca-certificates \
-  xclip
-
-git clone https://github.com/lastpass/lastpass-cli.git
-cd lastpass-cli
-sudo make
-sudo make install
-cd ../
-rm -rf lastpass-cli
-mkdir -p /home/ubuntu/.local/share/lpass
+  xclip \
+  jq
 
 # install puppeteer dependencies https://pptr.dev/15.3.0/troubleshooting#chrome-headless-doesnt-launch-on-unix
 sudo apt-get -yqq install \
@@ -88,6 +81,9 @@ export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 nvm install $(sudo cat tupaia/.nvmrc)
 npm install --global yarn
+
+# install bitwarden cli
+npm install --global @bitwarden/cli
 
 # install pm2
 npm install --global pm2

--- a/scripts/bash/downloadEnvironmentVariables.sh
+++ b/scripts/bash/downloadEnvironmentVariables.sh
@@ -24,9 +24,9 @@ for PACKAGE in $PACKAGES; do
     ENV_FILE_PATH=${DIR}/../../packages/${PACKAGE}/.env
 
     # checkout deployment specific env vars, or dev as fallback
-    DEPLOYEMNT_ENV_VARS=$(bw list items --search ${PACKAGE}.${DEPLOYMENT_NAME}.env | jq --raw-output "map(select(.collectionIds[] | contains ($COLLECTION_ID))) | .[] .notes")
-    if [ -n "$DEPLOYEMNT_ENV_VARS" ]; then
-        echo "$DEPLOYEMNT_ENV_VARS" > ${ENV_FILE_PATH}
+    DEPLOYMENT_ENV_VARS=$(bw list items --search ${PACKAGE}.${DEPLOYMENT_NAME}.env | jq --raw-output "map(select(.collectionIds[] | contains ($COLLECTION_ID))) | .[] .notes")
+    if [ -n "$DEPLOYMENT_ENV_VARS" ]; then
+        echo "$DEPLOYMENT_ENV_VARS" > ${ENV_FILE_PATH}
     else
         DEV_ENV_VARS=$(bw list items --search ${PACKAGE}.dev.env | jq --raw-output "map(select(.collectionIds[] | contains ($COLLECTION_ID))) | .[] .notes")
         echo "$DEV_ENV_VARS" > ${ENV_FILE_PATH}


### PR DESCRIPTION
### Issue RN-952:

Switch to pulling from bitwarden. We have to use `jq` to parse the responses from bitwarden cli since we can't filter the query.

#### Post merge tasks:
- [ ] Replace `setupGoldMaster.sh` in s3 with latest version
- [ ] Remove Lastpass parameter store entries
- [ ] Update the [monorepo setup docs](https://beyond-essential.slab.com/posts/tupaia-monorepo-setup-v5egpdpq)