### PR TITLE
fix(nginx): RN-1365: Fix occasional 504 Gateway Timeout errors

### DIFF
--- a/packages/devops/configs/nginx-template/servers.template.conf
+++ b/packages/devops/configs/nginx-template/servers.template.conf
@@ -572,7 +572,7 @@ server {
 
   # Nginx caches the ip address of the default frontend, which resolves to the ip address of the Elastic Load Balancer when hosting on AWS
   # Since this ip address can change, we need to make sure we refetch the cached ip address regularly to avoid pointing to the wrong ip address
-  resolver_timeout 30s;
+  resolver 127.0.0.53 valid=30s; # DNS address of 127.0.0.53 is used by systemd-resolved
   set $default_frontend "__SUBDOMAIN_PREFIX____DEFAULT_FRONTEND__.__DOMAIN__"; 
 
   location / {

--- a/packages/devops/configs/nginx-template/servers.template.conf
+++ b/packages/devops/configs/nginx-template/servers.template.conf
@@ -570,7 +570,12 @@ server {
   listen       [::]:__PORT__;
   server_name  __DOMAIN_PREFIX____DOMAIN__;
 
+  # Nginx caches the ip address of the default frontend, which resolves to the ip address of the Elastic Load Balancer when hosting on AWS
+  # Since this ip address can change, we need to make sure we refetch the cached ip address regularly to avoid pointing to the wrong ip address
+  resolver_timeout 30s;
+  set $default_frontend "__SUBDOMAIN_PREFIX____DEFAULT_FRONTEND__.__DOMAIN__"; 
+
   location / {
-    proxy_pass https://__SUBDOMAIN_PREFIX____DEFAULT_FRONTEND__.__DOMAIN__;
+    proxy_pass https://$default_frontend;
   }
 }


### PR DESCRIPTION
### Issue RN-1365:

Update nginx config to regularly update the cached ip address for the default frontend

