### PR TITLE
tweak(tupaiaWeb): RN-1370: Add support for hiding map overlay data from map overlay table

### DIFF
--- a/packages/types/src/schemas/schemas.ts
+++ b/packages/types/src/schemas/schemas.ts
@@ -32956,10 +32956,6 @@ export const MeasureConfigSchema = {
 			"description": "Whether to include this series in the table",
 			"type": "boolean"
 		},
-		"hideFromMap": {
-			"description": "Whether to include this series in the map",
-			"type": "boolean"
-		},
 		"name": {
 			"description": "Display name of this series",
 			"type": "string"
@@ -33505,10 +33501,6 @@ export const BaseMapOverlayConfigSchema = {
 					},
 					"hideFromTable": {
 						"description": "Whether to include this series in the table",
-						"type": "boolean"
-					},
-					"hideFromMap": {
-						"description": "Whether to include this series in the map",
 						"type": "boolean"
 					},
 					"name": {
@@ -34082,10 +34074,6 @@ export const SpectrumMapOverlayConfigSchema = {
 					},
 					"hideFromTable": {
 						"description": "Whether to include this series in the table",
-						"type": "boolean"
-					},
-					"hideFromMap": {
-						"description": "Whether to include this series in the map",
 						"type": "boolean"
 					},
 					"name": {
@@ -34766,10 +34754,6 @@ export const IconMapOverlayConfigSchema = {
 						"description": "Whether to include this series in the table",
 						"type": "boolean"
 					},
-					"hideFromMap": {
-						"description": "Whether to include this series in the map",
-						"type": "boolean"
-					},
 					"name": {
 						"description": "Display name of this series",
 						"type": "string"
@@ -35373,10 +35357,6 @@ export const RadiusMapOverlayConfigSchema = {
 						"description": "Whether to include this series in the table",
 						"type": "boolean"
 					},
-					"hideFromMap": {
-						"description": "Whether to include this series in the map",
-						"type": "boolean"
-					},
 					"name": {
 						"description": "Display name of this series",
 						"type": "string"
@@ -35952,10 +35932,6 @@ export const ColorMapOverlayConfigSchema = {
 					},
 					"hideFromTable": {
 						"description": "Whether to include this series in the table",
-						"type": "boolean"
-					},
-					"hideFromMap": {
-						"description": "Whether to include this series in the map",
 						"type": "boolean"
 					},
 					"name": {
@@ -36549,10 +36525,6 @@ export const ShadingMapOverlayConfigSchema = {
 						"description": "Whether to include this series in the table",
 						"type": "boolean"
 					},
-					"hideFromMap": {
-						"description": "Whether to include this series in the map",
-						"type": "boolean"
-					},
 					"name": {
 						"description": "Display name of this series",
 						"type": "string"
@@ -37134,10 +37106,6 @@ export const MapOverlayConfigSchema = {
 							},
 							"hideFromTable": {
 								"description": "Whether to include this series in the table",
-								"type": "boolean"
-							},
-							"hideFromMap": {
-								"description": "Whether to include this series in the map",
 								"type": "boolean"
 							},
 							"name": {
@@ -37817,10 +37785,6 @@ export const MapOverlayConfigSchema = {
 								"description": "Whether to include this series in the table",
 								"type": "boolean"
 							},
-							"hideFromMap": {
-								"description": "Whether to include this series in the map",
-								"type": "boolean"
-							},
 							"name": {
 								"description": "Display name of this series",
 								"type": "string"
@@ -38423,10 +38387,6 @@ export const MapOverlayConfigSchema = {
 								"description": "Whether to include this series in the table",
 								"type": "boolean"
 							},
-							"hideFromMap": {
-								"description": "Whether to include this series in the map",
-								"type": "boolean"
-							},
 							"name": {
 								"description": "Display name of this series",
 								"type": "string"
@@ -39001,10 +38961,6 @@ export const MapOverlayConfigSchema = {
 							},
 							"hideFromTable": {
 								"description": "Whether to include this series in the table",
-								"type": "boolean"
-							},
-							"hideFromMap": {
-								"description": "Whether to include this series in the map",
 								"type": "boolean"
 							},
 							"name": {
@@ -39595,10 +39551,6 @@ export const MapOverlayConfigSchema = {
 							},
 							"hideFromTable": {
 								"description": "Whether to include this series in the table",
-								"type": "boolean"
-							},
-							"hideFromMap": {
-								"description": "Whether to include this series in the map",
 								"type": "boolean"
 							},
 							"name": {
@@ -72606,10 +72558,6 @@ export const MapOverlaySchema = {
 										"description": "Whether to include this series in the table",
 										"type": "boolean"
 									},
-									"hideFromMap": {
-										"description": "Whether to include this series in the map",
-										"type": "boolean"
-									},
 									"name": {
 										"description": "Display name of this series",
 										"type": "string"
@@ -73287,10 +73235,6 @@ export const MapOverlaySchema = {
 										"description": "Whether to include this series in the table",
 										"type": "boolean"
 									},
-									"hideFromMap": {
-										"description": "Whether to include this series in the map",
-										"type": "boolean"
-									},
 									"name": {
 										"description": "Display name of this series",
 										"type": "string"
@@ -73893,10 +73837,6 @@ export const MapOverlaySchema = {
 										"description": "Whether to include this series in the table",
 										"type": "boolean"
 									},
-									"hideFromMap": {
-										"description": "Whether to include this series in the map",
-										"type": "boolean"
-									},
 									"name": {
 										"description": "Display name of this series",
 										"type": "string"
@@ -74471,10 +74411,6 @@ export const MapOverlaySchema = {
 									},
 									"hideFromTable": {
 										"description": "Whether to include this series in the table",
-										"type": "boolean"
-									},
-									"hideFromMap": {
-										"description": "Whether to include this series in the map",
 										"type": "boolean"
 									},
 									"name": {
@@ -75065,10 +75001,6 @@ export const MapOverlaySchema = {
 									},
 									"hideFromTable": {
 										"description": "Whether to include this series in the table",
-										"type": "boolean"
-									},
-									"hideFromMap": {
-										"description": "Whether to include this series in the map",
 										"type": "boolean"
 									},
 									"name": {
@@ -75715,10 +75647,6 @@ export const MapOverlayCreateSchema = {
 										"description": "Whether to include this series in the table",
 										"type": "boolean"
 									},
-									"hideFromMap": {
-										"description": "Whether to include this series in the map",
-										"type": "boolean"
-									},
 									"name": {
 										"description": "Display name of this series",
 										"type": "string"
@@ -76396,10 +76324,6 @@ export const MapOverlayCreateSchema = {
 										"description": "Whether to include this series in the table",
 										"type": "boolean"
 									},
-									"hideFromMap": {
-										"description": "Whether to include this series in the map",
-										"type": "boolean"
-									},
 									"name": {
 										"description": "Display name of this series",
 										"type": "string"
@@ -77002,10 +76926,6 @@ export const MapOverlayCreateSchema = {
 										"description": "Whether to include this series in the table",
 										"type": "boolean"
 									},
-									"hideFromMap": {
-										"description": "Whether to include this series in the map",
-										"type": "boolean"
-									},
 									"name": {
 										"description": "Display name of this series",
 										"type": "string"
@@ -77580,10 +77500,6 @@ export const MapOverlayCreateSchema = {
 									},
 									"hideFromTable": {
 										"description": "Whether to include this series in the table",
-										"type": "boolean"
-									},
-									"hideFromMap": {
-										"description": "Whether to include this series in the map",
 										"type": "boolean"
 									},
 									"name": {
@@ -78174,10 +78090,6 @@ export const MapOverlayCreateSchema = {
 									},
 									"hideFromTable": {
 										"description": "Whether to include this series in the table",
-										"type": "boolean"
-									},
-									"hideFromMap": {
-										"description": "Whether to include this series in the map",
 										"type": "boolean"
 									},
 									"name": {
@@ -78817,10 +78729,6 @@ export const MapOverlayUpdateSchema = {
 										"description": "Whether to include this series in the table",
 										"type": "boolean"
 									},
-									"hideFromMap": {
-										"description": "Whether to include this series in the map",
-										"type": "boolean"
-									},
 									"name": {
 										"description": "Display name of this series",
 										"type": "string"
@@ -79498,10 +79406,6 @@ export const MapOverlayUpdateSchema = {
 										"description": "Whether to include this series in the table",
 										"type": "boolean"
 									},
-									"hideFromMap": {
-										"description": "Whether to include this series in the map",
-										"type": "boolean"
-									},
 									"name": {
 										"description": "Display name of this series",
 										"type": "string"
@@ -80104,10 +80008,6 @@ export const MapOverlayUpdateSchema = {
 										"description": "Whether to include this series in the table",
 										"type": "boolean"
 									},
-									"hideFromMap": {
-										"description": "Whether to include this series in the map",
-										"type": "boolean"
-									},
 									"name": {
 										"description": "Display name of this series",
 										"type": "string"
@@ -80682,10 +80582,6 @@ export const MapOverlayUpdateSchema = {
 									},
 									"hideFromTable": {
 										"description": "Whether to include this series in the table",
-										"type": "boolean"
-									},
-									"hideFromMap": {
-										"description": "Whether to include this series in the map",
 										"type": "boolean"
 									},
 									"name": {
@@ -81276,10 +81172,6 @@ export const MapOverlayUpdateSchema = {
 									},
 									"hideFromTable": {
 										"description": "Whether to include this series in the table",
-										"type": "boolean"
-									},
-									"hideFromMap": {
-										"description": "Whether to include this series in the map",
 										"type": "boolean"
 									},
 									"name": {
@@ -96397,10 +96289,6 @@ export const TranslatedMapOverlaySchema = {
 								"description": "Whether to include this series in the table",
 								"type": "boolean"
 							},
-							"hideFromMap": {
-								"description": "Whether to include this series in the map",
-								"type": "boolean"
-							},
 							"name": {
 								"description": "Display name of this series",
 								"type": "string"
@@ -97101,10 +96989,6 @@ export const TranslatedMapOverlaySchema = {
 								"description": "Whether to include this series in the table",
 								"type": "boolean"
 							},
-							"hideFromMap": {
-								"description": "Whether to include this series in the map",
-								"type": "boolean"
-							},
 							"name": {
 								"description": "Display name of this series",
 								"type": "string"
@@ -97730,10 +97614,6 @@ export const TranslatedMapOverlaySchema = {
 								"description": "Whether to include this series in the table",
 								"type": "boolean"
 							},
-							"hideFromMap": {
-								"description": "Whether to include this series in the map",
-								"type": "boolean"
-							},
 							"name": {
 								"description": "Display name of this series",
 								"type": "string"
@@ -98331,10 +98211,6 @@ export const TranslatedMapOverlaySchema = {
 							},
 							"hideFromTable": {
 								"description": "Whether to include this series in the table",
-								"type": "boolean"
-							},
-							"hideFromMap": {
-								"description": "Whether to include this series in the map",
 								"type": "boolean"
 							},
 							"name": {
@@ -98948,10 +98824,6 @@ export const TranslatedMapOverlaySchema = {
 							},
 							"hideFromTable": {
 								"description": "Whether to include this series in the table",
-								"type": "boolean"
-							},
-							"hideFromMap": {
-								"description": "Whether to include this series in the map",
 								"type": "boolean"
 							},
 							"name": {

--- a/packages/types/src/schemas/schemas.ts
+++ b/packages/types/src/schemas/schemas.ts
@@ -32863,7 +32863,7 @@ export const MeasureConfigSchema = {
 	"type": "object",
 	"properties": {
 		"type": {
-			"description": "How to display this series (use popup-only to just show in the popup/tooltip)",
+			"description": "How to display this series (popup-only is deprecated)",
 			"enum": [
 				"color",
 				"icon",
@@ -32946,6 +32946,18 @@ export const MeasureConfigSchema = {
 		},
 		"hideFromLegend": {
 			"description": "Whether to include this series in the legend",
+			"type": "boolean"
+		},
+		"hideFromPopup": {
+			"description": "Whether to include this series in the popup/tooltip",
+			"type": "boolean"
+		},
+		"hideFromTable": {
+			"description": "Whether to include this series in the table",
+			"type": "boolean"
+		},
+		"hideFromMap": {
+			"description": "Whether to include this series in the map",
 			"type": "boolean"
 		},
 		"name": {
@@ -33402,7 +33414,7 @@ export const BaseMapOverlayConfigSchema = {
 				"type": "object",
 				"properties": {
 					"type": {
-						"description": "How to display this series (use popup-only to just show in the popup/tooltip)",
+						"description": "How to display this series (popup-only is deprecated)",
 						"enum": [
 							"color",
 							"icon",
@@ -33485,6 +33497,18 @@ export const BaseMapOverlayConfigSchema = {
 					},
 					"hideFromLegend": {
 						"description": "Whether to include this series in the legend",
+						"type": "boolean"
+					},
+					"hideFromPopup": {
+						"description": "Whether to include this series in the popup/tooltip",
+						"type": "boolean"
+					},
+					"hideFromTable": {
+						"description": "Whether to include this series in the table",
+						"type": "boolean"
+					},
+					"hideFromMap": {
+						"description": "Whether to include this series in the map",
 						"type": "boolean"
 					},
 					"name": {
@@ -33967,7 +33991,7 @@ export const SpectrumMapOverlayConfigSchema = {
 				"type": "object",
 				"properties": {
 					"type": {
-						"description": "How to display this series (use popup-only to just show in the popup/tooltip)",
+						"description": "How to display this series (popup-only is deprecated)",
 						"enum": [
 							"color",
 							"icon",
@@ -34050,6 +34074,18 @@ export const SpectrumMapOverlayConfigSchema = {
 					},
 					"hideFromLegend": {
 						"description": "Whether to include this series in the legend",
+						"type": "boolean"
+					},
+					"hideFromPopup": {
+						"description": "Whether to include this series in the popup/tooltip",
+						"type": "boolean"
+					},
+					"hideFromTable": {
+						"description": "Whether to include this series in the table",
+						"type": "boolean"
+					},
+					"hideFromMap": {
+						"description": "Whether to include this series in the map",
 						"type": "boolean"
 					},
 					"name": {
@@ -34637,7 +34673,7 @@ export const IconMapOverlayConfigSchema = {
 				"type": "object",
 				"properties": {
 					"type": {
-						"description": "How to display this series (use popup-only to just show in the popup/tooltip)",
+						"description": "How to display this series (popup-only is deprecated)",
 						"enum": [
 							"color",
 							"icon",
@@ -34720,6 +34756,18 @@ export const IconMapOverlayConfigSchema = {
 					},
 					"hideFromLegend": {
 						"description": "Whether to include this series in the legend",
+						"type": "boolean"
+					},
+					"hideFromPopup": {
+						"description": "Whether to include this series in the popup/tooltip",
+						"type": "boolean"
+					},
+					"hideFromTable": {
+						"description": "Whether to include this series in the table",
+						"type": "boolean"
+					},
+					"hideFromMap": {
+						"description": "Whether to include this series in the map",
 						"type": "boolean"
 					},
 					"name": {
@@ -35232,7 +35280,7 @@ export const RadiusMapOverlayConfigSchema = {
 				"type": "object",
 				"properties": {
 					"type": {
-						"description": "How to display this series (use popup-only to just show in the popup/tooltip)",
+						"description": "How to display this series (popup-only is deprecated)",
 						"enum": [
 							"color",
 							"icon",
@@ -35315,6 +35363,18 @@ export const RadiusMapOverlayConfigSchema = {
 					},
 					"hideFromLegend": {
 						"description": "Whether to include this series in the legend",
+						"type": "boolean"
+					},
+					"hideFromPopup": {
+						"description": "Whether to include this series in the popup/tooltip",
+						"type": "boolean"
+					},
+					"hideFromTable": {
+						"description": "Whether to include this series in the table",
+						"type": "boolean"
+					},
+					"hideFromMap": {
+						"description": "Whether to include this series in the map",
 						"type": "boolean"
 					},
 					"name": {
@@ -35801,7 +35861,7 @@ export const ColorMapOverlayConfigSchema = {
 				"type": "object",
 				"properties": {
 					"type": {
-						"description": "How to display this series (use popup-only to just show in the popup/tooltip)",
+						"description": "How to display this series (popup-only is deprecated)",
 						"enum": [
 							"color",
 							"icon",
@@ -35884,6 +35944,18 @@ export const ColorMapOverlayConfigSchema = {
 					},
 					"hideFromLegend": {
 						"description": "Whether to include this series in the legend",
+						"type": "boolean"
+					},
+					"hideFromPopup": {
+						"description": "Whether to include this series in the popup/tooltip",
+						"type": "boolean"
+					},
+					"hideFromTable": {
+						"description": "Whether to include this series in the table",
+						"type": "boolean"
+					},
+					"hideFromMap": {
+						"description": "Whether to include this series in the map",
 						"type": "boolean"
 					},
 					"name": {
@@ -36384,7 +36456,7 @@ export const ShadingMapOverlayConfigSchema = {
 				"type": "object",
 				"properties": {
 					"type": {
-						"description": "How to display this series (use popup-only to just show in the popup/tooltip)",
+						"description": "How to display this series (popup-only is deprecated)",
 						"enum": [
 							"color",
 							"icon",
@@ -36467,6 +36539,18 @@ export const ShadingMapOverlayConfigSchema = {
 					},
 					"hideFromLegend": {
 						"description": "Whether to include this series in the legend",
+						"type": "boolean"
+					},
+					"hideFromPopup": {
+						"description": "Whether to include this series in the popup/tooltip",
+						"type": "boolean"
+					},
+					"hideFromTable": {
+						"description": "Whether to include this series in the table",
+						"type": "boolean"
+					},
+					"hideFromMap": {
+						"description": "Whether to include this series in the map",
 						"type": "boolean"
 					},
 					"name": {
@@ -36959,7 +37043,7 @@ export const MapOverlayConfigSchema = {
 						"type": "object",
 						"properties": {
 							"type": {
-								"description": "How to display this series (use popup-only to just show in the popup/tooltip)",
+								"description": "How to display this series (popup-only is deprecated)",
 								"enum": [
 									"color",
 									"icon",
@@ -37042,6 +37126,18 @@ export const MapOverlayConfigSchema = {
 							},
 							"hideFromLegend": {
 								"description": "Whether to include this series in the legend",
+								"type": "boolean"
+							},
+							"hideFromPopup": {
+								"description": "Whether to include this series in the popup/tooltip",
+								"type": "boolean"
+							},
+							"hideFromTable": {
+								"description": "Whether to include this series in the table",
+								"type": "boolean"
+							},
+							"hideFromMap": {
+								"description": "Whether to include this series in the map",
 								"type": "boolean"
 							},
 							"name": {
@@ -37628,7 +37724,7 @@ export const MapOverlayConfigSchema = {
 						"type": "object",
 						"properties": {
 							"type": {
-								"description": "How to display this series (use popup-only to just show in the popup/tooltip)",
+								"description": "How to display this series (popup-only is deprecated)",
 								"enum": [
 									"color",
 									"icon",
@@ -37711,6 +37807,18 @@ export const MapOverlayConfigSchema = {
 							},
 							"hideFromLegend": {
 								"description": "Whether to include this series in the legend",
+								"type": "boolean"
+							},
+							"hideFromPopup": {
+								"description": "Whether to include this series in the popup/tooltip",
+								"type": "boolean"
+							},
+							"hideFromTable": {
+								"description": "Whether to include this series in the table",
+								"type": "boolean"
+							},
+							"hideFromMap": {
+								"description": "Whether to include this series in the map",
 								"type": "boolean"
 							},
 							"name": {
@@ -38222,7 +38330,7 @@ export const MapOverlayConfigSchema = {
 						"type": "object",
 						"properties": {
 							"type": {
-								"description": "How to display this series (use popup-only to just show in the popup/tooltip)",
+								"description": "How to display this series (popup-only is deprecated)",
 								"enum": [
 									"color",
 									"icon",
@@ -38305,6 +38413,18 @@ export const MapOverlayConfigSchema = {
 							},
 							"hideFromLegend": {
 								"description": "Whether to include this series in the legend",
+								"type": "boolean"
+							},
+							"hideFromPopup": {
+								"description": "Whether to include this series in the popup/tooltip",
+								"type": "boolean"
+							},
+							"hideFromTable": {
+								"description": "Whether to include this series in the table",
+								"type": "boolean"
+							},
+							"hideFromMap": {
+								"description": "Whether to include this series in the map",
 								"type": "boolean"
 							},
 							"name": {
@@ -38790,7 +38910,7 @@ export const MapOverlayConfigSchema = {
 						"type": "object",
 						"properties": {
 							"type": {
-								"description": "How to display this series (use popup-only to just show in the popup/tooltip)",
+								"description": "How to display this series (popup-only is deprecated)",
 								"enum": [
 									"color",
 									"icon",
@@ -38873,6 +38993,18 @@ export const MapOverlayConfigSchema = {
 							},
 							"hideFromLegend": {
 								"description": "Whether to include this series in the legend",
+								"type": "boolean"
+							},
+							"hideFromPopup": {
+								"description": "Whether to include this series in the popup/tooltip",
+								"type": "boolean"
+							},
+							"hideFromTable": {
+								"description": "Whether to include this series in the table",
+								"type": "boolean"
+							},
+							"hideFromMap": {
+								"description": "Whether to include this series in the map",
 								"type": "boolean"
 							},
 							"name": {
@@ -39372,7 +39504,7 @@ export const MapOverlayConfigSchema = {
 						"type": "object",
 						"properties": {
 							"type": {
-								"description": "How to display this series (use popup-only to just show in the popup/tooltip)",
+								"description": "How to display this series (popup-only is deprecated)",
 								"enum": [
 									"color",
 									"icon",
@@ -39455,6 +39587,18 @@ export const MapOverlayConfigSchema = {
 							},
 							"hideFromLegend": {
 								"description": "Whether to include this series in the legend",
+								"type": "boolean"
+							},
+							"hideFromPopup": {
+								"description": "Whether to include this series in the popup/tooltip",
+								"type": "boolean"
+							},
+							"hideFromTable": {
+								"description": "Whether to include this series in the table",
+								"type": "boolean"
+							},
+							"hideFromMap": {
+								"description": "Whether to include this series in the map",
 								"type": "boolean"
 							},
 							"name": {
@@ -72369,7 +72513,7 @@ export const MapOverlaySchema = {
 								"type": "object",
 								"properties": {
 									"type": {
-										"description": "How to display this series (use popup-only to just show in the popup/tooltip)",
+										"description": "How to display this series (popup-only is deprecated)",
 										"enum": [
 											"color",
 											"icon",
@@ -72452,6 +72596,18 @@ export const MapOverlaySchema = {
 									},
 									"hideFromLegend": {
 										"description": "Whether to include this series in the legend",
+										"type": "boolean"
+									},
+									"hideFromPopup": {
+										"description": "Whether to include this series in the popup/tooltip",
+										"type": "boolean"
+									},
+									"hideFromTable": {
+										"description": "Whether to include this series in the table",
+										"type": "boolean"
+									},
+									"hideFromMap": {
+										"description": "Whether to include this series in the map",
 										"type": "boolean"
 									},
 									"name": {
@@ -73038,7 +73194,7 @@ export const MapOverlaySchema = {
 								"type": "object",
 								"properties": {
 									"type": {
-										"description": "How to display this series (use popup-only to just show in the popup/tooltip)",
+										"description": "How to display this series (popup-only is deprecated)",
 										"enum": [
 											"color",
 											"icon",
@@ -73121,6 +73277,18 @@ export const MapOverlaySchema = {
 									},
 									"hideFromLegend": {
 										"description": "Whether to include this series in the legend",
+										"type": "boolean"
+									},
+									"hideFromPopup": {
+										"description": "Whether to include this series in the popup/tooltip",
+										"type": "boolean"
+									},
+									"hideFromTable": {
+										"description": "Whether to include this series in the table",
+										"type": "boolean"
+									},
+									"hideFromMap": {
+										"description": "Whether to include this series in the map",
 										"type": "boolean"
 									},
 									"name": {
@@ -73632,7 +73800,7 @@ export const MapOverlaySchema = {
 								"type": "object",
 								"properties": {
 									"type": {
-										"description": "How to display this series (use popup-only to just show in the popup/tooltip)",
+										"description": "How to display this series (popup-only is deprecated)",
 										"enum": [
 											"color",
 											"icon",
@@ -73715,6 +73883,18 @@ export const MapOverlaySchema = {
 									},
 									"hideFromLegend": {
 										"description": "Whether to include this series in the legend",
+										"type": "boolean"
+									},
+									"hideFromPopup": {
+										"description": "Whether to include this series in the popup/tooltip",
+										"type": "boolean"
+									},
+									"hideFromTable": {
+										"description": "Whether to include this series in the table",
+										"type": "boolean"
+									},
+									"hideFromMap": {
+										"description": "Whether to include this series in the map",
 										"type": "boolean"
 									},
 									"name": {
@@ -74200,7 +74380,7 @@ export const MapOverlaySchema = {
 								"type": "object",
 								"properties": {
 									"type": {
-										"description": "How to display this series (use popup-only to just show in the popup/tooltip)",
+										"description": "How to display this series (popup-only is deprecated)",
 										"enum": [
 											"color",
 											"icon",
@@ -74283,6 +74463,18 @@ export const MapOverlaySchema = {
 									},
 									"hideFromLegend": {
 										"description": "Whether to include this series in the legend",
+										"type": "boolean"
+									},
+									"hideFromPopup": {
+										"description": "Whether to include this series in the popup/tooltip",
+										"type": "boolean"
+									},
+									"hideFromTable": {
+										"description": "Whether to include this series in the table",
+										"type": "boolean"
+									},
+									"hideFromMap": {
+										"description": "Whether to include this series in the map",
 										"type": "boolean"
 									},
 									"name": {
@@ -74782,7 +74974,7 @@ export const MapOverlaySchema = {
 								"type": "object",
 								"properties": {
 									"type": {
-										"description": "How to display this series (use popup-only to just show in the popup/tooltip)",
+										"description": "How to display this series (popup-only is deprecated)",
 										"enum": [
 											"color",
 											"icon",
@@ -74865,6 +75057,18 @@ export const MapOverlaySchema = {
 									},
 									"hideFromLegend": {
 										"description": "Whether to include this series in the legend",
+										"type": "boolean"
+									},
+									"hideFromPopup": {
+										"description": "Whether to include this series in the popup/tooltip",
+										"type": "boolean"
+									},
+									"hideFromTable": {
+										"description": "Whether to include this series in the table",
+										"type": "boolean"
+									},
+									"hideFromMap": {
+										"description": "Whether to include this series in the map",
 										"type": "boolean"
 									},
 									"name": {
@@ -75418,7 +75622,7 @@ export const MapOverlayCreateSchema = {
 								"type": "object",
 								"properties": {
 									"type": {
-										"description": "How to display this series (use popup-only to just show in the popup/tooltip)",
+										"description": "How to display this series (popup-only is deprecated)",
 										"enum": [
 											"color",
 											"icon",
@@ -75501,6 +75705,18 @@ export const MapOverlayCreateSchema = {
 									},
 									"hideFromLegend": {
 										"description": "Whether to include this series in the legend",
+										"type": "boolean"
+									},
+									"hideFromPopup": {
+										"description": "Whether to include this series in the popup/tooltip",
+										"type": "boolean"
+									},
+									"hideFromTable": {
+										"description": "Whether to include this series in the table",
+										"type": "boolean"
+									},
+									"hideFromMap": {
+										"description": "Whether to include this series in the map",
 										"type": "boolean"
 									},
 									"name": {
@@ -76087,7 +76303,7 @@ export const MapOverlayCreateSchema = {
 								"type": "object",
 								"properties": {
 									"type": {
-										"description": "How to display this series (use popup-only to just show in the popup/tooltip)",
+										"description": "How to display this series (popup-only is deprecated)",
 										"enum": [
 											"color",
 											"icon",
@@ -76170,6 +76386,18 @@ export const MapOverlayCreateSchema = {
 									},
 									"hideFromLegend": {
 										"description": "Whether to include this series in the legend",
+										"type": "boolean"
+									},
+									"hideFromPopup": {
+										"description": "Whether to include this series in the popup/tooltip",
+										"type": "boolean"
+									},
+									"hideFromTable": {
+										"description": "Whether to include this series in the table",
+										"type": "boolean"
+									},
+									"hideFromMap": {
+										"description": "Whether to include this series in the map",
 										"type": "boolean"
 									},
 									"name": {
@@ -76681,7 +76909,7 @@ export const MapOverlayCreateSchema = {
 								"type": "object",
 								"properties": {
 									"type": {
-										"description": "How to display this series (use popup-only to just show in the popup/tooltip)",
+										"description": "How to display this series (popup-only is deprecated)",
 										"enum": [
 											"color",
 											"icon",
@@ -76764,6 +76992,18 @@ export const MapOverlayCreateSchema = {
 									},
 									"hideFromLegend": {
 										"description": "Whether to include this series in the legend",
+										"type": "boolean"
+									},
+									"hideFromPopup": {
+										"description": "Whether to include this series in the popup/tooltip",
+										"type": "boolean"
+									},
+									"hideFromTable": {
+										"description": "Whether to include this series in the table",
+										"type": "boolean"
+									},
+									"hideFromMap": {
+										"description": "Whether to include this series in the map",
 										"type": "boolean"
 									},
 									"name": {
@@ -77249,7 +77489,7 @@ export const MapOverlayCreateSchema = {
 								"type": "object",
 								"properties": {
 									"type": {
-										"description": "How to display this series (use popup-only to just show in the popup/tooltip)",
+										"description": "How to display this series (popup-only is deprecated)",
 										"enum": [
 											"color",
 											"icon",
@@ -77332,6 +77572,18 @@ export const MapOverlayCreateSchema = {
 									},
 									"hideFromLegend": {
 										"description": "Whether to include this series in the legend",
+										"type": "boolean"
+									},
+									"hideFromPopup": {
+										"description": "Whether to include this series in the popup/tooltip",
+										"type": "boolean"
+									},
+									"hideFromTable": {
+										"description": "Whether to include this series in the table",
+										"type": "boolean"
+									},
+									"hideFromMap": {
+										"description": "Whether to include this series in the map",
 										"type": "boolean"
 									},
 									"name": {
@@ -77831,7 +78083,7 @@ export const MapOverlayCreateSchema = {
 								"type": "object",
 								"properties": {
 									"type": {
-										"description": "How to display this series (use popup-only to just show in the popup/tooltip)",
+										"description": "How to display this series (popup-only is deprecated)",
 										"enum": [
 											"color",
 											"icon",
@@ -77914,6 +78166,18 @@ export const MapOverlayCreateSchema = {
 									},
 									"hideFromLegend": {
 										"description": "Whether to include this series in the legend",
+										"type": "boolean"
+									},
+									"hideFromPopup": {
+										"description": "Whether to include this series in the popup/tooltip",
+										"type": "boolean"
+									},
+									"hideFromTable": {
+										"description": "Whether to include this series in the table",
+										"type": "boolean"
+									},
+									"hideFromMap": {
+										"description": "Whether to include this series in the map",
 										"type": "boolean"
 									},
 									"name": {
@@ -78460,7 +78724,7 @@ export const MapOverlayUpdateSchema = {
 								"type": "object",
 								"properties": {
 									"type": {
-										"description": "How to display this series (use popup-only to just show in the popup/tooltip)",
+										"description": "How to display this series (popup-only is deprecated)",
 										"enum": [
 											"color",
 											"icon",
@@ -78543,6 +78807,18 @@ export const MapOverlayUpdateSchema = {
 									},
 									"hideFromLegend": {
 										"description": "Whether to include this series in the legend",
+										"type": "boolean"
+									},
+									"hideFromPopup": {
+										"description": "Whether to include this series in the popup/tooltip",
+										"type": "boolean"
+									},
+									"hideFromTable": {
+										"description": "Whether to include this series in the table",
+										"type": "boolean"
+									},
+									"hideFromMap": {
+										"description": "Whether to include this series in the map",
 										"type": "boolean"
 									},
 									"name": {
@@ -79129,7 +79405,7 @@ export const MapOverlayUpdateSchema = {
 								"type": "object",
 								"properties": {
 									"type": {
-										"description": "How to display this series (use popup-only to just show in the popup/tooltip)",
+										"description": "How to display this series (popup-only is deprecated)",
 										"enum": [
 											"color",
 											"icon",
@@ -79212,6 +79488,18 @@ export const MapOverlayUpdateSchema = {
 									},
 									"hideFromLegend": {
 										"description": "Whether to include this series in the legend",
+										"type": "boolean"
+									},
+									"hideFromPopup": {
+										"description": "Whether to include this series in the popup/tooltip",
+										"type": "boolean"
+									},
+									"hideFromTable": {
+										"description": "Whether to include this series in the table",
+										"type": "boolean"
+									},
+									"hideFromMap": {
+										"description": "Whether to include this series in the map",
 										"type": "boolean"
 									},
 									"name": {
@@ -79723,7 +80011,7 @@ export const MapOverlayUpdateSchema = {
 								"type": "object",
 								"properties": {
 									"type": {
-										"description": "How to display this series (use popup-only to just show in the popup/tooltip)",
+										"description": "How to display this series (popup-only is deprecated)",
 										"enum": [
 											"color",
 											"icon",
@@ -79806,6 +80094,18 @@ export const MapOverlayUpdateSchema = {
 									},
 									"hideFromLegend": {
 										"description": "Whether to include this series in the legend",
+										"type": "boolean"
+									},
+									"hideFromPopup": {
+										"description": "Whether to include this series in the popup/tooltip",
+										"type": "boolean"
+									},
+									"hideFromTable": {
+										"description": "Whether to include this series in the table",
+										"type": "boolean"
+									},
+									"hideFromMap": {
+										"description": "Whether to include this series in the map",
 										"type": "boolean"
 									},
 									"name": {
@@ -80291,7 +80591,7 @@ export const MapOverlayUpdateSchema = {
 								"type": "object",
 								"properties": {
 									"type": {
-										"description": "How to display this series (use popup-only to just show in the popup/tooltip)",
+										"description": "How to display this series (popup-only is deprecated)",
 										"enum": [
 											"color",
 											"icon",
@@ -80374,6 +80674,18 @@ export const MapOverlayUpdateSchema = {
 									},
 									"hideFromLegend": {
 										"description": "Whether to include this series in the legend",
+										"type": "boolean"
+									},
+									"hideFromPopup": {
+										"description": "Whether to include this series in the popup/tooltip",
+										"type": "boolean"
+									},
+									"hideFromTable": {
+										"description": "Whether to include this series in the table",
+										"type": "boolean"
+									},
+									"hideFromMap": {
+										"description": "Whether to include this series in the map",
 										"type": "boolean"
 									},
 									"name": {
@@ -80873,7 +81185,7 @@ export const MapOverlayUpdateSchema = {
 								"type": "object",
 								"properties": {
 									"type": {
-										"description": "How to display this series (use popup-only to just show in the popup/tooltip)",
+										"description": "How to display this series (popup-only is deprecated)",
 										"enum": [
 											"color",
 											"icon",
@@ -80956,6 +81268,18 @@ export const MapOverlayUpdateSchema = {
 									},
 									"hideFromLegend": {
 										"description": "Whether to include this series in the legend",
+										"type": "boolean"
+									},
+									"hideFromPopup": {
+										"description": "Whether to include this series in the popup/tooltip",
+										"type": "boolean"
+									},
+									"hideFromTable": {
+										"description": "Whether to include this series in the table",
+										"type": "boolean"
+									},
+									"hideFromMap": {
+										"description": "Whether to include this series in the map",
 										"type": "boolean"
 									},
 									"name": {
@@ -95980,7 +96304,7 @@ export const TranslatedMapOverlaySchema = {
 						"type": "object",
 						"properties": {
 							"type": {
-								"description": "How to display this series (use popup-only to just show in the popup/tooltip)",
+								"description": "How to display this series (popup-only is deprecated)",
 								"enum": [
 									"color",
 									"icon",
@@ -96063,6 +96387,18 @@ export const TranslatedMapOverlaySchema = {
 							},
 							"hideFromLegend": {
 								"description": "Whether to include this series in the legend",
+								"type": "boolean"
+							},
+							"hideFromPopup": {
+								"description": "Whether to include this series in the popup/tooltip",
+								"type": "boolean"
+							},
+							"hideFromTable": {
+								"description": "Whether to include this series in the table",
+								"type": "boolean"
+							},
+							"hideFromMap": {
+								"description": "Whether to include this series in the map",
 								"type": "boolean"
 							},
 							"name": {
@@ -96672,7 +97008,7 @@ export const TranslatedMapOverlaySchema = {
 						"type": "object",
 						"properties": {
 							"type": {
-								"description": "How to display this series (use popup-only to just show in the popup/tooltip)",
+								"description": "How to display this series (popup-only is deprecated)",
 								"enum": [
 									"color",
 									"icon",
@@ -96755,6 +97091,18 @@ export const TranslatedMapOverlaySchema = {
 							},
 							"hideFromLegend": {
 								"description": "Whether to include this series in the legend",
+								"type": "boolean"
+							},
+							"hideFromPopup": {
+								"description": "Whether to include this series in the popup/tooltip",
+								"type": "boolean"
+							},
+							"hideFromTable": {
+								"description": "Whether to include this series in the table",
+								"type": "boolean"
+							},
+							"hideFromMap": {
+								"description": "Whether to include this series in the map",
 								"type": "boolean"
 							},
 							"name": {
@@ -97289,7 +97637,7 @@ export const TranslatedMapOverlaySchema = {
 						"type": "object",
 						"properties": {
 							"type": {
-								"description": "How to display this series (use popup-only to just show in the popup/tooltip)",
+								"description": "How to display this series (popup-only is deprecated)",
 								"enum": [
 									"color",
 									"icon",
@@ -97372,6 +97720,18 @@ export const TranslatedMapOverlaySchema = {
 							},
 							"hideFromLegend": {
 								"description": "Whether to include this series in the legend",
+								"type": "boolean"
+							},
+							"hideFromPopup": {
+								"description": "Whether to include this series in the popup/tooltip",
+								"type": "boolean"
+							},
+							"hideFromTable": {
+								"description": "Whether to include this series in the table",
+								"type": "boolean"
+							},
+							"hideFromMap": {
+								"description": "Whether to include this series in the map",
 								"type": "boolean"
 							},
 							"name": {
@@ -97880,7 +98240,7 @@ export const TranslatedMapOverlaySchema = {
 						"type": "object",
 						"properties": {
 							"type": {
-								"description": "How to display this series (use popup-only to just show in the popup/tooltip)",
+								"description": "How to display this series (popup-only is deprecated)",
 								"enum": [
 									"color",
 									"icon",
@@ -97963,6 +98323,18 @@ export const TranslatedMapOverlaySchema = {
 							},
 							"hideFromLegend": {
 								"description": "Whether to include this series in the legend",
+								"type": "boolean"
+							},
+							"hideFromPopup": {
+								"description": "Whether to include this series in the popup/tooltip",
+								"type": "boolean"
+							},
+							"hideFromTable": {
+								"description": "Whether to include this series in the table",
+								"type": "boolean"
+							},
+							"hideFromMap": {
+								"description": "Whether to include this series in the map",
 								"type": "boolean"
 							},
 							"name": {
@@ -98485,7 +98857,7 @@ export const TranslatedMapOverlaySchema = {
 						"type": "object",
 						"properties": {
 							"type": {
-								"description": "How to display this series (use popup-only to just show in the popup/tooltip)",
+								"description": "How to display this series (popup-only is deprecated)",
 								"enum": [
 									"color",
 									"icon",
@@ -98568,6 +98940,18 @@ export const TranslatedMapOverlaySchema = {
 							},
 							"hideFromLegend": {
 								"description": "Whether to include this series in the legend",
+								"type": "boolean"
+							},
+							"hideFromPopup": {
+								"description": "Whether to include this series in the popup/tooltip",
+								"type": "boolean"
+							},
+							"hideFromTable": {
+								"description": "Whether to include this series in the table",
+								"type": "boolean"
+							},
+							"hideFromMap": {
+								"description": "Whether to include this series in the map",
 								"type": "boolean"
 							},
 							"name": {

--- a/packages/types/src/types/models-extra/mapOverlay.ts
+++ b/packages/types/src/types/models-extra/mapOverlay.ts
@@ -46,7 +46,7 @@ export type InlineValue = {
 
 type MeasureConfig = {
   /**
-   * @description How to display this series (use popup-only to just show in the popup/tooltip)
+   * @description How to display this series (popup-only is deprecated)
    */
   type: `${MeasureType}` | 'popup-only';
 
@@ -69,6 +69,16 @@ type MeasureConfig = {
    * @description Whether to include this series in the legend
    */
   hideFromLegend?: boolean;
+
+  /**
+   * @description Whether to include this series in the popup/tooltip
+   */
+  hideFromPopup?: boolean;
+
+  /**
+   * @description Whether to include this series in the table
+   */
+  hideFromTable?: boolean;
 
   /**
    * @description Display name of this series

--- a/packages/ui-map-components/src/components/Table/getMapTableData.tsx
+++ b/packages/ui-map-components/src/components/Table/getMapTableData.tsx
@@ -17,14 +17,16 @@ const processColumns = (serieses: Series[]) => {
     return [];
   }
 
-  const configColumns = serieses.map(column => {
-    return {
-      // @ts-ignore - The react table accessors don't work as strings if the key has a space so we
-      // need to use the function accessor. The row and column could be any type so we need to ignore
-      accessor: (row: any) => row[column.key],
-      Header: column.name,
-    };
-  });
+  const configColumns = serieses
+    .filter(column => !column.hideFromTable)
+    .map(column => {
+      return {
+        // @ts-ignore - The react table accessors don't work as strings if the key has a space so we
+        // need to use the function accessor. The row and column could be any type so we need to ignore
+        accessor: (row: any) => row[column.key],
+        Header: column.name,
+      };
+    });
 
   return [
     {

--- a/packages/ui-map-components/src/types/series.ts
+++ b/packages/ui-map-components/src/types/series.ts
@@ -38,6 +38,7 @@ export type BaseSeries = Pick<
   popupHeaderFormat?: string;
   startDate: string;
   endDate: string;
+  hideFromTable?: boolean;
 };
 
 export type RadiusSeries = BaseSeries & {


### PR DESCRIPTION
### Issue #: tweak(tupaiaWeb): RN-1370: tweak(tupaiaWeb): RN-1370: Add support for hiding map overlay data from map overlay table

This PR is to update the map overlay config to support hiding measures of data from the popup and map table

### Changes:
- fix type for hideFromPopup so that it can be set in the viz builder
- add support hideFromTable map overlay config
