### PR TITLE
tweak(meditrak): HOTFIX: Bump MediTrak target Android version to 14 (API level 34)

### DIFF
--- a/packages/meditrak-app/android/app/build.gradle
+++ b/packages/meditrak-app/android/app/build.gradle
@@ -84,8 +84,8 @@ android {
         applicationId "com.tupaiameditrak"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 142
-        versionName "1.14.142"
+        versionCode 143
+        versionName "1.14.143"
     }
     signingConfigs {
         debug {

--- a/packages/meditrak-app/android/build.gradle
+++ b/packages/meditrak-app/android/build.gradle
@@ -2,10 +2,10 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "33.0.0"
+        buildToolsVersion = "34.0.0"
         minSdkVersion = 21
-        compileSdkVersion = 33
-        targetSdkVersion = 33
+        compileSdkVersion = 34
+        targetSdkVersion = 34
 
         // We use NDK 23 which has both M1 support and is the side-by-side NDK version from AGP.
         ndkVersion = "23.1.7779620"

--- a/packages/meditrak-app/ios/TupaiaMediTrak.xcodeproj/project.pbxproj
+++ b/packages/meditrak-app/ios/TupaiaMediTrak.xcodeproj/project.pbxproj
@@ -495,7 +495,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 142;
+				CURRENT_PROJECT_VERSION = 143;
 				DEVELOPMENT_TEAM = 352QMCKRKJ;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 352QMCKRKJ;
 				ENABLE_BITCODE = NO;
@@ -528,7 +528,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 142;
+				CURRENT_PROJECT_VERSION = 143;
 				DEVELOPMENT_TEAM = 352QMCKRKJ;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 352QMCKRKJ;
 				INFOPLIST_FILE = TupaiaMediTrak/Info.plist;

--- a/packages/meditrak-app/ios/TupaiaMediTrak.xcodeproj/project.pbxproj
+++ b/packages/meditrak-app/ios/TupaiaMediTrak.xcodeproj/project.pbxproj
@@ -504,7 +504,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.14.142;
+				MARKETING_VERSION = 1.14.143;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -536,7 +536,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.14.142;
+				MARKETING_VERSION = 1.14.143;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/packages/meditrak-app/package.json
+++ b/packages/meditrak-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/meditrak-app",
-  "version": "1.14.142",
+  "version": "1.14.143",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
Releasing [RN-1389 ](https://linear.app/bes/issue/RN-1389/bump-meditrak-target-android-version-to-14-api-level-34) to production since we're potentially skipping next release and this is time sensitive

Note that I don't think this was originally branched off `master` but I don't think it matters since it doesn't seem to contain any changes from `dev` that don't already exist on `master` (as far as I can tell)