### PR TITLE
tweak(tupaiaWeb): RN-1458: Update table flippa sort order

### DIFF
--- a/packages/ui-components/src/components/DataTable/DataTable.tsx
+++ b/packages/ui-components/src/components/DataTable/DataTable.tsx
@@ -57,13 +57,6 @@ export const DataTable = ({
     {
       columns,
       data,
-      initialState: {
-        sortBy: [
-          {
-            id: getColumnId(columns[0]),
-          },
-        ],
-      },
     },
     useSortBy,
   );


### PR DESCRIPTION
### Issue #: tweak(tupaiaWeb): RN-1458: Update table flippa sort order

### Changes:

- Remove initial sort order from chart tables and simply render the report data in the order it is output from the report

Note: I have left a message in linear to Juliann and Georgia to make them aware that there will probably be a visual change on some reports as a result of this.