### PR TITLE
feat(meditrak): RN-1219: `tupaiameditrak://` URL scheme

### DIFF
--- a/packages/meditrak-app/ios/TupaiaMediTrak/Info.plist
+++ b/packages/meditrak-app/ios/TupaiaMediTrak/Info.plist
@@ -22,6 +22,17 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string></string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>tupaiameditrak</string>
+			</array>
+		</dict>
+	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
### Issue RN-1219: Add `tupaiameditrak://` URL scheme to MediTrak

### Changes

Explicitly link to MediTrak app with `tupaiameditrak://` URL scheme

### Screenshot

![Thursday, 06 Jun 2024 12:10:18](https://github.com/beyondessential/tupaia/assets/33956381/583bda97-d4b5-4424-93e6-38c3ab2018ba)