### PR TITLE
refactor(datatrak): update `<StickyMobileHeader>` interface

### DIFF
--- a/packages/datatrak-web/src/features/MobileSelectList/ListItem.tsx
+++ b/packages/datatrak-web/src/features/MobileSelectList/ListItem.tsx
@@ -104,7 +104,9 @@ export const ListItem = ({ item, onSelect, children }: ListItemProps) => {
           onClose={onClose}
           fullScreen
         >
-          <StickyMobileHeader onBack={onBack} onClose={onClose} title="Select a survey" />
+          <StickyMobileHeader onBack={onBack} onClose={onClose}>
+            Select a survey
+          </StickyMobileHeader>
           {children}
         </Dialog>
       )}

--- a/packages/datatrak-web/src/features/Survey/Components/CopySurveyUrlButton.tsx
+++ b/packages/datatrak-web/src/features/Survey/Components/CopySurveyUrlButton.tsx
@@ -55,7 +55,7 @@ export const useCopySurveyUrl = ({ toastOptions = {} }: { toastOptions: OptionsO
         });
       }
     } catch (err) {
-      console.warn('Failed to copy page url: ', err);
+      console.warn('Failed to copy page URL: ', err);
     }
   };
 };

--- a/packages/datatrak-web/src/features/Survey/Components/CopySurveyUrlButton.tsx
+++ b/packages/datatrak-web/src/features/Survey/Components/CopySurveyUrlButton.tsx
@@ -3,15 +3,17 @@
  *  Copyright (c) 2017 - 2023 Beyond Essential Systems Pty Ltd
  */
 
-import React from 'react';
 import IconButton from '@material-ui/core/IconButton';
-import { useParams, generatePath } from 'react-router-dom';
-import { Tooltip } from '@tupaia/ui-components';
-import styled from 'styled-components';
 import { OptionsObject } from 'notistack';
+import React from 'react';
+import { generatePath, useParams } from 'react-router-dom';
+import styled from 'styled-components';
+
+import { Tooltip } from '@tupaia/ui-components';
+
 import { CopyIcon } from '../../../components';
-import { getAndroidVersion, infoToast, isAndroidDevice } from '../../../utils';
 import { ROUTES } from '../../../constants';
+import { getAndroidVersion, infoToast } from '../../../utils';
 
 const StyledTooltip = styled(Tooltip)`
   text-align: center;
@@ -80,7 +82,7 @@ export const CopySurveyUrlButton = () => {
       enterDelay={500}
       enterTouchDelay={500}
     >
-      <Button aria-label="copy url to clipboard" onClick={copyPageUrl}>
+      <Button aria-label="Copy URL to clipboard" onClick={copyPageUrl}>
         <CopyIcon />
       </Button>
     </StyledTooltip>

--- a/packages/datatrak-web/src/features/Survey/Components/MobileSurveyHeader.tsx
+++ b/packages/datatrak-web/src/features/Survey/Components/MobileSurveyHeader.tsx
@@ -43,11 +43,9 @@ export const MobileSurveyHeader = () => {
 
   return (
     <>
-      <StickyHeader
-        title={<SurveyDisplayName />}
-        onBack={handleBack}
-        onClose={openCancelConfirmation}
-      />
+      <StickyHeader onBack={handleBack} onClose={openCancelConfirmation}>
+        <SurveyDisplayName />
+      </StickyHeader>
       {screenNumberParam && (
         <TopProgressBar
           currentSurveyQuestion={screenNumber}

--- a/packages/datatrak-web/src/features/Survey/Components/SurveySideMenu/SurveySideMenu.tsx
+++ b/packages/datatrak-web/src/features/Survey/Components/SurveySideMenu/SurveySideMenu.tsx
@@ -159,7 +159,11 @@ export const SurveySideMenu = () => {
         onClose={toggleSideMenu}
         variant={isMobile ? 'temporary' : 'persistent'}
       >
-        {isMobile && <StickyMobileHeader onClose={toggleSideMenu} title={<SurveyDisplayName />} />}
+        {isMobile && (
+          <StickyMobileHeader onClose={toggleSideMenu}>
+            <SurveyDisplayName />
+          </StickyMobileHeader>
+        )}
         <Header>
           <SideMenuButton />
         </Header>

--- a/packages/datatrak-web/src/features/Survey/Screens/SurveyReviewScreen.tsx
+++ b/packages/datatrak-web/src/features/Survey/Screens/SurveyReviewScreen.tsx
@@ -2,18 +2,14 @@
  * Tupaia
  * Copyright (c) 2017 - 2024 Beyond Essential Systems Pty Ltd
  */
-import React from 'react';
 import { Typography } from '@material-ui/core';
-import styled from 'styled-components';
+import React from 'react';
 import { useOutletContext } from 'react-router-dom';
-import {
-  MobileSurveyMenu,
-  SurveyPaginator,
-  SurveyReviewSection,
-  SurveySideMenu,
-} from '../Components';
+import styled from 'styled-components';
+
 import { ScrollableBody, StickyMobileHeader } from '../../../layout';
 import { useIsMobile } from '../../../utils';
+import { MobileSurveyMenu, SurveyPaginator, SurveyReviewSection } from '../Components';
 import { useSurveyForm } from '../SurveyContext';
 
 const Header = styled.div`
@@ -48,11 +44,11 @@ const StickyHeader = styled(StickyMobileHeader)`
   }
 `;
 
-type SurveyLayoutContext = {
+interface SurveyLayoutContext {
   isLoading: boolean;
   onStepPrevious: () => void;
   hasBackButton: boolean;
-};
+}
 
 const MobileHeader = () => {
   const { openCancelConfirmation } = useSurveyForm();
@@ -61,8 +57,11 @@ const MobileHeader = () => {
   const handleBack = () => {
     onStepPrevious();
   };
+
   return (
-    <StickyHeader title="Review & submit" onBack={handleBack} onClose={openCancelConfirmation} />
+    <StickyHeader onBack={handleBack} onClose={openCancelConfirmation}>
+      Review & submit
+    </StickyHeader>
   );
 };
 

--- a/packages/datatrak-web/src/layout/StickyMobileHeader.tsx
+++ b/packages/datatrak-web/src/layout/StickyMobileHeader.tsx
@@ -4,23 +4,24 @@
  */
 
 import { IconButton, Typography } from '@material-ui/core';
-import React from 'react';
+import { Close } from '@material-ui/icons';
+import React, { HTMLAttributes } from 'react';
 import styled from 'styled-components';
+
 import { ArrowLeftIcon } from '../components';
 import { HEADER_HEIGHT } from '../constants';
-import { Close } from '@material-ui/icons';
 
 export const MobileHeaderWrapper = styled.div`
   position: sticky;
-  top: 0;
-  left: 0;
-  width: 100%;
+  inset-block-start: 0;
+  inset-inline-start: 0;
+  inline-size: 100%;
   display: flex;
   align-items: center;
   justify-content: space-between;
   background-color: ${({ theme }) => theme.palette.background.paper};
-  min-height: ${HEADER_HEIGHT};
-  height: ${HEADER_HEIGHT};
+  min-block-size: ${HEADER_HEIGHT};
+  block-size: ${HEADER_HEIGHT};
   z-index: 1000;
 `;
 
@@ -39,31 +40,27 @@ const Title = styled(Typography).attrs({ variant: 'h2' })`
   display: inline;
   font-weight: ${({ theme }) => theme.typography.fontWeightMedium};
   font-size: 1rem;
-  margin-left: 1rem;
-  margin-right: 1rem;
+  margin-inline: 1rem;
   svg {
     vertical-align: middle;
   }
 `;
 
 const ButtonContainer = styled.div`
-  width: 3.5rem;
+  inline-size: 3.5rem;
 `;
 
-interface StickyMobileHeaderProps {
-  title: string | React.ReactNode;
+interface StickyMobileHeaderProps extends HTMLAttributes<HTMLDivElement> {
   onBack?: () => void;
   onClose?: (data: any) => void;
-  onClick?: () => void;
-  className?: string;
 }
 
 export const StickyMobileHeader = ({
+  children,
   onBack,
-  title,
-  onClose,
   onClick,
-  className,
+  onClose,
+  ...props
 }: StickyMobileHeaderProps) => {
   return (
     <MobileHeaderWrapper
@@ -71,7 +68,7 @@ export const StickyMobileHeader = ({
       role={onClick ? 'button' : undefined}
       tabIndex={onClick ? 0 : undefined}
       aria-label={onClick ? 'Header, click to scroll list back to top' : undefined}
-      className={className}
+      {...props}
     >
       {onBack && (
         <ButtonContainer>
@@ -80,7 +77,7 @@ export const StickyMobileHeader = ({
           </Button>
         </ButtonContainer>
       )}
-      <Title>{title}</Title>
+      <Title>{children}</Title>
       <ButtonContainer>
         {onClose && (
           <Button onClick={onClose}>

--- a/packages/datatrak-web/src/views/AccountSettingsPage/AccountSettingsPage.tsx
+++ b/packages/datatrak-web/src/views/AccountSettingsPage/AccountSettingsPage.tsx
@@ -55,15 +55,10 @@ export const AccountSettingsPage = () => {
   return (
     <>
       {isMobile && (
-        <StickyMobileHeader
-          onBack={onBack}
-          title={
-            <>
-              <SettingsIcon />
-              <MobilePageTitle>Account settings</MobilePageTitle>
-            </>
-          }
-        />
+        <StickyMobileHeader onBack={onBack}>
+          <SettingsIcon />
+          <MobilePageTitle>Account settings</MobilePageTitle>
+        </StickyMobileHeader>
       )}
       <Wrapper>
         {!isMobile && (

--- a/packages/datatrak-web/src/views/LandingPage/ActivityFeedSection/MobileActivityFeed.tsx
+++ b/packages/datatrak-web/src/views/LandingPage/ActivityFeedSection/MobileActivityFeed.tsx
@@ -66,7 +66,9 @@ const ExpandedList = ({ expanded, onClose }: { expanded: boolean; onClose: () =>
       fullScreen
     >
       <ExpandedWrapper>
-        <StickyMobileHeader onBack={onClose} title="Activity feed" onClick={scrollToTop} />
+        <StickyMobileHeader onBack={onClose} onClick={scrollToTop}>
+          Activity feed
+        </StickyMobileHeader>
         <InfiniteListWrapper>
           <InfiniteActivityFeed ref={feedRef} />
         </InfiniteListWrapper>

--- a/packages/datatrak-web/src/views/SurveySelectPage/MobileTemplate.tsx
+++ b/packages/datatrak-web/src/views/SurveySelectPage/MobileTemplate.tsx
@@ -66,7 +66,9 @@ export const MobileTemplate = ({
 
   return (
     <MobileContainer>
-      <StickyMobileHeader onBack={onClose} onClose={onClose} title="Select a survey" />
+      <StickyMobileHeader onBack={onClose} onClose={onClose}>
+        Select a survey
+      </StickyMobileHeader>
       <MobileSelectList
         items={groupedSurveys}
         onSelect={onNavigateToSurvey}

--- a/packages/datatrak-web/src/views/SurveySelectPage/MobileTemplate.tsx
+++ b/packages/datatrak-web/src/views/SurveySelectPage/MobileTemplate.tsx
@@ -53,16 +53,17 @@ export const MobileTemplate = ({
     selectedCountry,
   });
   const navigate = useNavigate();
+
+  if (showLoader) {
+    return <Loader />;
+  }
+
   const onClose = () => {
     navigate(ROUTES.HOME);
   };
   const onNavigateToSurvey = survey => {
     handleSelectSurvey(selectedCountry, survey.value);
   };
-
-  if (showLoader) {
-    return <Loader />;
-  }
 
   return (
     <MobileContainer>


### PR DESCRIPTION
### Changes

Setting myself up to begin work on RN-1465, but spotted this opportunity for a more versatile interface for `<StickyMobileHeader>`

Instead of passing it a `title` prop (which shadows the standard `title` attribute that most HTML elements can take), now just takes children and renders them as the title

Semantically, this makes a touch more sense—especially as there are some cases where we were giving an icon to the `title` prop

Small readability bonus: shallower indents!