### PR TITLE
deps: correctly declare `prettier` peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "nodemon": "^2.0.4",
     "npm-package-json-lint": "5.1.0",
     "pm2": "^5.3.0",
+    "prettier": "^3.5.1",
     "react-docgen-typescript-plugin": "^1.0.8",
     "storybook": "^8.2.9",
     "ts-jest": "^29.1.2",

--- a/packages/meditrak-app/package.json
+++ b/packages/meditrak-app/package.json
@@ -76,7 +76,7 @@
     "babel-jest": "^29.2.1",
     "eslint": "^8.19.0",
     "metro-react-native-babel-preset": "0.76.8",
-    "prettier": "^2.4.1",
+    "prettier": "^3.5.1",
     "prop-types": "^15.8.1",
     "react-test-renderer": "18.2.0",
     "typescript": "4.8.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10389,7 +10389,7 @@ __metadata:
     metro-react-native-babel-preset: 0.76.8
     moment: ^2.24.0
     nanoid: ^2.0.3
-    prettier: ^2.4.1
+    prettier: ^3.5.1
     prop-types: ^15.8.1
     react: 18.2.0
     react-native: 0.72.5
@@ -29190,21 +29190,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^2.4.1":
-  version: 2.8.8
-  resolution: "prettier@npm:2.8.8"
-  bin:
-    prettier: bin-prettier.js
-  checksum: b49e409431bf129dd89238d64299ba80717b57ff5a6d1c1a8b1a28b590d998a34e083fa13573bc732bb8d2305becb4c9a4407f8486c81fa7d55100eb08263cf8
-  languageName: node
-  linkType: hard
-
 "prettier@npm:^3.1.1":
   version: 3.3.3
   resolution: "prettier@npm:3.3.3"
   bin:
     prettier: bin/prettier.cjs
   checksum: bc8604354805acfdde6106852d14b045bb20827ad76a5ffc2455b71a8257f94de93f17f14e463fe844808d2ccc87248364a5691488a3304f1031326e62d9276e
+  languageName: node
+  linkType: hard
+
+"prettier@npm:^3.5.1":
+  version: 3.5.1
+  resolution: "prettier@npm:3.5.1"
+  bin:
+    prettier: bin/prettier.cjs
+  checksum: a3fc77235b5a30259641547c688a067bd9db10fbf741be2ba94901480937ae8f5d26c8d7b1b688f93091882ec6afb8e48f90b86ddc3deb85a0eed28164680cb2
   languageName: node
   linkType: hard
 
@@ -34813,6 +34813,7 @@ __metadata:
     nodemon: ^2.0.4
     npm-package-json-lint: 5.1.0
     pm2: ^5.3.0
+    prettier: ^3.5.1
     react-docgen-typescript-plugin: ^1.0.8
     storybook: ^8.2.9
     ts-jest: ^29.1.2


### PR DESCRIPTION
Suppresses this warning:

```
➤ YN0002: │ tupaia@workspace:. doesn't provide prettier (pf4afa), requested by @beyondessential/eslint-config-jest
➤ YN0002: │ tupaia@workspace:. doesn't provide prettier (p7908a), requested by @beyondessential/eslint-config-js
➤ YN0002: │ tupaia@workspace:. doesn't provide prettier (pa4b33), requested by @beyondessential/eslint-config-ts
```