### PR TITLE
tweak(environment): RN-1225: Override with local env if exists

### DIFF
--- a/packages/database/src/configureEnv.js
+++ b/packages/database/src/configureEnv.js
@@ -11,7 +11,6 @@ export const configureEnv = () => {
     path: [
       path.resolve(__dirname, '../../../env/db.env'),
       path.resolve(__dirname, '../../../env/pg.env'),
-      path.resolve(__dirname, '../.env'),
     ],
   });
 };

--- a/packages/server-utils/src/configureDotEnv.ts
+++ b/packages/server-utils/src/configureDotEnv.ts
@@ -6,5 +6,13 @@
 import dotenv from 'dotenv';
 
 export const configureDotEnv = (envFiles: string[]) => {
-  dotenv.config({ path: envFiles });
+  const filesThatExistInSystem = envFiles.filter(file => {
+    try {
+      require.resolve(file);
+      return true;
+    } catch (error) {
+      return false;
+    }
+  });
+  dotenv.config({ path: filesThatExistInSystem, override: true });
 };

--- a/packages/types/generate-models.ts
+++ b/packages/types/generate-models.ts
@@ -15,7 +15,8 @@ import config from './config/models/config.json';
 import * as dotenv from 'dotenv';
 import * as fs from 'fs';
 dotenv.config({
-  path: [path.resolve(__dirname, '../../../env/db.env'), path.resolve(__dirname, '.env')],
+  path: [path.resolve(__dirname, '../../env/db.env'), path.resolve(__dirname, '.env')],
+  override: true,
 });
 
 const db = Knex({


### PR DESCRIPTION
### Issue RN-1225: Override env vars with package file only if exists

### Changes:
- Turns out the first var is used if there is double up. We want it to use the last var, and only use the package env file if it exists.
