### PR TITLE
tweak(database): fix straggling “type” symbol name to use “record”

### DIFF
--- a/packages/data-broker/src/__tests__/services/weather/WeatherService.stubs.ts
+++ b/packages/data-broker/src/__tests__/services/weather/WeatherService.stubs.ts
@@ -61,7 +61,7 @@ export const createWeatherApiStubWithMockResponse = () => {
 export const createMockEntity = async (fieldValues?: Partial<Entity>) => {
   const mockModels = createMockModelsStub();
 
-  return mockModels.entity.createTypeInstance({
+  return mockModels.entity.createRecordInstance({
     code: 'MELB',
     name: 'Melbourne',
     point: JSON.stringify({ type: 'Point', coordinates: [144.986, -37.915] }),

--- a/packages/database/src/DatabaseModel.js
+++ b/packages/database/src/DatabaseModel.js
@@ -235,13 +235,13 @@ export class DatabaseModel {
       });
     });
 
-    return this.createTypeInstance(data);
+    return this.createRecordInstance(data);
   };
 
   /**
    * @returns {*} DatabaseRecordClass
    */
-  createTypeInstance = (data = {}) => {
+  createRecordInstance = (data = {}) => {
     return new this.DatabaseRecordClass(this, data);
   };
 


### PR DESCRIPTION
### Changes:

Renamed `createTypeInstance` → `createRecordInstance`