### PR TITLE
fix(adminPanel): Fix re-render issue on tables

### DIFF
--- a/packages/admin-panel/src/table/DataFetchingTable/Cells.jsx
+++ b/packages/admin-panel/src/table/DataFetchingTable/Cells.jsx
@@ -118,8 +118,7 @@ TableCell.defaultProps = {
 const CellLink = styled(Link)`
   color: inherit;
   text-decoration: none;
-  &:hover,
-  &:focus {
+  &:hover {
     tr:has(&) td > * {
       background-color: ${({ theme }) => `${theme.palette.primary.main}33`};
     }

--- a/packages/admin-panel/src/table/DataFetchingTable/DataFetchingTable.jsx
+++ b/packages/admin-panel/src/table/DataFetchingTable/DataFetchingTable.jsx
@@ -121,7 +121,7 @@ const DataFetchingTableComponent = ({
     gotoPage,
     setPageSize,
     visibleColumns,
-
+    setSortBy,
     // Get the state from the instance
     state: { pageIndex: tablePageIndex, pageSize: tablePageSize, sortBy: tableSorting },
   } = useTable(
@@ -178,6 +178,7 @@ const DataFetchingTableComponent = ({
       initialiseTable();
     }
     gotoPage(0);
+    setSortBy([]); // reset sorting when table is re-initialised
   }, [endpoint, baseFilter]);
 
   const onChangeFilters = newFilters => {

--- a/packages/admin-panel/src/table/DataFetchingTable/DataFetchingTable.jsx
+++ b/packages/admin-panel/src/table/DataFetchingTable/DataFetchingTable.jsx
@@ -121,6 +121,7 @@ const DataFetchingTableComponent = ({
     gotoPage,
     setPageSize,
     visibleColumns,
+
     // Get the state from the instance
     state: { pageIndex: tablePageIndex, pageSize: tablePageSize, sortBy: tableSorting },
   } = useTable(
@@ -141,22 +142,19 @@ const DataFetchingTableComponent = ({
     usePagination,
   );
 
-  // Listen for changes in pagination and use the state to fetch our new data
+  //  Listen for changes in pagination and use the state to fetch our new data
   useEffect(() => {
     onPageChange(tablePageIndex);
   }, [tablePageIndex]);
 
   useEffect(() => {
     onPageSizeChange(tablePageSize);
+    gotoPage(0);
   }, [tablePageSize]);
 
   useEffect(() => {
-    // If the redux pageIndex changes, update the table pageIndex
-    gotoPage(pageIndex);
-  }, [pageIndex]);
-
-  useEffect(() => {
     onSortedChange(tableSorting);
+    gotoPage(0);
   }, [tableSorting]);
 
   useEffect(() => {
@@ -179,7 +177,13 @@ const DataFetchingTableComponent = ({
     } else {
       initialiseTable();
     }
+    gotoPage(0);
   }, [endpoint, baseFilter]);
+
+  const onChangeFilters = newFilters => {
+    onFilteredChange(newFilters);
+    gotoPage(0);
+  };
 
   const isLoading = isFetchingData || isChangingDataOnServer;
 
@@ -246,7 +250,7 @@ const DataFetchingTableComponent = ({
                     <FilterCell
                       key={column.id}
                       column={column}
-                      onFilteredChange={onFilteredChange}
+                      onFilteredChange={onChangeFilters}
                       filters={filters}
                       width={column.colWidth}
                       isButtonColumn={column.isButtonColumn}

--- a/packages/admin-panel/src/table/reducer.js
+++ b/packages/admin-panel/src/table/reducer.js
@@ -72,11 +72,9 @@ const stateChanges = {
   [PAGE_INDEX_CHANGE]: payload => payload,
   [PAGE_SIZE_CHANGE]: payload => ({
     ...payload,
-    pageIndex: 0,
   }),
   [FILTERS_CHANGE]: payload => ({
     ...payload,
-    pageIndex: 0,
   }),
   [EXPANSIONS_CHANGE]: payload => payload,
   [EXPANSIONS_TAB_CHANGE]: ({ rowId, tabValue }, currentState) => ({
@@ -88,7 +86,6 @@ const stateChanges = {
   [COLUMNS_RESIZE]: payload => payload,
   [SORTING_CHANGE]: payload => ({
     ...payload,
-    pageIndex: 0,
   }),
 };
 


### PR DESCRIPTION
### Issue: Fix re-render issue on tables

### Changes:
- Fixed issue where pagination changes caused infinite re-render on tables. Now manually sets page when filters, sorting etc change for table. This is because react-table has it's own table state and we also have pagination stored in the redux store.
- Fix stuck focus effect when table changes
- Reset table sorting when table is reinitialised
