### PR TITLE
tweak(adminPanel): RN-1187: Move secondary labels to tooltips

### DIFF
--- a/packages/admin-panel/src/autocomplete/ReduxAutocomplete.jsx
+++ b/packages/admin-panel/src/autocomplete/ReduxAutocomplete.jsx
@@ -39,6 +39,7 @@ const ReduxAutocompleteComponent = ({
   helperText,
   required,
   error,
+  tooltip,
 }) => {
   const [hasUpdated, setHasUpdated] = React.useState(false);
   React.useEffect(() => {
@@ -84,6 +85,7 @@ const ReduxAutocompleteComponent = ({
       optionLabelKey={optionLabelKey}
       required={required}
       error={error}
+      tooltip={tooltip}
     />
   );
 };

--- a/packages/admin-panel/src/routes/projects/projects.js
+++ b/packages/admin-panel/src/routes/projects/projects.js
@@ -78,6 +78,7 @@ const DEFAULT_FIELDS = [
     Header: 'Config',
     source: 'config',
     type: 'jsonTooltip',
+    required: true,
     editConfig: {
       type: 'jsonEditor',
       labelTooltip: 'eg. { "tileSets": "osm,satellite,terrain", "permanentRegionLabels": true }',

--- a/packages/admin-panel/src/routes/projects/projects.js
+++ b/packages/admin-panel/src/routes/projects/projects.js
@@ -57,7 +57,7 @@ const DEFAULT_FIELDS = [
       type: 'image',
       name: 'image_url',
       avatarVariant: 'square',
-      secondaryLabel: 'Recommended size: 480x240px',
+      labelTooltip: 'Recommended size: 480x240px',
       maxHeight: 240,
       maxWidth: 480,
     },
@@ -69,7 +69,7 @@ const DEFAULT_FIELDS = [
       type: 'image',
       name: 'logo_url',
       avatarVariant: 'square',
-      secondaryLabel: 'Recommended size: 480x240px',
+      labelTooltip: 'Recommended size: 480x240px',
       maxHeight: 240,
       maxWidth: 480,
     },
@@ -80,8 +80,8 @@ const DEFAULT_FIELDS = [
     type: 'jsonTooltip',
     editConfig: {
       type: 'jsonEditor',
+      labelTooltip: 'eg. { "tileSets": "osm,satellite,terrain", "permanentRegionLabels": true }',
     },
-    secondaryLabel: 'eg. { "tileSets": "osm,satellite,terrain", "permanentRegionLabels": true }',
   },
   {
     Header: 'Sort',

--- a/packages/admin-panel/src/routes/surveys/optionSets.js
+++ b/packages/admin-panel/src/routes/surveys/optionSets.js
@@ -80,7 +80,7 @@ const IMPORT_CONFIG = {
   queryParameters: [
     {
       label: 'Option Set Names',
-      secondaryLabel:
+      labelTooltip:
         'Please enter the names of the option sets to be imported. These should match the tab names in the file.',
       parameterKey: 'optionSetNames',
       optionsEndpoint: 'optionSets',

--- a/packages/admin-panel/src/routes/surveys/surveyResponses.js
+++ b/packages/admin-panel/src/routes/surveys/surveyResponses.js
@@ -139,7 +139,7 @@ const IMPORT_CONFIG = {
   queryParameters: [
     {
       label: 'Surveys',
-      secondaryLabel:
+      labelTooltip:
         'Please enter the surveys for the responses to be imported against. Each tab in the file should be a matching survey code. Leave blank to import all tabs.',
       parameterKey: 'surveyCodes',
       optionsEndpoint: 'surveys',

--- a/packages/admin-panel/src/routes/surveys/surveys.js
+++ b/packages/admin-panel/src/routes/surveys/surveys.js
@@ -41,7 +41,6 @@ const SURVEY_FIELDS = {
     type: 'tooltip',
     editConfig: {
       maxLength: 50,
-      secondaryLabel: 'Max 50 characters',
       required: true,
     },
   },

--- a/packages/admin-panel/src/routes/users/accessRequests.js
+++ b/packages/admin-panel/src/routes/users/accessRequests.js
@@ -111,7 +111,7 @@ const USER_COLUMNS = [
           required: true,
           editConfig: {
             optionsEndpoint: 'permissionGroups',
-            secondaryLabel:
+            labelTooltip:
               'If a default is shown here, it will give the user access to the project they requested, but please review carefully as some projects have several permission levels.',
           },
         },

--- a/packages/admin-panel/src/routes/users/accessRequests.js
+++ b/packages/admin-panel/src/routes/users/accessRequests.js
@@ -62,7 +62,7 @@ const ACCESS_REQUEST_FIELDS = [
     required: true,
     editConfig: {
       optionsEndpoint: 'permissionGroups',
-      secondaryLabel:
+      labelTooltip:
         'If a default is shown here, it will give the user access to the project they requested, but please review carefully as some projects have several permission levels.',
     },
   },
@@ -119,7 +119,6 @@ const USER_COLUMNS = [
           Header: 'Approved',
           source: 'approved',
           type: 'boolean',
-          alwaysValidate: true,
           required: true,
           editConfig: {
             type: 'boolean',

--- a/packages/admin-panel/src/routes/users/users.jsx
+++ b/packages/admin-panel/src/routes/users/users.jsx
@@ -143,7 +143,7 @@ const CREATE_CONFIG = {
           optionsEndpoint: 'countries',
           optionLabelKey: 'name',
           optionValueKey: 'name',
-          secondaryLabel: 'Select the country to grant this user access to',
+          labelTooltip: 'Select the country to grant this user access to',
         },
       },
       {
@@ -155,7 +155,7 @@ const CREATE_CONFIG = {
           optionsEndpoint: 'permissionGroups',
           optionLabelKey: 'name',
           optionValueKey: 'name',
-          secondaryLabel: 'Select the permission group to grant this user access to',
+          labelTooltip: 'Select the permission group to grant this user access to',
         },
       },
       {

--- a/packages/admin-panel/src/routes/visualisations/dashboardMailingLists.js
+++ b/packages/admin-panel/src/routes/visualisations/dashboardMailingLists.js
@@ -17,7 +17,7 @@ const DASHBOARD_MAILING_LIST_FIELDS = {
       optionLabelKey: 'code',
       optionValueKey: 'id',
       allowMultipleValues: false,
-      secondaryLabel: 'Select the project this dashboard mailing list should be available in',
+      labelTooltip: 'Select the project this dashboard mailing list should be available in',
     },
   },
   dashboard_code: {
@@ -29,7 +29,7 @@ const DASHBOARD_MAILING_LIST_FIELDS = {
       optionsEndpoint: 'dashboards',
       optionLabelKey: 'code',
       optionValueKey: 'id',
-      secondaryLabel: 'Select the dashboard this mailing list should be for',
+      labelTooltip: 'Select the dashboard this mailing list should be for',
     },
   },
   dashboard_name: {
@@ -49,7 +49,7 @@ const DASHBOARD_MAILING_LIST_FIELDS = {
       optionsEndpoint: 'entities',
       optionLabelKey: 'name',
       optionValueKey: 'id',
-      secondaryLabel: 'Select the entity this dashboard mailing list should be for',
+      labelTooltip: 'Select the entity this dashboard mailing list should be for',
     },
   },
   admin_permission_groups: {
@@ -63,7 +63,7 @@ const DASHBOARD_MAILING_LIST_FIELDS = {
       optionValueKey: 'name',
       sourceKey: 'admin_permission_groups',
       allowMultipleValues: true,
-      secondaryLabel:
+      labelTooltip:
         'Users with any of these permissions can send out the dashboard to the mailing list',
     },
   },

--- a/packages/admin-panel/src/routes/visualisations/dashboardRelations.js
+++ b/packages/admin-panel/src/routes/visualisations/dashboardRelations.js
@@ -56,7 +56,7 @@ export const DASHBOARD_RELATION_COLUMNS = {
       canCreateNewOptions: true,
       optionLabelKey: 'entityTypes',
       optionValueKey: 'entityTypes',
-      secondaryLabel: "Input the entity types you want. Eg: 'country', 'sub_district'",
+      labelTooltip: "Input the entity types you want. Eg: 'country', 'sub_district'",
     },
   },
   ATTRIBUTES_FILTER: {

--- a/packages/admin-panel/src/routes/visualisations/mapOverlays.jsx
+++ b/packages/admin-panel/src/routes/visualisations/mapOverlays.jsx
@@ -102,7 +102,7 @@ const extraEditFields = [
     source: 'entity_attributes_filter',
     editConfig: {
       type: 'jsonEditor',
-      secondaryLabel: (
+      labelTooltip: (
         <>
           Case-sensitive. This field will be used to filter the entities that this map overlay will
           have data for. It is an extension of <code>config.measureLevel</code>. e.g.&nbsp;

--- a/packages/admin-panel/src/widgets/InputField/InputField.jsx
+++ b/packages/admin-panel/src/widgets/InputField/InputField.jsx
@@ -23,13 +23,44 @@ const getInputType = ({ options, optionsEndpoint, type }) => {
   return type;
 };
 
-export const InputField = ({ type, secondaryLabel, error, ...inputProps }) => {
+export const InputField = ({
+  type,
+  maxLength,
+  minLength,
+  secondaryLabel,
+  error,
+  ...inputProps
+}) => {
   const { options, optionsEndpoint } = inputProps;
   const inputType = getInputType({ options, optionsEndpoint, type });
   const InputComponent = InputFields[inputType];
+
+  const generateHelperText = () => {
+    if (secondaryLabel) return secondaryLabel;
+    if (maxLength && minLength !== undefined && minLength !== null) {
+      return `Must be between ${minLength} and ${maxLength} characters`;
+    }
+
+    if (maxLength) {
+      return `Max ${maxLength} characters`;
+    }
+
+    if (minLength !== undefined && minLength !== null) {
+      return `Min ${minLength} characters`;
+    }
+  };
+
+  const helperText = generateHelperText();
   return (
-    <InputWrapper errorText={error} helperText={secondaryLabel}>
-      {InputComponent && <InputComponent {...inputProps} error={!!error} />}
+    <InputWrapper errorText={error} helperText={helperText}>
+      {InputComponent && (
+        <InputComponent
+          {...inputProps}
+          error={!!error}
+          maxLength={maxLength}
+          minLength={minLength}
+        />
+      )}
     </InputWrapper>
   );
 };
@@ -61,6 +92,8 @@ export const inputFieldPropTypes = {
   variant: PropTypes.string,
   required: PropTypes.bool,
   error: PropTypes.string,
+  maxLength: PropTypes.number,
+  minLength: PropTypes.number,
 };
 
 export const inputFieldDefaultProps = {
@@ -81,6 +114,8 @@ export const inputFieldDefaultProps = {
   variant: null,
   required: false,
   error: null,
+  maxLength: null,
+  minLength: null,
 };
 
 InputField.propTypes = inputFieldPropTypes;

--- a/packages/admin-panel/src/widgets/InputField/JsonEditor.jsx
+++ b/packages/admin-panel/src/widgets/InputField/JsonEditor.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { FormLabel } from '@material-ui/core';
 import { JsonEditor as Editor } from '../JsonEditor';
+import { InputLabel } from '@tupaia/ui-components';
 
 const Container = styled.div`
   display: flex;
@@ -33,7 +34,16 @@ const Label = styled(FormLabel)`
   line-height: 1.1rem;
 `;
 
-export const JsonEditor = ({ inputKey, label, value, onChange, stringify, error, required }) => {
+export const JsonEditor = ({
+  inputKey,
+  label,
+  value,
+  onChange,
+  stringify,
+  error,
+  required,
+  tooltip,
+}) => {
   if (!value) {
     return null;
   }
@@ -46,9 +56,15 @@ export const JsonEditor = ({ inputKey, label, value, onChange, stringify, error,
 
   return (
     <Container $invalid={error}>
-      <Label gutterBottom required={required} error={error}>
-        {label}
-      </Label>
+      <InputLabel
+        label={label}
+        labelProps={{
+          required,
+          error,
+        }}
+        tooltip={tooltip}
+        as={Label}
+      />
       {/* Use json editor plugin. For configuration options @see https://github.com/vankop/jsoneditor-react */}
       <Editor
         mainMenuBar={false}

--- a/packages/admin-panel/src/widgets/InputField/JsonEditor.jsx
+++ b/packages/admin-panel/src/widgets/InputField/JsonEditor.jsx
@@ -6,9 +6,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { FormLabel } from '@material-ui/core';
-import { JsonEditor as Editor } from '../JsonEditor';
 import { InputLabel } from '@tupaia/ui-components';
+import { JsonEditor as Editor } from '../JsonEditor';
 
 const Container = styled.div`
   display: flex;
@@ -16,7 +15,7 @@ const Container = styled.div`
   min-height: 300px;
   margin-bottom: 20px;
 
-  > div {
+  .jsoneditor-parent {
     display: flex;
     flex: 1;
   }
@@ -27,11 +26,6 @@ const Container = styled.div`
       return $invalid ? theme.palette.error.main : theme.palette.text.primary;
     }};
   }
-`;
-
-const Label = styled(FormLabel)`
-  font-size: 0.9rem;
-  line-height: 1.1rem;
 `;
 
 export const JsonEditor = ({
@@ -63,7 +57,7 @@ export const JsonEditor = ({
           error,
         }}
         tooltip={tooltip}
-        as={Label}
+        applyWrapper
       />
       {/* Use json editor plugin. For configuration options @see https://github.com/vankop/jsoneditor-react */}
       <Editor
@@ -72,6 +66,9 @@ export const JsonEditor = ({
         mode="code"
         onChange={json => onChange(inputKey, stringify ? JSON.stringify(json) : json)}
         value={editorValue}
+        htmlElementProps={{
+          className: 'jsoneditor-parent',
+        }}
       />
     </Container>
   );
@@ -85,6 +82,7 @@ JsonEditor.propTypes = {
   stringify: PropTypes.bool,
   error: PropTypes.bool,
   required: PropTypes.bool,
+  tooltip: PropTypes.string,
 };
 
 JsonEditor.defaultProps = {
@@ -92,4 +90,5 @@ JsonEditor.defaultProps = {
   stringify: true,
   error: false,
   required: false,
+  tooltip: null,
 };

--- a/packages/admin-panel/src/widgets/InputField/registerInputFields.jsx
+++ b/packages/admin-panel/src/widgets/InputField/registerInputFields.jsx
@@ -120,6 +120,7 @@ export const registerInputFields = () => {
       helperText={props.secondaryLabel}
       required={props.required}
       error={props.error}
+      tooltip={props.labelTooltip}
     />
   ));
   registerInputField('jsonArray', props => (

--- a/packages/admin-panel/src/widgets/InputField/registerInputFields.jsx
+++ b/packages/admin-panel/src/widgets/InputField/registerInputFields.jsx
@@ -85,7 +85,6 @@ export const registerInputFields = () => {
     <JsonInputField
       id={props.id}
       label={props.label}
-      helperText={props.secondaryLabel}
       value={props.value}
       recordData={props.recordData}
       onChange={inputValue => props.onChange(props.inputKey, inputValue)}
@@ -101,7 +100,6 @@ export const registerInputFields = () => {
       id={props.id}
       label={props.label}
       placeholder={props.placeholder}
-      helperText={props.secondaryLabel}
       value={props.value || ''}
       options={props.options}
       onChange={event => props.onChange(props.inputKey, event.target.value)}
@@ -117,7 +115,6 @@ export const registerInputFields = () => {
       inputKey={props.inputKey}
       value={props.value}
       onChange={props.onChange}
-      helperText={props.secondaryLabel}
       required={props.required}
       error={props.error}
       tooltip={props.labelTooltip}
@@ -129,7 +126,6 @@ export const registerInputFields = () => {
       inputKey={props.inputKey}
       value={props.value}
       onChange={props.onChange}
-      helperText={props.secondaryLabel}
       stringify={false}
       required={props.required}
     />
@@ -153,7 +149,6 @@ export const registerInputFields = () => {
       ]}
       value={props.value}
       disabled={props.disabled}
-      helperText={props.secondaryLabel}
       tooltip={props.labelTooltip}
       required={props.required}
       error={props.error}
@@ -163,7 +158,6 @@ export const registerInputFields = () => {
     <DatePicker
       id={props.id}
       label={props.label}
-      helperText={props.secondaryLabel}
       value={props.moment(props.value).isValid() ? moment(props.value) : null}
       onChange={date => props.onChange(props.inputKey, date.toISOString())}
       disabled={props.disabled}
@@ -176,7 +170,6 @@ export const registerInputFields = () => {
     <DateTimePicker
       id={props.id}
       label={props.label}
-      helperText={props.secondaryLabel}
       format="yyyy-MM-dd HH:mm"
       value={
         props.value && moment(props.value).isValid
@@ -198,7 +191,6 @@ export const registerInputFields = () => {
     <DateTimePicker
       id={props.id}
       label={props.label}
-      helperText={props.secondaryLabel}
       format="yyyy-MM-dd HH:mm"
       value={
         props.value && moment(props.value).isValid
@@ -239,7 +231,6 @@ export const registerInputFields = () => {
       value={props.value || ''}
       onChange={event => props.onChange(props.inputKey, event.target.value)}
       disabled={props.disabled}
-      helperText={props.secondaryLabel}
       multiline
       type="textarea"
       rows="4"
@@ -261,7 +252,6 @@ export const registerInputFields = () => {
       value={props.value === undefined || props.value === null ? '' : props.value} // we still want to show 0 value
       onChange={event => props.onChange(props.inputKey, event.target.value)}
       disabled={props.disabled}
-      helperText={props.secondaryLabel}
       type={props.type}
       tooltip={props.labelTooltip}
       placeholder={props.placeholder}
@@ -287,7 +277,6 @@ export const registerInputFields = () => {
       value={props.value === undefined || props.value === null ? '' : props.value} // we still want to show 0 value
       onChange={event => props.onChange(props.inputKey, event.target.value)}
       disabled={props.disabled}
-      helperText={props.secondaryLabel}
       type="password"
       tooltip={props.labelTooltip}
       required={props.required}
@@ -320,7 +309,6 @@ export const registerInputFields = () => {
       value={props.value}
       onChange={value => props.onChange(props.inputKey, value)}
       disabled={props.disabled}
-      helperText={props.secondaryLabel}
       tooltip={props.labelTooltip}
       placeholder={props.placeholder}
       required={props.required}
@@ -336,7 +324,6 @@ export const registerInputFields = () => {
         value={props.optionValue}
         onChange={e => props.onChange(props.inputKey, e.target.checked ? props.optionValue : null)}
         disabled={props.disabled}
-        helperText={props.secondaryLabel}
         tooltip={props.labelTooltip}
         required={props.required}
         color="secondary"
@@ -351,7 +338,6 @@ export const registerInputFields = () => {
       options={props.options}
       value={props.value}
       disabled={props.disabled}
-      helperText={props.secondaryLabel}
       tooltip={props.labelTooltip}
       name={props.name}
       required={props.required}
@@ -362,7 +348,6 @@ export const registerInputFields = () => {
     <FileUploadField
       name={props.name}
       label={props.label}
-      helperText={props.secondaryLabel}
       required={props.required}
       onChange={({ fileName, file }) => props.onSetFormFile(props.inputKey, { fileName, file })}
     />

--- a/packages/ui-components/src/components/Inputs/ImageUploadField.tsx
+++ b/packages/ui-components/src/components/Inputs/ImageUploadField.tsx
@@ -75,10 +75,6 @@ const Label = styled.label`
   position: relative;
 `;
 
-const LabelWrapper = styled(FlexCenter)`
-  margin-block-end: 0.2rem;
-`;
-
 type Base64 = string | null | ArrayBuffer;
 
 interface ImageUploadFieldProps {
@@ -200,18 +196,17 @@ export const ImageUploadField = React.memo(
           )}
         </Box>
         <Label htmlFor={name}>
-          <LabelWrapper>
-            <InputLabel
-              className="file_upload_label"
-              label={label}
-              tooltip={tooltip}
-              as={TextLabel}
-              labelProps={{
-                required,
-                error: error || !!errorMessage,
-              }}
-            />
-          </LabelWrapper>
+          <InputLabel
+            className="file_upload_label"
+            label={label}
+            tooltip={tooltip}
+            as={TextLabel}
+            labelProps={{
+              required,
+              error: error || !!errorMessage,
+            }}
+            applyWrapper
+          />
           {secondaryLabel && (
             <FormHelperText component={FormHelperTextComponent || 'p'} id={`${name}-description`}>
               {secondaryLabel}

--- a/packages/ui-components/src/components/Inputs/ImageUploadField.tsx
+++ b/packages/ui-components/src/components/Inputs/ImageUploadField.tsx
@@ -7,7 +7,7 @@ import React, { useRef, useState } from 'react';
 import styled from 'styled-components';
 import { AvatarProps, Box, Fab, FormHelperText, FormLabel } from '@material-ui/core';
 import DeleteIcon from '@material-ui/icons/Delete';
-import { FlexStart } from '../Layout';
+import { FlexCenter, FlexStart } from '../Layout';
 import { GreyOutlinedButton } from '../Button';
 import { Avatar } from '../Avatar';
 import { InputLabel } from './InputLabel';
@@ -60,7 +60,6 @@ const TextLabel = styled(FormLabel).attrs({
   line-height: 0.8rem;
   text-transform: uppercase;
   color: ${props => props.theme.palette.text.tertiary};
-  margin-bottom: 0.6rem;
 `;
 
 const ErrorMessage = styled(FormHelperText)`
@@ -74,6 +73,10 @@ const Label = styled.label`
   display: flex;
   flex-direction: column;
   position: relative;
+`;
+
+const LabelWrapper = styled(FlexCenter)`
+  margin-block-end: 0.2rem;
 `;
 
 type Base64 = string | null | ArrayBuffer;
@@ -197,16 +200,18 @@ export const ImageUploadField = React.memo(
           )}
         </Box>
         <Label htmlFor={name}>
-          <InputLabel
-            className="file_upload_label"
-            label={label}
-            tooltip={tooltip}
-            as={TextLabel}
-            labelProps={{
-              required,
-              error: error || !!errorMessage,
-            }}
-          />
+          <LabelWrapper>
+            <InputLabel
+              className="file_upload_label"
+              label={label}
+              tooltip={tooltip}
+              as={TextLabel}
+              labelProps={{
+                required,
+                error: error || !!errorMessage,
+              }}
+            />
+          </LabelWrapper>
           {secondaryLabel && (
             <FormHelperText component={FormHelperTextComponent || 'p'} id={`${name}-description`}>
               {secondaryLabel}

--- a/packages/ui-components/src/components/Inputs/InputLabel.tsx
+++ b/packages/ui-components/src/components/Inputs/InputLabel.tsx
@@ -77,6 +77,7 @@ export const InputLabel = ({
   // If no label, don't render anything, so there isn't an empty label tag in the DOM
   if (!label) return null;
 
+  // wrapper won't work correctly when using TextField, so we need to conditionally apply it
   const Wrapper = applyWrapper ? LabelWrapper : React.Fragment;
   return (
     // allows us to pass in a custom element to render as, e.g. a span if it is going to be contained in a label element, for example when using MUI's TextField component. Otherwise defaults to a label element so that it can be a standalone label

--- a/packages/ui-components/src/components/Inputs/InputLabel.tsx
+++ b/packages/ui-components/src/components/Inputs/InputLabel.tsx
@@ -7,12 +7,11 @@ import React, { ComponentType } from 'react';
 import { HelpOutline } from '@material-ui/icons';
 import styled from 'styled-components';
 import { Tooltip as BaseTooltip } from '../Tooltip';
+import { FlexCenter } from '../Layout';
+import { FormLabel } from '@material-ui/core';
 
 /** Styled label for inputs. Handles tooltips for labels if present. */
-const LabelWrapper = styled.span`
-  display: flex;
-  align-items: center;
-`;
+const Label = styled.span``;
 
 const TooltipWrapper = styled.span`
   pointer-events: auto;
@@ -48,6 +47,12 @@ const Tooltip = styled(BaseTooltip)`
   }
 `;
 
+const LabelWrapper = styled(FlexCenter)`
+  margin-block-end: 0.25rem;
+  justify-content: space-between;
+  width: 100%;
+`;
+
 interface InputLabelProps {
   label?: string | React.ReactNode;
   tooltip?: string;
@@ -56,25 +61,29 @@ interface InputLabelProps {
   htmlFor?: string;
   labelProps?: any;
   TooltipIcon?: ComponentType<any>;
+  applyWrapper?: boolean;
 }
 
 export const InputLabel = ({
   label,
   tooltip,
-  as = 'label',
+  as = FormLabel,
   className,
   htmlFor,
   labelProps = {},
   TooltipIcon = HelpOutline,
+  applyWrapper = false,
 }: InputLabelProps) => {
   // If no label, don't render anything, so there isn't an empty label tag in the DOM
   if (!label) return null;
+
+  const Wrapper = applyWrapper ? LabelWrapper : React.Fragment;
   return (
     // allows us to pass in a custom element to render as, e.g. a span if it is going to be contained in a label element, for example when using MUI's TextField component. Otherwise defaults to a label element so that it can be a standalone label
-    <>
-      <LabelWrapper as={as} className={className} htmlFor={htmlFor} {...labelProps}>
+    <Wrapper>
+      <Label as={as} className={className} htmlFor={htmlFor} {...labelProps}>
         {label}
-      </LabelWrapper>
+      </Label>
       {tooltip && (
         <Tooltip title={tooltip} placement="top">
           <TooltipWrapper tabIndex={0}>
@@ -82,6 +91,6 @@ export const InputLabel = ({
           </TooltipWrapper>
         </Tooltip>
       )}
-    </>
+    </Wrapper>
   );
 };

--- a/packages/ui-components/src/components/Inputs/RadioGroup.tsx
+++ b/packages/ui-components/src/components/Inputs/RadioGroup.tsx
@@ -93,7 +93,7 @@ interface RadioGroupProps {
   inputProps?: React.HTMLAttributes<HTMLInputElement>;
   required?: boolean;
   radioGroupProps?: MuiRadioGroupProps;
-  invalid?: boolean;
+  error?: boolean;
 }
 
 export const RadioGroup = ({
@@ -112,7 +112,7 @@ export const RadioGroup = ({
   inputRef,
   inputProps,
   required,
-  invalid,
+  error,
   radioGroupProps,
 }: RadioGroupProps) => {
   return (
@@ -129,7 +129,7 @@ export const RadioGroup = ({
         as={Legend}
         tooltip={tooltip}
         labelProps={{
-          error: invalid,
+          error,
           required,
         }}
       />
@@ -151,7 +151,7 @@ export const RadioGroup = ({
             key={option[valueKey].toString()}
             value={option[valueKey]}
             label={<InputLabel label={option[labelKey]} tooltip={option[tooltipKey]} as="span" />}
-            className={invalid ? 'error' : undefined}
+            className={error ? 'error' : undefined}
           />
         ))}
       </StyledRadioGroup>

--- a/packages/ui-components/src/components/Inputs/RadioGroup.tsx
+++ b/packages/ui-components/src/components/Inputs/RadioGroup.tsx
@@ -13,11 +13,6 @@ import MuiFormControl, { FormControlProps } from '@material-ui/core/FormControl'
 import { OverrideableComponentProps } from '../../types';
 import { InputLabel } from './InputLabel';
 
-const LegendWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  margin-bottom: 0.25rem;
-`;
 const FormControl = styled(MuiFormControl)<OverrideableComponentProps<FormControlProps>>`
   display: block;
   margin-bottom: 1.2rem;
@@ -121,24 +116,16 @@ export const RadioGroup = ({
   radioGroupProps,
 }: RadioGroupProps) => {
   return (
-    <FormControl
-      component="fieldset"
-      className={className}
-      color="primary"
-      id={id}
-      required={required}
-      error={invalid}
-    >
-      <LegendWrapper>
-        <InputLabel
-          label={<Legend required={required}>{label}</Legend>}
-          tooltip={tooltip}
-          labelProps={{
-            error: invalid,
-            required,
-          }}
-        />
-      </LegendWrapper>
+    <FormControl component="fieldset" className={className} color="primary" id={id}>
+      <InputLabel
+        label={label}
+        as={Legend}
+        tooltip={tooltip}
+        labelProps={{
+          error: invalid,
+          required,
+        }}
+      />
 
       {helperText && <FormHelperText id={`${name}-helperText`}>{helperText}</FormHelperText>}
       <StyledRadioGroup name={name} value={value} onChange={onChange} {...radioGroupProps}>

--- a/packages/ui-components/src/components/Inputs/TextField.tsx
+++ b/packages/ui-components/src/components/Inputs/TextField.tsx
@@ -118,6 +118,8 @@ const StyledTextField = styled(MuiTextField)<TextFieldProps>`
 export const TextField = ({
   label = '',
   tooltip,
+  error,
+  required,
   ...props
 }: TextFieldProps & {
   tooltip?: string;
@@ -126,6 +128,20 @@ export const TextField = ({
     fullWidth
     {...props}
     variant="outlined"
-    label={label ? <InputLabel label={label} tooltip={tooltip} as="span" /> : null}
+    error={error}
+    required={required}
+    label={
+      label ? (
+        <InputLabel
+          label={label}
+          tooltip={tooltip}
+          as="span"
+          labelProps={{
+            required,
+            error,
+          }}
+        />
+      ) : null
+    }
   />
 );


### PR DESCRIPTION
### Issue RN-1187: Move secondary labels to tooltips

### Changes:
- Change secondary labels to be tooltips
- Autogenerate min/max length validation text if values are set

---

### Screenshots:
![Screen Shot 2024-05-22 at 9 06 20 AM](https://github.com/beyondessential/tupaia/assets/129009580/b2cc8ebe-b28c-4b66-b77b-f6d1fd0ad22c)
