### PR TITLE
fix(adminPanel): RN-1369: addition of entity codes in entity filters on admin panel

### DIFF
--- a/packages/admin-panel/src/VizBuilderApp/components/PreviewOptions/LocationField.jsx
+++ b/packages/admin-panel/src/VizBuilderApp/components/PreviewOptions/LocationField.jsx
@@ -7,6 +7,7 @@ import React, { useState } from 'react';
 import { Autocomplete } from './Autocomplete';
 import { useVizConfigContext } from '../../context';
 import { useEntityByCode, useLocations } from '../../api';
+import { EntityOptionLabel } from '../../../widgets/EntityOptionLabel';
 
 export const LocationField = () => {
   const [locationSearch, setLocationSearch] = useState('');
@@ -39,7 +40,9 @@ export const LocationField = () => {
         setLocationSearch(newValue);
       }}
       getOptionLabel={option => option.name}
-      renderOption={option => <span>{option.name}</span>}
+      renderOption={(option) => {
+        return ( <EntityOptionLabel {...option}/>);
+      }}
       onChange={(_, newLocation) => {
         setLocation(newLocation);
       }}

--- a/packages/admin-panel/src/autocomplete/Autocomplete.jsx
+++ b/packages/admin-panel/src/autocomplete/Autocomplete.jsx
@@ -38,6 +38,7 @@ export const Autocomplete = props => {
     canCreateNewOptions,
     allowMultipleValues,
     optionLabelKey,
+    renderOption,
     muiProps,
     tooltip,
     required,
@@ -109,6 +110,7 @@ export const Autocomplete = props => {
       options={options}
       getOptionSelected={getOptionSelected}
       getOptionLabel={getOptionLabel}
+      renderOption={renderOption}
       loading={isLoading}
       onChange={onChangeSelection}
       onInputChange={(event, newValue) => {
@@ -132,6 +134,7 @@ Autocomplete.propTypes = {
   options: PropTypes.array.isRequired,
   getOptionSelected: PropTypes.func.isRequired,
   getOptionLabel: PropTypes.func.isRequired,
+  renderOption: PropTypes.func,
   isLoading: PropTypes.bool,
   onChangeSelection: PropTypes.func.isRequired,
   onChangeSearchTerm: PropTypes.func,

--- a/packages/admin-panel/src/autocomplete/ReduxAutocomplete.jsx
+++ b/packages/admin-panel/src/autocomplete/ReduxAutocomplete.jsx
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
 import { getAutocompleteState } from './selectors';
 import { changeSelection, changeSearchTerm, clearState } from './actions';
 import { Autocomplete } from './Autocomplete';
+import { EntityOptionLabel } from '../widgets/EntityOptionLabel';
 
 const getPlaceholder = (placeholder, selection) => {
   if (selection && selection.length) {
@@ -39,6 +40,8 @@ const ReduxAutocompleteComponent = ({
   helperText,
   required,
   optionValueKey,
+  optionType,
+  sourceColumns
 }) => {
   const [hasUpdated, setHasUpdated] = React.useState(false);
   React.useEffect(() => {
@@ -67,6 +70,13 @@ const ReduxAutocompleteComponent = ({
     selectedValue = [];
   }
 
+  const renderOption = (option) => { 
+    if(optionType === 'entity'){
+      return <EntityOptionLabel {...option}/>
+    } 
+    return (option && option[optionLabelKey] ? option[optionLabelKey] : '');
+  }
+
   return (
     <Autocomplete
       value={selectedValue}
@@ -84,6 +94,7 @@ const ReduxAutocompleteComponent = ({
       allowMultipleValues={allowMultipleValues}
       optionLabelKey={optionLabelKey}
       required={required}
+      renderOption={renderOption}
     />
   );
 };
@@ -106,6 +117,7 @@ ReduxAutocompleteComponent.propTypes = {
   initialValue: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
   required: PropTypes.bool,
   optionValueKey: PropTypes.string.isRequired,
+  optionType: PropTypes.string
 };
 
 ReduxAutocompleteComponent.defaultProps = {
@@ -143,6 +155,7 @@ const mapDispatchToProps = (
     baseFilter,
     pageSize,
     distinct,
+    sourceColumns
   },
 ) => ({
   programaticallyChangeSelection: initialValue => {
@@ -193,6 +206,7 @@ const mapDispatchToProps = (
         baseFilter,
         pageSize,
         distinct,
+        sourceColumns
       ),
     ),
   onClearState: () => dispatch(clearState(reduxId)),

--- a/packages/admin-panel/src/autocomplete/actions.js
+++ b/packages/admin-panel/src/autocomplete/actions.js
@@ -31,6 +31,7 @@ export const changeSearchTerm =
     baseFilter = {},
     pageSize = MAX_AUTOCOMPLETE_RESULTS,
     distinct = null,
+    columns = null,
   ) =>
   async (dispatch, getState, { api }) => {
     const fetchId = generateId();
@@ -46,9 +47,10 @@ export const changeSearchTerm =
         filter: JSON.stringify(filter),
         pageSize,
         sort: JSON.stringify([`${labelColumn} ASC`]),
-        columns: JSON.stringify([labelColumn, valueColumn]),
+        columns: JSON.stringify(columns ? columns : [labelColumn, valueColumn]),
         distinct,
       });
+      console.log(response);
       dispatch({
         type: AUTOCOMPLETE_RESULTS_CHANGE,
         results: response.body,

--- a/packages/admin-panel/src/routes/visualisations/dashboardMailingLists.js
+++ b/packages/admin-panel/src/routes/visualisations/dashboardMailingLists.js
@@ -48,6 +48,8 @@ const DASHBOARD_MAILING_LIST_FIELDS = {
       optionsEndpoint: 'entities',
       optionLabelKey: 'name',
       optionValueKey: 'id',
+      optionType: 'entity',
+      sourceColumns: ['id', 'code', 'name'],
       secondaryLabel: 'Select the entity this dashboard mailing list should be for',
     },
   },

--- a/packages/admin-panel/src/surveyResponse/ResponseFields.jsx
+++ b/packages/admin-panel/src/surveyResponse/ResponseFields.jsx
@@ -82,8 +82,8 @@ export const ResponseFields = ({
             return option.id === selected.id;
           }}
           getOptionLabel={option => option?.name || ''}
-          renderOption={(props, option) => {
-            return ( <EntityOptionLabel {...props}/>);
+          renderOption={(option) => {
+            return ( <EntityOptionLabel {...option}/>);
           }}
           isLoading={entityIsLoading}
           onChangeSelection={(event, selectedValue) => {

--- a/packages/admin-panel/src/surveyResponse/ResponseFields.jsx
+++ b/packages/admin-panel/src/surveyResponse/ResponseFields.jsx
@@ -16,6 +16,7 @@ import { format } from 'date-fns';
 import { Autocomplete } from '../autocomplete';
 import { useDebounce } from '../utilities';
 import { useEntities } from '../VizBuilderApp/api';
+import { EntityOptionLabel } from '../widgets/EntityOptionLabel';
 
 const SectionWrapper = styled.div`
   display: grid;
@@ -81,6 +82,9 @@ export const ResponseFields = ({
             return option.id === selected.id;
           }}
           getOptionLabel={option => option?.name || ''}
+          renderOption={(props, option) => {
+            return ( <EntityOptionLabel {...props}/>);
+          }}
           isLoading={entityIsLoading}
           onChangeSelection={(event, selectedValue) => {
             if (!selectedValue) {

--- a/packages/admin-panel/src/widgets/EntityOptionLabel.jsx
+++ b/packages/admin-panel/src/widgets/EntityOptionLabel.jsx
@@ -1,0 +1,31 @@
+/*
+ * Tupaia
+ *  Copyright (c) 2017 - 2024 Beyond Essential Systems Pty Ltd
+ */
+
+import React from 'react';
+import styled from 'styled-components';
+
+const StyledEntityOptionLabel = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const Name = styled.span`
+  font-style: bold;
+  color: ${props => props.theme.palette.text.primary};
+`;
+
+const Code = styled.span`
+  margin-top: 4px; 
+  color: ${props => props.theme.palette.text.secondary}; 
+`;
+
+export const EntityOptionLabel = ({ name, code }) => {
+  return (
+    <StyledEntityOptionLabel>
+      <Name>{name}</Name>
+      <Code>{code}</Code>
+    </StyledEntityOptionLabel>
+  );
+};

--- a/packages/admin-panel/src/widgets/InputField/registerInputFields.jsx
+++ b/packages/admin-panel/src/widgets/InputField/registerInputFields.jsx
@@ -81,6 +81,8 @@ export const registerInputFields = () => {
       endpoint={props.optionsEndpoint}
       optionLabelKey={props.optionLabelKey}
       optionValueKey={props.optionValueKey}
+      optionType = {props.optionType}
+      sourceColumns = {props.sourceColumns}
       reduxId={props.inputKey}
       onChange={inputValue => props.onChange(props.inputKey, inputValue)}
       canCreateNewOptions={props.canCreateNewOptions}

--- a/packages/ui-components/src/components/Inputs/Autocomplete.tsx
+++ b/packages/ui-components/src/components/Inputs/Autocomplete.tsx
@@ -56,6 +56,7 @@ export interface BaseAutocompleteProps {
   onChange?: (event: Event, newValue: any) => void;
   getOptionSelected?: (option: any, value: any) => boolean;
   getOptionLabel?: (option: any) => string;
+  renderOption?: (option: any) => JSX.Element;
   placeholder?: string;
   muiProps?: any;
 }
@@ -79,6 +80,7 @@ export const Autocomplete = ({
   label = '',
   getOptionSelected,
   getOptionLabel,
+  renderOption,
   value,
   onChange,
   loading = false,
@@ -111,6 +113,7 @@ export const Autocomplete = ({
     inputValue={inputValue}
     getOptionSelected={getOptionSelected}
     getOptionLabel={getOptionLabel}
+    renderOption={renderOption}
     popupIcon={<KeyboardArrowDown />}
     PaperComponent={StyledPaper}
     renderInput={params => (


### PR DESCRIPTION
### Issue #: RN-1369

### Changes:

- Added custom entity option label component.
- Updated entity filters on viz builder, survey response edit modal and dashboard mailing list modal.

---

### Screenshots:
Before:
![image](https://github.com/beyondessential/tupaia/assets/114740396/97e941a4-312f-40fe-b1e3-525661137153)

After:

<img width="1440" alt="Screenshot 2024-07-10 at 4 38 20 pm" src="https://github.com/beyondessential/tupaia/assets/114740396/198e6cc3-45b9-4af9-aec9-62f576bf769b">
<img width="1440" alt="Screenshot 2024-07-10 at 4 36 22 pm" src="https://github.com/beyondessential/tupaia/assets/114740396/e4a2a83f-3fa8-46a3-9b2f-7f9a950ca9ca">
<img width="1440" alt="Screenshot 2024-07-10 at 4 35 50 pm" src="https://github.com/beyondessential/tupaia/assets/114740396/5a45ba34-61fd-40a8-bc82-2351a9cf15fb">
