### PR TITLE
tweak(logging): Log original error in handleError middleware

### DIFF
--- a/packages/central-server/src/apiV2/middleware/handleError.js
+++ b/packages/central-server/src/apiV2/middleware/handleError.js
@@ -22,6 +22,6 @@ export const handleError = (err, req, res, next) => {
       api_request_log_id: apiRequestLogId,
     });
   }
-  winston.error(error);
+  winston.error(err);
   error.respond(res);
 };

--- a/packages/server-boilerplate/src/utils/handleError.ts
+++ b/packages/server-boilerplate/src/utils/handleError.ts
@@ -19,7 +19,8 @@ export const handleError = (
     return;
   }
 
+  winston.error(err);
+
   const error = 'respond' in err ? err : new InternalServerError(err);
-  winston.error(error);
   error.respond(res);
 };

--- a/packages/web-config-server/src/utils/handleError.js
+++ b/packages/web-config-server/src/utils/handleError.js
@@ -28,6 +28,6 @@ export const handleError = (err, req, res, next) => {
       error = new InternalServerError(err);
     }
   }
-  winston.error(error);
+  winston.error(err);
   error.respond(res);
 };


### PR DESCRIPTION
Allows us to see the original stack trace which helps debugging