### PR TITLE
fix(adminPanel): NOTUP-722: Refresh data on admin panel on successful delete

### DIFF
--- a/packages/admin-panel/src/table/DataFetchingTable/DataFetchingTable.jsx
+++ b/packages/admin-panel/src/table/DataFetchingTable/DataFetchingTable.jsx
@@ -174,6 +174,14 @@ const DataFetchingTableComponent = memo(
       onRefreshData(filters, sorting, pageIndex, pageSize);
     }, [pageSize, pageIndex]);
 
+    // when a delete is successful, the confirmActionMessage will be set to null. Refresh the data here
+    useEffect(() => {
+      // Don't refresh data if there is a confirmActionMessage or errorMessage, or if data is being changed on the server
+      if (confirmActionMessage || errorMessage || isChangingDataOnServer) return;
+
+      onRefreshData(filters, sorting, pageIndex, pageSize);
+    }, [confirmActionMessage, errorMessage, isChangingDataOnServer]);
+
     useEffect(() => {
       if (editorState?.isOpen) return;
       onRefreshData(filters, sorting, pageIndex, pageSize);


### PR DESCRIPTION
### Issue NOTUP-722: Refresh data on admin panel on successful delete

### Changes:
- Fix tables not reloading on successful delete of data