### PR TITLE
no-issue: Bump GHA versions to latest

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -16,7 +16,7 @@ jobs:
     # Only run if Tupaia CI passed
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ap-southeast-2
           role-to-assume: arn:aws:iam::843218180240:role/Tupaia_GHA

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.11.1
+          node-version-file: '.nvmrc'
           cache: yarn
       - run: yarn set version 3.2.1
       - run: SKIP_BUILD_INTERNAL_DEPENDENCIES=true yarn install
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.11.1
+          node-version-file: '.nvmrc'
           cache: yarn
       - run: yarn set version 3.2.1
       - run: SKIP_BUILD_INTERNAL_DEPENDENCIES=true yarn install
@@ -168,7 +168,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.11.1
+          node-version-file: '.nvmrc'
           cache: yarn
       - run: yarn set version 3.2.1
       - run: SKIP_BUILD_INTERNAL_DEPENDENCIES=true yarn install
@@ -185,7 +185,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.11.1
+          node-version-file: '.nvmrc'
           cache: yarn
       - run: yarn set version 3.2.1
       - run: SKIP_BUILD_INTERNAL_DEPENDENCIES=true yarn install --immutable

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: yarn
-      - run: yarn set version 3.2.1
+      - run: corepack enable yarn
       - run: SKIP_BUILD_INTERNAL_DEPENDENCIES=true yarn install
       - run: yarn workspace @tupaia/utils build # /scripts/node/validateTests.js uses utils package
       - name: Validate unit tests
@@ -76,7 +76,7 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: yarn
-      - run: yarn set version 3.2.1
+      - run: corepack enable yarn
       - run: SKIP_BUILD_INTERNAL_DEPENDENCIES=true yarn install
       - run: yarn build:internal-dependencies
       - run: ./packages/devops/scripts/ci/validateTypesAndDbSchemaInSync.sh
@@ -170,7 +170,7 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: yarn
-      - run: yarn set version 3.2.1
+      - run: corepack enable yarn
       - run: SKIP_BUILD_INTERNAL_DEPENDENCIES=true yarn install
       - run: yarn build:internal-dependencies
       - run: yarn workspace @tupaia/${{ matrix.package }} setup-test || echo "No setup needed"
@@ -187,7 +187,7 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: yarn
-      - run: yarn set version 3.2.1
+      - run: corepack enable yarn
       - run: SKIP_BUILD_INTERNAL_DEPENDENCIES=true yarn install --immutable
       - run: yarn build
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
     name: Validate branch name
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Validate branch name
         run: packages/devops/scripts/ci/validateBranchName.sh
 
@@ -25,7 +25,7 @@ jobs:
     name: Validate new migrations
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Validate new migration
         run: packages/devops/scripts/ci/validateNewMigrations.sh
 
@@ -33,8 +33,8 @@ jobs:
     name: Validate tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20.11.1
           cache: yarn
@@ -71,8 +71,8 @@ jobs:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20.11.1
           cache: yarn
@@ -165,8 +165,8 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20.11.1
           cache: yarn
@@ -182,8 +182,8 @@ jobs:
     env:
       CI: false # react-scripts build treats warnings as errors if this is true
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20.11.1
           cache: yarn

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -18,8 +18,8 @@ jobs:
       CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
       TERM: xterm # workaround for issue where cypress fails to upload to cypress.io
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20.11.1
           cache: yarn

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -23,7 +23,7 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: yarn
-      - run: yarn set version 3.2.1
+      - run: corepack enable yarn
       - run: SKIP_BUILD_INTERNAL_DEPENDENCIES=true yarn install
       - run: yarn workspace @tupaia/utils build
       - run: yarn workspace "@tupaia/e2e" test-e2e --ciBuildId $GITHUB_RUN_ID

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.11.1
+          node-version-file: '.nvmrc'
           cache: yarn
       - run: yarn set version 3.2.1
       - run: SKIP_BUILD_INTERNAL_DEPENDENCIES=true yarn install

--- a/tupaia-packages.code-workspace
+++ b/tupaia-packages.code-workspace
@@ -167,7 +167,7 @@
     {
       "name": "web-config-server",
       "path": "packages/web-config-server"
-    },
+    }
   ],
   "settings": {
     "cSpell.caseSensitive": false,
@@ -182,9 +182,10 @@
       "Clazz",
       "cleanup",
       "Codeship",
+      "corepack",
       "ctes",
-      "datetime",
       "Datatrak",
+      "datetime",
       "debouncing",
       "deleters",
       "dhis",
@@ -237,10 +238,7 @@
       "Upserts",
       "vars"
     ],
-    "eslint.validate": [
-      "typescript",
-      "typescriptreact"
-    ],
+    "eslint.validate": ["typescript", "typescriptreact"],
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "files.exclude": {
       "packages/": true


### PR DESCRIPTION
We were getting warnings to upgrade these as node 16 is being deprecated