### PR TITLE
fix(datatrakWeb): Limit entity results to 100

### DIFF
--- a/packages/api-client/src/connections/EntityApi.ts
+++ b/packages/api-client/src/connections/EntityApi.ts
@@ -160,15 +160,28 @@ export class EntityApi extends BaseApi {
       field?: string;
       fields?: string[];
       filter?: any;
+      pageSize?: number;
     },
     includeRootEntity = false,
     isPublic = false,
   ) {
-    return this.connection.get(`hierarchy/${hierarchyName}/${entityCode}/descendants`, {
-      ...this.stringifyQueryParameters(queryOptions),
+    const { pageSize, ...otherQueryOptions } = queryOptions || {};
+    const params: {
+      pageSize?: number;
+      includeRootEntity: string;
+      isPublic: string;
+      field?: string;
+      fields?: string;
+      filter?: string;
+    } = {
+      ...this.stringifyQueryParameters(otherQueryOptions),
       includeRootEntity: `${includeRootEntity}`,
       isPublic: `${isPublic}`,
-    });
+    };
+    if (pageSize) {
+      params.pageSize = pageSize;
+    }
+    return this.connection.get(`hierarchy/${hierarchyName}/${entityCode}/descendants`, params);
   }
 
   public async getDescendantsOfEntities(

--- a/packages/database/src/modelClasses/Entity.js
+++ b/packages/database/src/modelClasses/Entity.js
@@ -183,8 +183,8 @@ export class EntityRecord extends DatabaseRecord {
     return this.model.getAncestorsOfEntities(hierarchyId, [this.id], criteria);
   }
 
-  async getDescendants(hierarchyId, criteria) {
-    return this.model.getDescendantsOfEntities(hierarchyId, [this.id], criteria);
+  async getDescendants(hierarchyId, criteria, options) {
+    return this.model.getDescendantsOfEntities(hierarchyId, [this.id], criteria, options);
   }
 
   async getRelatives(hierarchyId, criteria) {
@@ -442,9 +442,10 @@ export class EntityModel extends MaterializedViewLogDatabaseModel {
    * @param {*} ancestorsOrDescendants
    * @param {*} entityIds
    * @param {*} criteria
+   * @param {*} options
    * @returns {Promise<EntityRecord[]>}
    */
-  async getRelationsOfEntities(ancestorsOrDescendants, entityIds, criteria) {
+  async getRelationsOfEntities(ancestorsOrDescendants, entityIds, criteria, options) {
     const cacheKey = this.getCacheKey(this.getRelationsOfEntities.name, arguments);
     const [joinTablesOn, filterByEntityId] =
       ancestorsOrDescendants === ENTITY_RELATION_TYPE.ANCESTORS
@@ -461,6 +462,7 @@ export class EntityModel extends MaterializedViewLogDatabaseModel {
           joinWith: RECORDS.ANCESTOR_DESCENDANT_RELATION,
           joinCondition: ['entity.id', joinTablesOn],
           sort: ['generational_distance ASC'],
+          ...options,
         },
       );
       const relationData = await Promise.all(relations.map(async r => r.getData()));
@@ -477,11 +479,16 @@ export class EntityModel extends MaterializedViewLogDatabaseModel {
     });
   }
 
-  async getDescendantsOfEntities(hierarchyId, entityIds, criteria) {
-    return this.getRelationsOfEntities(ENTITY_RELATION_TYPE.DESCENDANTS, entityIds, {
-      entity_hierarchy_id: hierarchyId,
-      ...criteria,
-    });
+  async getDescendantsOfEntities(hierarchyId, entityIds, criteria, options) {
+    return this.getRelationsOfEntities(
+      ENTITY_RELATION_TYPE.DESCENDANTS,
+      entityIds,
+      {
+        entity_hierarchy_id: hierarchyId,
+        ...criteria,
+      },
+      options,
+    );
   }
 
   async getRelativesOfEntities(hierarchyId, entityIds, criteria) {

--- a/packages/datatrak-web-server/src/routes/EntityDescendantsRoute.ts
+++ b/packages/datatrak-web-server/src/routes/EntityDescendantsRoute.ts
@@ -63,6 +63,7 @@ export class EntityDescendantsRoute extends Route<EntityDescendantsRequest> {
       filter: { countryCode, projectCode, grandparentId, parentId, type, ...restOfFilter },
       searchString,
       fields = DEFAULT_FIELDS,
+      pageSize,
     } = query;
 
     if (isLoggedIn) {
@@ -108,6 +109,7 @@ export class EntityDescendantsRoute extends Route<EntityDescendantsRequest> {
       {
         fields,
         filter,
+        pageSize,
       },
       false,
       !isLoggedIn,

--- a/packages/datatrak-web/src/features/EntitySelector/EntitySelector.tsx
+++ b/packages/datatrak-web/src/features/EntitySelector/EntitySelector.tsx
@@ -36,6 +36,7 @@ const useSearchResults = (searchValue, filter, projectCode, disableSearch = fals
       fields: ['id', 'parent_name', 'code', 'name', 'type'],
       filter,
       searchString: debouncedSearch,
+      pageSize: 100,
     },
     !disableSearch,
   );

--- a/packages/entity-server/src/__tests__/__integration__/EntityDescendantRoutes.test.ts
+++ b/packages/entity-server/src/__tests__/__integration__/EntityDescendantRoutes.test.ts
@@ -162,6 +162,19 @@ describe('descendants', () => {
       expect(entities).toBeArray();
       expect(entities).toIncludeSameMembers(getEntitiesWithFields([], ['code', 'name', 'type']));
     });
+
+    it('can limit by page size', async () => {
+      const { body: entities } = await app.get('hierarchy/redblue/KANTO/descendants', {
+        query: {
+          fields: 'code,name',
+          filter: 'type==city',
+          pageSize: 5,
+        },
+      });
+
+      expect(entities).toBeArray();
+      expect(entities.length).toBe(5);
+    });
   });
 
   describe('/hierarchy/:hierarchyName/descendants', () => {

--- a/packages/entity-server/src/routes/hierarchy/EntityDescendantsRoute.ts
+++ b/packages/entity-server/src/routes/hierarchy/EntityDescendantsRoute.ts
@@ -17,16 +17,22 @@ export type DescendantsRequest = SingleEntityRequest<
   SingleEntityRequestParams,
   EntityResponse[],
   RequestBody,
-  EntityRequestQuery & { includeRootEntity?: string }
+  EntityRequestQuery & { includeRootEntity?: string; pageSize?: number }
 >;
 export class EntityDescendantsRoute extends Route<DescendantsRequest> {
   public async buildResponse() {
     const { hierarchyId, entity, fields, field, filter } = this.req.ctx;
-    const { includeRootEntity: includeRootEntityString = 'false' } = this.req.query;
+    const { includeRootEntity: includeRootEntityString = 'false', pageSize } = this.req.query;
     const includeRootEntity = includeRootEntityString?.toLowerCase() === 'true';
-    const descendants = await entity.getDescendants(hierarchyId, {
-      ...filter,
-    });
+    const descendants = await entity.getDescendants(
+      hierarchyId,
+      {
+        ...filter,
+      },
+      {
+        limit: pageSize,
+      },
+    );
     const responseEntities = includeRootEntity ? [entity].concat(descendants) : descendants;
 
     return formatEntitiesForResponse(

--- a/packages/entity-server/src/routes/hierarchy/middleware/attachCommonEntityContext.ts
+++ b/packages/entity-server/src/routes/hierarchy/middleware/attachCommonEntityContext.ts
@@ -4,8 +4,8 @@
  */
 import { NextFunction, Request, Response } from 'express';
 import { PermissionsError } from '@tupaia/utils';
-import { extractEntityFieldsFromQuery, extractEntityFieldFromQuery } from './fields';
 import { CommonContext } from '../types';
+import { extractEntityFieldsFromQuery, extractEntityFieldFromQuery } from './fields';
 
 const throwNoAccessError = (hierarchyName: string) => {
   throw new PermissionsError(`No access to requested hierarchy: ${hierarchyName}`);

--- a/packages/entity-server/src/routes/hierarchy/types.ts
+++ b/packages/entity-server/src/routes/hierarchy/types.ts
@@ -71,6 +71,7 @@ export type CommonContext = {
   fields: ExtendedEntityFieldName[];
   filter: EntityFilter;
   field?: FlattableEntityFieldName;
+  pageSize?: string;
 };
 
 export interface SingleEntityContext extends CommonContext {

--- a/packages/server-boilerplate/src/models/Entity.ts
+++ b/packages/server-boilerplate/src/models/Entity.ts
@@ -17,7 +17,11 @@ export type EntityFilter = DbFilter<EntityFilterFields>;
 export interface EntityRecord extends Entity, BaseEntityRecord {
   getChildren: (hierarchyId: string, criteria?: EntityFilter) => Promise<EntityRecord[]>;
   getParent: (hierarchyId: string) => Promise<EntityRecord | undefined>;
-  getDescendants: (hierarchyId: string, criteria?: EntityFilter) => Promise<EntityRecord[]>;
+  getDescendants: (
+    hierarchyId: string,
+    criteria?: EntityFilter,
+    options?: Record<string, unknown>,
+  ) => Promise<EntityRecord[]>;
   getAncestors: (hierarchyId: string, criteria?: EntityFilter) => Promise<EntityRecord[]>;
   getAncestorOfType: (hierarchyId: string, type: string) => Promise<EntityRecord | undefined>;
   getRelatives: (hierarchyId: string, criteria?: EntityFilter) => Promise<EntityRecord[]>;

--- a/packages/types/src/types/requests/datatrak-web-server/EntityDescendantsRequest.ts
+++ b/packages/types/src/types/requests/datatrak-web-server/EntityDescendantsRequest.ts
@@ -28,4 +28,5 @@ export type ReqQuery = {
     type?: string;
   };
   searchString?: string;
+  pageSize?: number;
 };


### PR DESCRIPTION
### Limit entity results to 100

### Changes:
- Allow setting `pageSize` param for entity descendants
- Limit entity descendants in Datatrak to 100

Note: This is to fix an issue where if a survey's primary entity filter is type `household`, for example, it will load all results, which can be upwards of 10000 results. This was causing a performance issue