### PR TITLE
fix(lesmis): RN-1335: Fix DataFetchingTable Action Label

### DIFF
--- a/packages/admin-panel/src/routes/users/users.jsx
+++ b/packages/admin-panel/src/routes/users/users.jsx
@@ -134,9 +134,7 @@ const CREATE_CONFIG = {
           optionsEndpoint: 'countries',
           optionLabelKey: 'name',
           optionValueKey: 'name',
-          labelTooltip: 'Select the country to grant this user access to',
-          type: 'checkboxList',
-          pageSize: 'ALL',
+          secondaryLabel: 'Select the country to grant this user access to',
         },
       },
       {

--- a/packages/admin-panel/src/table/DataFetchingTable/DataFetchingTable.jsx
+++ b/packages/admin-panel/src/table/DataFetchingTable/DataFetchingTable.jsx
@@ -113,7 +113,7 @@ const DataFetchingTableComponent = memo(
     baseFilter,
     basePath,
     resourceName,
-    actionLabel = 'Action',
+    actionLabel,
   }) => {
     const formattedColumns = useMemo(() => {
       const cols = columns.map(column => formatColumnForReactTable(column));
@@ -143,7 +143,7 @@ const DataFetchingTableComponent = memo(
       const buttonWidths = buttonColumns.reduce((acc, { width }) => acc + (width || 60), 0);
       // Group all button columns into a single column so they can be displayed together under a single header
       const singleButtonColumn = {
-        Header: actionLabel,
+        Header: actionLabel || 'Action',
         maxWidth: buttonWidths,
         width: buttonWidths,
         // eslint-disable-next-line react/prop-types


### PR DESCRIPTION
### Issue #: fix(lesmis): RN-1335: Fix DataFetchingTable Action Label

### Changes:

**Fix Lesmis Admin Panel Crash**
The action label can be null if the translation for admin.action in lesmis is blank and this causes the Header field of the action column to be null which creates an error in react query. I have fixed it by simply moving the Action label fallback to account for null values.

An alternative fix which I considered was to change the translation util function in lesmis to return the translation key as a string rather than null but it seemed like too wide of a change for a release fix.

**Revert User Countries Field To Single Select**
Revert the User Countries field back to being a dropdown select rather than a checkbox multi select. The scope of the ticket was to update the multi select drop downs to be checkbox multi selects but this field was accidentally updated too. See slack thread for more details
https://beyondessential.slack.com/archives/C01MAA3NKM1/p1719884909892329