### PR TITLE
feat(datatrakWeb): RN-1339: Link survey responses to tasks

### DIFF
--- a/packages/database/src/migrations/20240715234341-AddTaskSurveyResponseId-modifies-schema.js
+++ b/packages/database/src/migrations/20240715234341-AddTaskSurveyResponseId-modifies-schema.js
@@ -1,0 +1,40 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = async function (db) {
+  await db.addColumn('task', 'survey_response_id', {
+    type: 'text',
+    foreignKey: {
+      name: 'task_survey_response_id_fk',
+      table: 'survey_response',
+      mapping: 'id',
+      // Don't cascade delete, as we want to keep the task even if the survey response is deleted
+      rules: {},
+    },
+    ifNotExists: true,
+  });
+  return db.runSql(` 
+    CREATE INDEX task_survey_response_id_idx ON task USING btree (survey_response_id); 
+  `);
+};
+
+exports.down = function (db) {
+  return db.removeColumn('task', 'survey_response_id');
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/packages/database/src/migrations/20240715234341-AddTaskSurveyResponseId-modifies-schema.js
+++ b/packages/database/src/migrations/20240715234341-AddTaskSurveyResponseId-modifies-schema.js
@@ -21,8 +21,11 @@ exports.up = async function (db) {
       name: 'task_survey_response_id_fk',
       table: 'survey_response',
       mapping: 'id',
-      // Don't cascade delete, as we want to keep the task even if the survey response is deleted
-      rules: {},
+      // Don't cascade delete, as we want to keep the task even if the survey response is deleted, just set as null
+      rules: {
+        onDelete: 'SET NULL',
+        onUpdate: 'CASCADE',
+      },
     },
     ifNotExists: true,
   });

--- a/packages/types/src/schemas/schemas.ts
+++ b/packages/types/src/schemas/schemas.ts
@@ -85732,6 +85732,9 @@ export const TaskSchema = {
 		},
 		"survey_id": {
 			"type": "string"
+		},
+		"survey_response_id": {
+			"type": "string"
 		}
 	},
 	"additionalProperties": false,
@@ -85773,6 +85776,9 @@ export const TaskCreateSchema = {
 			"type": "string"
 		},
 		"survey_id": {
+			"type": "string"
+		},
+		"survey_response_id": {
 			"type": "string"
 		}
 	},
@@ -85816,6 +85822,9 @@ export const TaskUpdateSchema = {
 			"type": "string"
 		},
 		"survey_id": {
+			"type": "string"
+		},
+		"survey_response_id": {
 			"type": "string"
 		}
 	},
@@ -87893,6 +87902,9 @@ export const TaskResponseSchema = {
 				"completed",
 				"to_do"
 			],
+			"type": "string"
+		},
+		"surveyResponseId": {
 			"type": "string"
 		},
 		"assigneeName": {

--- a/packages/types/src/types/models.ts
+++ b/packages/types/src/types/models.ts
@@ -1542,6 +1542,7 @@ export interface Task {
   'repeat_schedule'?: {} | null;
   'status'?: TaskStatus | null;
   'survey_id': string;
+  'survey_response_id'?: string | null;
 }
 export interface TaskCreate {
   'assignee_id'?: string | null;
@@ -1551,6 +1552,7 @@ export interface TaskCreate {
   'repeat_schedule'?: {} | null;
   'status'?: TaskStatus | null;
   'survey_id': string;
+  'survey_response_id'?: string | null;
 }
 export interface TaskUpdate {
   'assignee_id'?: string | null;
@@ -1561,6 +1563,7 @@ export interface TaskUpdate {
   'repeat_schedule'?: {} | null;
   'status'?: TaskStatus | null;
   'survey_id'?: string;
+  'survey_response_id'?: string | null;
 }
 export interface TupaiaWebSession {
   'access_policy': {};


### PR DESCRIPTION
### Issue RN-1339: Link survey responses to tasks

### Changes:
- Added `survey_response_id` column to `task` table
- Updated task change handler to apply `survey_response_id` to completed task
