### PR TITLE
fix: `/report` endpoint date validation

### DIFF
--- a/packages/tsutils/src/datetime.ts
+++ b/packages/tsutils/src/datetime.ts
@@ -6,7 +6,7 @@
 import moment from 'moment';
 import momentTimezone from 'moment-timezone';
 
-export const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+export const ISO_DATE_PATTERN = /\d{4}-\d{2}-\d{2}/;
 
 /**
  * @returns ISO date string in the format "yyyy-mm-dd", discarding the timestamp.


### PR DESCRIPTION
### Issue: https://beyondessential.slack.com/archives/C01MAA3NKM1/p1712622483211609

### Changes

Just removed `^` and `$` from the regex pattern I was using to validate date parameters. Specifically, **it’s the `$` that breaks it**, but I cannot for the life of me see why 😕

Strictly speaking, this now allows anything that has a _substring_ in the `YYYY-MM-DD` format to pass validation, but these inputs aren’t ever hand-written anyway (as far as I know). Ultimately it would result in another error saying that the date is null (since the server would then fail to parse it)—just a slightly less helpful error message.
