### PR TITLE
fix: prevent word splitting in shell scripts

### DIFF
--- a/scripts/bash/ansiControlSequences.sh
+++ b/scripts/bash/ansiControlSequences.sh
@@ -11,7 +11,7 @@ export CURSOR_PREV_LINE='\033[F'
 export CURSOR_START_OF_LINE='\033[G'
 export CLEAR_LINE="\033[2K${CURSOR_START_OF_LINE}"
 
-## Select graphic rendition (SGR) parameters
+# Select graphic rendition (SGR) parameters
 
 if [ "$NO_COLOR" != "" ]; then
     # See https://no-color.org
@@ -26,6 +26,14 @@ if [ "$NO_COLOR" != "" ]; then
     export MAGENTA=''
     export CYAN=''
     export WHITE=''
+    export BG_BLACK=''
+    export BG_RED=''
+    export BG_GREEN=''
+    export BG_YELLOW=''
+    export BG_BLUE=''
+    export BG_MAGENTA=''
+    export BG_CYAN=''
+    export BG_WHITE=''
 else
     export RESET='\033[m'
     export BOLD='\033[1m'
@@ -38,5 +46,13 @@ else
     export MAGENTA='\033[35m'
     export CYAN='\033[36m'
     export WHITE='\033[37m'
+    export BG_BLACK='\033[40m'
+    export BG_RED='\033[41m'
+    export BG_GREEN='\033[42m'
+    export BG_YELLOW='\033[43m'
+    export BG_BLUE='\033[44m'
+    export BG_MAGENTA='\033[45m'
+    export BG_CYAN='\033[46m'
+    export BG_WHITE='\033[47m'
 fi
 

--- a/scripts/bash/ansiControlSequences.sh
+++ b/scripts/bash/ansiControlSequences.sh
@@ -14,6 +14,7 @@ export CLEAR_LINE="\033[2K${CURSOR_START_OF_LINE}"
 ## Select graphic rendition (SGR) parameters
 
 if [ "$NO_COLOR" != "" ]; then
+    # See https://no-color.org
     export RESET=''
     export BOLD=''
     export UNDERLINE=''

--- a/scripts/bash/ansiControlSequences.sh
+++ b/scripts/bash/ansiControlSequences.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # ANSI control sequences
 
@@ -55,4 +55,3 @@ else
     export BG_CYAN='\033[46m'
     export BG_WHITE='\033[47m'
 fi
-

--- a/scripts/bash/ansiControlSequences.sh
+++ b/scripts/bash/ansiControlSequences.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# ANSI control sequences
+
+export CURSOR_UP='\033[A'
+export CURSOR_DOWN='\033[B'
+export CURSOR_FORWARD='\033[C'
+export CURSOR_BACK='\033[D'
+export CURSOR_NEXT_LINE='\033[E'
+export CURSOR_PREV_LINE='\033[F'
+export CURSOR_START_OF_LINE='\033[G'
+export CLEAR_LINE="\033[2K${CURSOR_START_OF_LINE}"
+
+## Select graphic rendition (SGR) parameters
+
+if [ "$NO_COLOR" != "" ]; then
+    export RESET=''
+    export BOLD=''
+    export UNDERLINE=''
+    export BLACK=''
+    export RED=''
+    export GREEN=''
+    export YELLOW=''
+    export BLUE=''
+    export MAGENTA=''
+    export CYAN=''
+    export WHITE=''
+else
+    export RESET='\033[m'
+    export BOLD='\033[1m'
+    export UNDERLINE='\033[4m'
+    export BLACK='\033[30m'
+    export RED='\033[31m'
+    export GREEN='\033[32m'
+    export YELLOW='\033[33m'
+    export BLUE='\033[34m'
+    export MAGENTA='\033[35m'
+    export CYAN='\033[36m'
+    export WHITE='\033[37m'
+fi
+

--- a/scripts/bash/backendStartDev.sh
+++ b/scripts/bash/backendStartDev.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
+. ./ansiControlSequences.sh
 
 ##
 # usage:
@@ -9,7 +10,7 @@ set -e
 # Optionally provide '-ts' or '--typescript' to start typescript server
 
 ##
-USAGE="Usage: backendStartDev babel_port_inspector [-i --include-internal] [-ts --typescript]"
+USAGE="Usage: ${BOLD}backendStartDev babel_port_inspector${RESET} [${BOLD}-i${RESET}|${BOLD}--include-internal${RESET}] [${BOLD}-ts${RESET}|${BOLD}--typescript${RESET}]"
 DIR=$(dirname "$0")
 CONCURRENTLY_BIN="$DIR/../../node_modules/.bin/concurrently"
 watch_flags=""

--- a/scripts/bash/backendStartDev.sh
+++ b/scripts/bash/backendStartDev.sh
@@ -11,11 +11,11 @@ set -e
 ##
 USAGE="Usage: backendStartDev babel_port_inspector [-i --include-internal] [-ts --typescript]"
 DIR=$(dirname "$0")
-CONCURRENTLY_BIN="${DIR}/../../node_modules/.bin/concurrently"
+CONCURRENTLY_BIN="$DIR/../../node_modules/.bin/concurrently"
 watch_flags=""
 include_internal=false
 type_script=false
-inspect_port=${1}
+inspect_port="$1"
 
 # Start server command for JS
 start_server="nodemon -w src --exec \"babel-node src --inspect=${inspect_port} --config-file '../../babel.config.json'\""
@@ -35,7 +35,7 @@ while [ "$2" != "" ]; do
         exit 1
         ;;
     *)
-        echo $USAGE
+        echo "$USAGE"
         exit 1
         ;;
     esac
@@ -50,14 +50,13 @@ echo "Starting server"
 
 if [[ ${include_internal} == true ]]; then
     echo "Internal dependencies are under watch for hot reload"
-    for PACKAGE in $(${DIR}/getInternalDependencies.sh .); do
-        watch_flags="${watch_flags} --watch ../${PACKAGE}/dist"
+    for PACKAGE in $("$DIR/getInternalDependencies.sh" .); do
+        watch_flags="$watch_flags --watch ../$PACKAGE/dist"
     done
     # add the watch flags to the server start process, as well as a 1 second delay to debounce the
     # many restarts that otherwise happen during the initial build of internal dependencies
-    start_server="${start_server} --delay 1 ${watch_flags}"
-    ${CONCURRENTLY_BIN} "${DIR}/buildInternalDependencies.sh --watch --packagePath ." "eval ${start_server}"
+    start_server="$start_server --delay 1 $watch_flags"
 else
     echo "Starting server without internal dependency build and watch. To include internal dependencies, add the -i flag - it's much faster than it used to be!"
-    eval ${start_server}
+    eval "$start_server"
 fi

--- a/scripts/bash/backendStartDev.sh
+++ b/scripts/bash/backendStartDev.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+
+set -e
 
 ##
 # usage:

--- a/scripts/bash/backendStartDev.sh
+++ b/scripts/bash/backendStartDev.sh
@@ -56,6 +56,7 @@ if [[ ${include_internal} == true ]]; then
     # add the watch flags to the server start process, as well as a 1 second delay to debounce the
     # many restarts that otherwise happen during the initial build of internal dependencies
     start_server="$start_server --delay 1 $watch_flags"
+    "$CONCURRENTLY_BIN" "$DIR/buildInternalDependencies.sh --watch --packagePath ." "eval $start_server"
 else
     echo "Starting server without internal dependency build and watch. To include internal dependencies, add the -i flag - it's much faster than it used to be!"
     eval "$start_server"

--- a/scripts/bash/buildInternalDependencies.sh
+++ b/scripts/bash/buildInternalDependencies.sh
@@ -1,5 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 
+set -e
 DIR=$(dirname "$0")
 
 CONCURRENT_BUILD_BATCH_SIZE=1

--- a/scripts/bash/buildInternalDependencies.sh
+++ b/scripts/bash/buildInternalDependencies.sh
@@ -3,9 +3,10 @@
 DIR=$(dirname "$0")
 
 CONCURRENT_BUILD_BATCH_SIZE=1
-CONCURRENTLY_BIN="${DIR}/../../node_modules/.bin/concurrently"
+CONCURRENTLY_BIN="$DIR/../../node_modules/.bin/concurrently"
 
-USAGE="Usage: \033[1mbuildInternalDependencies.sh\033[m [\033[1m--watch\033[m] [\033[1m--packagePath\033[m|\033[1m-p\033[m]"
+. "$DIR/ansiControlSequences.sh"
+USAGE="Usage: ${BOLD}buildInternalDependencies.sh${RESET} [${BOLD}--watch${RESET}] [${BOLD}--packagePath${RESET}|${BOLD}-p${RESET}]"
 
 watch=false
 package_path=""
@@ -44,12 +45,12 @@ for PACKAGE in $(${DIR}/getInternalDependencies.sh ${package_path}); do
 done
 
 if [[ $watch == "true" ]]; then
-    echo -e "\033[1mConcurrently building and watching all internal dependencies\033[m"
+    echo -e "${BOLD}Concurrently building and watching all internal dependencies${RESET}"
     echo "> ${CONCURRENTLY_BIN} --names \"${build_prefixes[*]}\" ${build_commands[@]}"
     echo ""
     eval   "${CONCURRENTLY_BIN} --names \"${build_prefixes[*]}\" ${build_commands[@]}"
 else
-    echo -e "\033[1mConcurrently building internal dependencies in batches of ${CONCURRENT_BUILD_BATCH_SIZE}\033[m"
+    echo -e "${BOLD}Concurrently building internal dependencies in batches of ${CONCURRENT_BUILD_BATCH_SIZE}${RESET}"
     echo "> ${CONCURRENTLY_BIN} -m $CONCURRENT_BUILD_BATCH_SIZE --names \"${build_prefixes[*]}\" -k ${build_commands[*]}"
     echo ""
     eval   "${CONCURRENTLY_BIN} -m $CONCURRENT_BUILD_BATCH_SIZE --names \"${build_prefixes[*]}\" -k ${build_commands[*]}"

--- a/scripts/bash/buildInternalDependencies.sh
+++ b/scripts/bash/buildInternalDependencies.sh
@@ -40,7 +40,7 @@ build_commands=()
 build_prefixes=()
 
 # Build dependencies
-for PACKAGE in $(${DIR}/getInternalDependencies.sh ${package_path}); do
+for PACKAGE in $("$DIR/getInternalDependencies.sh" "$package_path"); do
     build_commands+=("\"NODE_ENV=production yarn workspace @tupaia/${PACKAGE} build-dev $build_args\"")
     build_prefixes+=("${PACKAGE},")
 done

--- a/scripts/bash/buildNonInternalDependencies.sh
+++ b/scripts/bash/buildNonInternalDependencies.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -ex
+#!/usr/bin/env bash
+
+set -ex
 
 PACKAGES="report-server admin-panel-server central-server data-table-server datatrak-web datatrak-web-server entity-server lesmis lesmis-server meditrak-app-server psss psss-server web-config-server tupaia-web tupaia-web-server"
 

--- a/scripts/bash/downloadEnvironmentVariables.sh
+++ b/scripts/bash/downloadEnvironmentVariables.sh
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 
-set +x # do not output commands in this script, as some would show credentials in plain text
+set -e +x # Do not output commands in this script, as some would show credentials in plain text
 
 DEPLOYMENT_NAME="$1"
 DIR=$(dirname "$0")

--- a/scripts/bash/downloadEnvironmentVariables.sh
+++ b/scripts/bash/downloadEnvironmentVariables.sh
@@ -6,7 +6,7 @@ DEPLOYMENT_NAME=$1
 DIR=$(dirname "$0")
 COLLECTION_PATH="Engineering/Tupaia General/Environment Variables" # Collection in BitWarden where .env vars are kept
 
-. './ansiControlSequences.sh' # Convenience variables for colour output et al
+. "$DIR/ansiControlSequences.sh" # Convenience variables for colour output et al
 
 
 # Log in to Bitwarden
@@ -28,14 +28,14 @@ else
 fi
 
 load_env_file_from_bw () {
-    FILE_NAME=$1
-    BASE_FILE_PATH=$2 
-    NEW_FILE_NAME=$3
-    ENV_FILE_PATH=${BASE_FILE_PATH}/${NEW_FILE_NAME}.env
+    FILE_NAME="$1"
+    BASE_FILE_PATH="$2"
+    NEW_FILE_NAME="$3"
+    ENV_FILE_PATH="$BASE_FILE_PATH/$NEW_FILE_NAME.env"
 
     echo -en "${YELLOW}🚚 Fetching variables for ${BOLD}${FILE_NAME}...${RESET}"
 
-    # Checkout deployment specific env vars, or dev as fallback
+    # Checkout deployment-specific env vars, or dev as fallback
     DEPLOYMENT_ENV_VARS=$(bw list items --search "${FILE_NAME}.${DEPLOYMENT_NAME}.env" | jq --raw-output "map(select(.collectionIds[] | contains ($COLLECTION_ID))) | .[] .notes")
 
     if [ "$DEPLOYMENT_ENV_VARS" != "" ]; then
@@ -64,7 +64,7 @@ load_env_file_from_bw () {
         sed -i -e 's/^###DEV_ONLY###//g' "$ENV_FILE_PATH"
     fi
 
-    echo -en "${CLEAR_LINE}"
+    echo -en "$CLEAR_LINE"
     echo -e "${GREEN}✅ Downloaded variables for ${BOLD}${FILE_NAME}${RESET} → $ENV_FILE_PATH"
 }
  

--- a/scripts/bash/downloadEnvironmentVariables.sh
+++ b/scripts/bash/downloadEnvironmentVariables.sh
@@ -6,7 +6,7 @@ DIR=$(dirname "$0")
 COLLECTION_PATH="Engineering/Tupaia General/Environment Variables" # Collection in BitWarden where .env vars are kept
 
 
-# can provide one or more packages as command line arguments, or will default to all
+# Can provide one or more packages as command line arguments, or will default to all
 if [ -z $2 ]; then
     echo "Fetching all .env files"
     PACKAGES=$(${DIR}/getPackagesWithEnvFiles.sh)
@@ -31,8 +31,8 @@ load_env_file_from_bw () {
 
     echo "Fetching environment variables for $FILE_NAME"
 
-    # checkout deployment specific env vars, or dev as fallback
 
+    # Checkout deployment specific env vars, or dev as fallback
     DEPLOYMENT_ENV_VARS=$(bw list items --search "${FILE_NAME}.${DEPLOYMENT_NAME}.env" | jq --raw-output "map(select(.collectionIds[] | contains ($COLLECTION_ID))) | .[] .notes")
 
     if [ -n "$DEPLOYMENT_ENV_VARS" ]; then
@@ -66,7 +66,7 @@ load_env_file_from_bw () {
 }
  
 for PACKAGE in $PACKAGES; do
-    # only download the env file if there is an example file in the package. If there isn't, this means it is a package that doesn't need env vars
+    # Only download the env file if there is an example file in the package. If there isn't, this means it is a package that doesn't need env vars
     has_example_env_in_package=$(find "$DIR/../../packages/$PACKAGE" -type f -name '*.env.example' | wc -l)
     if [ "$has_example_env_in_package" -eq 1 ]; then
         load_env_file_from_bw $PACKAGE "$DIR/../../packages/$PACKAGE" ""

--- a/scripts/bash/downloadEnvironmentVariables.sh
+++ b/scripts/bash/downloadEnvironmentVariables.sh
@@ -36,12 +36,12 @@ load_env_file_from_bw () {
     echo -en "${YELLOW}🚚 Fetching variables for ${BOLD}${FILE_NAME}...${RESET}"
 
     # Checkout deployment-specific env vars, or dev as fallback
-    DEPLOYMENT_ENV_VARS=$(bw list items --search "${FILE_NAME}.${DEPLOYMENT_NAME}.env" | jq --raw-output "map(select(.collectionIds[] | contains ($COLLECTION_ID))) | .[] .notes")
+    DEPLOYMENT_ENV_VARS=$(bw list items --search "$FILE_NAME.$DEPLOYMENT_NAME.env" | jq --raw-output "map(select(.collectionIds[] | contains ($COLLECTION_ID))) | .[] .notes")
 
-    if [ "$DEPLOYMENT_ENV_VARS" != "" ]; then
+    if [[ $DEPLOYMENT_ENV_VARS != '' ]]; then
         echo "$DEPLOYMENT_ENV_VARS" > "$ENV_FILE_PATH"
     else
-        DEV_ENV_VARS=$(bw list items --search "${FILE_NAME}.dev.env" | jq --raw-output "map(select(.collectionIds[] | contains ($COLLECTION_ID))) | .[] .notes")
+        DEV_ENV_VARS=$(bw list items --search "$FILE_NAME.dev.env" | jq --raw-output "map(select(.collectionIds[] | contains ($COLLECTION_ID))) | .[] .notes")
         echo "$DEV_ENV_VARS" > "$ENV_FILE_PATH"
     fi
 
@@ -50,14 +50,14 @@ load_env_file_from_bw () {
     sed -i -e "s/\[deployment-name\]/${DEPLOYMENT_NAME}/g" "$ENV_FILE_PATH"
    
 
-    if [[ "$DEPLOYMENT_NAME" == *-e2e || "$DEPLOYMENT_NAME" == e2e ]]; then
+    if [[ $DEPLOYMENT_NAME = *-e2e || $DEPLOYMENT_NAME = e2e ]]; then
         # Update e2e environment variables
-        if [[ ${FILE_NAME} == "aggregation" ]]; then
+        if [[ $FILE_NAME == 'aggregation' ]]; then
             sed -i -e 's/^AGGREGATION_URL_PREFIX="?dev-"?$/AGGREGATION_URL_PREFIX=e2e-/g' "$ENV_FILE_PATH"
         fi
     fi
 
-    if [[ "$DEPLOYMENT_NAME" == dev ]]; then
+    if [[ $DEPLOYMENT_NAME = dev ]]; then
         # Update dev specific environment variables
         # (removes ###DEV_ONLY### prefixes, leaving the key=value pair uncommented)
         # (after removing prefix, if there are duplicate keys, dotenv uses the last one in the file)
@@ -72,7 +72,7 @@ for PACKAGE in $PACKAGES; do
     # Only download the env file if there is an example file in the package. If there isn't, this means it is a package that doesn't need env vars
     has_example_env_in_package=$(find "$DIR/../../packages/$PACKAGE" -type f -name '*.env.example' | wc -l)
     if [ "$has_example_env_in_package" -eq 1 ]; then
-        load_env_file_from_bw "$PACKAGE" "$DIR/../../packages/$PACKAGE" ""
+        load_env_file_from_bw "$PACKAGE" "$DIR/../../packages/$PACKAGE" ''
     fi
 done
  

--- a/scripts/bash/downloadEnvironmentVariables.sh
+++ b/scripts/bash/downloadEnvironmentVariables.sh
@@ -16,9 +16,9 @@ COLLECTION_ID=$(bw get collection "$COLLECTION_PATH" | jq .id)
 echo ""
 
 # Can provide one or more packages as command line arguments, or will default to all
-if [ -z $2 ]; then
+if [ "$2" = "" ]; then
     echo -e "\033[34m==>️\033[m \033[1mFetching environment variables for all packages\033[m"
-    PACKAGES=$(${DIR}/getPackagesWithEnvFiles.sh)
+    PACKAGES=$("$DIR"/getPackagesWithEnvFiles.sh)
 else
     PACKAGES=${@:2}
     echo -e "\033[34m==>️\033[m \033[1mFetching environment variables for ${PACKAGES}\033[m"
@@ -35,41 +35,41 @@ load_env_file_from_bw () {
     # Checkout deployment specific env vars, or dev as fallback
     DEPLOYMENT_ENV_VARS=$(bw list items --search "${FILE_NAME}.${DEPLOYMENT_NAME}.env" | jq --raw-output "map(select(.collectionIds[] | contains ($COLLECTION_ID))) | .[] .notes")
 
-    if [ -n "$DEPLOYMENT_ENV_VARS" ]; then
-        echo "$DEPLOYMENT_ENV_VARS" > "${ENV_FILE_PATH}"
+    if [ "$DEPLOYMENT_ENV_VARS" != "" ]; then
+        echo "$DEPLOYMENT_ENV_VARS" > "$ENV_FILE_PATH"
     else
         DEV_ENV_VARS=$(bw list items --search "${FILE_NAME}.dev.env" | jq --raw-output "map(select(.collectionIds[] | contains ($COLLECTION_ID))) | .[] .notes")
-        echo "$DEV_ENV_VARS" > "${ENV_FILE_PATH}"
+        echo "$DEV_ENV_VARS" > "$ENV_FILE_PATH"
     fi
 
     # Replace any instances of the placeholder [deployment-name] in the .env file with the actual deployment
     # name (e.g. [deployment-name]-api.tupaia.org -> specific-deployment-api.tupaia.org)
-    sed -i -e "s/\[deployment-name\]/${DEPLOYMENT_NAME}/g" "${ENV_FILE_PATH}"
+    sed -i -e "s/\[deployment-name\]/${DEPLOYMENT_NAME}/g" "$ENV_FILE_PATH"
    
 
-    if [[ "${DEPLOYMENT_NAME}" == *-e2e || "${DEPLOYMENT_NAME}" == e2e ]]; then
+    if [[ "$DEPLOYMENT_NAME" == *-e2e || "$DEPLOYMENT_NAME" == e2e ]]; then
         # Update e2e environment variables
         if [[ ${FILE_NAME} == "aggregation" ]]; then
-            sed -i -e 's/^AGGREGATION_URL_PREFIX="?dev-"?$/AGGREGATION_URL_PREFIX=e2e-/g' "${ENV_FILE_PATH}"
+            sed -i -e 's/^AGGREGATION_URL_PREFIX="?dev-"?$/AGGREGATION_URL_PREFIX=e2e-/g' "$ENV_FILE_PATH"
         fi
     fi
 
-    if [[ "${DEPLOYMENT_NAME}" == dev ]]; then
+    if [[ "$DEPLOYMENT_NAME" == dev ]]; then
         # Update dev specific environment variables
         # (removes ###DEV_ONLY### prefixes, leaving the key=value pair uncommented)
         # (after removing prefix, if there are duplicate keys, dotenv uses the last one in the file)
-        sed -i -e 's/^###DEV_ONLY###//g' "${ENV_FILE_PATH}"
+        sed -i -e 's/^###DEV_ONLY###//g' "$ENV_FILE_PATH"
     fi
 
     echo -en "\033[2K\033[G" # Clear current line and set cursor to start of line
-    echo -e "\033[32m✅ Downloaded variables for \033[1m$FILE_NAME\033[m → ${ENV_FILE_PATH}"
+    echo -e "\033[32m✅ Downloaded variables for \033[1m$FILE_NAME\033[m → $ENV_FILE_PATH"
 }
  
 for PACKAGE in $PACKAGES; do
     # Only download the env file if there is an example file in the package. If there isn't, this means it is a package that doesn't need env vars
     has_example_env_in_package=$(find "$DIR/../../packages/$PACKAGE" -type f -name '*.env.example' | wc -l)
     if [ "$has_example_env_in_package" -eq 1 ]; then
-        load_env_file_from_bw $PACKAGE "$DIR/../../packages/$PACKAGE" ""
+        load_env_file_from_bw "$PACKAGE" "$DIR/../../packages/$PACKAGE" ""
     fi
 done
  
@@ -80,8 +80,8 @@ file_names=$(find "$DIR/../../env" -type f -name '*.env.example' -exec basename 
  
 # for each file, get the extract the filename without the .example extension
 for file_name in $file_names; do
-    env_name=$(echo $file_name | sed 's/\.env.example//')
-    load_env_file_from_bw $env_name "$DIR/../../env" $env_name
+    env_name=$(echo "$file_name" | sed 's/\.env.example//')
+    load_env_file_from_bw "$env_name" "$DIR/../../env" "$env_name"
 done
 
 

--- a/scripts/bash/downloadEnvironmentVariables.sh
+++ b/scripts/bash/downloadEnvironmentVariables.sh
@@ -1,13 +1,12 @@
 #!/bin/bash -e
 
-
 set +x # do not output commands in this script, as some would show credentials in plain text
 
 DEPLOYMENT_NAME=$1
 DIR=$(dirname "$0")
 COLLECTION_PATH="Engineering/Tupaia General/Environment Variables" # Collection in BitWarden where .env vars are kept
 
-. "$DIR/ansiControlSequences.sh"
+. './ansiControlSequences.sh' # Convenience variables for colour output et al
 
 
 # Log in to Bitwarden

--- a/scripts/bash/downloadEnvironmentVariables.sh
+++ b/scripts/bash/downloadEnvironmentVariables.sh
@@ -74,13 +74,12 @@ for PACKAGE in $PACKAGES; do
 done
  
 
-# get all .env.*.example files in the env directory
+# Get all *.env.example files in the env directory
 file_names=$(find "$DIR/../../env" -type f -name '*.env.example' -exec basename {} \;)
- 
- 
-# for each file, get the extract the filename without the .example extension
+
+# For each file, get the base filename without the .env.example extension
 for file_name in $file_names; do
-    env_name=$(echo "$file_name" | sed 's/\.env.example//')
+    env_name="${file_name%.env.example}"
     load_env_file_from_bw "$env_name" "$DIR/../../env" "$env_name"
 done
 

--- a/scripts/bash/downloadEnvironmentVariables.sh
+++ b/scripts/bash/downloadEnvironmentVariables.sh
@@ -1,13 +1,17 @@
 #!/bin/bash -e
+
+
 set +x # do not output commands in this script, as some would show credentials in plain text
 
 DEPLOYMENT_NAME=$1
 DIR=$(dirname "$0")
 COLLECTION_PATH="Engineering/Tupaia General/Environment Variables" # Collection in BitWarden where .env vars are kept
 
+. "$DIR/ansiControlSequences.sh"
+
 
 # Log in to Bitwarden
-echo -e "\033[34m==>️\033[m \033[1mLogging into Bitwarden\033[m"
+echo -e "${BLUE}==>️${RESET} ${BOLD}Logging into Bitwarden${RESET}"
 bw login --check || bw login "$BITWARDEN_EMAIL" "$BITWARDEN_PASSWORD"
 eval "$(bw unlock "$BITWARDEN_PASSWORD" | grep -o -m 1 'export BW_SESSION=.*$')"
 
@@ -17,11 +21,11 @@ echo ""
 
 # Can provide one or more packages as command line arguments, or will default to all
 if [ "$2" = "" ]; then
-    echo -e "\033[34m==>️\033[m \033[1mFetching environment variables for all packages\033[m"
     PACKAGES=$("$DIR"/getPackagesWithEnvFiles.sh)
+    echo -e "${BLUE}==>️${RESET} ${BOLD}Fetching environment variables for all packages${RESET}"
 else
     PACKAGES=${@:2}
-    echo -e "\033[34m==>️\033[m \033[1mFetching environment variables for ${PACKAGES}\033[m"
+    echo -e "${BLUE}==>️${RESET} ${BOLD}Fetching environment variables for ${PACKAGES}${RESET}"
 fi
 
 load_env_file_from_bw () {
@@ -30,7 +34,7 @@ load_env_file_from_bw () {
     NEW_FILE_NAME=$3
     ENV_FILE_PATH=${BASE_FILE_PATH}/${NEW_FILE_NAME}.env
 
-    echo -en "\033[33m🚚 Fetching variables for \033[1m${FILE_NAME}...\033[m"
+    echo -en "${YELLOW}🚚 Fetching variables for ${BOLD}${FILE_NAME}...${RESET}"
 
     # Checkout deployment specific env vars, or dev as fallback
     DEPLOYMENT_ENV_VARS=$(bw list items --search "${FILE_NAME}.${DEPLOYMENT_NAME}.env" | jq --raw-output "map(select(.collectionIds[] | contains ($COLLECTION_ID))) | .[] .notes")
@@ -61,8 +65,8 @@ load_env_file_from_bw () {
         sed -i -e 's/^###DEV_ONLY###//g' "$ENV_FILE_PATH"
     fi
 
-    echo -en "\033[2K\033[G" # Clear current line and set cursor to start of line
-    echo -e "\033[32m✅ Downloaded variables for \033[1m$FILE_NAME\033[m → $ENV_FILE_PATH"
+    echo -en "${CLEAR_LINE}"
+    echo -e "${GREEN}✅ Downloaded variables for ${BOLD}${FILE_NAME}${RESET} → $ENV_FILE_PATH"
 }
  
 for PACKAGE in $PACKAGES; do
@@ -86,5 +90,5 @@ done
 
 # Log out of Bitwarden
 echo ""
-echo -e "\033[34m==>️\033[m \033[1mLogging out of Bitwarden\033[m"
+echo -e "${BLUE}==>️${RESET} ${BOLD}Logging out of Bitwarden${RESET}"
 bw logout

--- a/scripts/bash/downloadEnvironmentVariables.sh
+++ b/scripts/bash/downloadEnvironmentVariables.sh
@@ -16,7 +16,7 @@ eval "$(bw unlock "$BITWARDEN_PASSWORD" | grep -o -m 1 'export BW_SESSION=.*$')"
 
 COLLECTION_ID=$(bw get collection "$COLLECTION_PATH" | jq .id)
 
-echo ""
+echo
 
 # Can provide one or more packages as command line arguments, or will default to all
 if [ "$2" = "" ]; then
@@ -88,6 +88,6 @@ done
 
 
 # Log out of Bitwarden
-echo ""
+echo
 echo -e "${BLUE}==>️${RESET} ${BOLD}Logging out of Bitwarden${RESET}"
 bw logout

--- a/scripts/bash/downloadEnvironmentVariables.sh
+++ b/scripts/bash/downloadEnvironmentVariables.sh
@@ -32,14 +32,14 @@ load_env_file_from_bw () {
     echo "Fetching environment variables for $FILE_NAME"
 
     # checkout deployment specific env vars, or dev as fallback
-    DEPLOYMENT_ENV_VARS=$(bw list items --search ${FILE_NAME}.${DEPLOYMENT_NAME}.env | jq --raw-output "map(select(.collectionIds[] | contains ($COLLECTION_ID))) | .[] .notes")
 
+    DEPLOYMENT_ENV_VARS=$(bw list items --search "${FILE_NAME}.${DEPLOYMENT_NAME}.env" | jq --raw-output "map(select(.collectionIds[] | contains ($COLLECTION_ID))) | .[] .notes")
 
     if [ -n "$DEPLOYMENT_ENV_VARS" ]; then
-        echo "$DEPLOYMENT_ENV_VARS" > ${ENV_FILE_PATH}
+        echo "$DEPLOYMENT_ENV_VARS" > "${ENV_FILE_PATH}"
     else
-        DEV_ENV_VARS=$(bw list items --search ${FILE_NAME}.dev.env | jq --raw-output "map(select(.collectionIds[] | contains ($COLLECTION_ID))) | .[] .notes")
-        echo "$DEV_ENV_VARS" > ${ENV_FILE_PATH}
+        DEV_ENV_VARS=$(bw list items --search "${FILE_NAME}.dev.env" | jq --raw-output "map(select(.collectionIds[] | contains ($COLLECTION_ID))) | .[] .notes")
+        echo "$DEV_ENV_VARS" > "${ENV_FILE_PATH}"
     fi
 
     # Replace any instances of the placeholder [deployment-name] in the .env file with the actual deployment
@@ -50,7 +50,7 @@ load_env_file_from_bw () {
     if [[ "${DEPLOYMENT_NAME}" == *-e2e || "${DEPLOYMENT_NAME}" == e2e ]]; then
         # Update e2e environment variables
         if [[ ${FILE_NAME} == "aggregation" ]]; then
-            sed -i -e 's/^AGGREGATION_URL_PREFIX="?dev-"?$/AGGREGATION_URL_PREFIX=e2e-/g' ${ENV_FILE_PATH}
+            sed -i -e 's/^AGGREGATION_URL_PREFIX="?dev-"?$/AGGREGATION_URL_PREFIX=e2e-/g' "${ENV_FILE_PATH}"
         fi
     fi
 
@@ -58,7 +58,7 @@ load_env_file_from_bw () {
         # Update dev specific environment variables
         # (removes ###DEV_ONLY### prefixes, leaving the key=value pair uncommented)
         # (after removing prefix, if there are duplicate keys, dotenv uses the last one in the file)
-        sed -i -e 's/^###DEV_ONLY###//g' ${ENV_FILE_PATH}
+        sed -i -e 's/^###DEV_ONLY###//g' "${ENV_FILE_PATH}"
     fi
  
 
@@ -67,21 +67,21 @@ load_env_file_from_bw () {
  
 for PACKAGE in $PACKAGES; do
     # only download the env file if there is an example file in the package. If there isn't, this means it is a package that doesn't need env vars
-    has_example_env_in_package=$(find $DIR/../../packages/$PACKAGE -type f -name '*.env.example' | wc -l)
-    if [ $has_example_env_in_package -eq 1 ]; then
-        load_env_file_from_bw $PACKAGE $DIR/../../packages/$PACKAGE ""
+    has_example_env_in_package=$(find "$DIR/../../packages/$PACKAGE" -type f -name '*.env.example' | wc -l)
+    if [ "$has_example_env_in_package" -eq 1 ]; then
+        load_env_file_from_bw $PACKAGE "$DIR/../../packages/$PACKAGE" ""
     fi
 done
  
 
 # get all .env.*.example files in the env directory
-file_names=$(find $DIR/../../env -type f -name '*.env.example' -exec basename {} \;)
+file_names=$(find "$DIR/../../env" -type f -name '*.env.example' -exec basename {} \;)
  
  
 # for each file, get the extract the filename without the .example extension
 for file_name in $file_names; do
     env_name=$(echo $file_name | sed 's/\.env.example//')
-    load_env_file_from_bw $env_name $DIR/../../env $env_name
+    load_env_file_from_bw $env_name "$DIR/../../env" $env_name
 done
 
 

--- a/scripts/bash/downloadEnvironmentVariables.sh
+++ b/scripts/bash/downloadEnvironmentVariables.sh
@@ -2,9 +2,9 @@
 
 set +x # do not output commands in this script, as some would show credentials in plain text
 
-DEPLOYMENT_NAME=$1
+DEPLOYMENT_NAME="$1"
 DIR=$(dirname "$0")
-COLLECTION_PATH="Engineering/Tupaia General/Environment Variables" # Collection in BitWarden where .env vars are kept
+COLLECTION_PATH='Engineering/Tupaia General/Environment Variables' # Collection in BitWarden where .env vars are kept
 
 . "$DIR/ansiControlSequences.sh" # Convenience variables for colour output et al
 

--- a/scripts/bash/getDeployablePackages.sh
+++ b/scripts/bash/getDeployablePackages.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 
+set -e
 echo "admin-panel" "lesmis" "psss" "datatrak-web" "tupaia-web" "central-server" "data-table-server" "datatrak-web-server" "entity-server" "lesmis-server" "meditrak-app-server" "psss-server" "report-server" "tupaia-web-server" "web-config-server" "admin-panel-server" # admin-panel-server last as it depends on report-server
 exit 0

--- a/scripts/bash/getInternalDependencies.sh
+++ b/scripts/bash/getInternalDependencies.sh
@@ -1,5 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 
+set -e
 DIR=$(dirname "$0")
 if [ "$1" != "" ]; then
   # pop the package_path off, and interpret the rest as dependencies that have been checked earlier

--- a/scripts/bash/getPackagesWithEnvFiles.sh
+++ b/scripts/bash/getPackagesWithEnvFiles.sh
@@ -1,5 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 
+set -e
 DIR=$(dirname "$0")
 
 # packages with .env files are (currently) all deployable, plus auth, data-api, and database

--- a/scripts/bash/getPackagesWithEnvFiles.sh
+++ b/scripts/bash/getPackagesWithEnvFiles.sh
@@ -3,7 +3,7 @@
 DIR=$(dirname "$0")
 
 # packages with .env files are (currently) all deployable, plus auth, data-api, and database
-PACKAGES=$(${DIR}/getDeployablePackages.sh)
+PACKAGES=$("$DIR"/getDeployablePackages.sh)
 PACKAGES+=" data-api"
-echo $PACKAGES
+echo "$PACKAGES"
 exit 0

--- a/scripts/bash/mergeEnvForDB.sh
+++ b/scripts/bash/mergeEnvForDB.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -e 
+#!/usr/bin/env bash
+
+set -e
 
 # Function to get the directory of the package that's calling this script
 get_caller_package_directory() {

--- a/scripts/bash/pm2startInline.sh
+++ b/scripts/bash/pm2startInline.sh
@@ -1,7 +1,7 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 
+set -e
 cd "$(dirname "${BASH_SOURCE[0]}")"
-
 . ./ansiControlSequences.sh
 
 if [[ $1 = '' ]]; then

--- a/scripts/bash/pm2startInline.sh
+++ b/scripts/bash/pm2startInline.sh
@@ -6,10 +6,10 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 
 if [ -z "$1" ]; then
   echo -e "Usage: ${BOLD}yarn start-stack${RESET} ${UNDERLINE}stack${RESET}"
-  echo    ""
+  echo
   echo -e "All ${UNDERLINE}stack${RESET}s:"
   ls -1 ../../packages/devops/configs/pm2/ | sed 's|.config.js||g' | grep -v 'base' | awk '$0="  "$0'
-  echo    ""
+  echo
   echo    "Tips:"
   echo -e "  - Normal PM2 commands work e.g. \033[1myarn pm2 status${RESET}"
   echo    "  - Start multiple stacks by calling this command multiple times"

--- a/scripts/bash/pm2startInline.sh
+++ b/scripts/bash/pm2startInline.sh
@@ -11,7 +11,7 @@ if [ -z "$1" ]; then
   ls -1 ../../packages/devops/configs/pm2/ | sed 's|.config.js||g' | grep -v 'base' | awk '$0="  "$0'
   echo
   echo    "Tips:"
-  echo -e "  - Normal PM2 commands work e.g. \033[1myarn pm2 status${RESET}"
+  echo -e "  - Normal PM2 commands work e.g. ${BOLD}yarn pm2 status${RESET}"
   echo    "  - Start multiple stacks by calling this command multiple times"
   exit 1
 fi

--- a/scripts/bash/pm2startInline.sh
+++ b/scripts/bash/pm2startInline.sh
@@ -2,14 +2,16 @@
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
+. ./ansiControlSequences.sh
+
 if [ -z "$1" ]; then
-  echo -e "Usage: \033[1myarn start-stack\033[0m \033[4mstack\033[0m"
+  echo -e "Usage: ${BOLD}yarn start-stack${RESET} ${UNDERLINE}stack${RESET}"
   echo    ""
-  echo -e "All \033[4mstack\033[0ms:"
+  echo -e "All ${UNDERLINE}stack${RESET}s:"
   ls -1 ../../packages/devops/configs/pm2/ | sed 's|.config.js||g' | grep -v 'base' | awk '$0="  "$0'
   echo    ""
   echo    "Tips:"
-  echo -e "  - Normal PM2 commands work e.g. \033[1myarn pm2 status\033[0m"
+  echo -e "  - Normal PM2 commands work e.g. \033[1myarn pm2 status${RESET}"
   echo    "  - Start multiple stacks by calling this command multiple times"
   exit 1
 fi
@@ -17,6 +19,6 @@ fi
 yarn pm2 start "../../packages/devops/configs/pm2/$1.config.js"
 
 # When user quits logs, stop everything
-trap "echo -e '\n\033[1;41;97m  Stopping...  \033[0m' && yarn pm2 delete all" EXIT
+trap 'echo -e "\n${RED}[start-stack]${RESET} Stopping..." && yarn pm2 delete all' EXIT
 
 yarn pm2 logs --lines 0

--- a/scripts/bash/pm2startInline.sh
+++ b/scripts/bash/pm2startInline.sh
@@ -4,11 +4,11 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 
 . ./ansiControlSequences.sh
 
-if [ -z "$1" ]; then
+if [[ $1 = '' ]]; then
   echo -e "Usage: ${BOLD}yarn start-stack${RESET} ${UNDERLINE}stack${RESET}"
   echo
   echo -e "All ${UNDERLINE}stack${RESET}s:"
-  ls -1 ../../packages/devops/configs/pm2/ | sed 's|.config.js||g' | grep -v 'base' | awk '$0="  "$0'
+  ls -1 ../../packages/devops/configs/pm2/ | sed 's|.config.js||g' | grep -v 'base' | awk '$0=" "$0'
   echo
   echo    "Tips:"
   echo -e "  - Normal PM2 commands work e.g. ${BOLD}yarn pm2 status${RESET}"

--- a/scripts/bash/validate.sh
+++ b/scripts/bash/validate.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 DIR=$(dirname "$0")
-. ${DIR}/../../packages/devops/scripts/ci/utils.sh
+. "$DIR/../../packages/devops/scripts/ci/utils.sh"
 
 yarn workspace @tupaia/devops validate-branch-name
 yarn workspace @tupaia/devops validate-tests

--- a/scripts/bash/validate.sh
+++ b/scripts/bash/validate.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+
+set -e
 
 DIR=$(dirname "$0")
 . "$DIR/../../packages/devops/scripts/ci/utils.sh"


### PR DESCRIPTION
### Changes

- Double-quotes shell variables so spaces in paths don’t break commands
- Prettifies the output

---

### Screenshots

![Screenshot 2024-04-05T213533](https://github.com/beyondessential/tupaia/assets/33956381/bb097caf-60b6-40b4-908d-b41435936f09)

