### PR TITLE
no-issue: Set Prettier as default formatter in workspace

### DIFF
--- a/tupaia-packages.code-workspace
+++ b/tupaia-packages.code-workspace
@@ -241,6 +241,7 @@
       "typescript",
       "typescriptreact"
     ],
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
     "files.exclude": {
       "packages/": true
     },


### PR DESCRIPTION
### Changes

Sets Prettier as the default formatter in the workspace, regardless of what your user settings are

### Remarks

We recommend _format on save_ in the repo setup instructions and in the README, so I thought about also enforcing it, but that felt a little too opinionated