### PR TITLE
fix(datatrakWeb): RN-1483: Fix issue with code gen replacing saved values on resubmit

### DIFF
--- a/packages/datatrak-web/src/features/Survey/SurveyContext/SurveyContext.tsx
+++ b/packages/datatrak-web/src/features/Survey/SurveyContext/SurveyContext.tsx
@@ -36,6 +36,9 @@ const defaultContext = {
   cancelModalOpen: false,
   countryCode: '',
   primaryEntityQuestion: null,
+  isResubmitScreen: false,
+  isResubmitReviewScreen: false,
+  isResubmit: false,
 } as SurveyFormContextType;
 
 const SurveyFormContext = createContext(defaultContext);
@@ -52,7 +55,11 @@ export const SurveyContext = ({ children, surveyCode, countryCode }) => {
   const screenNumber = params.screenNumber ? parseInt(params.screenNumber!, 10) : null;
   const { data: survey } = useSurvey(surveyCode);
   const isResponseScreen = !!urlSearchParams.get('responseId');
-  const isReviewScreen = !!useMatch(ROUTES.SURVEY_REVIEW);
+  const isResubmitReviewScreen = !!useMatch(ROUTES.SURVEY_RESUBMIT_REVIEW);
+  const isReviewScreen = !!useMatch(ROUTES.SURVEY_REVIEW) || isResubmitReviewScreen;
+  const isResubmitScreen = !!useMatch(ROUTES.SURVEY_RESUBMIT_SCREEN);
+  const isResubmit =
+    !!useMatch(ROUTES.SURVEY_RESUBMIT) || isResubmitScreen || isResubmitReviewScreen;
 
   let { formData } = state;
 
@@ -101,7 +108,7 @@ export const SurveyContext = ({ children, surveyCode, countryCode }) => {
   const activeScreen = visibleScreens?.[screenNumber! - 1]?.surveyScreenComponents || [];
 
   const initialiseFormData = () => {
-    if (!surveyCode || isResponseScreen) return;
+    if (!surveyCode || isResponseScreen || isResubmit) return;
     // if we are on the response screen, we don't want to initialise the form data, because we want to show the user's saved answers
     const initialFormData = generateCodeForCodeGeneratorQuestions(
       flattenedScreenComponents,
@@ -146,6 +153,9 @@ export const SurveyContext = ({ children, surveyCode, countryCode }) => {
         countryCode,
         surveyCode,
         primaryEntityQuestion,
+        isResubmitScreen,
+        isResubmitReviewScreen,
+        isResubmit,
       }}
     >
       <SurveyFormDispatchContext.Provider value={dispatch}>
@@ -164,10 +174,6 @@ export const useSurveyForm = () => {
   const numberOfScreens = visibleScreens?.length || 0;
   const isLast = screenNumber === numberOfScreens;
   const isSuccessScreen = !!useMatch(ROUTES.SURVEY_SUCCESS);
-  const isResubmitScreen = !!useMatch(ROUTES.SURVEY_RESUBMIT_SCREEN);
-  const isResubmitReviewScreen = !!useMatch(ROUTES.SURVEY_RESUBMIT_REVIEW);
-  const isResubmit =
-    !!useMatch(ROUTES.SURVEY_RESUBMIT) || isResubmitScreen || isResubmitReviewScreen;
 
   const toggleSideMenu = () => {
     dispatch({ type: ACTION_TYPES.TOGGLE_SIDE_MENU });
@@ -211,8 +217,5 @@ export const useSurveyForm = () => {
     getAnswerByQuestionId,
     openCancelConfirmation,
     closeCancelConfirmation,
-    isResubmitScreen,
-    isResubmitReviewScreen,
-    isResubmit,
   };
 };

--- a/packages/datatrak-web/src/features/Survey/SurveyContext/reducer.ts
+++ b/packages/datatrak-web/src/features/Survey/SurveyContext/reducer.ts
@@ -28,6 +28,9 @@ export type SurveyFormContextType = {
   cancelModalOpen: boolean;
   countryCode: string;
   primaryEntityQuestion?: SurveyScreenComponent | null;
+  isResubmitScreen: boolean;
+  isResubmitReviewScreen: boolean;
+  isResubmit: boolean;
 };
 
 export const surveyReducer = (

--- a/packages/datatrak-web/src/features/Survey/SurveyContext/utils.ts
+++ b/packages/datatrak-web/src/features/Survey/SurveyContext/utils.ts
@@ -248,6 +248,17 @@ const updateDependentQuestions = (
   return formDataCopy;
 };
 
+const generateCodeAnswer = (question: SurveyScreenComponent, formData: Record<string, any>) => {
+  const { config, questionId } = question;
+  const { codeGenerator } = config as {
+    codeGenerator: CodeGeneratorQuestionConfig;
+  };
+  if (hasCodeGeneratorConfig(question) && !formData[questionId]) {
+    return codeGenerator.type === 'shortid' ? generateShortId(codeGenerator) : generateMongoId();
+  }
+  return formData[questionId];
+};
+
 export const generateCodeForCodeGeneratorQuestions = (
   screenComponents: SurveyScreenComponent[],
   formData: Record<string, any>,
@@ -255,15 +266,8 @@ export const generateCodeForCodeGeneratorQuestions = (
   const formDataCopy = { ...formData };
   screenComponents?.forEach(question => {
     if (!question.config) return;
-    const { config, questionId } = question;
-    const { codeGenerator } = config as {
-      codeGenerator: CodeGeneratorQuestionConfig;
-    };
-    if (hasCodeGeneratorConfig(question) && !formDataCopy[questionId]) {
-      const code =
-        codeGenerator.type === 'shortid' ? generateShortId(codeGenerator) : generateMongoId();
-      formDataCopy[questionId] = code;
-    }
+    const { questionId } = question;
+    formDataCopy[questionId] = generateCodeAnswer(question, formDataCopy);
   });
   return formDataCopy;
 };

--- a/packages/datatrak-web/src/features/Survey/utils/useSurveyResponseWithForm.ts
+++ b/packages/datatrak-web/src/features/Survey/utils/useSurveyResponseWithForm.ts
@@ -74,7 +74,7 @@ export const useSurveyResponseWithForm = (
 
     const combinedData = { ...formattedAnswers, ...formData };
 
-    // combine this so that formData always takes precedence, and apply a code to any code generator questions without answers
+    // combine this so that formData always takes precedence, and apply a code to any code generator questions without answers when resubmitting. This is because otherwise, if there is no code generator answer already saved, the code generator will not be triggered and the answer will remain empty.
     const newData = isResponseScreen
       ? combinedData
       : generateCodeForCodeGeneratorQuestions(flattenedScreenComponents, combinedData);

--- a/packages/datatrak-web/src/features/Survey/utils/useSurveyResponseWithForm.ts
+++ b/packages/datatrak-web/src/features/Survey/utils/useSurveyResponseWithForm.ts
@@ -9,6 +9,7 @@ import { stripTimezoneFromDate } from '@tupaia/utils';
 import { useSurvey } from '../../../api';
 import { useSurveyForm } from '../SurveyContext';
 import { getAllSurveyComponents } from '../utils';
+import { generateCodeForCodeGeneratorQuestions } from '../SurveyContext/utils';
 
 /**
  * Utility hook to process survey response data and populate the form with it
@@ -16,7 +17,7 @@ import { getAllSurveyComponents } from '../utils';
 export const useSurveyResponseWithForm = (
   surveyResponse?: DatatrakWebSingleSurveyResponseRequest.ResBody,
 ) => {
-  const { setFormData, surveyScreens, surveyCode, formData } = useSurveyForm();
+  const { setFormData, surveyScreens, surveyCode, formData, isResponseScreen } = useSurveyForm();
 
   const { isLoading, isFetched, isSuccess } = useSurvey(surveyCode);
   const surveyLoading = isLoading || !isFetched;
@@ -71,11 +72,12 @@ export const useSurveyResponseWithForm = (
       formattedAnswers[dateOfDataQuestion.questionId] = surveyResponse.dataTime;
     }
 
-    // combine this so that formData always takes precedence
-    const newData = {
-      ...formattedAnswers,
-      ...formData,
-    };
+    const combinedData = { ...formattedAnswers, ...formData };
+
+    // combine this so that formData always takes precedence, and apply a code to any code generator questions without answers
+    const newData = isResponseScreen
+      ? combinedData
+      : generateCodeForCodeGeneratorQuestions(flattenedScreenComponents, combinedData);
 
     setFormData(newData);
     // Reset the form context with the new answers, to trigger re-render of the form


### PR DESCRIPTION
### Issue RN-1483: Fix issue with code gen replacing saved values on resubmit

### Changes:
- Make `initialiseFormData` not run on resubmit screens
- Make code generator values get created when in resubmit mode and no saved answer
