### PR TITLE
feat(datatrakWeb): RN-1335: Setup skeleton backend for tasking

### DIFF
--- a/packages/central-server/src/apiV2/index.js
+++ b/packages/central-server/src/apiV2/index.js
@@ -144,7 +144,7 @@ import {
   GETDashboardMailingListEntries,
 } from './dashboardMailingListEntries';
 import { EditEntityHierarchy, GETEntityHierarchy } from './entityHierarchy';
-import { GETTasks } from './tasks';
+import { CreateTask, GETTasks } from './tasks';
 
 // quick and dirty permission wrapper for open endpoints
 const allowAnyone = routeHandler => (req, res, next) => {
@@ -315,7 +315,7 @@ apiV2.post('/landingPages', useRouteHandler(CreateLandingPage));
 apiV2.post('/surveys', multipartJson(), useRouteHandler(CreateSurvey));
 apiV2.post('/dhisInstances', useRouteHandler(BESAdminCreateHandler));
 apiV2.post('/supersetInstances', useRouteHandler(BESAdminCreateHandler));
-
+apiV2.post('/tasks', useRouteHandler(CreateTask));
 /**
  * PUT routes
  */

--- a/packages/central-server/src/apiV2/index.js
+++ b/packages/central-server/src/apiV2/index.js
@@ -144,7 +144,7 @@ import {
   GETDashboardMailingListEntries,
 } from './dashboardMailingListEntries';
 import { EditEntityHierarchy, GETEntityHierarchy } from './entityHierarchy';
-import { CreateTask, GETTasks } from './tasks';
+import { CreateTask, EditTask, GETTasks } from './tasks';
 
 // quick and dirty permission wrapper for open endpoints
 const allowAnyone = routeHandler => (req, res, next) => {
@@ -353,6 +353,7 @@ apiV2.put('/landingPages/:recordId', useRouteHandler(EditLandingPage));
 apiV2.put('/surveys/:recordId', multipartJson(), useRouteHandler(EditSurvey));
 apiV2.put('/dhisInstances/:recordId', useRouteHandler(BESAdminEditHandler));
 apiV2.put('/supersetInstances/:recordId', useRouteHandler(BESAdminEditHandler));
+apiV2.put('/tasks/:recordId', useRouteHandler(EditTask));
 
 /**
  * DELETE routes

--- a/packages/central-server/src/apiV2/index.js
+++ b/packages/central-server/src/apiV2/index.js
@@ -144,6 +144,7 @@ import {
   GETDashboardMailingListEntries,
 } from './dashboardMailingListEntries';
 import { EditEntityHierarchy, GETEntityHierarchy } from './entityHierarchy';
+import { GETTasks } from './tasks';
 
 // quick and dirty permission wrapper for open endpoints
 const allowAnyone = routeHandler => (req, res, next) => {
@@ -267,7 +268,7 @@ apiV2.get(
 apiV2.get('/entityHierarchy/:recordId?', useRouteHandler(GETEntityHierarchy));
 apiV2.get('/landingPages/:recordId?', useRouteHandler(GETLandingPages));
 apiV2.get('/suggestSurveyCode', catchAsyncErrors(suggestSurveyCode));
-
+apiV2.get('/tasks/:recordId?', useRouteHandler(GETTasks));
 /**
  * POST routes
  */

--- a/packages/central-server/src/apiV2/tasks/CreateTask.js
+++ b/packages/central-server/src/apiV2/tasks/CreateTask.js
@@ -1,0 +1,26 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2024 Beyond Essential Systems Pty Ltd
+ */
+import { CreateHandler } from '../CreateHandler';
+import { assertAnyPermissions, assertBESAdminAccess } from '../../permissions';
+import { assertUserHasPermissionToCreateTask } from './assertTaskPermissions';
+/**
+ * Handles POST endpoints:
+ * - /tasks
+ */
+
+export class CreateTask extends CreateHandler {
+  async assertUserHasAccess() {
+    const createPermissionChecker = accessPolicy =>
+      assertUserHasPermissionToCreateTask(accessPolicy, this.models, this.newRecordData);
+
+    await this.assertPermissions(
+      assertAnyPermissions([assertBESAdminAccess, createPermissionChecker]),
+    );
+  }
+
+  async createRecord() {
+    await this.insertRecord();
+  }
+}

--- a/packages/central-server/src/apiV2/tasks/EditTask.js
+++ b/packages/central-server/src/apiV2/tasks/EditTask.js
@@ -1,0 +1,20 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2024 Beyond Essential Systems Pty Ltd
+ */
+
+import { EditHandler } from '../EditHandler';
+import { assertAnyPermissions, assertBESAdminAccess } from '../../permissions';
+import { assertUserCanEditTask } from './assertTaskPermissions';
+
+export class EditTask extends EditHandler {
+  async assertUserHasAccess() {
+    const permissionChecker = accessPolicy =>
+      assertUserCanEditTask(accessPolicy, this.models, this.recordId, this.updatedFields);
+    await this.assertPermissions(assertAnyPermissions([assertBESAdminAccess, permissionChecker]));
+  }
+
+  async editRecord() {
+    await this.updateRecord();
+  }
+}

--- a/packages/central-server/src/apiV2/tasks/GETTasks.js
+++ b/packages/central-server/src/apiV2/tasks/GETTasks.js
@@ -1,0 +1,41 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2020 Beyond Essential Systems Pty Ltd
+ */
+
+import { assertAnyPermissions, assertBESAdminAccess } from '../../permissions';
+import { GETHandler } from '../GETHandler';
+import { assertUserHasTaskPermissions, createTaskDBFilter } from './assertTaskPermissions';
+
+export class GETTasks extends GETHandler {
+  permissionsFilteredInternally = true;
+
+  customJoinConditions = {
+    entity: {
+      nearTableKey: 'task.entity_id',
+      farTableKey: 'entity.id',
+    },
+    survey: {
+      nearTableKey: 'task.survey_id',
+      farTableKey: 'survey.id',
+    },
+    user_account: {
+      nearTableKey: 'task.assignee_id',
+      farTableKey: 'user_account.id',
+    },
+  };
+
+  async getPermissionsFilter(criteria, options) {
+    return createTaskDBFilter(this.accessPolicy, this.models, criteria, options);
+  }
+
+  async findSingleRecord(projectId, options) {
+    const taskPermissionChecker = accessPolicy =>
+      assertUserHasTaskPermissions(accessPolicy, this.models, projectId);
+    await this.assertPermissions(
+      assertAnyPermissions([assertBESAdminAccess, taskPermissionChecker]),
+    );
+
+    return super.findSingleRecord(projectId, options);
+  }
+}

--- a/packages/central-server/src/apiV2/tasks/assertTaskPermissions.js
+++ b/packages/central-server/src/apiV2/tasks/assertTaskPermissions.js
@@ -1,0 +1,83 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2024 Beyond Essential Systems Pty Ltd
+ */
+
+import { RECORDS } from '@tupaia/database';
+import { hasBESAdminAccess } from '../../permissions';
+import { fetchCountryCodesByPermissionGroupId, mergeFilter, mergeMultiJoin } from '../utilities';
+
+const getUserSurveysForProject = async (models, accessPolicy, projectId) => {
+  const userSurveys = await models.survey.findByAccessPolicy(
+    accessPolicy,
+    {
+      project_id: projectId,
+    },
+    {
+      columns: ['id'],
+    },
+  );
+  return userSurveys;
+};
+
+export const createTaskDBFilter = async (accessPolicy, models, criteria, options) => {
+  if (hasBESAdminAccess(accessPolicy)) {
+    return { dbConditions: criteria, dbOptions: options };
+  }
+  const { projectId, ...dbConditions } = { ...criteria };
+  const dbOptions = { ...options };
+
+  const countryCodesByPermissionGroupId = await fetchCountryCodesByPermissionGroupId(
+    accessPolicy,
+    models,
+  );
+
+  const surveys = await getUserSurveysForProject(models, accessPolicy, projectId);
+
+  dbConditions['entity.country_code'] = mergeFilter(
+    {
+      comparator: 'IN',
+      comparisonValue: Object.values(countryCodesByPermissionGroupId).flat(),
+    },
+    dbConditions['entity.country_code'],
+  );
+
+  dbConditions['task.survey_id'] = mergeFilter(
+    {
+      comparator: 'IN',
+      comparisonValue: surveys.map(survey => survey.id),
+    },
+    dbConditions['task.survey_id'],
+  );
+
+  dbOptions.multiJoin = mergeMultiJoin(
+    [
+      {
+        joinWith: RECORDS.ENTITY,
+        joinCondition: [`${RECORDS.ENTITY}.id`, `${RECORDS.TASK}.entity_id`],
+      },
+    ],
+    dbOptions.multiJoin,
+  );
+  return { dbConditions, dbOptions };
+};
+
+export const assertUserHasTaskPermissions = async (accessPolicy, models, taskId) => {
+  const task = await models.task.findById(taskId);
+  if (!task) {
+    throw new Error(`No task found with id ${taskId}`);
+  }
+
+  const entity = await task.entity();
+  if (!accessPolicy.allows(entity.country_code)) {
+    throw new Error('Need to have access to the country of the task');
+  }
+
+  const userSurveys = await getUserSurveysForProject(models, accessPolicy, task.project_id);
+  const survey = userSurveys.find(({ id }) => id === task.survey_id);
+  if (!survey) {
+    throw new Error('Need to have access to the survey of the task');
+  }
+
+  return true;
+};

--- a/packages/central-server/src/apiV2/tasks/assertTaskPermissions.js
+++ b/packages/central-server/src/apiV2/tasks/assertTaskPermissions.js
@@ -109,14 +109,14 @@ export const assertUserCanEditTask = async (accessPolicy, models, taskId, newRec
       throw new Error(`No entity found with id ${newRecordData.entity_id}`);
     }
     if (!accessPolicy.allows(entity.country_code)) {
-      throw new Error('Need to have access to the country of the task');
+      throw new Error('Need to have access to the new entity of the task');
     }
   }
   if (newRecordData.survey_id) {
     const userSurveys = await getUserSurveys(models, accessPolicy);
     const survey = userSurveys.find(({ id }) => id === newRecordData.survey_id);
     if (!survey) {
-      throw new Error('Need to have access to the survey of the task');
+      throw new Error('Need to have access to the new survey of the task');
     }
   }
   return true;

--- a/packages/central-server/src/apiV2/tasks/assertTaskPermissions.js
+++ b/packages/central-server/src/apiV2/tasks/assertTaskPermissions.js
@@ -81,3 +81,24 @@ export const assertUserHasTaskPermissions = async (accessPolicy, models, taskId)
 
   return true;
 };
+
+export const assertUserHasPermissionToCreateTask = async (accessPolicy, models, taskData) => {
+  const { entity_id: entityId, survey_id: surveyId } = taskData;
+
+  const entity = await models.entity.findById(entityId);
+  if (!entity) {
+    throw new Error(`No entity found with id ${entityId}`);
+  }
+
+  if (!accessPolicy.allows(entity.country_code)) {
+    throw new Error('Need to have access to the country of the task');
+  }
+
+  const userSurveys = await getUserSurveysForProject(models, accessPolicy, entity.project_id);
+  const survey = userSurveys.find(({ id }) => id === surveyId);
+  if (!survey) {
+    throw new Error('Need to have access to the survey of the task');
+  }
+
+  return true;
+};

--- a/packages/central-server/src/apiV2/tasks/index.js
+++ b/packages/central-server/src/apiV2/tasks/index.js
@@ -1,0 +1,6 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2024 Beyond Essential Systems Pty Ltd
+ */
+
+export { GETTasks } from './GETTasks';

--- a/packages/central-server/src/apiV2/tasks/index.js
+++ b/packages/central-server/src/apiV2/tasks/index.js
@@ -5,3 +5,4 @@
 
 export { GETTasks } from './GETTasks';
 export { CreateTask } from './CreateTask';
+export { EditTask } from './EditTask';

--- a/packages/central-server/src/apiV2/tasks/index.js
+++ b/packages/central-server/src/apiV2/tasks/index.js
@@ -4,3 +4,4 @@
  */
 
 export { GETTasks } from './GETTasks';
+export { CreateTask } from './CreateTask';

--- a/packages/central-server/src/apiV2/utilities/constructNewRecordValidationRules.js
+++ b/packages/central-server/src/apiV2/utilities/constructNewRecordValidationRules.js
@@ -440,6 +440,22 @@ export const constructForSingle = (models, recordType) => {
         code: [isAString],
         config: [hasContent],
       };
+    case RECORDS.TASK:
+      return {
+        entity_id: [constructRecordExistsWithId(models.entity)],
+        survey_id: [constructRecordExistsWithId(models.survey)],
+        assignee_id: [constructRecordExistsWithId(models.user)],
+        due_date: [hasContent],
+        is_recurring: [hasContent, isBoolean],
+        repeat_frequency: [
+          (value, { is_recurring: isRecurring }) => {
+            if (isRecurring && !value) {
+              throw new Error('Repeat frequency is required for recurring tasks');
+            }
+            return true;
+          },
+        ],
+      };
     default:
       throw new ValidationError(`${recordType} is not a valid POST endpoint`);
   }

--- a/packages/central-server/src/tests/apiV2/tasks/CreateTask.test.js
+++ b/packages/central-server/src/tests/apiV2/tasks/CreateTask.test.js
@@ -1,0 +1,160 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2024 Beyond Essential Systems Pty Ltd
+ */
+
+import { expect } from 'chai';
+import {
+  buildAndInsertSurveys,
+  findOrCreateDummyCountryEntity,
+  findOrCreateDummyRecord,
+  generateId,
+} from '@tupaia/database';
+import { TestableApp, resetTestData } from '../../testUtilities';
+import { BES_ADMIN_PERMISSION_GROUP } from '../../../permissions';
+
+describe('Permissions checker for CreateTask', async () => {
+  const BES_ADMIN_POLICY = {
+    DL: [BES_ADMIN_PERMISSION_GROUP],
+  };
+
+  const DEFAULT_POLICY = {
+    TO: ['Donor'],
+  };
+
+  const PUBLIC_POLICY = {
+    DL: ['Public'],
+  };
+
+  const app = new TestableApp();
+  const { models } = app;
+  let surveys;
+  const facilities = [
+    {
+      id: generateId(),
+      code: 'TEST_FACILITY_1',
+      name: 'Test Facility 1',
+      country_code: 'TO',
+    },
+    {
+      id: generateId(),
+      code: 'TEST_FACILITY_2',
+      name: 'Test Facility 2',
+      country_code: 'DL',
+    },
+  ];
+  const assignee = {
+    id: generateId(),
+    first_name: 'Peter',
+    last_name: 'Pan',
+  };
+
+  before(async () => {
+    const { country: tongaCountry } = await findOrCreateDummyCountryEntity(models, {
+      code: 'TO',
+      name: 'Tonga',
+    });
+
+    const { country: dlCountry } = await findOrCreateDummyCountryEntity(models, {
+      code: 'DL',
+      name: 'Demo Land',
+    });
+
+    const donorPermission = await findOrCreateDummyRecord(models.permissionGroup, {
+      name: 'Donor',
+    });
+    const BESAdminPermission = await findOrCreateDummyRecord(models.permissionGroup, {
+      name: 'Admin',
+    });
+
+    await Promise.all(
+      facilities.map(async facility => {
+        await findOrCreateDummyRecord(models.entity, facility);
+      }),
+    );
+
+    surveys = await buildAndInsertSurveys(models, [
+      {
+        code: 'TEST_SURVEY_1',
+        name: 'Test Survey 1',
+        permission_group_id: BESAdminPermission.id,
+        country_ids: [tongaCountry.id, dlCountry.id],
+      },
+      {
+        code: 'TEST_SURVEY_2',
+        name: 'Test Survey 2',
+        permission_group_id: donorPermission.id,
+        country_ids: [tongaCountry.id],
+      },
+    ]);
+
+    await findOrCreateDummyRecord(models.user, assignee);
+  });
+
+  afterEach(() => {
+    app.revokeAccess();
+  });
+
+  after(async () => {
+    await resetTestData();
+  });
+
+  describe('POST /tasks', async () => {
+    it('Sufficient permissions: allows a user to create a task if they have BES Admin permission', async () => {
+      await app.grantAccess(BES_ADMIN_POLICY);
+      const { body: result } = await app.post('tasks', {
+        body: {
+          entity_id: facilities[0].id,
+          survey_id: surveys[0].survey.id,
+          assignee_id: assignee.id,
+          is_recurring: false,
+          due_date: new Date('2021-12-31'),
+        },
+      });
+
+      expect(result.message).to.equal('Successfully created tasks');
+    });
+
+    it('Sufficient permissions: Allows a user to create a task for a survey and entity they have access to', async () => {
+      await app.grantAccess(DEFAULT_POLICY);
+      const { body: result } = await app.post('tasks', {
+        body: {
+          entity_id: facilities[0].id,
+          survey_id: surveys[1].survey.id,
+          assignee_id: assignee.id,
+          is_recurring: false,
+          due_date: new Date('2021-12-31'),
+        },
+      });
+      expect(result.message).to.equal('Successfully created tasks');
+    });
+
+    it('Insufficient permissions: Does not allow user to create a task for an entity they do not have access to', async () => {
+      await app.grantAccess(DEFAULT_POLICY);
+      const { body: result } = await app.post('tasks', {
+        body: {
+          entity_id: facilities[1].id,
+          survey_id: surveys[1].survey.id,
+          assignee_id: assignee.id,
+          is_recurring: false,
+          due_date: new Date('2021-12-31'),
+        },
+      });
+      expect(result).to.have.keys('error');
+    });
+
+    it('Insufficient permissions: Does not allow user to create a task for a survey they do not have access to', async () => {
+      await app.grantAccess(DEFAULT_POLICY);
+      const { body: result } = await app.post('tasks', {
+        body: {
+          entity_id: facilities[0].id,
+          survey_id: surveys[0].survey.id,
+          assignee_id: assignee.id,
+          is_recurring: false,
+          due_date: new Date('2021-12-31'),
+        },
+      });
+      expect(result).to.have.keys('error');
+    });
+  });
+});

--- a/packages/central-server/src/tests/apiV2/tasks/GETTasks.test.js
+++ b/packages/central-server/src/tests/apiV2/tasks/GETTasks.test.js
@@ -64,11 +64,7 @@ describe('Permissions checker for GETTasks', async () => {
       },
     ];
 
-    await Promise.all(
-      facilities.map(async facility => {
-        await findOrCreateDummyRecord(models.entity, facility);
-      }),
-    );
+    await Promise.all(facilities.map(facility => findOrCreateDummyRecord(models.entity, facility)));
 
     const surveys = await buildAndInsertSurveys(models, [
       {
@@ -99,9 +95,7 @@ describe('Permissions checker for GETTasks', async () => {
     ];
 
     await Promise.all(
-      assignees.map(async assignee => {
-        await findOrCreateDummyRecord(models.user, assignee);
-      }),
+      assignees.map(async assignee => findOrCreateDummyRecord(models.user, assignee)),
     );
 
     const dueDate = new Date('2021-12-31');
@@ -125,11 +119,7 @@ describe('Permissions checker for GETTasks', async () => {
       },
     ];
 
-    await Promise.all(
-      tasks.map(async task => {
-        await findOrCreateDummyRecord(models.task, task);
-      }),
-    );
+    await Promise.all(tasks.map(task => findOrCreateDummyRecord(models.task, task)));
   });
 
   afterEach(() => {

--- a/packages/central-server/src/tests/apiV2/tasks/GETTasks.test.js
+++ b/packages/central-server/src/tests/apiV2/tasks/GETTasks.test.js
@@ -1,0 +1,192 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2024 Beyond Essential Systems Pty Ltd
+ */
+
+import { expect } from 'chai';
+import {
+  buildAndInsertSurveys,
+  findOrCreateDummyCountryEntity,
+  findOrCreateDummyRecord,
+  generateId,
+} from '@tupaia/database';
+import { TestableApp, resetTestData } from '../../testUtilities';
+import { BES_ADMIN_PERMISSION_GROUP } from '../../../permissions';
+
+describe('Permissions checker for GETTasks', async () => {
+  const BES_ADMIN_POLICY = {
+    DL: [BES_ADMIN_PERMISSION_GROUP],
+  };
+
+  const DEFAULT_POLICY = {
+    DL: ['Donor'],
+    TO: ['Donor'],
+  };
+
+  const PUBLIC_POLICY = {
+    DL: ['Public'],
+  };
+
+  const app = new TestableApp();
+  const { models } = app;
+  let tasks;
+
+  before(async () => {
+    const { country: tongaCountry } = await findOrCreateDummyCountryEntity(models, {
+      code: 'TO',
+      name: 'Tonga',
+    });
+
+    const { country: dlCountry } = await findOrCreateDummyCountryEntity(models, {
+      code: 'DL',
+      name: 'Demo Land',
+    });
+
+    const donorPermission = await findOrCreateDummyRecord(models.permissionGroup, {
+      name: 'Donor',
+    });
+    const BESAdminPermission = await findOrCreateDummyRecord(models.permissionGroup, {
+      name: 'Admin',
+    });
+
+    const facilities = [
+      {
+        id: generateId(),
+        code: 'TEST_FACILITY_1',
+        name: 'Test Facility 1',
+        country_code: tongaCountry.code,
+      },
+      {
+        id: generateId(),
+        code: 'TEST_FACILITY_2',
+        name: 'Test Facility 2',
+        country_code: dlCountry.code,
+      },
+    ];
+
+    await Promise.all(
+      facilities.map(async facility => {
+        await findOrCreateDummyRecord(models.entity, facility);
+      }),
+    );
+
+    const surveys = await buildAndInsertSurveys(models, [
+      {
+        code: 'TEST_SURVEY_1',
+        name: 'Test Survey 1',
+        permission_group_id: BESAdminPermission.id,
+        country_ids: [tongaCountry.id, dlCountry.id],
+      },
+      {
+        code: 'TEST_SURVEY_2',
+        name: 'Test Survey 2',
+        permission_group_id: donorPermission.id,
+        country_ids: [tongaCountry.id, dlCountry.id],
+      },
+    ]);
+
+    const assignees = [
+      {
+        id: generateId(),
+        first_name: 'Peter',
+        last_name: 'Pan',
+      },
+      {
+        id: generateId(),
+        first_name: 'Minnie',
+        last_name: 'Mouse',
+      },
+    ];
+
+    await Promise.all(
+      assignees.map(async assignee => {
+        await findOrCreateDummyRecord(models.user, assignee);
+      }),
+    );
+
+    const dueDate = new Date('2021-12-31');
+
+    tasks = [
+      {
+        id: generateId(),
+        survey_id: surveys[0].survey.id,
+        entity_id: facilities[0].id,
+        assignee_id: assignees[0].id,
+        is_recurring: false,
+        due_date: dueDate,
+      },
+      {
+        id: generateId(),
+        survey_id: surveys[1].survey.id,
+        entity_id: facilities[1].id,
+        assignee_id: assignees[1].id,
+        is_recurring: false,
+        due_date: dueDate,
+      },
+    ];
+
+    await Promise.all(
+      tasks.map(async task => {
+        await findOrCreateDummyRecord(models.task, task);
+      }),
+    );
+  });
+
+  afterEach(() => {
+    app.revokeAccess();
+  });
+
+  after(async () => {
+    await resetTestData();
+  });
+
+  describe('GET /tasks/:id', async () => {
+    it('Sufficient permissions: returns a requested task when user has BES admin permissions', async () => {
+      await app.grantAccess(BES_ADMIN_POLICY);
+      const { body: result } = await app.get(`tasks/${tasks[0].id}`);
+      expect(result.id).to.equal(tasks[0].id);
+    });
+
+    it('Sufficient permissions: returns a requested task when user has permissions', async () => {
+      await app.grantAccess(DEFAULT_POLICY);
+      const { body: result } = await app.get(`tasks/${tasks[1].id}`);
+
+      expect(result.id).to.equal(tasks[1].id);
+    });
+
+    it('Insufficient permissions: throws an error if requesting task when user does not have permissions', async () => {
+      await app.grantAccess(DEFAULT_POLICY);
+      const { body: result } = await app.get(`tasks/${tasks[0].id}`);
+
+      expect(result).to.have.keys('error');
+    });
+  });
+
+  describe('GET /tasks', async () => {
+    it('Sufficient permissions: returns all tasks if the user has BES admin access', async () => {
+      await app.grantAccess(BES_ADMIN_POLICY);
+      const { body: results } = await app.get('tasks');
+      expect(results.length).to.equal(tasks.length);
+      const resultIds = results.map(r => r.id);
+      tasks.forEach(task => {
+        expect(resultIds.includes(task.id)).to.equal(true);
+      });
+    });
+
+    it('Sufficient permissions: returns tasks when user has permissions', async () => {
+      await app.grantAccess(DEFAULT_POLICY);
+      const { body: results } = await app.get('tasks');
+
+      expect(results.length).to.equal(1);
+      const resultIds = results.map(r => r.id);
+      expect(resultIds[0]).to.equal(tasks[1].id);
+    });
+
+    it('Insufficient permissions: returns an empty array if users do not have access to any project', async () => {
+      await app.grantAccess(PUBLIC_POLICY);
+      const { body: results } = await app.get('tasks');
+
+      expect(results).to.be.empty;
+    });
+  });
+});

--- a/packages/database/src/migrations/20240617005418-CreateTaskTable-modifies-schema.js
+++ b/packages/database/src/migrations/20240617005418-CreateTaskTable-modifies-schema.js
@@ -1,0 +1,73 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+const createDataSourceFK = (columnName, table) => ({
+  name: `task_${columnName}_fk`,
+  table,
+  mapping: 'id',
+  rules: {
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+});
+
+const createStatusEnum = db => {
+  return db.runSql(`
+    CREATE TYPE TASK_STATUS AS ENUM('to_do', 'completed', 'overdue', 'cancelled');
+ 
+  `);
+};
+
+const createTaskTable = db => {
+  return db.createTable('task', {
+    columns: {
+      id: { type: 'text', primaryKey: true },
+      survey_id: {
+        type: 'text',
+        notNull: true,
+        foreignKey: createDataSourceFK('survey_id', 'survey'),
+      },
+      entity_id: {
+        type: 'text',
+        notNull: true,
+        foreignKey: createDataSourceFK('entity_id', 'entity'),
+      },
+      assignee_id: {
+        type: 'text',
+        notNull: true,
+        foreignKey: createDataSourceFK('assignee_id', 'user_account'),
+      },
+      is_recurring: { type: 'boolean', notNull: true, defaultValue: false },
+      repeat_frequency: { type: 'jsonb', notNull: true, defaultValue: '{}' },
+      due_date: { type: 'timestamp', notNull: true },
+      status: { type: 'TASK_STATUS', notNull: true, defaultValue: 'to_do' },
+    },
+    ifNotExists: true,
+  });
+};
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = async function (db) {
+  await createStatusEnum(db);
+  return createTaskTable(db);
+};
+
+exports.down = function (db) {
+  return db.dropTable('task');
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/packages/database/src/migrations/20240617005418-CreateTaskTable-modifies-schema.js
+++ b/packages/database/src/migrations/20240617005418-CreateTaskTable-modifies-schema.js
@@ -66,8 +66,8 @@ exports.up = async function (db) {
 };
 
 exports.down = async function (db) {
-  await db.runSql('DROP TYPE TASK_STATUS;');
-  return db.dropTable('task');
+  await db.dropTable('task');
+  return db.runSql('DROP TYPE TASK_STATUS;');
 };
 
 exports._meta = {

--- a/packages/database/src/migrations/20240617005418-CreateTaskTable-modifies-schema.js
+++ b/packages/database/src/migrations/20240617005418-CreateTaskTable-modifies-schema.js
@@ -16,6 +16,7 @@ const createDataSourceFK = (columnName, table) => ({
 
 const createStatusEnum = db => {
   return db.runSql(`
+    DROP TYPE IF EXISTS TASK_STATUS;
     CREATE TYPE TASK_STATUS AS ENUM('to_do', 'completed', 'overdue', 'cancelled');
  
   `);
@@ -64,7 +65,8 @@ exports.up = async function (db) {
   return createTaskTable(db);
 };
 
-exports.down = function (db) {
+exports.down = async function (db) {
+  await db.runSql('DROP TYPE TASK_STATUS;');
   return db.dropTable('task');
 };
 

--- a/packages/database/src/modelClasses/Task.js
+++ b/packages/database/src/modelClasses/Task.js
@@ -1,6 +1,6 @@
 /**
  * Tupaia
- * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ * Copyright (c) 2017 - 2024 Beyond Essential Systems Pty Ltd
  */
 
 import { DatabaseModel } from '../DatabaseModel';

--- a/packages/database/src/modelClasses/Task.js
+++ b/packages/database/src/modelClasses/Task.js
@@ -1,0 +1,37 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2021 Beyond Essential Systems Pty Ltd
+ */
+
+import { DatabaseModel } from '../DatabaseModel';
+import { DatabaseRecord } from '../DatabaseRecord';
+import { RECORDS } from '../records';
+
+class TaskRecord extends DatabaseRecord {
+  static databaseRecord = RECORDS.TASK;
+
+  async entity() {
+    return this.otherModels.entity.findById(this.entity_id);
+  }
+
+  async assignee() {
+    return this.otherModels.userAccount.findById(this.assignee_id);
+  }
+
+  async survey() {
+    return this.otherModels.survey.findById(this.survey_id);
+  }
+}
+
+export class TaskModel extends DatabaseModel {
+  get DatabaseRecordClass() {
+    return TaskRecord;
+  }
+
+  taskStatuses = {
+    TO_DO: 'to_do',
+    COMPLETED: 'completed',
+    OVERDUE: 'overdue',
+    CANCELLED: 'cancelled',
+  };
+}

--- a/packages/database/src/modelClasses/Task.js
+++ b/packages/database/src/modelClasses/Task.js
@@ -7,7 +7,7 @@ import { DatabaseModel } from '../DatabaseModel';
 import { DatabaseRecord } from '../DatabaseRecord';
 import { RECORDS } from '../records';
 
-class TaskRecord extends DatabaseRecord {
+export class TaskRecord extends DatabaseRecord {
   static databaseRecord = RECORDS.TASK;
 
   async entity() {

--- a/packages/database/src/modelClasses/index.js
+++ b/packages/database/src/modelClasses/index.js
@@ -59,6 +59,7 @@ import { DataServiceEntityModel } from './DataServiceEntity';
 import { DhisInstanceModel } from './DhisInstance';
 import { DataElementDataServiceModel } from './DataElementDataService';
 import { SupersetInstanceModel } from './SupersetInstance';
+import { TaskModel } from './Task';
 
 // export all models to be used in constructing a ModelRegistry
 export const modelClasses = {
@@ -114,6 +115,7 @@ export const modelClasses = {
   SurveyScreen: SurveyScreenModel,
   SurveyScreenComponent: SurveyScreenComponentModel,
   SyncGroupLog: SyncGroupLogModel,
+  Task: TaskModel,
   User: UserModel,
   UserEntityPermission: UserEntityPermissionModel,
   UserFavouriteDashboardItem: UserFavouriteDashboardItemModel,
@@ -181,3 +183,4 @@ export {
 export { DashboardRelationRecord, DashboardRelationModel } from './DashboardRelation';
 export { OneTimeLoginRecord, OneTimeLoginModel } from './OneTimeLogin';
 export { AnswerModel, AnswerRecord } from './Answer';
+export { TaskModel, TaskRecord } from './Task';

--- a/packages/database/src/records.js
+++ b/packages/database/src/records.js
@@ -62,6 +62,7 @@ export const RECORDS = {
   SURVEY_SCREEN: 'survey_screen',
   SURVEY: 'survey',
   SYNC_GROUP_LOG: 'sync_group_log',
+  TASK: 'task',
   USER_ACCOUNT: 'user_account',
   USER_ENTITY_PERMISSION: 'user_entity_permission',
   USER_FAVOURITE_DASHBOARD_ITEM: 'user_favourite_dashboard_item',

--- a/packages/types/src/schemas/schemas.ts
+++ b/packages/types/src/schemas/schemas.ts
@@ -85599,6 +85599,136 @@ export const SyncGroupLogUpdateSchema = {
 	"additionalProperties": false
 } 
 
+export const TaskSchema = {
+	"type": "object",
+	"properties": {
+		"assignee_id": {
+			"type": "string"
+		},
+		"due_date": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"entity_id": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"is_recurring": {
+			"type": "boolean"
+		},
+		"repeat_frequency": {
+			"type": "object",
+			"properties": {}
+		},
+		"status": {
+			"enum": [
+				"cancelled",
+				"completed",
+				"overdue",
+				"to_do"
+			],
+			"type": "string"
+		},
+		"survey_id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"assignee_id",
+		"due_date",
+		"entity_id",
+		"id",
+		"is_recurring",
+		"repeat_frequency",
+		"status",
+		"survey_id"
+	]
+} 
+
+export const TaskCreateSchema = {
+	"type": "object",
+	"properties": {
+		"assignee_id": {
+			"type": "string"
+		},
+		"due_date": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"entity_id": {
+			"type": "string"
+		},
+		"is_recurring": {
+			"type": "boolean"
+		},
+		"repeat_frequency": {
+			"type": "object",
+			"properties": {}
+		},
+		"status": {
+			"enum": [
+				"cancelled",
+				"completed",
+				"overdue",
+				"to_do"
+			],
+			"type": "string"
+		},
+		"survey_id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"assignee_id",
+		"due_date",
+		"entity_id",
+		"survey_id"
+	]
+} 
+
+export const TaskUpdateSchema = {
+	"type": "object",
+	"properties": {
+		"assignee_id": {
+			"type": "string"
+		},
+		"due_date": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"entity_id": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"is_recurring": {
+			"type": "boolean"
+		},
+		"repeat_frequency": {
+			"type": "object",
+			"properties": {}
+		},
+		"status": {
+			"enum": [
+				"cancelled",
+				"completed",
+				"overdue",
+				"to_do"
+			],
+			"type": "string"
+		},
+		"survey_id": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
+} 
+
 export const TupaiaWebSessionSchema = {
 	"type": "object",
 	"properties": {
@@ -86135,6 +86265,16 @@ export const VerifiedEmailSchema = {
 		"new_user",
 		"unverified",
 		"verified"
+	],
+	"type": "string"
+} 
+
+export const TaskStatusSchema = {
+	"enum": [
+		"cancelled",
+		"completed",
+		"overdue",
+		"to_do"
 	],
 	"type": "string"
 } 

--- a/packages/types/src/types/models.ts
+++ b/packages/types/src/types/models.ts
@@ -1533,6 +1533,35 @@ export interface SyncGroupLogUpdate {
   'sync_group_code'?: string;
   'timestamp'?: Date | null;
 }
+export interface Task {
+  'assignee_id': string;
+  'due_date': Date;
+  'entity_id': string;
+  'id': string;
+  'is_recurring': boolean;
+  'repeat_frequency': {};
+  'status': TaskStatus;
+  'survey_id': string;
+}
+export interface TaskCreate {
+  'assignee_id': string;
+  'due_date': Date;
+  'entity_id': string;
+  'is_recurring'?: boolean;
+  'repeat_frequency'?: {};
+  'status'?: TaskStatus;
+  'survey_id': string;
+}
+export interface TaskUpdate {
+  'assignee_id'?: string;
+  'due_date'?: Date;
+  'entity_id'?: string;
+  'id'?: string;
+  'is_recurring'?: boolean;
+  'repeat_frequency'?: {};
+  'status'?: TaskStatus;
+  'survey_id'?: string;
+}
 export interface TupaiaWebSession {
   'access_policy': {};
   'access_token': string;
@@ -1664,6 +1693,12 @@ export enum VerifiedEmail {
   'unverified' = 'unverified',
   'new_user' = 'new_user',
   'verified' = 'verified',
+}
+export enum TaskStatus {
+  'to_do' = 'to_do',
+  'completed' = 'completed',
+  'overdue' = 'overdue',
+  'cancelled' = 'cancelled',
 }
 export enum SyncGroupSyncStatus {
   'IDLE' = 'IDLE',


### PR DESCRIPTION
### Issue RN-1335: Setup skeleton backend for tasking

### Changes:
- Added `task` table to database
- Added `task` db model
- Added `get`, `create`, `edit` task endpoints and tests
