### PR TITLE
fix(security): RN-1084: Remove refresh token from access token

### DIFF
--- a/packages/auth/src/__tests__/userAuth.test.js
+++ b/packages/auth/src/__tests__/userAuth.test.js
@@ -14,57 +14,39 @@ describe('userAuth', () => {
   describe('accessToken', () => {
     it('can construct access token', async () => {
       const userId = 'user1';
-      const refreshToken = 'refresh';
 
-      return expect(constructAccessToken({ userId, refreshToken })).toBeString();
+      return expect(constructAccessToken({ userId })).toBeString();
     });
 
     it('can construct access token with apiClientId', async () => {
       const userId = 'user1';
-      const refreshToken = 'refresh';
       const apiClientUserId = 'apiClient1';
 
-      return expect(constructAccessToken({ userId, refreshToken, apiClientUserId })).toBeString();
+      return expect(constructAccessToken({ userId, apiClientUserId })).toBeString();
     });
 
     it('throws error when constructing access token without userId', async () => {
-      const refreshToken = 'refresh';
       const apiClientUserId = 'apiClient1';
 
-      return expect(() => constructAccessToken({ refreshToken, apiClientUserId })).toThrow(
+      return expect(() => constructAccessToken({ apiClientUserId })).toThrow(
         'Cannot construct accessToken: missing userId',
-      );
-    });
-
-    it('throws error when constructing access token without refreshToken', async () => {
-      const userId = 'user1';
-      const apiClientUserId = 'apiClient1';
-
-      return expect(() => constructAccessToken({ userId, apiClientUserId })).toThrow(
-        'Cannot construct accessToken: missing refreshToken',
       );
     });
 
     it('can decrypt access token claims', async () => {
       const userId = 'user1';
-      const refreshToken = 'refresh';
       const apiClientUserId = 'apiClient1';
 
-      const accessToken = constructAccessToken({ userId, refreshToken, apiClientUserId });
+      const accessToken = constructAccessToken({ userId, apiClientUserId });
       const authHeader = createBearerHeader(accessToken);
-      const {
-        userId: decryptedUserId,
-        refreshToken: decryptedRefreshToken,
-        apiClientUserId: decryptedApiClientUserId,
-      } = getTokenClaimsFromBearerAuth(authHeader);
+      const { userId: decryptedUserId, apiClientUserId: decryptedApiClientUserId } =
+        getTokenClaimsFromBearerAuth(authHeader);
 
       return expect({
         userId: decryptedUserId,
-        refreshToken: decryptedRefreshToken,
         apiClientUserId: decryptedApiClientUserId,
       }).toEqual({
         userId,
-        refreshToken,
         apiClientUserId,
       });
     });

--- a/packages/auth/src/userAuth.js
+++ b/packages/auth/src/userAuth.js
@@ -9,18 +9,13 @@ import { getJwtToken } from './security';
 
 const ACCESS_TOKEN_EXPIRY_SECONDS = 15 * 60; // User's access expires every 15 mins
 
-export const constructAccessToken = ({ userId, apiClientUserId, refreshToken }) => {
+export const constructAccessToken = ({ userId, apiClientUserId }) => {
   if (!userId) {
     throw new Error('Cannot construct accessToken: missing userId');
   }
 
-  if (!refreshToken) {
-    throw new Error('Cannot construct accessToken: missing refreshToken');
-  }
-
   const jwtPayload = {
     userId,
-    refreshToken,
   };
 
   if (apiClientUserId) {
@@ -96,7 +91,6 @@ export const getAuthorizationObject = async ({
 }) => {
   const tokenClaims = {
     userId: user.id,
-    refreshToken,
   };
 
   if (apiClientUser) {

--- a/packages/meditrak-app-server/src/__tests__/__integration__/ChangePasswordRoute.test.ts
+++ b/packages/meditrak-app-server/src/__tests__/__integration__/ChangePasswordRoute.test.ts
@@ -8,7 +8,7 @@ import { clearTestData, getTestDatabase } from '@tupaia/database';
 import { TestableServer } from '@tupaia/server-boilerplate';
 import { createBearerHeader } from '@tupaia/utils';
 import { grantUserAccess, revokeAccess, setupTestApp, setupTestUser } from '../utilities';
-import { CAT_USER, CAT_USER_SESSION } from './fixtures';
+import { CAT_USER } from './fixtures';
 
 const mockResponseMsg = 'Successfully changed password';
 
@@ -37,7 +37,6 @@ describe('me/changePassword', () => {
     authHeader = createBearerHeader(
       constructAccessToken({
         userId: user.id,
-        refreshToken: CAT_USER_SESSION.refresh_token,
         apiClientUserId: undefined,
       }),
     );

--- a/packages/meditrak-app-server/src/__tests__/__integration__/UserRewardsRoute.test.ts
+++ b/packages/meditrak-app-server/src/__tests__/__integration__/UserRewardsRoute.test.ts
@@ -15,7 +15,7 @@ import { TestableServer } from '@tupaia/server-boilerplate';
 import { createBearerHeader } from '@tupaia/utils';
 import { TestModelRegistry } from '../types';
 import { grantUserAccess, revokeAccess, setupTestApp, setupTestUser } from '../utilities';
-import { CAT_QUESTION, CAT_SURVEY, CAT_USER_SESSION } from './fixtures';
+import { CAT_QUESTION, CAT_SURVEY } from './fixtures';
 
 describe('me/rewards', () => {
   const numberOfSurveyResponses = 100;
@@ -30,7 +30,6 @@ describe('me/rewards', () => {
     authHeader = createBearerHeader(
       constructAccessToken({
         userId: user.id,
-        refreshToken: CAT_USER_SESSION.refresh_token,
         apiClientUserId: undefined,
       }),
     );

--- a/packages/meditrak-app-server/src/__tests__/__integration__/socialFeed/SocialFeedRoute.test.ts
+++ b/packages/meditrak-app-server/src/__tests__/__integration__/socialFeed/SocialFeedRoute.test.ts
@@ -23,7 +23,6 @@ import {
   replaceItemsCountryWithCountryId,
 } from './helper';
 import { COUNTRIES, FEED_ITEMS, GONDOR } from './SocialFeedRoute.fixtures';
-import { CAT_USER_SESSION } from '../fixtures';
 
 describe('socialFeed', () => {
   const CURRENT_DATE_STUB = '2020-12-15T00:00:00.000Z';
@@ -81,7 +80,6 @@ describe('socialFeed', () => {
     authHeader = createBearerHeader(
       constructAccessToken({
         userId: user.id,
-        refreshToken: CAT_USER_SESSION.refresh_token,
         apiClientUserId: undefined,
       }),
     );

--- a/packages/meditrak-app-server/src/__tests__/__integration__/sync/PushChangesRoute.test.ts
+++ b/packages/meditrak-app-server/src/__tests__/__integration__/sync/PushChangesRoute.test.ts
@@ -25,7 +25,6 @@ import {
   grantUserAccess,
   revokeAccess,
 } from '../../utilities';
-import { CAT_USER_SESSION } from '../fixtures';
 import { TEST_IMAGE_DATA } from './testImageData';
 import {
   upsertQuestion,
@@ -127,7 +126,6 @@ describe('changes (POST)', () => {
     authHeader = createBearerHeader(
       constructAccessToken({
         userId,
-        refreshToken: CAT_USER_SESSION.refresh_token,
         apiClientUserId: undefined,
       }),
     );

--- a/packages/meditrak-app-server/src/__tests__/__integration__/sync/pullChanges/ChangesMetadataRoute.test.ts
+++ b/packages/meditrak-app-server/src/__tests__/__integration__/sync/pullChanges/ChangesMetadataRoute.test.ts
@@ -11,7 +11,6 @@ import { SyncableChangeEnqueuer, createPermissionsBasedMeditrakSyncQueue } from 
 import { MeditrakAppServerModelRegistry } from '../../../../types';
 import { TestModelRegistry } from '../../../types';
 import { grantUserAccess, revokeAccess, setupTestApp, setupTestUser } from '../../../utilities';
-import { CAT_USER_SESSION } from '../../fixtures';
 
 import { PERMISSIONS_BASED_SYNC_MIN_APP_VERSION } from '../../../../routes/sync/pullChanges/supportsPermissionsBasedSync';
 import { BASIC_ACCESS } from '../../../utilities/grantUserAccess';
@@ -55,7 +54,6 @@ describe('changes/metadata', () => {
     authHeader = createBearerHeader(
       constructAccessToken({
         userId: user.id,
-        refreshToken: CAT_USER_SESSION.refresh_token,
         apiClientUserId: undefined,
       }),
     );

--- a/packages/meditrak-app-server/src/__tests__/__integration__/sync/pullChanges/CountChangesRoute.test.ts
+++ b/packages/meditrak-app-server/src/__tests__/__integration__/sync/pullChanges/CountChangesRoute.test.ts
@@ -11,7 +11,6 @@ import { SyncableChangeEnqueuer, createPermissionsBasedMeditrakSyncQueue } from 
 import { MeditrakAppServerModelRegistry } from '../../../../types';
 import { TestModelRegistry } from '../../../types';
 import { grantUserAccess, revokeAccess, setupTestApp, setupTestUser } from '../../../utilities';
-import { CAT_USER_SESSION } from '../../fixtures';
 import { upsertDummyQuestion } from '../upsertDummyQuestion';
 
 describe('changes/count', () => {
@@ -32,7 +31,6 @@ describe('changes/count', () => {
     authHeader = createBearerHeader(
       constructAccessToken({
         userId: user.id,
-        refreshToken: CAT_USER_SESSION.refresh_token,
         apiClientUserId: undefined,
       }),
     );

--- a/packages/meditrak-app-server/src/__tests__/__integration__/sync/pullChanges/PullChangesRoute.test.ts
+++ b/packages/meditrak-app-server/src/__tests__/__integration__/sync/pullChanges/PullChangesRoute.test.ts
@@ -24,7 +24,6 @@ import {
 import { MeditrakAppServerModelRegistry } from '../../../../types';
 import { TestModelRegistry } from '../../../types';
 import { grantUserAccess, revokeAccess, setupTestApp, setupTestUser } from '../../../utilities';
-import { CAT_USER_SESSION } from '../../fixtures';
 import { upsertDummyQuestion } from '../upsertDummyQuestion';
 import {
   findRecordsWithPermissions,
@@ -125,7 +124,6 @@ describe('changes (GET)', () => {
     authHeader = createBearerHeader(
       constructAccessToken({
         userId,
-        refreshToken: CAT_USER_SESSION.refresh_token,
         apiClientUserId: undefined,
       }),
     );


### PR DESCRIPTION
### fix(security): RN-1084: Remove refresh token from access token

### Changes:
- Removed refresh token from access token.
Note: After discussion with @rohan-bes it was agreed that apart from this change, our current approach for auth is fine.
