### PR TITLE
tweak: Remove LoggedError class

### DIFF
--- a/packages/central-server/src/apiV2/middleware/handleError.js
+++ b/packages/central-server/src/apiV2/middleware/handleError.js
@@ -2,6 +2,7 @@
  * Tupaia
  * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
  */
+import winston from 'winston';
 import { InternalServerError } from '@tupaia/utils';
 
 export const handleError = (err, req, res, next) => {
@@ -21,5 +22,6 @@ export const handleError = (err, req, res, next) => {
       api_request_log_id: apiRequestLogId,
     });
   }
+  winston.error(error);
   error.respond(res);
 };

--- a/packages/server-boilerplate/src/utils/handleError.ts
+++ b/packages/server-boilerplate/src/utils/handleError.ts
@@ -5,6 +5,7 @@
  */
 import { InternalServerError, RespondingError } from '@tupaia/utils';
 import { Request, Response, NextFunction } from 'express';
+import winston from 'winston';
 
 export const handleError = (
   err: RespondingError | Error,
@@ -19,5 +20,6 @@ export const handleError = (
   }
 
   const error = 'respond' in err ? err : new InternalServerError(err);
+  winston.error(error);
   error.respond(res);
 };

--- a/packages/utils/src/errors.js
+++ b/packages/utils/src/errors.js
@@ -3,42 +3,22 @@
  * Copyright (c) 2017 Beyond Essential Systems Pty Ltd
  */
 
-import winston from 'winston';
 import { respond } from './respond';
-
-/**
- * Logged errors print out to the server's logs so that we have a record of all errors. In future
- * this may change to saving the error info to the database, notifying the admin, or similar
- */
-class LoggedError extends Error {
-  constructor(message, originalError = null) {
-    super(message);
-    this.message = message;
-
-    // We may be in a context where winston is not defined (eg. frontend packages), just console log in that case
-    const logger = winston?.error ? winston.error : console.log;
-
-    if (originalError) {
-      logger('Original error:', { stack: originalError.stack });
-    }
-    logger(this.message, { stack: this.stack });
-  }
-}
 
 /**
  * Responding errors are able to respond to the client's request, informing them of the error with
  * the appropriate http status code
  */
-export class RespondingError extends LoggedError {
+export class RespondingError extends Error {
   constructor(message, statusCode, extraFields = {}, originalError = null) {
-    super(message, originalError);
+    super(message, { cause: originalError });
     this.statusCode = statusCode;
     this.extraFields = extraFields;
     this.respond = res => respond(res, { error: this.message, ...extraFields }, statusCode);
   }
 }
 
-export class HttpError extends LoggedError {
+export class HttpError extends Error {
   constructor(response) {
     super(`Attempt to post data returned ${response.status}: ${response.statusText}`);
     this.status = response.status;

--- a/packages/web-config-server/src/utils/handleError.js
+++ b/packages/web-config-server/src/utils/handleError.js
@@ -25,9 +25,9 @@ export const handleError = (err, req, res, next) => {
         err,
       });
     } else {
-      winston.error(err.stack);
       error = new InternalServerError(err);
     }
   }
+  winston.error(error);
   error.respond(res);
 };


### PR DESCRIPTION
It's very noisy and difficult to silence. I'll do a check to make sure we still get a useful error when routes fail, but aside from that I don't think the logging was really doing much for us (and had a lot of false positives).