### PR TITLE
fix(datatrakWeb): NOTUP-710 Make visibility criteria comparisons convert to strings

### DIFF
--- a/packages/datatrak-web/src/features/Survey/SurveyContext/utils.ts
+++ b/packages/datatrak-web/src/features/Survey/SurveyContext/utils.ts
@@ -28,7 +28,12 @@ export const getIsQuestionVisible = (
   return Object.entries(dependantQuestions)[operator](([questionId, validAnswers]) => {
     const answer = formData[questionId];
     if (answer === undefined) return false;
-    return Array.isArray(validAnswers) ? validAnswers?.includes(answer) : validAnswers === answer;
+
+    // stringify the answer to compare with the validAnswers so that the types are always the same
+    const stringifiedAnswer = String(answer);
+    return Array.isArray(validAnswers)
+      ? validAnswers?.map(validAnswer => String(validAnswer)).includes(stringifiedAnswer)
+      : String(validAnswers) === stringifiedAnswer;
   });
 };
 


### PR DESCRIPTION
###  Issue NOTUP-710: Make visibility criteria comparisons convert to strings

### Changes:
- Fix issue where admin panel saves visibility criteria answers as strings, but we compare the absolute value. Changed to converting everything to a string to compare.