### PR TITLE
fix(adminPanel): RN-1190: Fix permissions editing

### DIFF
--- a/packages/admin-panel/src/routes/users/permissions.js
+++ b/packages/admin-panel/src/routes/users/permissions.js
@@ -24,7 +24,14 @@ const EntityField = {
 };
 export const PERMISSIONS_ENDPOINT = 'userEntityPermissions';
 export const PERMISSIONS_COLUMNS = [
-  EntityField,
+  {
+    Header: 'Entity',
+    source: 'entity.name',
+    editConfig: {
+      optionsEndpoint: 'entities',
+      baseFilter: { type: 'country' },
+    },
+  },
   {
     Header: 'Permission group',
     source: 'permission_group.name',


### PR DESCRIPTION
### Issue #: RN-1190: Fix permissions editing

In the admin panel, permissions can be bulk created by selecting multiple entities when filling out the create permission group form. However when editing a permission group, the user is in the context of a single permission group so the ui should only allow for selecting one entity.