### PR TITLE
fix(datatrak): survey response type

### DIFF
--- a/packages/datatrak-web/src/features/Tasks/TaskDetails/TaskDetails.tsx
+++ b/packages/datatrak-web/src/features/Tasks/TaskDetails/TaskDetails.tsx
@@ -1,19 +1,21 @@
-import React, { useEffect, useState } from 'react';
-import { useForm, Controller } from 'react-hook-form';
-import styled from 'styled-components';
 import { Paper, Typography } from '@material-ui/core';
 import { TaskStatus } from '@tupaia/types';
 import { LoadingContainer } from '@tupaia/ui-components';
+import { parseISO } from 'date-fns';
+import React, { useEffect, useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import styled from 'styled-components';
+
 import { useEditTask, useSurveyResponse } from '../../../api';
-import { displayDate } from '../../../utils';
 import { Button as BaseButton, SurveyTickIcon, Tile } from '../../../components';
+import { DateTimeDisplay } from '../../../components/DateTimeDisplay';
 import { SingleTaskResponse } from '../../../types';
-import { RepeatScheduleInput } from '../RepeatScheduleInput';
-import { DueDatePicker } from '../DueDatePicker';
 import { AssigneeInput } from '../AssigneeInput';
+import { DueDatePicker } from '../DueDatePicker';
+import { RepeatScheduleInput } from '../RepeatScheduleInput';
 import { TaskForm } from '../TaskForm';
-import { TaskMetadata } from './TaskMetadata';
 import { TaskComments } from './TaskComments';
+import { TaskMetadata } from './TaskMetadata';
 
 const Container = styled(Paper).attrs({
   variant: 'outlined',
@@ -130,7 +132,7 @@ const InitialRequest = ({ initialRequestId }) => {
       }
       Icon={SurveyTickIcon}
     >
-      {countryName}, {displayDate(dataTime as Date)}
+      {countryName}, <DateTimeDisplay date={parseISO(dataTime)} variant="date" />
     </Tile>
   );
 };

--- a/packages/types/src/types/requests/datatrak-web-server/SingleSurveyResponseRequest.ts
+++ b/packages/types/src/types/requests/datatrak-web-server/SingleSurveyResponseRequest.ts
@@ -5,7 +5,7 @@ export type Params = {
   id: string;
 };
 
-export interface ResBody extends KeysToCamelCase<Omit<SurveyResponse, 'dataTime'>> {
+export interface ResBody extends KeysToCamelCase<Omit<SurveyResponse, 'data_time'>> {
   answers: Record<string, string>;
   countryName: Country['name'];
   entityName: Entity['name'];
@@ -13,7 +13,8 @@ export interface ResBody extends KeysToCamelCase<Omit<SurveyResponse, 'dataTime'
   surveyName: Survey['name'];
   surveyCode: Survey['code'];
   countryCode: Country['code'];
-  dataTime: Date;
+  /** ISO9075 format */
+  dataTime: string;
   entityParentName: Entity['name'];
 }
 export type ReqBody = Record<string, never>;


### PR DESCRIPTION
Stored as a `TIMESTAMP WITH TIME ZONE` in the database, but it comes through to us as an ISO9075 string (without a time zone??)

This sorts out the type, but let me know if it breaks semantics