### PR TITLE
fix(ci): Fix script for downloading env vars for packages

### DIFF
--- a/scripts/bash/downloadEnvironmentVariables.sh
+++ b/scripts/bash/downloadEnvironmentVariables.sh
@@ -72,7 +72,7 @@ load_env_file_from_bw() {
     echo -e "${GREEN}✅ Downloaded variables for ${BOLD}${FILE_NAME}${RESET} → $ENV_FILE_PATH"
 }
 
-for PACKAGE in "${PACKAGES[@]}"; do
+for PACKAGE in $PACKAGES; do
     # Only download the env file if there is an example file in the package. If there isn’t, this
     # means it is a package that doesn’t need env vars
     if [[ -f $REPO_ROOT/packages/$PACKAGE/.env.example ]]; then


### PR DESCRIPTION
### Issue #:

Currently we don't download the .env vars for packages, just the global ones