### PR TITLE
fix(vizBuilder): Fix duplicate ID issue on viz builder transforms

### DIFF
--- a/packages/admin-panel/src/VizBuilderApp/components/DataLibrary/TransformDataLibrary.jsx
+++ b/packages/admin-panel/src/VizBuilderApp/components/DataLibrary/TransformDataLibrary.jsx
@@ -26,12 +26,15 @@ const transformToValue = transform =>
   }));
 
 const valueToTransform = value =>
-  value.map(({ id, code, isDisabled = false, ...restOfConfig }, index) => ({
-    id: id || `${code}-${index}`, // option from selectable options does not have id.
-    transform: code,
-    isDisabled,
-    ...restOfConfig,
-  }));
+  value.map(({ id, code, isDisabled = false, ...restOfConfig }) => {
+    const uniqueId = Math.random() * 1000000; // unique id to add to the code
+    return {
+      id: id || `${code}-${uniqueId}`, // option from selectable options does not have id.
+      transform: code,
+      isDisabled,
+      ...restOfConfig,
+    };
+  });
 
 export const TransformDataLibrary = ({ transform, onTransformChange, onInvalidChange }) => {
   const [dataType, setDataType] = useState(DATA_TYPES.TRANSFORM);


### PR DESCRIPTION
### Fix duplicate ID issue on viz builder transforms

### Changes:
- Fixed issue where adding. removing, and reordering transforms in the viz builder causes duplicate IDs and buggy behaviours
