### PR TITLE
tweak(centralServer): RN-1351: Handle bad DHIS2 sync requests

### DIFF
--- a/packages/central-server/src/dhis/pushLatest.js
+++ b/packages/central-server/src/dhis/pushLatest.js
@@ -19,6 +19,7 @@ export async function pushLatest(models, syncQueue, dataBroker, batchSize) {
     if (successfullyPushed) {
       await syncQueue.use(change);
     } else {
+      await syncQueue.registerBadRequest(change);
       await syncQueue.deprioritise(change);
     }
   }

--- a/packages/central-server/src/dhis/pushers/entity/TrackedEntityPusher.js
+++ b/packages/central-server/src/dhis/pushers/entity/TrackedEntityPusher.js
@@ -74,6 +74,10 @@ export class TrackedEntityPusher extends EntityPusher {
       filter: { displayName: this.entityToTypeName(entity) },
     });
 
+    if (!trackedEntityType) {
+      throw new Error(`Tracked entity type not found for ${type}`);
+    }
+
     return trackedEntityType.id;
   }
 

--- a/packages/central-server/src/externalApiSync/ExternalApiSyncQueue.js
+++ b/packages/central-server/src/externalApiSync/ExternalApiSyncQueue.js
@@ -165,11 +165,11 @@ export class ExternalApiSyncQueue {
   }
 
   registerBadRequest(change) {
-    // Update also causes change_time to be reset to current time
-    // so it will slot in at the back of its new priority group
+    // If the bad request count is over the limit, mark it as a dead letter
     if (change.bad_request_count > BAD_REQUEST_LIMIT) {
       return this.syncQueueModel.updateById(change.id, { is_dead_letter: true });
-    } // Cap the priority
+    }
+    // Otherwise, increment the bad request count
     return this.syncQueueModel.updateById(change.id, {
       bad_request_count: change.bad_request_count + 1,
     });


### PR DESCRIPTION
### Issue RN-1351: Handle bad DHIS2 sync requests

### Changes:
- On error getting tracked entity type, throw a more descriptive error
- Mark bad requests in db, and after 8 bad requests, mark record as dead letter
