### PR TITLE
fix(scripts): fix `download-env-vars`

### DIFF
--- a/scripts/bash/ansiControlSequences.sh
+++ b/scripts/bash/ansiControlSequences.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Defines (and exports) a handful of the more widely supported ANSI control sequences for
+# manipulating font and colour when writing to stdout. Honours the NO_COLOR environment variable if
+# it is set.
+#
+# EXAMPLE USAGE
+#   source "path/to/ansiControlSequence.sh"
+#   echo -e "${BOLD}${WHITE}${ON_RED}ERROR${RESET} File does not exist."
+#   printf 'See %bhttp://bes.au%b for more info.\n' "$MAGENTA" "$RESET"
+#
+# REMARKS
+#   - If using echo, remember to use -e. Otherwise, the ANSI codes will be printed literally.
+#   - Avoid using variables in the printf format string: https://github.com/koalaman/shellcheck/wiki/SC2059
+#
+# REFERENCE
+#   https://en.wikipedia.org/wiki/ANSI_escape_code
+
+# ANSI control sequences
+
+export CURSOR_UP='\033[A'
+export CURSOR_DOWN='\033[B'
+export CURSOR_FORWARD='\033[C'
+export CURSOR_BACK='\033[D'
+export CURSOR_NEXT_LINE='\033[E'
+export CURSOR_PREV_LINE='\033[F'
+export CURSOR_START_OF_LINE='\033[G'
+export CLEAR_LINE="\033[2K${CURSOR_START_OF_LINE}"
+
+# Select graphic rendition (SGR) parameters
+
+if [[ $NO_COLOR != '' ]]; then
+	# See https://no-color.org
+	export RESET=''
+	export BOLD=''
+	export UNDERLINE=''
+	export BLACK=''
+	export RED=''
+	export GREEN=''
+	export YELLOW=''
+	export BLUE=''
+	export MAGENTA=''
+	export CYAN=''
+	export WHITE=''
+	export ON_BLACK=''
+	export ON_RED=''
+	export ON_GREEN=''
+	export ON_YELLOW=''
+	export ON_BLUE=''
+	export ON_MAGENTA=''
+	export ON_CYAN=''
+	export ON_WHITE=''
+else
+	export RESET='\033[m'
+	export BOLD='\033[1m'
+	export UNDERLINE='\033[4m'
+	export BLACK='\033[30m'
+	export RED='\033[31m'
+	export GREEN='\033[32m'
+	export YELLOW='\033[33m'
+	export BLUE='\033[34m'
+	export MAGENTA='\033[35m'
+	export CYAN='\033[36m'
+	export WHITE='\033[37m'
+	export ON_BLACK='\033[40m'
+	export ON_RED='\033[41m'
+	export ON_GREEN='\033[42m'
+	export ON_YELLOW='\033[43m'
+	export ON_BLUE='\033[44m'
+	export ON_MAGENTA='\033[45m'
+	export ON_CYAN='\033[46m'
+	export ON_WHITE='\033[47m'
+fi

--- a/scripts/bash/downloadEnvironmentVariables.sh
+++ b/scripts/bash/downloadEnvironmentVariables.sh
@@ -1,99 +1,94 @@
-#!/bin/bash -e
-set +x # do not output commands in this script, as some would show credentials in plain text
+#!/usr/bin/env bash
+set -e +x # Do not output commands in this script, as some would show credentials in plain text
 
 DEPLOYMENT_NAME=$1
 DIR=$(dirname "$0")
-COLLECTION_PATH="Engineering/Tupaia General/Environment Variables" # Collection in BitWarden where .env vars are kept
+REPO_ROOT="$DIR/../.."
+. "$DIR/ansiControlSequences.sh"
 
+# Collection in BitWarden where .env vars are kept
+COLLECTION_PATH='Engineering/Tupaia General/Environment Variables'
 
-# can provide one or more packages as command line arguments, or will default to all
-if [ -z $2 ]; then
-    echo "Fetching all .env files"
-    PACKAGES=$(${DIR}/getPackagesWithEnvFiles.sh)
-else
-    PACKAGES=${@:2}
-    echo "Fetching environment variables for ${PACKAGES}"
-fi
-
-# Login to bitwarden
-bw login --check || bw login $BITWARDEN_EMAIL $BITWARDEN_PASSWORD
-eval "$(bw unlock $BITWARDEN_PASSWORD | grep -o -m 1 'export BW_SESSION=.*$')"
+# Log in to bitwarden
+echo -e "${BLUE}==>️${RESET} ${BOLD}Logging into Bitwarden${RESET}"
+bw login --check || bw login "$BITWARDEN_EMAIL" "$BITWARDEN_PASSWORD"
+eval "$(bw unlock "$BITWARDEN_PASSWORD" | grep -o -m 1 'export BW_SESSION=.*$')"
 
 COLLECTION_ID=$(bw get collection "$COLLECTION_PATH" | jq .id)
 
-load_env_file_from_bw () {
+echo
+
+# Can provide one or more packages as command line arguments, or will default to all
+if [[ -z $2 ]]; then
+    PACKAGES=$("$DIR/getPackagesWithEnvFiles.sh")
+    echo -e "${BLUE}==>️${RESET} ${BOLD}Fetching environment variables for all packages${RESET}"
+else
+    PACKAGES=("${@:2}")
+    echo -e "${BLUE}==>️${RESET} ${BOLD}Fetching environment variables for ${PACKAGES[*]}${RESET}"
+fi
+
+load_env_file_from_bw() {
     FILE_NAME=$1
     BASE_FILE_PATH=$2
     NEW_FILE_NAME=$3
-    ENV_FILE_PATH=${BASE_FILE_PATH}/${NEW_FILE_NAME}.env
+    ENV_FILE_PATH=$BASE_FILE_PATH/$NEW_FILE_NAME.env
 
-    echo "Fetching environment variables for $FILE_NAME: $ENV_FILE_PATH"
-
-    echo "Fetching environment variables for $FILE_NAME"
+    echo -en "${YELLOW}🚚 Fetching variables for ${BOLD}${FILE_NAME}...${RESET}"
 
     # checkout deployment specific env vars, or dev as fallback
-    DEPLOYMENT_ENV_VARS=$(bw list items --search ${FILE_NAME}.${DEPLOYMENT_NAME}.env | jq --raw-output "map(select(.collectionIds[] | contains ($COLLECTION_ID))) | .[] .notes")
+    DEPLOYMENT_ENV_VARS=$(bw list items --search "$FILE_NAME.$DEPLOYMENT_NAME.env" | jq --raw-output "map(select(.collectionIds[] | contains ($COLLECTION_ID))) | .[] .notes")
 
-
-    if [ -n "$DEPLOYMENT_ENV_VARS" ]; then
-        echo "$DEPLOYMENT_ENV_VARS" > ${ENV_FILE_PATH}
+    if [[ -n $DEPLOYMENT_ENV_VARS ]]; then
+        echo "$DEPLOYMENT_ENV_VARS" >"$ENV_FILE_PATH"
     else
-        DEV_ENV_VARS=$(bw list items --search ${FILE_NAME}.dev.env | jq --raw-output "map(select(.collectionIds[] | contains ($COLLECTION_ID))) | .[] .notes")
-        echo "$DEV_ENV_VARS" > ${ENV_FILE_PATH}
+        DEV_ENV_VARS=$(bw list items --search "$FILE_NAME.dev.env" | jq --raw-output "map(select(.collectionIds[] | contains ($COLLECTION_ID))) | .[] .notes")
+        echo "$DEV_ENV_VARS" >"$ENV_FILE_PATH"
     fi
 
-    # Replace any instances of the placeholder [deployment-name] in the .env file with the actual deployment
-    # name (e.g. [deployment-name]-api.tupaia.org -> specific-deployment-api.tupaia.org)
-    sed -i -e "s/\[deployment-name\]/${DEPLOYMENT_NAME}/g" "${ENV_FILE_PATH}"
-
+    # Replace any instances of the placeholder [deployment-name] in the .env file with the actual
+    # deployment name (e.g. [deployment-name]-api.tupaia.org -> specific-deployment-api.tupaia.org)
+    sed -i -e "s/\[deployment-name\]/$DEPLOYMENT_NAME/g" "$ENV_FILE_PATH"
 
     if [[ -v DOMAIN ]]; then
         # Replace the placeholder [domain]
-        sed -i -e "s/\[domain\]/${DOMAIN}/g" ${ENV_FILE_PATH}
+        sed -i -e "s/\[domain\]/$DOMAIN/g" "$ENV_FILE_PATH"
     fi
 
-    if [[ "${DEPLOYMENT_NAME}" == *-e2e || "${DEPLOYMENT_NAME}" == e2e ]]; then
+    if [[ $DEPLOYMENT_NAME = *-e2e || $DEPLOYMENT_NAME = e2e ]]; then
         # Update e2e environment variables
-        if [[ ${FILE_NAME} == "aggregation" ]]; then
-            sed -i -e 's/^AGGREGATION_URL_PREFIX="?dev-"?$/AGGREGATION_URL_PREFIX=e2e-/g' ${ENV_FILE_PATH}
+        if [[ $FILE_NAME = aggregation ]]; then
+            sed -i -e 's/^AGGREGATION_URL_PREFIX="?dev-"?$/AGGREGATION_URL_PREFIX=e2e-/g' "$ENV_FILE_PATH"
         fi
     fi
 
-    if [[ "${DEPLOYMENT_NAME}" == dev ]]; then
+    if [[ $DEPLOYMENT_NAME = dev ]]; then
         # Update dev specific environment variables
         # (removes ###DEV_ONLY### prefixes, leaving the key=value pair uncommented)
         # (after removing prefix, if there are duplicate keys, dotenv uses the last one in the file)
-        sed -i -e 's/^###DEV_ONLY###//g' ${ENV_FILE_PATH}
+        sed -i -e 's/^###DEV_ONLY###//g' "$ENV_FILE_PATH"
     fi
 
-
-     echo "downloaded .env vars for $FILE_NAME"
+    echo -en "$CLEAR_LINE"
+    echo -e "${GREEN}✅ Downloaded variables for ${BOLD}${FILE_NAME}${RESET} → $ENV_FILE_PATH"
 }
 
-for PACKAGE in $PACKAGES; do
-    # only download the env file if there is an example file in the package. If there isn't, this means it is a package that doesn't need env vars
-    has_example_env_in_package=$(find $DIR/../../packages/$PACKAGE -type f -name '*.env.example' | wc -l)
-    if [ $has_example_env_in_package -eq 1 ]; then
-        load_env_file_from_bw $PACKAGE $DIR/../../packages/$PACKAGE ""
+for PACKAGE in "${PACKAGES[@]}"; do
+    # Only download the env file if there is an example file in the package. If there isn’t, this
+    # means it is a package that doesn’t need env vars
+    if [[ -f $REPO_ROOT/packages/$PACKAGE/.env.example ]]; then
+        load_env_file_from_bw "$PACKAGE" "$REPO_ROOT/packages/$PACKAGE" ''
     fi
 done
 
-
-# get all .env.*.example files in the env directory
-file_names=$(find $DIR/../../env -type f -name '*.env.example' -exec basename {} \;)
-
-
-# for each file, get the extract the filename without the .example extension
-for file_name in $file_names; do
-    env_name=$(echo $file_name | sed 's/\.env.example//')
-    load_env_file_from_bw $env_name $DIR/../../env $env_name
+for file_name in "$REPO_ROOT"/env/*.env.example; do
+    package_name=$(basename "$file_name" '.env.example')
+    load_env_file_from_bw "$package_name" "$REPO_ROOT/env" "$package_name"
 done
 
-
-
-
+# Log out of Bitwarden
+echo
+echo -e "${BLUE}==>️${RESET} ${BOLD}Logging out of Bitwarden${RESET}"
 bw logout
-
 
 # Clean up detritus on macOS
 # macOS and Ubuntu’s interfaces for sed are slightly different. In this script, we use it in a way

--- a/scripts/bash/getDeployablePackages.sh
+++ b/scripts/bash/getDeployablePackages.sh
@@ -1,4 +1,24 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
-echo "admin-panel" "lesmis" "psss" "datatrak-web" "tupaia-web" "central-server" "data-table-server" "datatrak-web-server" "entity-server" "lesmis-server" "meditrak-app-server" "psss-server" "report-server" "tupaia-web-server" "web-config-server" "admin-panel-server" # admin-panel-server last as it depends on report-server
+DEPLOYABLE_PACKAGES=(
+    'admin-panel'
+    'lesmis'
+    'psss'
+    'datatrak-web'
+    'tupaia-web'
+    'central-server'
+    'data-table-server'
+    'datatrak-web-server'
+    'entity-server'
+    'lesmis-server'
+    'meditrak-app-server'
+    'psss-server'
+    'report-server'
+    'tupaia-web-server'
+    'web-config-server'
+    'admin-panel-server' # admin-panel-server last as it depends on report-server
+)
+echo "${DEPLOYABLE_PACKAGES[@]}"
+
 exit 0

--- a/scripts/bash/getPackagesWithEnvFiles.sh
+++ b/scripts/bash/getPackagesWithEnvFiles.sh
@@ -1,9 +1,11 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 DIR=$(dirname "$0")
 
-# packages with .env files are (currently) all deployable, plus auth, data-api, and database
-PACKAGES=$(${DIR}/getDeployablePackages.sh)
-PACKAGES+=" data-api viz-test-tool"
-echo $PACKAGES
+# Packages with .env files are (currently) all deployable, plus auth, data-api, and database
+PACKAGES=$("$DIR/getDeployablePackages.sh")
+PACKAGES+=('data-api' 'viz-test-tool')
+echo "${PACKAGES[@]}"
+
 exit 0


### PR DESCRIPTION
Found that the `downloadEnvironmentVariables.sh` script wasn’t working. #5568 previously made modifications to the script (though hasn't been merged)

I used that as a starting point to fix up the script