### PR TITLE
fix(auth): RN-1108: Securely read client ip for rate limiting

### DIFF
--- a/packages/central-server/package.json
+++ b/packages/central-server/package.json
@@ -65,6 +65,7 @@
     "morgan": "^1.9.0",
     "multer": "^1.4.3",
     "node-schedule": "^2.1.1",
+    "public-ip": "4.0.4",
     "rate-limiter-flexible": "^5.0.3",
     "react-autobind": "^1.0.6",
     "react-native-uuid": "^1.4.9",

--- a/packages/central-server/src/createApp.js
+++ b/packages/central-server/src/createApp.js
@@ -1,6 +1,6 @@
 /**
- * Tupaia MediTrak
- * Copyright (c) 2017 Beyond Essential Systems Pty Ltd
+ * Tupaia
+ * Copyright (c) 2017 - 2024 Beyond Essential Systems Pty Ltd
  */
 
 import express from 'express';
@@ -14,21 +14,39 @@ import { buildBasicBearerAuthMiddleware } from '@tupaia/server-boilerplate';
 import { handleError } from './apiV2/middleware';
 import { apiV2 } from './apiV2';
 
+const TRUSTED_PROXIES_INTERVAL = 60000; // 1 minute
+
+/**
+ * Dynamically set trusted proxy so that we can trust the IP address of the client
+ */
+function setTrustedProxies(app) {
+  const trustedProxyIPs = process.env.TRUSTED_PROXY_IPS
+    ? process.env.TRUSTED_PROXY_IPS.split(',').map(ip => ip.trim())
+    : [];
+
+  publicIp
+    .v4()
+    .then(publicIp => {
+      this.app.set('trust proxy', ['loopback', ...trustedProxyIPs, publicIp]);
+    })
+    .catch(err => {
+      console.error('Error fetching public IP:', err);
+    });
+}
+
 /**
  * Set up express server with middleware,
  */
 export function createApp(database, models) {
   const app = express();
 
-  // Dynamically set trusted proxy so that we can trust the IP address of the client
-  publicIp
-    .v4()
-    .then(publicIp => {
-      app.set('trust proxy', ['loopback', process.env.AWS_TRUSTED_PROXY_IP, publicIp]);
-    })
-    .catch(err => {
-      console.error('Error fetching public IP:', err);
-    });
+  /**
+   * Call the setTrustedProxies function periodically to update the trusted proxies
+   * because it's possible for the server's IP address to change while server is running
+   */
+  setTrustedProxies(app); // Call it once immediately
+  setInterval(setTrustedProxies, TRUSTED_PROXIES_INTERVAL);
+
   /**
    * Add middleware
    */

--- a/packages/central-server/src/createApp.js
+++ b/packages/central-server/src/createApp.js
@@ -8,6 +8,7 @@ import cors from 'cors';
 import bodyParser from 'body-parser';
 import errorHandler from 'api-error-handler';
 import morgan from 'morgan';
+import publicIp from 'public-ip';
 import { Authenticator } from '@tupaia/auth';
 import { buildBasicBearerAuthMiddleware } from '@tupaia/server-boilerplate';
 import { handleError } from './apiV2/middleware';
@@ -19,6 +20,15 @@ import { apiV2 } from './apiV2';
 export function createApp(database, models) {
   const app = express();
 
+  // Dynamically set trusted proxy so that we can trust the IP address of the client
+  publicIp
+    .v4()
+    .then(publicIp => {
+      app.set('trust proxy', ['loopback', process.env.AWS_TRUSTED_PROXY_IP, publicIp]);
+    })
+    .catch(err => {
+      console.error('Error fetching public IP:', err);
+    });
   /**
    * Add middleware
    */

--- a/packages/server-boilerplate/package.json
+++ b/packages/server-boilerplate/package.json
@@ -41,6 +41,7 @@
     "http-proxy-middleware": "^2.0.1",
     "i18n": "^0.13.3",
     "morgan": "^1.9.0",
+    "public-ip": "4.0.4",
     "winston": "^3.3.3"
   },
   "devDependencies": {

--- a/packages/server-boilerplate/src/connections/ApiConnection.ts
+++ b/packages/server-boilerplate/src/connections/ApiConnection.ts
@@ -8,6 +8,10 @@ import { fetchWithTimeout, verifyResponseStatus, stringifyQuery } from '@tupaia/
 import { QueryParameters, RequestBody } from '../types';
 import { AuthHandler } from './types';
 
+type CustomHeaders = {
+  'x-forwarded-for'?: string;
+};
+
 /**
  * @deprecated use @tupaia/api-client
  */
@@ -23,8 +27,13 @@ export class ApiConnection {
     return this.request('GET', endpoint, queryParameters);
   }
 
-  protected async post(endpoint: string, queryParameters: QueryParameters, body: RequestBody) {
-    return this.request('POST', endpoint, queryParameters, body);
+  protected async post(
+    endpoint: string,
+    queryParameters: QueryParameters,
+    body: RequestBody,
+    headers: CustomHeaders = {},
+  ) {
+    return this.request('POST', endpoint, queryParameters, body, headers);
   }
 
   protected async put(endpoint: string, queryParameters: QueryParameters, body: RequestBody) {
@@ -40,6 +49,7 @@ export class ApiConnection {
     endpoint: string,
     queryParameters: QueryParameters = {},
     body?: RequestBody,
+    headers: CustomHeaders = {},
   ) {
     const queryUrl = stringifyQuery(this.baseUrl, endpoint, queryParameters);
     const fetchConfig: RequestInit = {
@@ -47,6 +57,7 @@ export class ApiConnection {
       headers: {
         Authorization: await this.authHandler.getAuthHeader(),
         'Content-Type': 'application/json',
+        ...headers,
       },
     };
     if (body) {

--- a/packages/server-boilerplate/src/orchestrator/auth/AuthConnection.ts
+++ b/packages/server-boilerplate/src/orchestrator/auth/AuthConnection.ts
@@ -38,11 +38,14 @@ export class AuthConnection extends ApiConnection {
   public async login(
     { emailAddress, password, deviceName }: Credentials,
     serverName: string = DEFAULT_NAME,
+    ip: string,
   ) {
     const response = await this.post(
       'auth',
       { grantType: 'password' },
       { emailAddress, password, deviceName: `${serverName}: ${deviceName}` },
+      // forward the client's IP address to the auth server
+      { 'x-forwarded-for': ip },
     );
     return this.parseAuthResponse(response);
   }

--- a/packages/server-boilerplate/src/orchestrator/routes/LoginRoute.ts
+++ b/packages/server-boilerplate/src/orchestrator/routes/LoginRoute.ts
@@ -30,8 +30,8 @@ export class LoginRoute extends Route<LoginRequest> {
   public async buildResponse() {
     const { apiName } = this.req.ctx;
     const credentials = this.req.body;
-
-    const response = await this.authConnection.login(credentials, apiName);
+    const clientIp = this.req.ip;
+    const response = await this.authConnection.login(credentials, apiName, clientIp);
 
     if (this.req.ctx.verifyLogin) {
       this.req.ctx.verifyLogin(new AccessPolicy(response.accessPolicy));


### PR DESCRIPTION
### Issue #: fix(auth): RN-1108: Securely read client ip for rate limiting

### Changes:

- Forward client ip address to central-server when logging in on orchestration servers
- Add a list of trusted proxies on orchestration and central servers to prevent spoofing of ip address

