### PR TITLE
ci: fix never-ending `run_tests`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,6 +83,7 @@ jobs:
 
   run_tests:
     name: Run tests
+    timeout-minutes: 15 # Sometimes Jest does not exit properly for meditrak-app-server tests
     runs-on: ubuntu-latest
     env:
       # common

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,7 +83,7 @@ jobs:
 
   run_tests:
     name: Run tests
-    timeout-minutes: 15 # Sometimes Jest does not exit properly for meditrak-app-server tests
+    timeout-minutes: 15 # Sometimes Jest doesn’t exit properly for meditrak-app-server tests
     runs-on: ubuntu-latest
     env:
       # common


### PR DESCRIPTION
### Changes

Occasionally `meditrak-app-server` tests might run for hours in GitHub Actions because Jest doesn’t exit properly. (Likely an async-related problem.)

This is a band-aid fix. If the error happens, CI will fail due to timeout—just manually rerun the test.