### PR TITLE
repo: mark lockfile as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 *.pbxproj -text
 packages/types/src/schemas/schemas.ts linguist-generated=true
 packages/types/src/types/models.ts linguist-generated=true
+yarn.lock linguist-generated=true


### PR DESCRIPTION
### Changes

Marks `yarn.lock` as a generated file, making GitHub hide its diffs _by default_ when reviewing.