### PR TITLE
fix(vizBuilder): Fix pre-filling entities not working

### DIFF
--- a/packages/admin-panel/src/VizBuilderApp/api/queries/useEntities.js
+++ b/packages/admin-panel/src/VizBuilderApp/api/queries/useEntities.js
@@ -43,9 +43,9 @@ export const useEntityByCode = (entityCode, onSuccess) =>
     () =>
       get('entities', {
         params: {
-          filter: {
+          filter: JSON.stringify({
             code: entityCode,
-          },
+          }),
         },
       }),
     {


### PR DESCRIPTION
### Fix pre-filling entities not working

### Changes:
- Fix issue where filter for entities was not stringified so didn't fetch last used entity
