### PR TITLE
ci: CI-compatible Dependabot branch names

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,8 @@
+# Reference: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
 version: 2
 updates:
-  - # "npm" is the YAML value for Yarn
-    # See: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem
-    package-ecosystem: "npm"
+  - package-ecosystem: "npm" # "npm" is the YAML value for Yarn
     directory: "/"
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - # "npm" is the YAML value for Yarn
+    # See: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem
+    package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    pull-request-branch-name:
+      # By default, Dependabot separates sections of its branch names with `/`, which fails our
+      # ‘Validate branch name’ CI step
+      #
+      # This makes it use
+      #   dependabot-npm_and_yarn-express-4.19.2
+      # instead of
+      #   dependabot/npm_and_yarn/express-4.19.2
+      separator: "-"


### PR DESCRIPTION
### Changes

Introduces a `dependabot.yml` to configure Dependabot **not** to use `/`s in its branch names, which immediately fail our CI’s branch name validation. (Slashes are prohibited because it interferes with feature branch deployments.)

This doesn’t get around the fact that Dependabot puts version numbers in its branch names, and `.` is also prohibited 😕

This can’t guarantee that Dependabot’s branch names will always pass validation, but as far as I know there’s no way to limit it to a maximum length. If the package it tries to update has a long name, it might still exceed the maximum 46 characters we allow.