### PR TITLE
fix(adminPanel): RN-1496: Roll back download button change

### DIFF
--- a/packages/admin-panel/src/importExport/ExportButton.jsx
+++ b/packages/admin-panel/src/importExport/ExportButton.jsx
@@ -41,7 +41,7 @@ export const ExportButton = ({ actionConfig, row }) => {
         await api.download(
           endpoint,
           { queryParameters, ...extraQueryParameters },
-          `${processedFileName}.json`,
+          processedFileName,
         );
       }}
     >


### PR DESCRIPTION
### Issue #: fix(adminPanel): RN-1496: Roll back download button change

### Changes:

This change was mistake since some downloads are json and some are xlsx. This PR is to rollback the change and then in the next PR I will explicitly set the file type with the file name for each of the downloads see https://github.com/beyondessential/tupaia/pull/5948
