### PR TITLE
fix(vizBuilder): vizBuilder crashes Admin Panel

### DIFF
--- a/packages/admin-panel/package.json
+++ b/packages/admin-panel/package.json
@@ -32,7 +32,6 @@
     "@material-ui/lab": "^4.0.0-alpha.47",
     "@material-ui/styles": "^4.9.10",
     "@tupaia/access-policy": "workspace:*",
-    "@tupaia/tsutils": "workspace:*",
     "@tupaia/types": "workspace:*",
     "@tupaia/ui-chart-components": "workspace:*",
     "@tupaia/ui-components": "workspace:*",

--- a/packages/admin-panel/src/VizBuilderApp/components/PreviewOptions/DateRangeField.jsx
+++ b/packages/admin-panel/src/VizBuilderApp/components/PreviewOptions/DateRangeField.jsx
@@ -5,7 +5,6 @@
 import React, { useEffect } from 'react';
 import styled from 'styled-components';
 import { DatePicker as DatePickerComponent } from '@tupaia/ui-components';
-import { getIsoDateString } from '@tupaia/tsutils';
 import { useVizConfigContext } from '../../context';
 
 const DatePicker = styled(DatePickerComponent)`
@@ -62,7 +61,9 @@ export const DateRangeField = () => {
   const convertDateToIsoString = date => {
     if (!date || isNaN(new Date(date).getTime())) return null;
     const correctedDate = shiftEpoch(date);
-    return getIsoDateString(correctedDate);
+
+    // Slice to discard timestamp, keeping only "yyyy-mm-dd"
+    return correctedDate.toISOString().slice(0, 10);
   };
 
   const handleChangeStartDate = date => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11714,7 +11714,6 @@ __metadata:
     "@material-ui/lab": ^4.0.0-alpha.47
     "@material-ui/styles": ^4.9.10
     "@tupaia/access-policy": "workspace:*"
-    "@tupaia/tsutils": "workspace:*"
     "@tupaia/types": "workspace:*"
     "@tupaia/ui-chart-components": "workspace:*"
     "@tupaia/ui-components": "workspace:*"


### PR DESCRIPTION
We’ve had trouble with using helpers from **tsusils** in frontend packages, which crashes in remote deployments (but doesn’t affect devs locally).

Accidentally snuck one in #647 which is causing VizBuilder to immediately crash the entire Admin Panel. forcing a reload.

### Changes

Fixes the issue described above by not using tsutils in admin-panel. Also removed the dependency for good measure (it was the only usage in the package).