### PR TITLE
fix(datatrakWeb): show question detail when first question is an instruction

### DIFF
--- a/packages/datatrak-web/src/features/Survey/Screens/SurveyScreen.tsx
+++ b/packages/datatrak-web/src/features/Survey/Screens/SurveyScreen.tsx
@@ -1,7 +1,8 @@
 /*
  * Tupaia
- *  Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ * Copyright (c) 2017 - 2024 Beyond Essential Systems Pty Ltd
  */
+
 import React from 'react';
 import styled from 'styled-components';
 import { Typography } from '@material-ui/core';
@@ -30,8 +31,7 @@ const ScreenHeading = styled(Typography)<{
  * This is the component that renders survey questions.
  */
 export const SurveyScreen = () => {
-  const { displayQuestions, screenHeader, activeScreen } = useSurveyForm();
-
+  const { displayQuestions, screenHeader, screenDetail, activeScreen } = useSurveyForm();
   return (
     <>
       <ScrollableBody $hasSidebar>
@@ -41,6 +41,7 @@ export const SurveyScreen = () => {
         >
           {screenHeader}
         </ScreenHeading>
+        <Typography variant="body1">{screenDetail}</Typography>
         <SurveyQuestionGroup questions={displayQuestions} />
       </ScrollableBody>
       <SurveyPaginator />

--- a/packages/datatrak-web/src/features/Survey/Screens/SurveyScreen.tsx
+++ b/packages/datatrak-web/src/features/Survey/Screens/SurveyScreen.tsx
@@ -41,7 +41,7 @@ export const SurveyScreen = () => {
         >
           {screenHeader}
         </ScreenHeading>
-        <Typography variant="body1">{screenDetail}</Typography>
+        {screenDetail && <Typography variant="body1">{screenDetail}</Typography>}
         <SurveyQuestionGroup questions={displayQuestions} />
       </ScrollableBody>
       <SurveyPaginator />

--- a/packages/datatrak-web/src/features/Survey/SurveyContext/SurveyContext.tsx
+++ b/packages/datatrak-web/src/features/Survey/SurveyContext/SurveyContext.tsx
@@ -1,6 +1,6 @@
 /*
  * Tupaia
- * Copyright (c) 2017 - 202 Beyond Essential Systems Pty Ltd
+ * Copyright (c) 2017 - 2024 Beyond Essential Systems Pty Ltd
  */
 
 import React, { createContext, Dispatch, useContext, useEffect, useReducer } from 'react';

--- a/packages/datatrak-web/src/features/Survey/SurveyContext/SurveyContext.tsx
+++ b/packages/datatrak-web/src/features/Survey/SurveyContext/SurveyContext.tsx
@@ -1,9 +1,9 @@
 /*
  * Tupaia
- *  Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ * Copyright (c) 2017 - 202 Beyond Essential Systems Pty Ltd
  */
 
-import React, { Dispatch, createContext, useContext, useEffect, useReducer } from 'react';
+import React, { createContext, Dispatch, useContext, useEffect, useReducer } from 'react';
 import { useMatch, useParams } from 'react-router-dom';
 import { ROUTES } from '../../../constants';
 import { SurveyParams } from '../../../types';
@@ -26,6 +26,7 @@ const defaultContext = {
   numberOfScreens: 0,
   screenNumber: 1,
   screenHeader: '',
+  screenDetail: '',
   surveyProjectCode: '',
   displayQuestions: [],
   sideMenuOpen: false,
@@ -88,7 +89,9 @@ export const SurveyContext = ({ children }) => {
     flattenedScreenComponents,
     screenNumber,
   );
+  console.log('activeScreen', activeScreen);
   const screenHeader = activeScreen?.[0]?.text;
+  const screenDetail = activeScreen?.[0]?.detail;
 
   return (
     <SurveyFormContext.Provider
@@ -100,6 +103,7 @@ export const SurveyContext = ({ children }) => {
         displayQuestions,
         surveyScreens,
         screenHeader,
+        screenDetail,
         visibleScreens,
       }}
     >

--- a/packages/datatrak-web/src/features/Survey/SurveyContext/SurveyContext.tsx
+++ b/packages/datatrak-web/src/features/Survey/SurveyContext/SurveyContext.tsx
@@ -89,7 +89,6 @@ export const SurveyContext = ({ children }) => {
     flattenedScreenComponents,
     screenNumber,
   );
-  console.log('activeScreen', activeScreen);
   const screenHeader = activeScreen?.[0]?.text;
   const screenDetail = activeScreen?.[0]?.detail;
 

--- a/packages/datatrak-web/src/features/Survey/SurveyContext/reducer.ts
+++ b/packages/datatrak-web/src/features/Survey/SurveyContext/reducer.ts
@@ -16,7 +16,7 @@ export type SurveyFormContextType = {
   numberOfScreens: number;
   screenNumber: number | null;
   screenHeader?: string;
-  screenDetail?: string;
+  screenDetail?: string | null;
   displayQuestions: SurveyScreenComponent[];
   sideMenuOpen?: boolean;
   isReviewScreen?: boolean;

--- a/packages/datatrak-web/src/features/Survey/SurveyContext/reducer.ts
+++ b/packages/datatrak-web/src/features/Survey/SurveyContext/reducer.ts
@@ -1,9 +1,9 @@
 /*
  * Tupaia
- *  Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ * Copyright (c) 2017 - 2024 Beyond Essential Systems Pty Ltd
  */
 
-import { SurveyScreenComponent, SurveyScreen } from '../../../types';
+import { SurveyScreen, SurveyScreenComponent } from '../../../types';
 import { ACTION_TYPES, SurveyFormAction } from './actions';
 
 export type SurveyFormContextType = {
@@ -16,6 +16,7 @@ export type SurveyFormContextType = {
   numberOfScreens: number;
   screenNumber: number | null;
   screenHeader?: string;
+  screenDetail?: string;
   displayQuestions: SurveyScreenComponent[];
   sideMenuOpen?: boolean;
   isReviewScreen?: boolean;


### PR DESCRIPTION
### Issue RN-1230: In DataTrak, if an Instruction question is the first question on a screen the Detail will not display

### Changes

Now shows the `detail` field of a question on `SurveyScreen` under the existing heading.

---

### Screenshots

![Screenshot 2024-04-09T170040](https://github.com/beyondessential/tupaia/assets/33956381/c417b60d-bf2a-4226-96e0-88e462d52283)
