### PR TITLE
refactor(datatrak): RN-1543: clean up `useUserCountries` interface

### DIFF
--- a/packages/datatrak-web/src/api/queries/index.ts
+++ b/packages/datatrak-web/src/api/queries/index.ts
@@ -6,6 +6,7 @@ export { useSurvey } from './useSurvey';
 export { useSurveyResponse } from './useSurveyResponse';
 export { useSurveyResponses, useCurrentUserSurveyResponses } from './useSurveyResponses';
 export { useProjectEntities } from './useProjectEntities';
+export type { UseProjectEntitiesQueryOptions } from './useProjectEntities';
 export { useEntityById, useEntityByCode } from './useEntity';
 export { useAutocompleteOptions } from './useAutocompleteOptions';
 export { useProject } from './useProject';

--- a/packages/datatrak-web/src/api/queries/useProjectEntities.ts
+++ b/packages/datatrak-web/src/api/queries/useProjectEntities.ts
@@ -1,20 +1,27 @@
-import { useQuery } from '@tanstack/react-query';
+import { UseQueryOptions, useQuery } from '@tanstack/react-query';
 import { DatatrakWebEntityDescendantsRequest } from '@tupaia/types';
 import { get } from '../api';
+
+export type UseProjectEntitiesQueryOptions = UseQueryOptions<
+  DatatrakWebEntityDescendantsRequest.ResBody,
+  Error
+>;
 
 export const useProjectEntities = (
   projectCode?: string,
   params?: DatatrakWebEntityDescendantsRequest.ReqBody,
-  enabled = true,
-  options?: { onError?: (error: any) => void },
+  useQueryOptions?: UseProjectEntitiesQueryOptions,
 ) => {
-  return useQuery(
+  return useQuery<DatatrakWebEntityDescendantsRequest.ResBody, Error>(
     ['entityDescendants', projectCode, params],
-    (): Promise<DatatrakWebEntityDescendantsRequest.ResBody> => {
+    () => {
       return get('entityDescendants', {
         params: { ...params, filter: { ...params?.filter, projectCode } },
       });
     },
-    { enabled: !!projectCode && enabled, onError: options?.onError ?? undefined },
+    {
+      enabled: !!projectCode,
+      ...useQueryOptions,
+    },
   );
 };

--- a/packages/datatrak-web/src/api/queries/useProjectEntities.ts
+++ b/packages/datatrak-web/src/api/queries/useProjectEntities.ts
@@ -20,8 +20,8 @@ export const useProjectEntities = (
       });
     },
     {
-      enabled: !!projectCode,
       ...useQueryOptions,
+      enabled: !!projectCode && useQueryOptions?.enabled,
     },
   );
 };

--- a/packages/datatrak-web/src/features/CountrySelector/useUserCountries.ts
+++ b/packages/datatrak-web/src/features/CountrySelector/useUserCountries.ts
@@ -1,22 +1,31 @@
 import { useState } from 'react';
-import { useProjectEntities, useCurrentUserContext } from '../../api';
+
+import {
+  UseProjectEntitiesQueryOptions,
+  useCurrentUserContext,
+  useProjectEntities,
+} from '../../api';
 import { Entity } from '../../types';
 
-export const useUserCountries = (onError?: (error: any) => void) => {
+export const useUserCountries = (
+  useProjectEntitiesQueryOptions?: UseProjectEntitiesQueryOptions,
+) => {
   const user = useCurrentUserContext();
   const [newSelectedCountry, setSelectedCountry] = useState<Entity | null>(null);
+
+  const projectCode = user.project?.code;
+  const entityRequestParams = {
+    filter: { type: 'country' },
+  };
+  const queryOptions = {
+    enabled: !!projectCode,
+    ...useProjectEntitiesQueryOptions,
+  };
   const {
     data: countries,
     isLoading: isLoadingCountries,
     isError,
-  } = useProjectEntities(
-    user.project?.code,
-    {
-      filter: { type: 'country' },
-    },
-    undefined,
-    { onError },
-  );
+  } = useProjectEntities(projectCode, entityRequestParams, queryOptions);
 
   // sort the countries alphabetically so they are in a consistent order for the user
   const alphabetisedCountries = countries?.sort((a, b) => a.name.localeCompare(b.name)) ?? [];
@@ -31,7 +40,7 @@ export const useUserCountries = (onError?: (error: any) => void) => {
     }
 
     // if the selected project is 'explore', return demo land
-    if (user.project?.code === 'explore') {
+    if (projectCode === 'explore') {
       return alphabetisedCountries?.find(({ code }) => code === 'DL');
     }
 

--- a/packages/datatrak-web/src/features/EntitySelector/EntitySelector.tsx
+++ b/packages/datatrak-web/src/features/EntitySelector/EntitySelector.tsx
@@ -33,7 +33,7 @@ const useSearchResults = (searchValue, filter, projectCode, disableSearch = fals
       searchString: debouncedSearch,
       pageSize: 100,
     },
-    !disableSearch,
+    { enabled: !disableSearch },
   );
 };
 

--- a/packages/datatrak-web/src/features/Tasks/CreateTaskModal/CreateTaskModal.tsx
+++ b/packages/datatrak-web/src/features/Tasks/CreateTaskModal/CreateTaskModal.tsx
@@ -129,7 +129,7 @@ export const CreateTaskModal = ({ onClose }: CreateTaskModalProps) => {
     selectedCountry,
     updateSelectedCountry,
     isLoading: isLoadingCountries,
-  } = useUserCountries(handleCountriesError);
+  } = useUserCountries({ onError: handleCountriesError });
   const { isLoading: isLoadingUser, isFetching: isFetchingUser } = useUser();
 
   const isLoadingData = isLoadingCountries || isLoadingUser || isFetchingUser;


### PR DESCRIPTION
Instead of picking `UseQueryOptions` one-by-one to pass through as separate parameters, now just bring the entire options object through

All existing behaviour preserved. A bit easier to set overrides in code now

Tightened up the typing, which should flow through quite well to the consumers