### PR TITLE
feat(tupaiaWeb): RN-1402: Ability to generate continuous PDF for dashboard export

### DIFF
--- a/packages/server-utils/src/downloadPageAsPDF.ts
+++ b/packages/server-utils/src/downloadPageAsPDF.ts
@@ -32,6 +32,8 @@ const buildParams = (pdfPageUrl: string, userCookie: string, cookieDomain: strin
   return { verifiedPDFPageUrl, cookies: finalisedCookieObjects };
 };
 
+const pageNumberHTML = `<div style="text-align: right;width: 297mm;font-size: 8px;font-family: Arial, Helvetica, sans-serif;"><span style="margin-right: 1cm"><span class="pageNumber"></span></span></div>`;
+
 /**
  * @param pdfPageUrl the url to visit and download as a pdf
  * @param userCookie the user's cookie to bypass auth, and ensure page renders under the correct user context
@@ -43,6 +45,7 @@ export const downloadPageAsPDF = async (
   userCookie = '',
   cookieDomain: string | undefined,
   landscape = false,
+  includePageNumber = false,
 ) => {
   let browser;
   let buffer;
@@ -57,6 +60,12 @@ export const downloadPageAsPDF = async (
       format: 'a4',
       printBackground: true,
       landscape,
+      displayHeaderFooter: includePageNumber,
+      // remove the default header so that only the page number is displayed, not a header
+      headerTemplate: `<div></div>`,
+      footerTemplate: pageNumberHTML,
+      //add a margin so the page number doesn't overlap with the content, and the top margin is set for overflow content
+      margin: includePageNumber ? { bottom: '10mm', top: '10mm' } : undefined,
     });
   } catch (e) {
     throw new Error(`puppeteer error: ${(e as Error).message}`);

--- a/packages/tupaia-web-server/src/utils/downloadDashboardAsPdf.ts
+++ b/packages/tupaia-web-server/src/utils/downloadDashboardAsPdf.ts
@@ -18,6 +18,7 @@ export const downloadDashboardAsPdf = (
   settings: TupaiaWebExportDashboardRequest.ReqBody['settings'] = {
     exportWithLabels: false,
     exportWithTable: false,
+    separatePagePerItem: true,
   },
 ) => {
   const endpoint = `${projectCode}/${entityCode}/${dashboardName}/dashboard-pdf-export`;
@@ -25,6 +26,8 @@ export const downloadDashboardAsPdf = (
     selectedDashboardItems: selectedDashboardItems?.join(','),
     settings: JSON.stringify(settings),
   });
+
+  console.log('pdfPageUrl', pdfPageUrl);
 
   return downloadPageAsPDF(pdfPageUrl, cookie, cookieDomain);
 };

--- a/packages/tupaia-web-server/src/utils/downloadDashboardAsPdf.ts
+++ b/packages/tupaia-web-server/src/utils/downloadDashboardAsPdf.ts
@@ -27,7 +27,5 @@ export const downloadDashboardAsPdf = (
     settings: JSON.stringify(settings),
   });
 
-  console.log('pdfPageUrl', pdfPageUrl);
-
-  return downloadPageAsPDF(pdfPageUrl, cookie, cookieDomain);
+  return downloadPageAsPDF(pdfPageUrl, cookie, cookieDomain, false, true);
 };

--- a/packages/tupaia-web/src/features/Dashboard/ExportDashboard/ExportConfig.tsx
+++ b/packages/tupaia-web/src/features/Dashboard/ExportDashboard/ExportConfig.tsx
@@ -158,11 +158,17 @@ export const ExportConfig = ({ onClose, selectedDashboardItems }: ExportDashboar
                 settings={{
                   exportWithTable,
                   exportWithLabels,
+                  separatePagePerItem,
                 }}
               />
             </ExportSetting>
           </ExportSettingsContainer>
-          {!isLoading && <Preview selectedDashboardItems={selectedDashboardItems} />}
+          {!isLoading && (
+            <Preview
+              selectedDashboardItems={selectedDashboardItems}
+              separatePagePerItem={separatePagePerItem}
+            />
+          )}
         </Container>
       </Wrapper>
       <ButtonGroup>

--- a/packages/tupaia-web/src/features/Dashboard/ExportDashboard/ExportConfig.tsx
+++ b/packages/tupaia-web/src/features/Dashboard/ExportDashboard/ExportConfig.tsx
@@ -109,7 +109,7 @@ export const ExportConfig = ({ onClose, selectedDashboardItems }: ExportDashboar
   const { data: project } = useProject(projectCode);
   const { data: entity } = useEntity(projectCode, entityCode);
   const { activeDashboard } = useDashboard();
-  const { exportWithLabels, exportWithTable } = useExportSettings();
+  const { exportWithLabels, exportWithTable, separatePagePerItem } = useExportSettings();
 
   const exportFileName = `${project?.name}-${entity?.name}-${dashboardName}-dashboard-export`;
 
@@ -124,6 +124,7 @@ export const ExportConfig = ({ onClose, selectedDashboardItems }: ExportDashboar
       settings: {
         exportWithLabels,
         exportWithTable,
+        separatePagePerItem,
       },
     });
 

--- a/packages/tupaia-web/src/features/Dashboard/ExportDashboard/ExportDashboard.tsx
+++ b/packages/tupaia-web/src/features/Dashboard/ExportDashboard/ExportDashboard.tsx
@@ -87,6 +87,7 @@ export const ExportDashboard = () => {
           exportWithLabels: false,
           exportWithTable: true,
           exportWithTableDisabled: false,
+          separatePagePerItem: true,
         }}
       >
         <Wrapper>

--- a/packages/tupaia-web/src/features/Dashboard/ExportDashboard/Preview.tsx
+++ b/packages/tupaia-web/src/features/Dashboard/ExportDashboard/Preview.tsx
@@ -57,24 +57,34 @@ const PreviewTitle = styled(Typography).attrs({
   line-height: 1.4;
 `;
 
-export const Preview = ({ selectedDashboardItems }: { selectedDashboardItems: string[] }) => {
+export const Preview = ({
+  selectedDashboardItems,
+  separatePagePerItem,
+}: {
+  selectedDashboardItems: string[];
+  separatePagePerItem: boolean;
+}) => {
   const [page, setPage] = useState(1);
   const onPageChange = (_: unknown, newPage: number) => setPage(newPage);
-  const visualisationToPreview = selectedDashboardItems[page - 1];
+  const visualisationToPreview = separatePagePerItem
+    ? [selectedDashboardItems[page - 1]]
+    : selectedDashboardItems;
 
   return (
     <PreviewPanelContainer>
       <PreviewHeaderContainer>
         <PreviewTitle>Preview</PreviewTitle>
-        <PreviewPagination
-          size="small"
-          siblingCount={0}
-          count={selectedDashboardItems.length}
-          onChange={onPageChange}
-        />
+        {separatePagePerItem && (
+          <PreviewPagination
+            size="small"
+            siblingCount={0}
+            count={selectedDashboardItems.length}
+            onChange={onPageChange}
+          />
+        )}
       </PreviewHeaderContainer>
       <PreviewContainer>
-        <DashboardPDFExport selectedDashboardItems={[visualisationToPreview]} isPreview={true} />
+        <DashboardPDFExport selectedDashboardItems={visualisationToPreview} isPreview={true} />
       </PreviewContainer>
     </PreviewPanelContainer>
   );

--- a/packages/tupaia-web/src/features/Dashboard/ExportDashboard/Preview.tsx
+++ b/packages/tupaia-web/src/features/Dashboard/ExportDashboard/Preview.tsx
@@ -7,6 +7,7 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { Typography } from '@material-ui/core';
 import { Pagination } from '@material-ui/lab';
+import { A4Page } from '@tupaia/ui-components';
 import { DashboardPDFExport } from '../../../views';
 import { MOBILE_BREAKPOINT } from '../../../constants';
 
@@ -46,6 +47,13 @@ const PreviewContainer = styled.div`
   min-width: 20rem;
   overflow-y: auto;
   overflow-x: hidden;
+  ${A4Page} {
+    // simulate the margins of the printed page
+    padding-block-start: 5rem;
+    &:last-child {
+      padding-block-end: 5rem;
+    }
+  }
 `;
 
 const PreviewTitle = styled(Typography).attrs({

--- a/packages/tupaia-web/src/features/ExportSettings/DisplayOptionsSettings.tsx
+++ b/packages/tupaia-web/src/features/ExportSettings/DisplayOptionsSettings.tsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import styled from 'styled-components';
-import { FormControl, FormGroup } from '@material-ui/core';
+import { FormControl, FormControlLabel, FormGroup, Radio, RadioGroup } from '@material-ui/core';
 import { Checkbox as BaseCheckbox } from '@tupaia/ui-components';
 import { ExportFormats, useExportSettings } from './ExportSettingsContext';
 import { ExportSettingLabel } from './ExportSettingLabel';
@@ -29,6 +29,32 @@ const Group = styled(FormGroup)`
   }
 `;
 
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const Container = styled.div`
+  padding-block-end: 2.5rem;
+  & + & {
+    padding-block-start: 1.5rem;
+    border-top: 0.1rem solid ${({ theme }) => theme.palette.text.secondary};
+  }
+  &:last-child {
+    padding-block-end: 0;
+  }
+`;
+
+const RadioItem = styled(FormControlLabel)`
+  padding-block-end: 0.625rem;
+  &:first-child {
+    padding-block-start: 0.625rem;
+  }
+  .MuiButtonBase-root {
+    padding-block: 0;
+  }
+`;
+
 export const DisplayOptionsSettings = () => {
   const {
     exportWithLabels,
@@ -37,32 +63,51 @@ export const DisplayOptionsSettings = () => {
     updateExportWithTable,
     exportWithTableDisabled,
     exportFormat,
+    separatePagePerItem,
+    updateSeparatePagePerItem,
   } = useExportSettings();
   if (exportFormat !== ExportFormats.PNG) return null;
 
   return (
-    <FormControl component="fieldset">
-      <ExportSettingLabel as="legend">Display options</ExportSettingLabel>
-      <Group>
-        <Checkbox
-          label="Export with labels"
-          value={true}
-          name="displayOptions"
-          color="primary"
-          checked={exportWithLabels}
-          onChange={updateExportWithLabels}
-        />
-        {!exportWithTableDisabled && (
-          <Checkbox
-            label="Export with table"
-            value={true}
-            name="displayOptions"
-            color="primary"
-            checked={exportWithTable}
-            onChange={updateExportWithTable}
-          />
-        )}
-      </Group>
-    </FormControl>
+    <Wrapper>
+      <Container>
+        <FormControl component="fieldset">
+          <ExportSettingLabel as="legend">Format</ExportSettingLabel>
+          <RadioGroup
+            name="separatePagePerItem"
+            value={separatePagePerItem}
+            onChange={updateSeparatePagePerItem}
+          >
+            <RadioItem value={true} control={<Radio color="primary" />} label="One per page" />
+            <RadioItem value={false} control={<Radio color="primary" />} label="Print continuous" />
+          </RadioGroup>
+        </FormControl>
+      </Container>
+      <Container>
+        <FormControl component="fieldset">
+          <ExportSettingLabel as="legend">Display options</ExportSettingLabel>
+          <Group>
+            <Checkbox
+              label="Export with labels"
+              value={true}
+              name="displayOptions"
+              color="primary"
+              checked={exportWithLabels}
+              onChange={updateExportWithLabels}
+            />
+            {!exportWithTableDisabled && (
+              <Checkbox
+                label="Export with table"
+                value={true}
+                name="displayOptions"
+                color="primary"
+                checked={exportWithTable}
+                onChange={updateExportWithTable}
+              />
+            )}
+          </Group>
+        </FormControl>
+      </Container>
+    </Wrapper>
   );
 };

--- a/packages/tupaia-web/src/features/ExportSettings/DisplayOptionsSettings.tsx
+++ b/packages/tupaia-web/src/features/ExportSettings/DisplayOptionsSettings.tsx
@@ -35,7 +35,7 @@ const Wrapper = styled.div`
 `;
 
 const Container = styled.div`
-  padding-block-end: 2.5rem;
+  padding-block-end: 2rem;
   & + & {
     padding-block-start: 1.5rem;
     border-top: 0.1rem solid ${({ theme }) => theme.palette.text.secondary};

--- a/packages/tupaia-web/src/features/ExportSettings/ExportSettingsContext.tsx
+++ b/packages/tupaia-web/src/features/ExportSettings/ExportSettingsContext.tsx
@@ -15,12 +15,14 @@ type ExportSettings = {
   exportWithLabels: boolean;
   exportWithTable: boolean;
   exportWithTableDisabled: boolean;
+  separatePagePerItem: boolean;
 };
 
 type ExportSettingsContextType = ExportSettings & {
   setExportFormat: (value: ExportFormats) => void;
   setExportWithLabels: (value: boolean) => void;
   setExportWithTable: (value: boolean) => void;
+  setSeparatePagePerItem: (value: boolean) => void;
 };
 
 const defaultContext = {
@@ -28,9 +30,11 @@ const defaultContext = {
   exportWithLabels: false,
   exportWithTable: true,
   exportWithTableDisabled: false,
+  separatePagePerItem: true,
   setExportFormat: () => {},
   setExportWithLabels: () => {},
   setExportWithTable: () => {},
+  setSeparatePagePerItem: () => {},
 } as ExportSettingsContextType;
 
 // This is the context for the export settings
@@ -45,6 +49,8 @@ export const useExportSettings = () => {
     setExportFormat,
     setExportWithLabels,
     setExportWithTable,
+    separatePagePerItem,
+    setSeparatePagePerItem,
   } = useContext(ExportSettingsContext);
 
   const updateExportFormat = (e: ChangeEvent<HTMLInputElement>) =>
@@ -58,10 +64,15 @@ export const useExportSettings = () => {
     setExportWithTable(e.target.checked);
   };
 
+  const updateSeparatePagePerItem = (e: ChangeEvent<HTMLInputElement>) => {
+    setSeparatePagePerItem(e.target.value === 'true');
+  };
+
   const resetExportSettings = (dashboardItemType?: string) => {
     setExportFormat(dashboardItemType === 'matrix' ? ExportFormats.XLSX : ExportFormats.PNG);
     setExportWithLabels(false);
     setExportWithTable(true);
+    setSeparatePagePerItem(true);
   };
 
   return {
@@ -73,6 +84,8 @@ export const useExportSettings = () => {
     updateExportWithLabels,
     updateExportWithTable,
     resetExportSettings,
+    separatePagePerItem,
+    updateSeparatePagePerItem,
   };
 };
 
@@ -95,6 +108,11 @@ export const ExportSettingsContextProvider = ({
   const [exportWithTableDisabled] = useState<boolean>(
     defaultSettings?.exportWithTableDisabled || false,
   );
+
+  const [separatePagePerItem, setSeparatePagePerItem] = useState<boolean>(
+    defaultSettings?.separatePagePerItem || true,
+  );
+
   return (
     <ExportSettingsContext.Provider
       value={{
@@ -105,6 +123,8 @@ export const ExportSettingsContextProvider = ({
         setExportFormat,
         setExportWithLabels,
         setExportWithTable,
+        separatePagePerItem,
+        setSeparatePagePerItem,
       }}
     >
       {children}

--- a/packages/tupaia-web/src/features/PDFExportDashboardItem/PDFExportDashboardItem.tsx
+++ b/packages/tupaia-web/src/features/PDFExportDashboardItem/PDFExportDashboardItem.tsx
@@ -100,6 +100,7 @@ interface PDFExportDashboardItemProps {
   activeDashboard?: Dashboard;
   isPreview?: boolean;
   settings?: TupaiaWebExportDashboardRequest.ReqBody['settings'];
+  displayHeader?: boolean;
 }
 
 /**
@@ -112,6 +113,7 @@ export const PDFExportDashboardItem = ({
   activeDashboard,
   isPreview = false,
   settings,
+  displayHeader,
 }: PDFExportDashboardItemProps) => {
   const [width, setWidth] = useState(0);
   const pageRef = useRef<HTMLDivElement | null>(null);
@@ -164,6 +166,8 @@ export const PDFExportDashboardItem = ({
   const period = getDatesAsString(periodGranularity, startDate, endDate);
 
   const data = isLoading ? undefined : (report as BaseReport)?.data;
+
+  console.log(displayHeader);
   return (
     <StyledA4Page
       ref={pageRef}
@@ -172,11 +176,13 @@ export const PDFExportDashboardItem = ({
       $previewZoom={previewZoom}
       separatePage={separatePagePerItem}
     >
-      <PDFExportHeader imageUrl={projectLogoUrl} imageDescription={projectLogoDescription}>
-        {entityName}
-      </PDFExportHeader>
+      {displayHeader && (
+        <PDFExportHeader imageUrl={projectLogoUrl} imageDescription={projectLogoDescription}>
+          {entityName}
+        </PDFExportHeader>
+      )}
       <PDFExportBody>
-        <DashboardName>{activeDashboard?.name}</DashboardName>
+        {displayHeader && <DashboardName>{activeDashboard?.name}</DashboardName>}
         <Title>{title}</Title>
         {reference && <ReferenceTooltip reference={reference} />}
         {period && <ExportPeriod>{period}</ExportPeriod>}

--- a/packages/tupaia-web/src/features/PDFExportDashboardItem/PDFExportDashboardItem.tsx
+++ b/packages/tupaia-web/src/features/PDFExportDashboardItem/PDFExportDashboardItem.tsx
@@ -32,10 +32,12 @@ const StyledA4Page = styled(A4Page)<{
 }>`
   ${({ $isPreview, $previewZoom = 0.25 }) =>
     $isPreview ? `width: 100%; zoom: ${$previewZoom};` : ''};
+  padding-block-start: 0;
+  padding-block-end: 1cm;
 `;
 
 const PDFExportBody = styled.main`
-  margin-block: 36pt;
+  margin-block-start: 36pt;
 `;
 
 const Title = styled.h3`
@@ -167,7 +169,6 @@ export const PDFExportDashboardItem = ({
 
   const data = isLoading ? undefined : (report as BaseReport)?.data;
 
-  console.log(displayHeader);
   return (
     <StyledA4Page
       ref={pageRef}

--- a/packages/tupaia-web/src/features/PDFExportDashboardItem/PDFExportDashboardItem.tsx
+++ b/packages/tupaia-web/src/features/PDFExportDashboardItem/PDFExportDashboardItem.tsx
@@ -144,13 +144,14 @@ export const PDFExportDashboardItem = ({
 
   const { config = {} as DashboardItemConfig } = dashboardItem || ({} as DashboardItem);
 
+  const { separatePagePerItem, ...restOfSettings } = settings || {};
   const presentationOptions =
     config && 'presentationOptions' in config ? config.presentationOptions : undefined;
   const dashboardItemConfig = {
     ...config,
     presentationOptions: {
       ...presentationOptions,
-      ...settings,
+      ...restOfSettings,
     },
   } as DashboardItemConfig;
   const { description, entityHeader, name, periodGranularity, reference } = dashboardItemConfig;
@@ -169,6 +170,7 @@ export const PDFExportDashboardItem = ({
       key={dashboardItem?.code}
       $isPreview={isPreview}
       $previewZoom={previewZoom}
+      separatePage={separatePagePerItem}
     >
       <PDFExportHeader imageUrl={projectLogoUrl} imageDescription={projectLogoDescription}>
         {entityName}

--- a/packages/tupaia-web/src/features/PDFExportDashboardItem/PDFExportHeader.tsx
+++ b/packages/tupaia-web/src/features/PDFExportDashboardItem/PDFExportHeader.tsx
@@ -16,7 +16,7 @@ const Container = styled.div`
 
 const HeaderImage = styled.img`
   aspect-ratio: 1;
-  height: 3.5cm; // equivalent to 132px
+  height: 1.5cm;
   object-fit: contain;
 `;
 

--- a/packages/tupaia-web/src/features/Visuals/Chart.tsx
+++ b/packages/tupaia-web/src/features/Visuals/Chart.tsx
@@ -140,10 +140,11 @@ const ContentWrapper = styled.div<{
   padding: ${({ $isEnlarged }) => ($isEnlarged ? '1rem 0' : 'initial')};
   height: ${({ $isExporting }) =>
     $isExporting ? 'auto' : '15rem'}; // to stop charts from shrinking to nothing at mobile size
-  min-height: ${({ $isEnlarged }) =>
-    $isEnlarged
-      ? '24rem'
-      : '0'}; // so that the chart table doesn't shrink the modal size when opened, of doesn't have much data
+  min-height: ${({ $isEnlarged, $isExporting }) => {
+    if ($isExporting) return '5rem'; // mainly for the 'no data' message
+    if ($isEnlarged) return '24rem';
+    return 0; // so that the chart table doesn't shrink the modal size when opened, of doesn't have much data
+  }};
   ${A4Page} & {
     padding: 0;
     height: auto;

--- a/packages/tupaia-web/src/views/DashboardPDFExport.tsx
+++ b/packages/tupaia-web/src/views/DashboardPDFExport.tsx
@@ -42,7 +42,7 @@ export const DashboardPDFExport = ({
 
   const { activeDashboard } = useDashboard();
   const { data: entity } = useEntity(projectCode, entityCode);
-  const { exportWithLabels, exportWithTable } = useExportSettings();
+  const { exportWithLabels, exportWithTable, separatePagePerItem } = useExportSettings();
 
   if (!activeDashboard) return null;
 
@@ -60,6 +60,7 @@ export const DashboardPDFExport = ({
         JSON.parse(urlSettings) || {
           exportWithLabels,
           exportWithTable,
+          separatePagePerItem,
         }
       );
     }
@@ -67,6 +68,7 @@ export const DashboardPDFExport = ({
     return {
       exportWithLabels,
       exportWithTable,
+      separatePagePerItem,
     };
   };
 

--- a/packages/tupaia-web/src/views/DashboardPDFExport.tsx
+++ b/packages/tupaia-web/src/views/DashboardPDFExport.tsx
@@ -87,7 +87,7 @@ export const DashboardPDFExport = ({
 
   return (
     <Parent $isPreview={isPreview}>
-      {dashboardItems?.map(dashboardItem => (
+      {dashboardItems?.map((dashboardItem, i) => (
         <PDFExportDashboardItem
           key={dashboardItem.code}
           dashboardItem={dashboardItem}
@@ -95,6 +95,7 @@ export const DashboardPDFExport = ({
           activeDashboard={activeDashboard}
           isPreview={isPreview}
           settings={settings}
+          displayHeader={settings.separatePagePerItem || i === 0}
         />
       ))}
     </Parent>

--- a/packages/types/src/types/requests/tupaia-web-server/EmailDashboardRequest.ts
+++ b/packages/types/src/types/requests/tupaia-web-server/EmailDashboardRequest.ts
@@ -18,6 +18,7 @@ export type ReqBody = {
   settings?: {
     exportWithTable: boolean;
     exportWithLabels: boolean;
+    separatePagePerItem: boolean;
   };
 };
 export type ReqQuery = Record<string, string>;

--- a/packages/types/src/types/requests/tupaia-web-server/ExportDashboardRequest.ts
+++ b/packages/types/src/types/requests/tupaia-web-server/ExportDashboardRequest.ts
@@ -20,6 +20,7 @@ export type ReqBody = {
   settings?: {
     exportWithTable: boolean;
     exportWithLabels: boolean;
+    separatePagePerItem: boolean;
   };
 };
 export type ReqQuery = Record<string, string>;

--- a/packages/ui-components/src/components/PDFExportComponent.tsx
+++ b/packages/ui-components/src/components/PDFExportComponent.tsx
@@ -16,10 +16,12 @@ export const A4_PAGE_HEIGHT_MM = 297;
 export const A4_PAGE_WIDTH_PX = 1191; // at 144ppi
 export const A4_PAGE_HEIGHT_PX = 1683; // at 144ppi
 
-export const A4Page = styled.div`
+export const A4Page = styled.div<{
+  separatePage?: boolean;
+}>`
   width: ${A4_PAGE_WIDTH_PX}px;
-
-  break-after: page;
+  page-break-after: ${({ separatePage }) => (separatePage ? 'always' : 'auto')};
+  break-inside: avoid;
   flex-direction: column;
   padding: 1.5cm 4.5cm 2cm; // Bottom slightly taller than top for *optical* alignment
 `;


### PR DESCRIPTION
### Issue RN-1402: Ability to generate continuous PDF for dashboard export

### Changes:
- Added format settings to export dashboard modal
- Added support for page numbers in pdf export
- Added support for continuous PDF export

---

### Screenshots:
![Screenshot 2024-09-13 at 10 05 31 AM](https://github.com/user-attachments/assets/8f43a184-8bd8-4d50-ad84-8d72e9782e25)
![Screenshot 2024-09-13 at 10 09 03 AM](https://github.com/user-attachments/assets/8d2654fb-4f7c-4beb-840b-54cac7368912)
