### PR TITLE
hotfix: Fixup broken dhis2 api endpoint for trackedEntityTypes

### DIFF
--- a/packages/dhis-api/src/types.js
+++ b/packages/dhis-api/src/types.js
@@ -21,7 +21,7 @@ const ORGANISATION_UNIT_GROUP = 'organisationUnitGroups';
 const PROGRAM = 'programs';
 const TRACKED_ENTITY_ATTRIBUTE = 'trackedEntityAttributes';
 const TRACKED_ENTITY_INSTANCE = 'trackedEntityInstances';
-const TRACKED_ENTITY_TYPE = 'trackedEntityRecords';
+const TRACKED_ENTITY_TYPE = 'trackedEntityTypes';
 const INDICATOR = 'indicators';
 
 export const DHIS2_RESOURCE_TYPES = {


### PR DESCRIPTION
### Issue https://beyondessential.slack.com/archives/C01MAA3NKM1/p1711402662314859:

I think this got accidentally renamed as part of changing from `<model>Type` -> `<model>Record`