### PR TITLE
tweak: disable login alerts

### DIFF
--- a/packages/central-server/src/apiV2/authenticate/authenticate.js
+++ b/packages/central-server/src/apiV2/authenticate/authenticate.js
@@ -1,9 +1,11 @@
 import winston from 'winston';
+
 import { getAuthorizationObject, getUserAndPassFromBasicAuth } from '@tupaia/auth';
-import { respond, reduceToDictionary } from '@tupaia/utils';
-import { ConsecutiveFailsRateLimiter } from './ConsecutiveFailsRateLimiter';
-import { BruteForceRateLimiter } from './BruteForceRateLimiter';
+import { reduceToDictionary, respond } from '@tupaia/utils';
+
 import { allowNoPermissions } from '../../permissions';
+import { BruteForceRateLimiter } from './BruteForceRateLimiter';
+import { ConsecutiveFailsRateLimiter } from './ConsecutiveFailsRateLimiter';
 import { respondToRateLimitedUser } from './respondToRateLimitedUser';
 
 const GRANT_TYPES = {

--- a/packages/central-server/src/apiV2/authenticate/authenticate.js
+++ b/packages/central-server/src/apiV2/authenticate/authenticate.js
@@ -4,7 +4,6 @@ import { respond, reduceToDictionary } from '@tupaia/utils';
 import { ConsecutiveFailsRateLimiter } from './ConsecutiveFailsRateLimiter';
 import { BruteForceRateLimiter } from './BruteForceRateLimiter';
 import { allowNoPermissions } from '../../permissions';
-import { checkUserLocationAccess } from './checkUserLocationAccess';
 import { respondToRateLimitedUser } from './respondToRateLimitedUser';
 
 const GRANT_TYPES = {
@@ -138,8 +137,6 @@ export async function authenticate(req, res) {
       apiClientUser,
       permissionGroups: permissionGroupsByCountryId,
     });
-
-    await checkUserLocationAccess(req, user);
 
     // Reset rate limiting on successful authorisation
     await consecutiveFailsRateLimiter.resetFailedAttempts(req);

--- a/packages/central-server/src/tests/apiV2/authenticate/authenticate.test.js
+++ b/packages/central-server/src/tests/apiV2/authenticate/authenticate.test.js
@@ -1,12 +1,14 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { encryptPassword, hashAndSaltPassword, getTokenClaims } from '@tupaia/auth';
-import { findOrCreateDummyRecord, findOrCreateDummyCountryEntity } from '@tupaia/database';
+
+import { encryptPassword, getTokenClaims, hashAndSaltPassword } from '@tupaia/auth';
+import { findOrCreateDummyCountryEntity, findOrCreateDummyRecord } from '@tupaia/database';
 import { createBasicHeader } from '@tupaia/utils';
-import { resetTestData, TestableApp } from '../../testUtilities';
-import { configureEnv } from '../../../configureEnv';
-import { ConsecutiveFailsRateLimiter } from '../../../apiV2/authenticate/ConsecutiveFailsRateLimiter';
+
 import { BruteForceRateLimiter } from '../../../apiV2/authenticate/BruteForceRateLimiter';
+import { ConsecutiveFailsRateLimiter } from '../../../apiV2/authenticate/ConsecutiveFailsRateLimiter';
+import { configureEnv } from '../../../configureEnv';
+import { TestableApp, resetTestData } from '../../testUtilities';
 
 configureEnv();
 const sandbox = sinon.createSandbox();
@@ -124,7 +126,7 @@ describe('Authenticate', function () {
     expect(apiClientUserId).to.equal(apiClientUserAccount.id);
   });
 
-  it('should add a new entry to the user_country_access_attempts table if one does not already exist', async () => {
+  it.skip('should add a new entry to the user_country_access_attempts table if one does not already exist', async () => {
     await app.post('auth?grantType=password', {
       headers: {
         authorization: createBasicHeader(apiClientUserAccount.email, apiClientSecret),
@@ -143,7 +145,7 @@ describe('Authenticate', function () {
     expect(entries).to.have.length(1);
   });
 
-  it('should not add a new entry to the user_country_access_attempts table if one does already exist', async () => {
+  it.skip('should not add a new entry to the user_country_access_attempts table if one does already exist', async () => {
     await models.userCountryAccessAttempt.create({
       user_id: userAccount.id,
       country_code: 'WS',

--- a/packages/central-server/src/utilities/createSupportTicket.js
+++ b/packages/central-server/src/utilities/createSupportTicket.js
@@ -1,5 +1,5 @@
-import { fetchWithTimeout, getIsProductionEnvironment, requireEnv } from '@tupaia/utils';
 import { sendEmail } from '@tupaia/server-utils';
+import { fetchWithTimeout, getIsProductionEnvironment, requireEnv } from '@tupaia/utils';
 
 const emailInternally = async (subject, message) => {
   const sendTo = requireEnv('DEV_EMAIL_ADDRESS');


### PR DESCRIPTION
### Changes

Temporarily disables support alerts sent when logging in from a new location, following [this internal discussion](https://beyondessential.slack.com/archives/C01JD93J4E6/p1738634862196829)

Alerts are planned to be restored in RN-1526
