### PR TITLE
fix(tupaia): RN-1494: Fix PDF export settings

### DIFF
--- a/packages/tupaia-web/src/features/Dashboard/ExportDashboard/ExportConfig.tsx
+++ b/packages/tupaia-web/src/features/Dashboard/ExportDashboard/ExportConfig.tsx
@@ -163,16 +163,16 @@ export const ExportConfig = ({ onClose, selectedDashboardItems }: ExportDashboar
               <ExportSubtitle>Edit export settings and click 'Download'.</ExportSubtitle>
             </ExportSettingsInstructionsContainer>
             <ExportSetting>
-              {hasChartItems && (
-                <section>
-                  <ExportSettingsWrapper>
-                    <DisplayFormatSettings />
-                  </ExportSettingsWrapper>
+              <section>
+                <ExportSettingsWrapper>
+                  <DisplayFormatSettings />
+                </ExportSettingsWrapper>
+                {hasChartItems && (
                   <ExportSettingsWrapper>
                     <DisplayOptionsSettings />
                   </ExportSettingsWrapper>
-                </section>
-              )}
+                )}
+              </section>
               <MailingListSection
                 selectedDashboardItems={selectedDashboardItems}
                 settings={{


### PR DESCRIPTION
### Issue #: fix(tupaia): RN-1494: Fix PDF export settings

### Changes:

Fix issue where the PDF settings were being hidden when there are no charts. The chart settings should be dependent on whether or not there are charts but the PDF settings should always display.

