### PR TITLE
feat(datatrak): RN-1314: Auto populate entity question

### DIFF
--- a/packages/datatrak-web-server/src/routes/SingleSurveyResponseRoute.ts
+++ b/packages/datatrak-web-server/src/routes/SingleSurveyResponseRoute.ts
@@ -22,6 +22,7 @@ const DEFAULT_FIELDS = [
   'country.name',
   'data_time',
   'entity.name',
+  'entity.id',
   'id',
   'survey.name',
   'survey.code',

--- a/packages/datatrak-web/src/features/Survey/SurveyContext/SurveyContext.tsx
+++ b/packages/datatrak-web/src/features/Survey/SurveyContext/SurveyContext.tsx
@@ -33,6 +33,7 @@ const defaultContext = {
   displayQuestions: [],
   sideMenuOpen: false,
   cancelModalOpen: false,
+  primaryEntityQuestion: null,
 } as SurveyFormContextType;
 
 const SurveyFormContext = createContext(defaultContext);
@@ -66,6 +67,9 @@ export const SurveyContext = ({ children }) => {
     .filter(screen => screen.surveyScreenComponents.length > 0);
 
   const activeScreen = visibleScreens?.[screenNumber! - 1]?.surveyScreenComponents || [];
+  const primaryEntityQuestion = flattenedScreenComponents.find(
+    question => question.type === QuestionType.PrimaryEntity,
+  );
 
   const initialiseFormData = () => {
     if (!surveyCode || isResponseScreen) return;
@@ -75,13 +79,8 @@ export const SurveyContext = ({ children }) => {
       formData,
     );
 
-    if (primaryEntity) {
-      const primaryEntityQuestion = flattenedScreenComponents.find(
-        question => question.type === QuestionType.PrimaryEntity,
-      );
-      if (primaryEntityQuestion) {
-        initialFormData[primaryEntityQuestion.id] = primaryEntity;
-      }
+    if (primaryEntity && primaryEntityQuestion) {
+      initialFormData[primaryEntityQuestion.id as string] = primaryEntity;
     }
     dispatch({ type: ACTION_TYPES.SET_FORM_DATA, payload: initialFormData });
     // update the start time when a survey is started, so that it can be passed on when submitting the survey
@@ -115,6 +114,7 @@ export const SurveyContext = ({ children }) => {
         screenHeader,
         screenDetail,
         visibleScreens,
+        primaryEntityQuestion,
       }}
     >
       <SurveyFormDispatchContext.Provider value={dispatch}>

--- a/packages/datatrak-web/src/features/Survey/SurveyContext/reducer.ts
+++ b/packages/datatrak-web/src/features/Survey/SurveyContext/reducer.ts
@@ -25,6 +25,7 @@ export type SurveyFormContextType = {
   surveyStartTime?: string;
   isSuccessScreen?: boolean;
   cancelModalOpen: boolean;
+  primaryEntityQuestion?: SurveyScreenComponent | null;
 };
 
 export const surveyReducer = (

--- a/packages/datatrak-web/src/features/Tasks/TasksTable/ActionButton.tsx
+++ b/packages/datatrak-web/src/features/Tasks/TasksTable/ActionButton.tsx
@@ -65,6 +65,7 @@ export const ActionButton = ({ task }: ActionButtonProps) => {
       variant="contained"
       state={{
         from: location.pathname,
+        primaryEntity: entity.id,
       }}
     >
       Complete task

--- a/packages/datatrak-web/src/utils/index.ts
+++ b/packages/datatrak-web/src/utils/index.ts
@@ -14,3 +14,4 @@ export {
   getTaskFilterSetting,
   removeTaskFilterSetting,
 } from './taskFilterSettings';
+export { usePrimaryEntityLocation } from './usePrimaryEntityLocation';

--- a/packages/datatrak-web/src/utils/usePrimaryEntityLocation.ts
+++ b/packages/datatrak-web/src/utils/usePrimaryEntityLocation.ts
@@ -1,0 +1,18 @@
+/*
+ * Tupaia
+ *  Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
+ */
+
+import { useLocation } from 'react-router-dom';
+
+function hasPrimaryEntity(state: unknown): state is { primaryEntity: string } {
+  if (state !== null && typeof state === 'object' && 'primaryEntity' in state) {
+    return typeof state.primaryEntity === 'string';
+  }
+  return false;
+}
+
+export function usePrimaryEntityLocation() {
+  const location = useLocation();
+  return hasPrimaryEntity(location.state) ? location.state.primaryEntity : undefined;
+}

--- a/packages/datatrak-web/src/views/SurveyResponsePage.tsx
+++ b/packages/datatrak-web/src/views/SurveyResponsePage.tsx
@@ -80,20 +80,24 @@ const getSubHeadingText = surveyResponse => {
 
 export const SurveyResponsePage = () => {
   const { surveyResponseId } = useParams();
-  const { setFormData } = useSurveyForm();
+  const { setFormData, primaryEntityQuestion } = useSurveyForm();
   const formContext = useFormContext();
   const { data: surveyResponse } = useSurveyResponse(surveyResponseId);
   const answers = surveyResponse?.answers || {};
+  const primaryEntityId = surveyResponse?.entityId;
   const subHeading = getSubHeadingText(surveyResponse);
 
   useEffect(() => {
     if (answers) {
       // Format the answers to be compatible with the form, i.e. parse stringified objects
-      const formattedAnswers = Object.entries(answers).reduce((acc, [key, value]) => {
+      let formattedAnswers = Object.entries(answers).reduce((acc, [key, value]) => {
         // If the value is a stringified object, parse it
         const isStringifiedObject = typeof value === 'string' && value.startsWith('{');
         return { ...acc, [key]: isStringifiedObject ? JSON.parse(value) : value };
       }, {});
+      if (primaryEntityQuestion) {
+        formattedAnswers[primaryEntityQuestion.id as string] = primaryEntityId;
+      }
       formContext.reset(formattedAnswers);
       setFormData(formattedAnswers);
     }

--- a/packages/datatrak-web/src/views/SurveyResponsePage.tsx
+++ b/packages/datatrak-web/src/views/SurveyResponsePage.tsx
@@ -90,7 +90,7 @@ export const SurveyResponsePage = () => {
   useEffect(() => {
     if (answers) {
       // Format the answers to be compatible with the form, i.e. parse stringified objects
-      let formattedAnswers = Object.entries(answers).reduce((acc, [key, value]) => {
+      const formattedAnswers = Object.entries(answers).reduce((acc, [key, value]) => {
         // If the value is a stringified object, parse it
         const isStringifiedObject = typeof value === 'string' && value.startsWith('{');
         return { ...acc, [key]: isStringifiedObject ? JSON.parse(value) : value };

--- a/packages/types/src/types/requests/datatrak-web-server/SingleSurveyResponseRequest.ts
+++ b/packages/types/src/types/requests/datatrak-web-server/SingleSurveyResponseRequest.ts
@@ -14,6 +14,7 @@ export interface ResBody extends KeysToCamelCase<SurveyResponse> {
   answers: Record<string, string>;
   countryName: Country['name'];
   entityName: Entity['name'];
+  entityId: Entity['id'];
   surveyName: Survey['name'];
   surveyCode: Survey['code'];
 }

--- a/packages/types/src/types/requests/datatrak-web-server/SurveyRequest.ts
+++ b/packages/types/src/types/requests/datatrak-web-server/SurveyRequest.ts
@@ -56,6 +56,7 @@ export type SurveyScreenComponent = CamelCasedComponent &
     label?: BaseSurveyScreenComponent['question_label'];
     options?: Option[] | null;
     screenId?: string;
+    id?: string;
   };
 
 type CamelCasedSurveyScreen = KeysToCamelCase<Pick<BaseSurveyScreen, 'id' | 'screen_number'>>;


### PR DESCRIPTION
### Issue #: RN-1314: Auto populate entity question

### Changes:

- Add ability to set the primary entity in location state for a survey
- Set the primary entity on the Complete tasks action
- Fetch and include the primary entity on the survey response page 

---

