### PR TITLE
fix(adminPanel): Stop no file message showing between import views

### DIFF
--- a/packages/admin-panel/src/importExport/ImportModal.jsx
+++ b/packages/admin-panel/src/importExport/ImportModal.jsx
@@ -37,7 +37,6 @@ export const ImportModalComponent = React.memo(
     confirmButtonText,
     cancelButtonText,
     uploadButtonText,
-    noFileMessage,
   }) => {
     const api = useApiContext();
     const [status, setStatus] = useState(STATUS.IDLE);
@@ -62,7 +61,7 @@ export const ImportModalComponent = React.memo(
       setErrorMessage(null);
       setFinishedMessage(null);
       setFiles([]);
-      setFileName(noFileMessage);
+      setFileName(null);
     };
 
     const handleClose = () => {
@@ -72,7 +71,7 @@ export const ImportModalComponent = React.memo(
       setIsOpen(false);
       setValues({});
       setFiles([]);
-      setFileName(noFileMessage);
+      setFileName(null);
     };
 
     const handleSubmit = async event => {
@@ -234,7 +233,6 @@ ImportModalComponent.propTypes = {
   confirmButtonText: PropTypes.string,
   cancelButtonText: PropTypes.string,
   uploadButtonText: PropTypes.string,
-  noFileMessage: PropTypes.string,
 };
 
 ImportModalComponent.defaultProps = {
@@ -247,7 +245,6 @@ ImportModalComponent.defaultProps = {
   confirmButtonText: 'Import',
   cancelButtonText: 'Cancel',
   uploadButtonText: 'Choose file',
-  noFileMessage: 'No file chosen',
 };
 
 const mapDispatchToProps = dispatch => ({

--- a/packages/lesmis/src/views/AdminPanel/routes/helpers/getImportConfigs.js
+++ b/packages/lesmis/src/views/AdminPanel/routes/helpers/getImportConfigs.js
@@ -8,7 +8,6 @@ const getImportModalText = translate => ({
   confirmButtonText: translate('admin.import'),
   cancelButtonText: translate('admin.cancel'),
   uploadButtonText: translate('admin.chooseFile'),
-  noFileMessage: translate('admin.noFileChosen'),
 });
 
 export const getImportConfigs = (translate, importConfigs) => ({


### PR DESCRIPTION
### Stop no file message showing between import views

### Changes:
- Fix issue where file name was being reset incorrectly on admin panel import modal when closing and reopening the modal