### PR TITLE
fix(viz): Ensure that the `Date` column in the viz table is formatted the same as the X axis

### DIFF
--- a/packages/ui-chart-components/src/components/Reference/ChartTooltip.tsx
+++ b/packages/ui-chart-components/src/components/Reference/ChartTooltip.tsx
@@ -127,7 +127,11 @@ const MultiValueTooltip = ({
         {headline ||
           (getIsTimeSeries([data]) &&
             periodGranularity &&
-            formatTimestampForChart(timestamp, periodGranularity))}
+            formatTimestampForChart(
+              timestamp,
+              periodGranularity,
+              presentationOptions?.periodTickFormat,
+            ))}
       </Heading>
       <List>{valueLabels}</List>
     </TooltipContainer>
@@ -138,6 +142,7 @@ const SingleValueTooltip = ({
   valueType,
   payload,
   periodGranularity,
+  presentationOptions,
   labelType,
 }: ChartTooltipPropsWithData) => {
   const data = payload[0].payload;
@@ -150,7 +155,13 @@ const SingleValueTooltip = ({
     <TooltipContainer>
       {getIsTimeSeries([payload[0].payload]) && periodGranularity ? (
         <>
-          <Heading>{formatTimestampForChart(timestamp, periodGranularity)}</Heading>
+          <Heading>
+            {formatTimestampForChart(
+              timestamp,
+              periodGranularity,
+              presentationOptions?.periodTickFormat,
+            )}
+          </Heading>
           <Text>{formatDataValueByType({ value, metadata }, valueTypeForLabel)}</Text>
         </>
       ) : (
@@ -163,10 +174,8 @@ const SingleValueTooltip = ({
 const NoDataTooltip = ({
   payload,
   periodGranularity,
-}: {
-  payload: any[];
-  periodGranularity?: `${VizPeriodGranularity}`;
-}) => {
+  presentationOptions,
+}: ChartTooltipPropsWithData) => {
   const data = payload[0]?.payload;
   const { name = undefined, timestamp = undefined } = data || {};
 
@@ -176,7 +185,11 @@ const NoDataTooltip = ({
         {name ||
           (getIsTimeSeries([data]) &&
             periodGranularity &&
-            formatTimestampForChart(timestamp, periodGranularity))}
+            formatTimestampForChart(
+              timestamp,
+              periodGranularity,
+              presentationOptions?.periodTickFormat,
+            ))}
       </Heading>
       <Text>No Data</Text>
     </TooltipContainer>

--- a/packages/ui-chart-components/src/utils/getChartTableData.tsx
+++ b/packages/ui-chart-components/src/utils/getChartTableData.tsx
@@ -78,9 +78,17 @@ const processColumns = (report?: ChartReport, config?: ChartConfig, sortByTimest
   }
 
   if (hasTimeSeriesData) {
+    const periodTickFormat =
+      config &&
+      'presentationOptions' in config &&
+      typeof config.presentationOptions?.periodTickFormat === 'string' // Must check for string as otherwise might be a PieChart presentationOption
+        ? config.presentationOptions?.periodTickFormat
+        : undefined;
+
     firstColumn = makeFirstColumn(
       xName || 'Date',
-      (row: LooseObject) => formatTimestampForChart(row.timestamp, config?.periodGranularity),
+      (row: LooseObject) =>
+        formatTimestampForChart(row.timestamp, config?.periodGranularity, periodTickFormat),
       sortByTimestamp,
     );
   }


### PR DESCRIPTION
@SimonCarryer found this issue when building vizes with where date picker and the X axis didn't have the same period granularity. In this case you can override the default formatting using `periodTickFormat` but that formatting wasn't being respected by the data table (or the hover tooltip).