### PR TITLE
fix(adminPanel): Fix admin panel dashboard relations table

### DIFF
--- a/packages/central-server/src/apiV2/GETHandler/helpers.js
+++ b/packages/central-server/src/apiV2/GETHandler/helpers.js
@@ -42,9 +42,6 @@ export const generateLinkHeader = (resource, pageString, lastPage, originalQuery
   return formatLinkHeader(linkHeader);
 };
 
-/**
- * Used only by {@link processColumnSelector}, so not exported.
- */
 export const fullyQualifyColumnSelector = (models, unprocessedColumnSelector, baseRecordType) => {
   const [resource, column] = unprocessedColumnSelector.includes('.')
     ? unprocessedColumnSelector.split('.')

--- a/packages/central-server/src/apiV2/GETHandler/helpers.js
+++ b/packages/central-server/src/apiV2/GETHandler/helpers.js
@@ -45,7 +45,7 @@ export const generateLinkHeader = (resource, pageString, lastPage, originalQuery
 /**
  * Used only by {@link processColumnSelector}, so not exported.
  */
-const fullyQualifyColumnSelector = (models, unprocessedColumnSelector, baseRecordType) => {
+export const fullyQualifyColumnSelector = (models, unprocessedColumnSelector, baseRecordType) => {
   const [resource, column] = unprocessedColumnSelector.includes('.')
     ? unprocessedColumnSelector.split('.')
     : [baseRecordType, unprocessedColumnSelector];

--- a/packages/central-server/src/apiV2/dashboardRelations/GETDashboardRelations.js
+++ b/packages/central-server/src/apiV2/dashboardRelations/GETDashboardRelations.js
@@ -14,6 +14,7 @@ import {
   createDashboardRelationsViaParentDashboardDBFilter,
   createDashboardRelationsViaParentDashboardItemDBFilter,
 } from './assertDashboardRelationsPermissions';
+import { fullyQualifyColumnSelector } from '../GETHandler/helpers';
 
 /**
  * Handles endpoints:
@@ -33,6 +34,19 @@ export class GETDashboardRelations extends GETHandler {
       farTableKey: 'dashboard_item.id',
     },
   };
+
+  getDbQueryCriteria() {
+    const { filter: filterString } = this.req.query;
+    const filter = filterString ? JSON.parse(filterString) : {};
+    const processedObject = {};
+    Object.entries(filter).forEach(([columnSelector, value]) => {
+      // We don't want to use the customColumnSelectors for dashboard relations since they are not
+      // compatible with the database query so just use fullyQualifyColumnSelector
+      processedObject[fullyQualifyColumnSelector(this.models, columnSelector, this.recordType)] =
+        value;
+    });
+    return processedObject;
+  }
 
   async findSingleRecord(dashboardRelationId, options) {
     const dashboardRelation = await super.findSingleRecord(dashboardRelationId, options);

--- a/packages/central-server/src/apiV2/dashboardRelations/GETDashboardRelations.js
+++ b/packages/central-server/src/apiV2/dashboardRelations/GETDashboardRelations.js
@@ -4,6 +4,7 @@
  */
 
 import { RECORDS } from '@tupaia/database';
+import { fullyQualifyColumnSelector } from '../GETHandler/helpers';
 import { GETHandler } from '../GETHandler';
 import { assertAnyPermissions, assertBESAdminAccess } from '../../permissions';
 import { assertDashboardGetPermissions } from '../dashboards';
@@ -14,7 +15,6 @@ import {
   createDashboardRelationsViaParentDashboardDBFilter,
   createDashboardRelationsViaParentDashboardItemDBFilter,
 } from './assertDashboardRelationsPermissions';
-import { fullyQualifyColumnSelector } from '../GETHandler/helpers';
 
 /**
  * Handles endpoints:


### PR DESCRIPTION
### Issue #: fix(admin panel): Fix admin panel dashboard relations table

### Changes:

- In a recent change [here](https://github.com/beyondessential/tupaia/commit/18b4128b7bed133344ffacfaf07f186f71e35583) there was a change to how getDbQueryCriteria works in the api Getter class to include the custom column selectors which caused an error in the dashboard relations tab query. The custom selector for dashboard relations is used in an unknown number of places so it doesn't seem safe to edit the format of the custom selector. So I have opted to overwrite the getDBQueryCriteria method for GetDashboardRelations instead.

