### PR TITLE
no-issue: Don’t render schema diffs by default

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 *.md linguist-documentation
 *.pbxproj -text
 packages/types/src/schemas/schemas.ts linguist-generated=true
+packages/types/src/types/models.ts linguist-generated=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.pbxproj -text
+packages/types/src/schemas/schemas.ts linguist-generated=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
+*.md linguist-documentation
 *.pbxproj -text
 packages/types/src/schemas/schemas.ts linguist-generated=true


### PR DESCRIPTION
### Changes

Marks the `schemas.ts` file as generated, which makes GitHub not render its diff by default. (Not listing `yarn.lock` because GitHub already does this for the major package managers by default)

(Also marks Markdown files as documentation, which excludes it from the bar chart of the repo’s language makeup in GitHub’s sidebar)