### PR TITLE
tweak(datatrakWeb): RN-1426: Shift activity feed upwards when less than 2 recent surveys

### DIFF
--- a/packages/datatrak-web/src/views/LandingPage/RecentSurveysSection.tsx
+++ b/packages/datatrak-web/src/views/LandingPage/RecentSurveysSection.tsx
@@ -16,10 +16,13 @@ const RecentSurveys = styled.section`
   flex-direction: column;
 `;
 
-const ScrollBody = styled.div`
+const ScrollBody = styled.div<{
+  $hasMoreThanOneSurvey: boolean;
+}>`
   border-radius: 10px;
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(calc(33.3% - 1rem), 1fr));
+  grid-template-columns: ${({ $hasMoreThanOneSurvey }) =>
+    $hasMoreThanOneSurvey ? ' repeat(auto-fill, minmax(calc(33.3% - 1rem), 1fr))' : '1fr'};
   grid-column-gap: 1rem;
   grid-row-gap: 0.6rem;
 
@@ -41,11 +44,12 @@ const ScrollBody = styled.div`
 
 export const RecentSurveysSection = () => {
   const { data: recentSurveys = [], isSuccess, isLoading } = useCurrentUserRecentSurveys();
+  const hasMoreThanOneSurvey = recentSurveys.length > 1;
 
   return (
     <RecentSurveys>
       <SectionHeading>Top surveys</SectionHeading>
-      <ScrollBody>
+      <ScrollBody $hasMoreThanOneSurvey={hasMoreThanOneSurvey}>
         {isLoading && <LoadingTile />}
         {isSuccess && (
           <>


### PR DESCRIPTION
### Issue RN-1426: Shift activity feed upwards when less than 2 recent surveys

### Changes:
- Shift layout on larger screens when less than 2 recent surveys

---

### Screenshots:
![Screenshot 2024-09-27 at 8 52 13 AM](https://github.com/user-attachments/assets/002f6706-2d2b-4bb3-b594-acd16e2584cb)
![Screenshot 2024-09-27 at 8 51 35 AM](https://github.com/user-attachments/assets/fb5f5ddf-e720-41a0-a6de-f92a61929a09)
![Screenshot 2024-09-27 at 8 50 58 AM](https://github.com/user-attachments/assets/03c50548-c1ba-47dc-bccb-eebc15a875b1)
