### PR TITLE
tweak(datatrakWeb): RN-1417: save parent task to completed repeating tasks

### DIFF
--- a/packages/database/src/__tests__/changeHandlers/TaskCompletionHandler.test.js
+++ b/packages/database/src/__tests__/changeHandlers/TaskCompletionHandler.test.js
@@ -135,7 +135,7 @@ describe('TaskCompletionHandler', () => {
   });
 
   describe('Repeating tasks', () => {
-    it('updating a survey response for a repeating task creates a new completed task', async () => {
+    it('creating a survey response for a repeating task creates a new completed task', async () => {
       const samoa = await findOrCreateDummyRecord(models.entity, { code: 'WS' });
       const repeatTask = await findOrCreateDummyRecord(models.task, {
         entity_id: samoa.id,
@@ -154,11 +154,12 @@ describe('TaskCompletionHandler', () => {
       const newTask = await models.task.findOne({
         survey_response_id: responses[0],
         entity_id: samoa.id,
+        parent_task_id: repeatTask.id,
       });
       await assertTaskStatus(newTask.id, 'completed', responses[0]);
     });
 
-    it('updating a survey response for a repeating task with status do_do creates a new completed task', async () => {
+    it('creating a survey response for a repeating task with status to_do creates a new completed task', async () => {
       const fiji = await findOrCreateDummyRecord(models.entity, { code: 'FJ' });
       const repeatTask = await findOrCreateDummyRecord(models.task, {
         entity_id: fiji.id,
@@ -176,6 +177,7 @@ describe('TaskCompletionHandler', () => {
       const newTask = await models.task.findOne({
         survey_response_id: responses[0],
         entity_id: fiji.id,
+        parent_task_id: repeatTask.id,
       });
       await assertTaskStatus(newTask.id, 'completed', responses[0]);
     });

--- a/packages/database/src/migrations/20240813211928-AddParentTaskColumn-modifies-schema.js
+++ b/packages/database/src/migrations/20240813211928-AddParentTaskColumn-modifies-schema.js
@@ -1,0 +1,45 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = async function (db) {
+  await db.addColumn('task', 'parent_task_id', {
+    type: 'text',
+    foreignKey: {
+      name: 'task_parent_task_id_fk',
+      table: 'task',
+      mapping: 'id',
+      // Don't cascade delete, as we want to keep the task even if the parent task is deleted, just set as null
+      rules: {
+        onDelete: 'SET NULL',
+        onUpdate: 'CASCADE',
+      },
+    },
+    ifNotExists: true,
+  });
+  return db.runSql(` 
+    CREATE INDEX IF NOT EXISTS task_parent_task_id_fk ON task USING btree (parent_task_id); 
+  `);
+};
+
+exports.down = function (db) {
+  return db.removeColumn('task', 'parent_task_id', {
+    ifExists: true,
+  });
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/packages/database/src/modelClasses/Task.js
+++ b/packages/database/src/modelClasses/Task.js
@@ -144,6 +144,7 @@ export class TaskRecord extends DatabaseRecord {
         repeat_schedule: repeatSchedule,
         status: 'completed',
         survey_response_id: surveyResponseId,
+        parent_task_id: id,
       };
 
       // Check for an existing task so that multiple tasks aren't created for the same survey response

--- a/packages/types/src/schemas/schemas.ts
+++ b/packages/types/src/schemas/schemas.ts
@@ -85899,6 +85899,9 @@ export const TaskSchema = {
 		"initial_request_id": {
 			"type": "string"
 		},
+		"parent_task_id": {
+			"type": "string"
+		},
 		"repeat_schedule": {
 			"type": "object",
 			"properties": {}
@@ -85945,6 +85948,9 @@ export const TaskCreateSchema = {
 			"type": "string"
 		},
 		"initial_request_id": {
+			"type": "string"
+		},
+		"parent_task_id": {
 			"type": "string"
 		},
 		"repeat_schedule": {
@@ -85994,6 +86000,9 @@ export const TaskUpdateSchema = {
 			"type": "string"
 		},
 		"initial_request_id": {
+			"type": "string"
+		},
+		"parent_task_id": {
 			"type": "string"
 		},
 		"repeat_schedule": {
@@ -87977,6 +87986,9 @@ export const TaskResponseSchema = {
 			"type": "string"
 		},
 		"initialRequestId": {
+			"type": "string"
+		},
+		"parentTaskId": {
 			"type": "string"
 		},
 		"status": {

--- a/packages/types/src/types/models.ts
+++ b/packages/types/src/types/models.ts
@@ -1540,6 +1540,7 @@ export interface Task {
   'entity_id': string;
   'id': string;
   'initial_request_id'?: string | null;
+  'parent_task_id'?: string | null;
   'repeat_schedule'?: {} | null;
   'status'?: TaskStatus | null;
   'survey_id': string;
@@ -1551,6 +1552,7 @@ export interface TaskCreate {
   'due_date'?: Date | null;
   'entity_id': string;
   'initial_request_id'?: string | null;
+  'parent_task_id'?: string | null;
   'repeat_schedule'?: {} | null;
   'status'?: TaskStatus | null;
   'survey_id': string;
@@ -1563,6 +1565,7 @@ export interface TaskUpdate {
   'entity_id'?: string;
   'id'?: string;
   'initial_request_id'?: string | null;
+  'parent_task_id'?: string | null;
   'repeat_schedule'?: {} | null;
   'status'?: TaskStatus | null;
   'survey_id'?: string;


### PR DESCRIPTION
### Issue RN-1417: save parent task to completed repeating tasks

### Changes:
- Added `parent_task_id` column to `tasks` table
- Updated task completion to include parent task id for repeating tasks
