### PR TITLE
fix: `ZENDESK_NOTIFICATIONS_DISABLE` behaviour

### DIFF
--- a/packages/central-server/src/utilities/createSupportTicket.js
+++ b/packages/central-server/src/utilities/createSupportTicket.js
@@ -14,13 +14,13 @@ const emailInternally = async (subject, message) => {
 };
 
 export const createSupportTicket = async (subject, message) => {
-  // If ZENDESK_NOTIFICATIONS_DISABLE is set to true, do not create a support ticket
-  if (process.env.ZENDESK_NOTIFICATIONS_DISABLE === 'true') return;
-
   // If we are not in a production environment, send an email to the dev team instead of creating a support ticket
   if (!getIsProductionEnvironment()) {
     return emailInternally(subject, message);
   }
+
+  // If ZENDESK_NOTIFICATIONS_DISABLE is set to true, do not create a support ticket
+  if (process.env.ZENDESK_NOTIFICATIONS_DISABLE === 'true') return;
 
   try {
     const zendeskApi = requireEnv('ZENDESK_API_URL');


### PR DESCRIPTION
In non-production environments, we want to send an email to `DEV_EMAIL_ADDRESS` instead of creating a support ticket

This is controlled by the `ZENDESK_NOTIFICATIONS_DISABLE` environment variable, but its naming doesn’t suggest that it completely short-circuits **central-server**’s `createSupportTicket` function

This means that in **dev** and feature branch deployments, `ZENDESK_NOTIFICATIONS_DISABLE` needs to be unset for email notifications to go through, and no ticket is created in Zendesk anyway

This PR flips the order in which the production-ness of an environment and the `ZENDESK_NOTIFICATIONS_DISABLE` value so that the variable does what it says on the label

**Non-production environments will continue to bypass creation of support tickets**