### PR TITLE
fix(adminPanel): RN-1534: Fix matrix preview

### DIFF
--- a/packages/admin-panel/src/VizBuilderApp/constants.js
+++ b/packages/admin-panel/src/VizBuilderApp/constants.js
@@ -171,7 +171,7 @@ export const DASHBOARD_ITEM_VIZ_TYPES = {
   // Matrix
   MATRIX: {
     name: 'Matrix',
-    // schema: MatrixVizBuilderConfigSchema,
+    schema: MatrixVizBuilderConfigSchema,
     vizMatchesType: viz => viz.type === 'matrix',
     initialConfig: {
       type: 'matrix',

--- a/packages/types/src/schemas/schemas.ts
+++ b/packages/types/src/schemas/schemas.ts
@@ -2284,16 +2284,10 @@ export const MatrixVizBuilderConfigSchema = {
 				},
 				"columns": {
 					"description": "The columns of the data-table that should be included as columns in the matrix.\nCan be either:\na list of column names,\n'*' to indicate all columns\nor a list of objects with an entityCode and entityLabel to generate entity links",
-					"anyOf": [
-						{
-							"type": "array",
-							"items": {
-								"type": "string"
-							}
-						},
-						{
-							"type": "array",
-							"items": {
+					"type": "array",
+					"items": {
+						"anyOf": [
+							{
 								"type": "object",
 								"properties": {
 									"entityCode": {
@@ -2308,12 +2302,12 @@ export const MatrixVizBuilderConfigSchema = {
 									"entityCode",
 									"entityLabel"
 								]
+							},
+							{
+								"type": "string"
 							}
-						},
-						{
-							"type": "string"
-						}
-					]
+						]
+					}
 				}
 			},
 			"additionalProperties": false,

--- a/packages/types/src/types/models-extra/dashboard-item/matricies.ts
+++ b/packages/types/src/types/models-extra/dashboard-item/matricies.ts
@@ -72,7 +72,7 @@ export type MatrixVizBuilderConfig = MatrixConfig & {
      * '*' to indicate all columns
      * or a list of objects with an entityCode and entityLabel to generate entity links
      */
-    columns?: string | string[] | MatrixEntityCell[];
+    columns?: (string | { entityCode: string; entityLabel: string })[];
   };
 };
 


### PR DESCRIPTION
### Issue #: RN-1534: Fix matrix preview

### Changes:
There was a regression in the recent entity links feature caused by the schema for MatrixVizes in the admin panel being commented out. It looks like they were commented out because the schema was incorrect and was causing an error. I re-included the schema and updated it to match the config for the output columns and now it is working as expected.
