### PR TITLE
fix(tupaiaWeb): RN-1512: Fix broken arithmetic visuals

### DIFF
--- a/packages/data-api/src/utils.ts
+++ b/packages/data-api/src/utils.ts
@@ -25,6 +25,7 @@ export const sanitizeAnalyticsTableValue = (value: string, type: string) => {
   switch (type) {
     case 'Binary':
     case 'Checkbox':
+    case 'Arithmetic':
     case 'Number': {
       const sanitizedValue = parseFloat(value);
       return Number.isNaN(sanitizedValue) ? '' : sanitizedValue;


### PR DESCRIPTION
### Issue #: RN-1512: Fix broken arithmetic visuals

When sum calculations are run on data for arithmetic questions, the values were not being cast to float and so were being concatenated instead of summed. Data for Arithmetic questions was intentionally not being casted because it used to be possible to have expressions as return values but since this is no longer possible, it is now safe to cast to float. The query below was run to confirm that all Arithmetic data are valid floats.

```
SELECT value
FROM analytics
WHERE type = 'Arithmetic'
AND value !~ '^[+-]?[0-9]*\.?[0-9]+([eE][+-]?[0-9]+)?$';
```

**Note: since this is a production hotfix I opted not to add additional casting in the aggregator sum functions as that would increase regression risk.**