### PR TITLE
fix(meditrak): HOTFIX: Remove banner for production meditrak builds

### DIFF
--- a/packages/meditrak-app/app/version/isBeta.jsx
+++ b/packages/meditrak-app/app/version/isBeta.jsx
@@ -7,5 +7,4 @@ import Config from 'react-native-config';
 
 export const isBeta = !!Config.BETA_BRANCH;
 export const betaBranch = Config.BETA_BRANCH;
-export const centralApiUrl =
-  Config.CENTRAL_API_URL || 'http://10.0.2.2:8090/v2';
+export const centralApiUrl = Config.CENTRAL_API_URL;


### PR DESCRIPTION
The latest meditrak master build has the emulator base url as the banner:
![image](https://github.com/beyondessential/tupaia/assets/59544282/c9d5bdaf-db13-4555-8202-12b925693466)

Decided to just remove the default value since it's just for convenience anyway (devs can just use .env vars)