### PR TITLE
tweak(datatrakWeb): RN-1331: Update to task details/comments

### DIFF
--- a/packages/central-server/src/apiV2/index.js
+++ b/packages/central-server/src/apiV2/index.js
@@ -145,7 +145,7 @@ import {
 } from './dashboardMailingListEntries';
 import { EditEntityHierarchy, GETEntityHierarchy } from './entityHierarchy';
 import { CreateTask, EditTask, GETTasks } from './tasks';
-import { GETTaskComments } from './taskComments';
+import { CreateTaskComment, GETTaskComments } from './taskComments';
 
 // quick and dirty permission wrapper for open endpoints
 const allowAnyone = routeHandler => (req, res, next) => {
@@ -318,6 +318,7 @@ apiV2.post('/surveys', multipartJson(), useRouteHandler(CreateSurvey));
 apiV2.post('/dhisInstances', useRouteHandler(BESAdminCreateHandler));
 apiV2.post('/supersetInstances', useRouteHandler(BESAdminCreateHandler));
 apiV2.post('/tasks', useRouteHandler(CreateTask));
+apiV2.post('/tasks/:parentRecordId/taskComments', useRouteHandler(CreateTaskComment));
 /**
  * PUT routes
  */

--- a/packages/central-server/src/apiV2/taskComments/CreateTaskComment.js
+++ b/packages/central-server/src/apiV2/taskComments/CreateTaskComment.js
@@ -1,0 +1,31 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2024 Beyond Essential Systems Pty Ltd
+ */
+import { CreateHandler } from '../CreateHandler';
+import { assertAnyPermissions, assertBESAdminAccess } from '../../permissions';
+import { assertUserHasTaskPermissions } from '../tasks/assertTaskPermissions';
+/**
+ * Handles POST endpoints:
+ * - /tasks/:parentRecordId/taskComments
+ */
+
+export class CreateTaskComment extends CreateHandler {
+  async assertUserHasAccess() {
+    const createPermissionChecker = accessPolicy =>
+      assertUserHasTaskPermissions(accessPolicy, this.models, this.parentRecordId);
+
+    await this.assertPermissions(
+      assertAnyPermissions([assertBESAdminAccess, createPermissionChecker]),
+    );
+  }
+
+  async createRecord() {
+    return this.models.wrapInTransaction(async transactingModels => {
+      const task = await transactingModels.task.findById(this.parentRecordId);
+      const { message, type } = this.newRecordData;
+      const newComment = await task.addComment(message, this.req.user.id, type);
+      return { id: newComment.id };
+    });
+  }
+}

--- a/packages/central-server/src/apiV2/taskComments/index.js
+++ b/packages/central-server/src/apiV2/taskComments/index.js
@@ -4,3 +4,4 @@
  */
 
 export { GETTaskComments } from './GETTaskComments';
+export { CreateTaskComment } from './CreateTaskComment';

--- a/packages/central-server/src/apiV2/tasks/EditTask.js
+++ b/packages/central-server/src/apiV2/tasks/EditTask.js
@@ -15,17 +15,10 @@ export class EditTask extends EditHandler {
   }
 
   async editRecord() {
-    const { comment, ...updatedFields } = this.updatedFields;
     return this.models.wrapInTransaction(async transactingModels => {
       const originalTask = await transactingModels.task.findById(this.recordId);
-      let task = originalTask;
-      // Sometimes an update can just be a comment, so we don't want to update the task if there are no fields to update, because we would get an error
-      if (Object.keys(updatedFields).length > 0) {
-        task = await transactingModels.task.updateById(this.recordId, updatedFields);
-      }
-      if (comment) {
-        await originalTask.addComment(comment, this.req.user.id);
-      }
+      const task = await transactingModels.task.updateById(this.recordId, this.updatedFields);
+
       await originalTask.addSystemCommentsOnUpdate(this.updatedFields, this.req.user.id);
       return task;
     });

--- a/packages/central-server/src/tests/apiV2/taskComments/CreateTaskComment.test.js
+++ b/packages/central-server/src/tests/apiV2/taskComments/CreateTaskComment.test.js
@@ -1,0 +1,169 @@
+/**
+ * Tupaia
+ * Copyright (c) 2017 - 2024 Beyond Essential Systems Pty Ltd
+ */
+
+import { expect } from 'chai';
+import {
+  buildAndInsertSurveys,
+  findOrCreateDummyCountryEntity,
+  findOrCreateDummyRecord,
+  generateId,
+} from '@tupaia/database';
+import { TestableApp, resetTestData } from '../../testUtilities';
+import { BES_ADMIN_PERMISSION_GROUP } from '../../../permissions';
+
+describe('Permissions checker for CreateTaskComment', async () => {
+  const BES_ADMIN_POLICY = {
+    DL: [BES_ADMIN_PERMISSION_GROUP],
+  };
+
+  const DEFAULT_POLICY = {
+    DL: ['Donor'],
+    TO: ['Donor'],
+  };
+
+  const app = new TestableApp();
+  const { models } = app;
+  let tasks;
+
+  before(async () => {
+    const { country: tongaCountry } = await findOrCreateDummyCountryEntity(models, {
+      code: 'TO',
+      name: 'Tonga',
+    });
+
+    const { country: dlCountry } = await findOrCreateDummyCountryEntity(models, {
+      code: 'DL',
+      name: 'Demo Land',
+    });
+
+    const donorPermission = await findOrCreateDummyRecord(models.permissionGroup, {
+      name: 'Donor',
+    });
+    const BESAdminPermission = await findOrCreateDummyRecord(models.permissionGroup, {
+      name: 'Admin',
+    });
+
+    const facilities = [
+      {
+        id: generateId(),
+        code: 'TEST_FACILITY_1',
+        name: 'Test Facility 1',
+        country_code: tongaCountry.code,
+      },
+      {
+        id: generateId(),
+        code: 'TEST_FACILITY_2',
+        name: 'Test Facility 2',
+        country_code: dlCountry.code,
+      },
+    ];
+
+    await Promise.all(facilities.map(facility => findOrCreateDummyRecord(models.entity, facility)));
+
+    const surveys = await buildAndInsertSurveys(models, [
+      {
+        code: 'TEST_SURVEY_1',
+        name: 'Test Survey 1',
+        permission_group_id: BESAdminPermission.id,
+        country_ids: [tongaCountry.id, dlCountry.id],
+      },
+      {
+        code: 'TEST_SURVEY_2',
+        name: 'Test Survey 2',
+        permission_group_id: donorPermission.id,
+        country_ids: [tongaCountry.id, dlCountry.id],
+      },
+    ]);
+
+    const assignee = {
+      id: generateId(),
+      first_name: 'Minnie',
+      last_name: 'Mouse',
+    };
+    await findOrCreateDummyRecord(models.user, assignee);
+
+    const dueDate = new Date('2021-12-31');
+
+    tasks = [
+      {
+        id: generateId(),
+        survey_id: surveys[0].survey.id,
+        entity_id: facilities[0].id,
+        due_date: dueDate,
+        status: 'to_do',
+        repeat_schedule: null,
+      },
+      {
+        id: generateId(),
+        survey_id: surveys[1].survey.id,
+        entity_id: facilities[1].id,
+        assignee_id: assignee.id,
+        due_date: null,
+        repeat_schedule: '{}',
+        status: null,
+      },
+    ];
+
+    await Promise.all(
+      tasks.map(task =>
+        findOrCreateDummyRecord(
+          models.task,
+          {
+            'task.id': task.id,
+          },
+          task,
+        ),
+      ),
+    );
+  });
+
+  afterEach(async () => {
+    await models.taskComment.delete({ task_id: tasks[0].id });
+    await models.taskComment.delete({ task_id: tasks[1].id });
+    app.revokeAccess();
+  });
+
+  after(async () => {
+    await resetTestData();
+  });
+
+  describe('POST /tasks/:id/taskComments', async () => {
+    it('Sufficient permissions: Successfully creates a task comment when the user has BES Admin permissions', async () => {
+      await app.grantAccess(BES_ADMIN_POLICY);
+      await app.post(`tasks/${tasks[0].id}/taskComments`, {
+        body: {
+          message: 'This is a test comment',
+          type: 'user',
+        },
+      });
+      const comment = await models.taskComment.findOne({ task_id: tasks[0].id });
+      expect(comment.message).to.equal('This is a test comment');
+    });
+
+    it('Sufficient permissions: Successfully creates a task comment when user has access to the task', async () => {
+      await app.grantAccess(DEFAULT_POLICY);
+      await app.post(`tasks/${tasks[1].id}/taskComments`, {
+        body: {
+          message: 'This is a test comment',
+          type: 'user',
+        },
+      });
+      const comment = await models.taskComment.findOne({ task_id: tasks[1].id });
+      expect(comment.message).to.equal('This is a test comment');
+    });
+
+    it('Insufficient permissions: throws an error if trying to create a comment for a task the user does not have permissions for', async () => {
+      await app.grantAccess(DEFAULT_POLICY);
+      const { body: result } = await app.post(`tasks/${tasks[0].id}/taskComments`, {
+        body: {
+          message: 'This is a test comment',
+          type: 'user',
+        },
+      });
+
+      expect(result).to.have.keys('error');
+    });
+  });
+});

--- a/packages/central-server/src/tests/apiV2/tasks/EditTask.test.js
+++ b/packages/central-server/src/tests/apiV2/tasks/EditTask.test.js
@@ -210,55 +210,6 @@ describe('Permissions checker for EditTask', async () => {
       });
     });
 
-    describe('User generated comments', async () => {
-      it('Handles adding a comment when editing a task', async () => {
-        await app.grantAccess({
-          DL: ['Donor'],
-          TO: ['Donor'],
-        });
-        await app.put(`tasks/${tasks[1].id}`, {
-          body: {
-            survey_id: surveys[1].survey.id,
-            entity_id: facilities[1].id,
-            comment: 'This is a test comment',
-          },
-        });
-        const result = await models.task.find({
-          id: tasks[1].id,
-        });
-        expect(result[0].entity_id).to.equal(facilities[1].id);
-        expect(result[0].survey_id).to.equal(surveys[1].survey.id);
-
-        const comment = await models.taskComment.findOne({
-          task_id: tasks[1].id,
-          message: 'This is a test comment',
-        });
-        expect(comment).not.to.be.null;
-      });
-
-      it('Handles adding a comment when no other edits are made', async () => {
-        await app.grantAccess({
-          DL: ['Donor'],
-          TO: ['Donor'],
-        });
-        await app.put(`tasks/${tasks[1].id}`, {
-          body: {
-            comment: 'This is a test comment',
-          },
-        });
-        const result = await models.task.find({
-          id: tasks[1].id,
-        });
-        expect(result[0].entity_id).to.equal(tasks[1].entity_id);
-
-        const comment = await models.taskComment.findOne({
-          task_id: tasks[1].id,
-          message: 'This is a test comment',
-        });
-        expect(comment).not.to.be.null;
-      });
-    });
-
     describe('System generated comments', () => {
       it('Adds a comment when the due date changes on a task', async () => {
         await app.grantAccess({
@@ -390,53 +341,6 @@ describe('Permissions checker for EditTask', async () => {
         });
         expect(comment).not.to.be.null;
       });
-    });
-
-    it('Handles adding a comment when editing a task', async () => {
-      await app.grantAccess({
-        DL: ['Donor'],
-        TO: ['Donor'],
-      });
-      await app.put(`tasks/${tasks[1].id}`, {
-        body: {
-          survey_id: surveys[1].survey.id,
-          entity_id: facilities[1].id,
-          comment: 'This is a test comment',
-        },
-      });
-      const result = await models.task.find({
-        id: tasks[1].id,
-      });
-      expect(result[0].entity_id).to.equal(facilities[1].id);
-      expect(result[0].survey_id).to.equal(surveys[1].survey.id);
-
-      const comment = await models.taskComment.findOne({
-        task_id: tasks[1].id,
-        message: 'This is a test comment',
-      });
-      expect(comment).not.to.be.undefined;
-    });
-
-    it('Handles adding a comment when no other edits are made', async () => {
-      await app.grantAccess({
-        DL: ['Donor'],
-        TO: ['Donor'],
-      });
-      await app.put(`tasks/${tasks[1].id}`, {
-        body: {
-          comment: 'This is a test comment',
-        },
-      });
-      const result = await models.task.find({
-        id: tasks[1].id,
-      });
-      expect(result[0].entity_id).to.equal(tasks[1].entity_id);
-
-      const comment = await models.taskComment.findOne({
-        task_id: tasks[1].id,
-        message: 'This is a test comment',
-      });
-      expect(comment).not.to.be.undefined;
     });
   });
 });

--- a/packages/datatrak-web/src/api/mutations/index.ts
+++ b/packages/datatrak-web/src/api/mutations/index.ts
@@ -18,3 +18,4 @@ export { useOneTimeLogin } from './useOneTimeLogin';
 export * from './useExportSurveyResponses';
 export { useTupaiaRedirect } from './useTupaiaRedirect';
 export { useCreateTask } from './useCreateTask';
+export { useCreateTaskComment } from './useCreateTaskComment';

--- a/packages/datatrak-web/src/api/mutations/useCreateTaskComment.ts
+++ b/packages/datatrak-web/src/api/mutations/useCreateTaskComment.ts
@@ -1,0 +1,33 @@
+/*
+ * Tupaia
+ *  Copyright (c) 2017 - 2024 Beyond Essential Systems Pty Ltd
+ */
+
+import { useMutation, useQueryClient } from 'react-query';
+import { Task, TaskCommentType } from '@tupaia/types';
+import { post } from '../api';
+import { successToast } from '../../utils';
+
+export const useCreateTaskComment = (taskId?: Task['id'], onSuccess?: () => void) => {
+  const queryClient = useQueryClient();
+  return useMutation<any, Error, string, unknown>(
+    (comment: string) => {
+      return post(`tasks/${taskId}/taskComments`, {
+        data: {
+          message: comment,
+          type: TaskCommentType.user,
+        },
+      });
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries('tasks');
+        queryClient.invalidateQueries(['tasks', taskId]);
+        successToast('Comment added successfully');
+        if (onSuccess) {
+          onSuccess();
+        }
+      },
+    },
+  );
+};

--- a/packages/datatrak-web/src/api/mutations/useEditTask.ts
+++ b/packages/datatrak-web/src/api/mutations/useEditTask.ts
@@ -6,6 +6,7 @@
 import { useMutation, useQueryClient } from 'react-query';
 import { Task } from '@tupaia/types';
 import { put } from '../api';
+import { successToast } from '../../utils';
 
 type PartialTask = Partial<Task>;
 
@@ -21,6 +22,7 @@ export const useEditTask = (taskId?: Task['id'], onSuccess?: () => void) => {
       onSuccess: () => {
         queryClient.invalidateQueries('tasks');
         queryClient.invalidateQueries(['tasks', taskId]);
+        successToast('Task updated successfully');
         if (onSuccess) onSuccess();
       },
     },

--- a/packages/datatrak-web/src/components/Icons/ArrowLeftIcon.tsx
+++ b/packages/datatrak-web/src/components/Icons/ArrowLeftIcon.tsx
@@ -1,0 +1,24 @@
+/*
+ * Tupaia
+ * Copyright (c) 2017 - 2024 Beyond Essential Systems Pty Ltd
+ */
+import React from 'react';
+import { SvgIcon, SvgIconProps } from '@material-ui/core';
+
+export const ArrowLeftIcon = (props: SvgIconProps) => {
+  return (
+    <SvgIcon
+      width="20"
+      height="20"
+      viewBox="0 0 20 20"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path
+        d="M4.28954 9.99976C4.28954 9.68727 4.41516 9.38789 4.63954 9.16727L13.5883 0.343591C14.0545 -0.114531 14.8095 -0.114531 15.2752 0.343592C15.7408 0.802963 15.7408 1.54983 15.2752 2.00733L7.16891 9.99977L15.2758 17.991C15.7414 18.4509 15.7414 19.1966 15.2758 19.6559C14.8102 20.1147 14.0552 20.1147 13.5889 19.6559L4.63891 10.8323C4.41516 10.6104 4.28954 10.311 4.28954 9.99976Z"
+        fill="#2E2F33"
+      />
+    </SvgIcon>
+  );
+};

--- a/packages/datatrak-web/src/components/Icons/index.ts
+++ b/packages/datatrak-web/src/components/Icons/index.ts
@@ -14,3 +14,4 @@ export { ReportsIcon } from './ReportsIcon';
 export { CopyIcon } from './CopyIcon';
 export { TaskIcon } from './TaskIcon';
 export { CommentIcon } from './CommentIcon';
+export { ArrowLeftIcon } from './ArrowLeftIcon';

--- a/packages/datatrak-web/src/features/Tasks/CommentsCount.tsx
+++ b/packages/datatrak-web/src/features/Tasks/CommentsCount.tsx
@@ -6,8 +6,8 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Typography } from '@material-ui/core';
-import { CommentIcon } from '../../components';
 import { Tooltip } from '@tupaia/ui-components';
+import { CommentIcon } from '../../components';
 
 const CommentsCountWrapper = styled.div`
   color: ${({ theme }) => theme.palette.text.secondary};

--- a/packages/datatrak-web/src/features/Tasks/TaskDetails/TaskComments.tsx
+++ b/packages/datatrak-web/src/features/Tasks/TaskDetails/TaskComments.tsx
@@ -5,20 +5,23 @@
 
 import React from 'react';
 import styled from 'styled-components';
+import { useForm } from 'react-hook-form';
 import { Typography } from '@material-ui/core';
 import { TaskCommentType } from '@tupaia/types';
+import { TextField } from '@tupaia/ui-components';
 import { displayDateTime } from '../../../utils';
 import { SingleTaskResponse } from '../../../types';
+import { TaskForm } from '../TaskForm';
+import { Button } from '../../../components';
 
-const Wrapper = styled.div`
+const TaskCommentsDisplayContainer = styled.div`
   width: 100%;
   border: 1px solid ${({ theme }) => theme.palette.divider};
   background-color: ${({ theme }) => theme.palette.background.default};
-  margin-block-end: 1.2rem;
   padding: 1rem;
   border-radius: 4px;
   overflow-y: auto;
-  height: 19rem;
+  flex: 1;
 `;
 
 const CommentContainer = styled.div`
@@ -28,10 +31,34 @@ const CommentContainer = styled.div`
   }
 `;
 
+const CommentsInput = styled(TextField).attrs({
+  multiline: true,
+  variant: 'outlined',
+  fullWidth: true,
+  rows: 4,
+})`
+  margin-block-end: 0;
+  height: 11rem;
+  .MuiOutlinedInput-inputMultiline {
+    padding-inline: 1rem;
+  }
+  .MuiInputBase-root {
+    height: 100%;
+  }
+`;
+
 const Message = styled(Typography).attrs({
   variant: 'body2',
 })`
   margin-block-start: 0.2rem;
+`;
+
+const Form = styled(TaskForm)`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  flex: 1;
+  align-items: flex-end;
 `;
 
 type Comments = SingleTaskResponse['comments'];
@@ -51,11 +78,24 @@ const SingleComment = ({ comment }: { comment: Comments[0] }) => {
 };
 
 export const TaskComments = ({ comments }: { comments: Comments }) => {
+  const {
+    register,
+    handleSubmit,
+    formState: { isDirty },
+  } = useForm();
+
+  const onSubmit = data => {};
   return (
-    <Wrapper>
-      {comments.map((comment, index) => (
-        <SingleComment key={index} comment={comment} />
-      ))}
-    </Wrapper>
+    <Form onSubmit={handleSubmit(onSubmit)}>
+      <TaskCommentsDisplayContainer>
+        {comments.map((comment, index) => (
+          <SingleComment key={index} comment={comment} />
+        ))}
+      </TaskCommentsDisplayContainer>
+      <CommentsInput label="Add comment" name="comment" inputRef={register} />
+      <Button type="submit" disabled={!isDirty}>
+        Add comment
+      </Button>
+    </Form>
   );
 };

--- a/packages/datatrak-web/src/features/Tasks/TaskDetails/TaskComments.tsx
+++ b/packages/datatrak-web/src/features/Tasks/TaskDetails/TaskComments.tsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { useForm } from 'react-hook-form';
+import { useParams } from 'react-router';
 import { Typography } from '@material-ui/core';
 import { TaskCommentType } from '@tupaia/types';
 import { TextField } from '@tupaia/ui-components';
@@ -13,6 +14,7 @@ import { displayDateTime } from '../../../utils';
 import { SingleTaskResponse } from '../../../types';
 import { TaskForm } from '../TaskForm';
 import { Button } from '../../../components';
+import { useCreateTaskComment } from '../../../api';
 
 const TaskCommentsDisplayContainer = styled.div`
   width: 100%;
@@ -22,6 +24,7 @@ const TaskCommentsDisplayContainer = styled.div`
   border-radius: 4px;
   overflow-y: auto;
   flex: 1;
+  max-height: 18rem;
 `;
 
 const CommentContainer = styled.div`
@@ -35,15 +38,13 @@ const CommentsInput = styled(TextField).attrs({
   multiline: true,
   variant: 'outlined',
   fullWidth: true,
-  rows: 4,
+  rows: 5,
 })`
-  margin-block-end: 0;
-  height: 11rem;
-  .MuiOutlinedInput-inputMultiline {
+  margin-block: 1.2rem;
+  height: 9.5rem;
+  .MuiOutlinedInput-inputMultiline.MuiInputBase-input {
     padding-inline: 1rem;
-  }
-  .MuiInputBase-root {
-    height: 100%;
+    padding-block: 1rem;
   }
 `;
 
@@ -78,13 +79,25 @@ const SingleComment = ({ comment }: { comment: Comments[0] }) => {
 };
 
 export const TaskComments = ({ comments }: { comments: Comments }) => {
+  const { taskId } = useParams();
+
   const {
     register,
     handleSubmit,
+    reset,
     formState: { isDirty },
-  } = useForm();
+  } = useForm({
+    defaultValues: {
+      comment: '',
+    },
+  });
 
-  const onSubmit = data => {};
+  const { mutate: createTaskComment, isLoading: isSaving } = useCreateTaskComment(taskId, reset);
+
+  const onSubmit = data => {
+    createTaskComment(data.comment);
+  };
+
   return (
     <Form onSubmit={handleSubmit(onSubmit)}>
       <TaskCommentsDisplayContainer>
@@ -93,8 +106,8 @@ export const TaskComments = ({ comments }: { comments: Comments }) => {
         ))}
       </TaskCommentsDisplayContainer>
       <CommentsInput label="Add comment" name="comment" inputRef={register} />
-      <Button type="submit" disabled={!isDirty}>
-        Add comment
+      <Button type="submit" disabled={!isDirty || isSaving}>
+        {isSaving ? 'Saving...' : 'Add comment'}
       </Button>
     </Form>
   );

--- a/packages/datatrak-web/src/features/Tasks/TaskDetails/TaskDetails.tsx
+++ b/packages/datatrak-web/src/features/Tasks/TaskDetails/TaskDetails.tsx
@@ -9,7 +9,7 @@ import { useForm, Controller } from 'react-hook-form';
 import styled from 'styled-components';
 import { Paper } from '@material-ui/core';
 import { TaskStatus } from '@tupaia/types';
-import { LoadingContainer, TextField } from '@tupaia/ui-components';
+import { LoadingContainer } from '@tupaia/ui-components';
 import { useEditTask } from '../../../api';
 import { Button } from '../../../components';
 import { useFromLocation } from '../../../utils';
@@ -41,9 +41,16 @@ const MainColumn = styled.div`
   justify-content: space-between;
   flex: 1;
   margin-block: 1.2rem;
+  border-color: ${({ theme }) => theme.palette.divider};
+  border-style: solid;
+  border-width: 1px 0;
+  padding-block: 1.2rem;
   ${({ theme }) => theme.breakpoints.up('md')} {
-    width: 44%;
+    width: 50%;
     margin-block: 0;
+    padding-inline: 1.2rem;
+    padding-block: 0;
+    border-width: 0 1px;
   }
 `;
 
@@ -52,7 +59,7 @@ const SideColumn = styled.div`
   flex-direction: column;
   justify-content: space-between;
   ${({ theme }) => theme.breakpoints.up('md')} {
-    width: 28%;
+    width: 25%;
   }
 `;
 

--- a/packages/datatrak-web/src/features/Tasks/TaskDetails/TaskDetails.tsx
+++ b/packages/datatrak-web/src/features/Tasks/TaskDetails/TaskDetails.tsx
@@ -157,7 +157,6 @@ export const TaskDetails = ({ task }: { task: SingleTaskResponse }) => {
                 <Controller
                   name="due_date"
                   control={control}
-                  defaultValue={defaultValues.due_date}
                   render={({ value, onChange, ref }, { invalid }) => (
                     <DueDatePicker
                       value={value}
@@ -178,7 +177,6 @@ export const TaskDetails = ({ task }: { task: SingleTaskResponse }) => {
                 <Controller
                   name="repeat_schedule"
                   control={control}
-                  defaultValue={defaultValues.repeat_schedule}
                   render={({ value, onChange }) => (
                     <RepeatScheduleInput
                       value={value}
@@ -193,7 +191,6 @@ export const TaskDetails = ({ task }: { task: SingleTaskResponse }) => {
                 <Controller
                   name="assignee_id"
                   control={control}
-                  defaultValue={defaultValues.assignee_id}
                   render={({ value, onChange, ref }) => (
                     <AssigneeInput
                       value={value}

--- a/packages/datatrak-web/src/features/Tasks/TaskDetails/TaskDetails.tsx
+++ b/packages/datatrak-web/src/features/Tasks/TaskDetails/TaskDetails.tsx
@@ -62,18 +62,6 @@ const ItemWrapper = styled.div`
   }
 `;
 
-const CommentsInput = styled(TextField).attrs({
-  multiline: true,
-  variant: 'outlined',
-  fullWidth: true,
-  rows: 4,
-})`
-  margin-block-end: 0;
-  .MuiOutlinedInput-inputMultiline {
-    padding-inline: 1rem;
-  }
-`;
-
 const ClearButton = styled(Button).attrs({
   variant: 'text',
 })`
@@ -88,6 +76,11 @@ const ButtonWrapper = styled.div`
 `;
 
 const Form = styled(TaskForm)`
+  display: flex;
+  flex-direction: column;
+`;
+
+const Wrapper = styled.div`
   .loading-screen {
     border: 1px solid ${({ theme }) => theme.palette.divider};
   }
@@ -110,7 +103,6 @@ export const TaskDetails = ({ task }: { task: SingleTaskResponse }) => {
     control,
     handleSubmit,
     watch,
-    register,
     formState: { dirtyFields },
     reset,
   } = formContext;
@@ -142,83 +134,83 @@ export const TaskDetails = ({ task }: { task: SingleTaskResponse }) => {
   };
 
   return (
-    <Form onSubmit={handleSubmit(onSubmit)}>
+    <Wrapper>
       <LoadingContainer isLoading={isSaving} heading="Saving task" text="">
         <Container>
           <SideColumn>
-            <ItemWrapper>
-              <TaskMetadata task={task} />
-            </ItemWrapper>
-            <ItemWrapper>
-              <Controller
-                name="due_date"
-                control={control}
-                defaultValue={defaultValues.due_date}
-                render={({ value, onChange, ref }, { invalid }) => (
-                  <DueDatePicker
-                    value={value}
-                    onChange={onChange}
-                    inputRef={ref}
-                    label="Due date"
-                    disablePast
-                    fullWidth
-                    required
-                    invalid={invalid}
-                    disabled={!canEditFields}
-                  />
-                )}
-              />
-            </ItemWrapper>
+            <Form onSubmit={handleSubmit(onSubmit)}>
+              <ItemWrapper>
+                <TaskMetadata task={task} />
+              </ItemWrapper>
+              <ItemWrapper>
+                <Controller
+                  name="due_date"
+                  control={control}
+                  defaultValue={defaultValues.due_date}
+                  render={({ value, onChange, ref }, { invalid }) => (
+                    <DueDatePicker
+                      value={value}
+                      onChange={onChange}
+                      inputRef={ref}
+                      label="Due date"
+                      disablePast
+                      fullWidth
+                      required
+                      invalid={invalid}
+                      disabled={!canEditFields}
+                    />
+                  )}
+                />
+              </ItemWrapper>
 
-            <ItemWrapper>
-              <Controller
-                name="repeat_schedule"
-                control={control}
-                defaultValue={defaultValues.repeat_schedule}
-                render={({ value, onChange }) => (
-                  <RepeatScheduleInput
-                    value={value}
-                    onChange={onChange}
-                    disabled={!canEditFields}
-                    dueDate={dueDate}
-                  />
-                )}
-              />
-            </ItemWrapper>
-            <ItemWrapper>
-              <Controller
-                name="assignee_id"
-                control={control}
-                defaultValue={defaultValues.assignee_id}
-                render={({ value, onChange, ref }) => (
-                  <AssigneeInput
-                    value={value}
-                    onChange={onChange}
-                    inputRef={ref}
-                    countryCode={task.entity.countryCode}
-                    surveyCode={task.survey.code}
-                    disabled={!canEditFields}
-                  />
-                )}
-              />
-            </ItemWrapper>
+              <ItemWrapper>
+                <Controller
+                  name="repeat_schedule"
+                  control={control}
+                  defaultValue={defaultValues.repeat_schedule}
+                  render={({ value, onChange }) => (
+                    <RepeatScheduleInput
+                      value={value}
+                      onChange={onChange}
+                      disabled={!canEditFields}
+                      dueDate={dueDate}
+                    />
+                  )}
+                />
+              </ItemWrapper>
+              <ItemWrapper>
+                <Controller
+                  name="assignee_id"
+                  control={control}
+                  defaultValue={defaultValues.assignee_id}
+                  render={({ value, onChange, ref }) => (
+                    <AssigneeInput
+                      value={value}
+                      onChange={onChange}
+                      inputRef={ref}
+                      countryCode={task.entity.countryCode}
+                      surveyCode={task.survey.code}
+                      disabled={!canEditFields}
+                    />
+                  )}
+                />
+              </ItemWrapper>
+              <ButtonWrapper>
+                <ClearButton disabled={!isDirty} onClick={onClearEdit}>
+                  Clear changes
+                </ClearButton>
+                <Button type="submit" disabled={!isDirty} variant="outlined">
+                  Save changes
+                </Button>
+              </ButtonWrapper>
+            </Form>
           </SideColumn>
           <MainColumn>
             <TaskComments comments={task.comments} />
-            <CommentsInput label="Add comment" name="comment" inputRef={register} />
           </MainColumn>
-          <SideColumn>
-            <ButtonWrapper>
-              <ClearButton disabled={!isDirty} onClick={onClearEdit}>
-                Clear changes
-              </ClearButton>
-              <Button type="submit" disabled={!isDirty} variant="outlined">
-                Save changes
-              </Button>
-            </ButtonWrapper>
-          </SideColumn>
+          <SideColumn></SideColumn>
         </Container>
       </LoadingContainer>
-    </Form>
+    </Wrapper>
   );
 };

--- a/packages/datatrak-web/src/features/Tasks/TaskTile.tsx
+++ b/packages/datatrak-web/src/features/Tasks/TaskTile.tsx
@@ -12,10 +12,11 @@ import { ButtonLink } from '../../components';
 import { StatusPill } from './StatusPill';
 import { CommentsCount } from './CommentsCount';
 
-const TileContainer = styled.div`
+const TileContainer = styled(Link)`
   display: flex;
   text-align: left;
   justify-content: space-between;
+  text-decoration: none;
   border-radius: 10px;
   border: 1px solid ${({ theme }) => theme.palette.divider};
   width: 100%;
@@ -28,6 +29,14 @@ const TileContainer = styled.div`
 
   .MuiButton-label {
     font-size: 0.75rem;
+  }
+
+  &:hover {
+    background-color: ${({ theme }) => theme.palette.primaryHover};
+    border-color: ${({ theme }) => theme.palette.primary.main};
+  }
+  &:focus-within {
+    border-color: ${({ theme }) => theme.palette.primary.main};
   }
 `;
 
@@ -69,8 +78,16 @@ export const TaskTile = ({ task }) => {
     surveyCode: survey.code,
     countryCode: entity.countryCode,
   });
+  const taskLink = generatePath(ROUTES.TASK_DETAILS, {
+    taskId: task.id,
+  });
   return (
-    <TileContainer>
+    <TileContainer
+      to={taskLink}
+      state={{
+        from: '/',
+      }}
+    >
       <TileLeft>
         <TileTitle>{survey.name}</TileTitle>
         <TileContent>

--- a/packages/datatrak-web/src/views/LandingPage/TasksSection.tsx
+++ b/packages/datatrak-web/src/views/LandingPage/TasksSection.tsx
@@ -7,11 +7,11 @@ import React from 'react';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import { FlexSpaceBetween, TextButton, Button as UIButton } from '@tupaia/ui-components';
-import { SectionHeading } from './SectionHeading';
 import { useCurrentUserContext, useTasks } from '../../api';
 import { NoTasksSection, TaskTile } from '../../features/Tasks';
 import { ROUTES } from '../../constants';
 import { LoadingTile } from '../../components';
+import { SectionHeading } from './SectionHeading';
 
 const SectionContainer = styled.section`
   grid-area: tasks;

--- a/packages/datatrak-web/src/views/Tasks/TaskDetailsPage.tsx
+++ b/packages/datatrak-web/src/views/Tasks/TaskDetailsPage.tsx
@@ -7,6 +7,7 @@ import React, { useState } from 'react';
 import { generatePath, useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import { Typography } from '@material-ui/core';
+import { KeyboardArrowLeft } from '@material-ui/icons';
 import { TaskStatus } from '@tupaia/types';
 import { Modal, ModalCenteredContent, SpinningLoader } from '@tupaia/ui-components';
 import { Button } from '../../components';
@@ -15,6 +16,17 @@ import { useTask } from '../../api';
 import { ROUTES } from '../../constants';
 import { useFromLocation } from '../../utils';
 import { SingleTaskResponse } from '../../types';
+
+const BackButton = styled(Button)`
+  position: absolute;
+  left: 0;
+  color: ${({ theme }) => theme.palette.text.primary};
+  padding: 0.2rem;
+  border-radius: 50%;
+  .MuiSvgIcon-root {
+    font-size: 2.5rem;
+  }
+`;
 
 const ButtonWrapper = styled.div`
   display: flex;
@@ -90,10 +102,14 @@ export const TaskDetailsPage = () => {
   const [errorModalOpen, setErrorModalOpen] = useState(false);
   const { taskId } = useParams();
   const { data: task, isLoading } = useTask(taskId);
+  const from = useFromLocation();
 
   return (
     <>
       <TaskPageHeader title="Task details">
+        <BackButton to={from || ROUTES.TASKS} variant="text" title="Back">
+          <KeyboardArrowLeft />
+        </BackButton>
         <ButtonWrapper>
           <ButtonComponent task={task} openErrorModal={() => setErrorModalOpen(true)} />
           {task && <TaskActionsMenu task={task} />}

--- a/packages/datatrak-web/src/views/Tasks/TaskDetailsPage.tsx
+++ b/packages/datatrak-web/src/views/Tasks/TaskDetailsPage.tsx
@@ -7,10 +7,9 @@ import React, { useState } from 'react';
 import { generatePath, useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import { Typography } from '@material-ui/core';
-import { KeyboardArrowLeft } from '@material-ui/icons';
 import { TaskStatus } from '@tupaia/types';
 import { Modal, ModalCenteredContent, SpinningLoader } from '@tupaia/ui-components';
-import { Button } from '../../components';
+import { ArrowLeftIcon, Button } from '../../components';
 import { TaskDetails, TaskPageHeader, TaskActionsMenu } from '../../features';
 import { useTask } from '../../api';
 import { ROUTES } from '../../constants';
@@ -20,11 +19,12 @@ import { SingleTaskResponse } from '../../types';
 const BackButton = styled(Button)`
   position: absolute;
   left: 0;
+  min-width: 0;
   color: ${({ theme }) => theme.palette.text.primary};
-  padding: 0.2rem;
+  padding: 0.7rem;
   border-radius: 50%;
   .MuiSvgIcon-root {
-    font-size: 2.5rem;
+    font-size: 1.3rem;
   }
 `;
 
@@ -108,7 +108,7 @@ export const TaskDetailsPage = () => {
     <>
       <TaskPageHeader title="Task details">
         <BackButton to={from || ROUTES.TASKS} variant="text" title="Back">
-          <KeyboardArrowLeft />
+          <ArrowLeftIcon />
         </BackButton>
         <ButtonWrapper>
           <ButtonComponent task={task} openErrorModal={() => setErrorModalOpen(true)} />


### PR DESCRIPTION
### Issue RN-1331: Update to task details/comments

### Changes:
- Updated styling of task details view to have separate save button for comments
- Added 'back' button to task details page, per the design
- Added link to task tiles on landing page
- Added endpoint for creating task comments via parent task `id`
- Changed handling of successful task save to not navigate back anymore, per discussion with Georgia and Felicity

---

### Screenshots:
![Screenshot 2024-08-02 at 8 59 59 AM](https://github.com/user-attachments/assets/0bf7c426-0aa5-42d8-816a-b4bd3b11115b)
