### PR TITLE
tweak(datatrakWeb): RN-1559: Update Entity Question UI

### DIFF
--- a/packages/datatrak-web/src/features/EntitySelector/ResultsList.tsx
+++ b/packages/datatrak-web/src/features/EntitySelector/ResultsList.tsx
@@ -10,11 +10,14 @@ const DARK_BLUE = '#004975';
 
 const ListWrapper = styled.div`
   padding-top: 1rem;
-  border-top: 1px solid ${({ theme }) => theme.palette.divider};
   display: flex;
   flex-direction: column;
   overflow: auto;
-  margin-top: 0.9rem;
+
+  ${({ theme }) => theme.breakpoints.down('sm')} {
+    margin-top: 0.9rem;
+    border-top: 1px solid ${({ theme }) => theme.palette.divider};
+  }
 
   li .MuiSvgIcon-root:not(.MuiSvgIcon-colorPrimary) {
     color: ${DARK_BLUE};
@@ -114,7 +117,7 @@ export const ResultsList = ({
           <SelectList
             items={recentEntities}
             onSelect={onSelect}
-            subTitle="Recent entities"
+            subTitle="Recently used"
             variant="borderless"
           />
         </SubListWrapper>
@@ -125,7 +128,7 @@ export const ResultsList = ({
           onSelect={onSelect}
           variant="borderless"
           noResultsMessage={noResultsMessage}
-          subTitle={!searchValue ? 'All entities' : undefined}
+          subTitle={!searchValue ? 'All' : undefined}
         />
       </SubListWrapper>
     </ListWrapper>

--- a/packages/datatrak-web/src/features/EntitySelector/ResultsList.tsx
+++ b/packages/datatrak-web/src/features/EntitySelector/ResultsList.tsx
@@ -9,14 +9,14 @@ import { useIsMobile } from '../../utils';
 const DARK_BLUE = '#004975';
 
 const ListWrapper = styled.div`
-  padding-top: 1rem;
+  padding-block-start: 1rem;
   display: flex;
   flex-direction: column;
   overflow: auto;
 
   ${({ theme }) => theme.breakpoints.down('sm')} {
-    margin-top: 0.9rem;
-    border-top: 1px solid ${({ theme }) => theme.palette.divider};
+    margin-block-start: 0.9rem;
+    border-block-start: max(0.0625rem, 1px) solid ${({ theme }) => theme.palette.divider};
   }
 
   li .MuiSvgIcon-root:not(.MuiSvgIcon-colorPrimary) {

--- a/packages/datatrak-web/src/features/EntitySelector/SearchField.tsx
+++ b/packages/datatrak-web/src/features/EntitySelector/SearchField.tsx
@@ -75,14 +75,15 @@ type SearchFieldProps = TextFieldProps & {
 export const SearchField = React.forwardRef<HTMLDivElement, SearchFieldProps>((props, ref) => {
   const {
     name,
+    label,
     id,
     searchValue,
     onChangeSearch,
     isDirty,
     invalid,
+    detailLabel,
     required,
     inputProps,
-    detailLabel,
   } = props;
 
   const displayValue = isDirty ? searchValue : '';
@@ -98,6 +99,7 @@ export const SearchField = React.forwardRef<HTMLDivElement, SearchFieldProps>((p
   return (
     <StyledField
       id={id}
+      label={label}
       name={name}
       inputRef={ref}
       required={required}

--- a/packages/datatrak-web/src/features/Questions/EntityQuestion.tsx
+++ b/packages/datatrak-web/src/features/Questions/EntityQuestion.tsx
@@ -7,19 +7,30 @@ import { EntitySelector } from '../EntitySelector';
 export const EntityQuestion = ({
   id,
   label,
+  detailLabel,
   name,
   required,
   controllerProps: { onChange, value, ref, invalid },
   config,
 }: SurveyQuestionInputProps) => {
-  const { isReviewScreen, isResponseScreen, formData, countryCode } = useSurveyForm();
-  const { surveyProjectCode } = useSurveyForm();
+  const {
+    isReviewScreen,
+    isResponseScreen,
+    formData,
+    countryCode,
+    displayQuestions,
+    screenHeader,
+    surveyProjectCode,
+  } = useSurveyForm();
+
+  // Hide the question label if there is only one question, and it is the same as the screen header
+  const hideQuestionLabel = displayQuestions.length === 1 && screenHeader == label;
 
   return (
     <EntitySelector
       id={id}
-      label={label}
-      detailLabel={`Select an entity from the list below ${required ? '*' : ''}`}
+      label={hideQuestionLabel ? '' : label}
+      detailLabel={detailLabel}
       name={name}
       required={required}
       controllerProps={{

--- a/packages/datatrak-web/src/features/Questions/EntityQuestion.tsx
+++ b/packages/datatrak-web/src/features/Questions/EntityQuestion.tsx
@@ -29,7 +29,7 @@ export const EntityQuestion = ({
   return (
     <EntitySelector
       id={id}
-      label={hideQuestionLabel ? '' : label}
+      label={hideQuestionLabel ? null : label}
       detailLabel={detailLabel}
       name={name}
       required={required}

--- a/packages/ui-components/src/components/SelectList/ListItem.tsx
+++ b/packages/ui-components/src/components/SelectList/ListItem.tsx
@@ -28,7 +28,14 @@ export const BaseListItem = styled(MuiListItem)<MuiListItemProps>`
     &.Mui-selected:hover,
     &:focus,
     &.Mui-selected:focus {
-      background: none;
+      background-color: ${({ theme }) =>
+        theme.palette.type === 'light'
+          ? `${theme.palette.primary.main}33`
+          : 'rgba(96, 99, 104, 0.50)'};
+
+      ${({ theme }) => theme.breakpoints.down('sm')} {
+        background: none;
+      }
     }
   }
 

--- a/packages/ui-components/src/components/SelectList/SelectList.tsx
+++ b/packages/ui-components/src/components/SelectList/SelectList.tsx
@@ -58,7 +58,17 @@ const Subtitle = styled(Typography)`
   font-size: 0.875rem;
   color: ${({ theme }) => theme.palette.text.secondary};
   font-weight: 400;
-  margin: 0 0 0.5rem 0.9rem;
+  margin-block: 0 0.5rem;
+  margin-inline: 0 0.9rem;
+
+  ${({ theme }) => theme.breakpoints.up('md')} {
+    color: ${({ theme }) => theme.palette.text.primary};
+    border-bottom: 1px solid ${({ theme }) => theme.palette.divider};
+    margin-block: 0 0.5rem;
+    margin-inline: 0;
+    padding-block-end: 0.2rem;
+    font-weight: 500;
+  }
 `;
 
 interface SelectListProps {

--- a/packages/ui-components/src/components/SelectList/SelectList.tsx
+++ b/packages/ui-components/src/components/SelectList/SelectList.tsx
@@ -63,7 +63,7 @@ const Subtitle = styled(Typography)`
 
   ${({ theme }) => theme.breakpoints.up('md')} {
     color: ${({ theme }) => theme.palette.text.primary};
-    border-bottom: 1px solid ${({ theme }) => theme.palette.divider};
+    border-block-end: max(0.0265rem, 1px) solid ${({ theme }) => theme.palette.divider};
     margin-block: 0 0.5rem;
     margin-inline: 0;
     padding-block-end: 0.2rem;


### PR DESCRIPTION
### Issue #: tweak(datatrakWeb): RN-1559: Update Entity Question UI

### Changes:

- Put back question detail label
- Change wording of "All entities" and "Recent entities"
- Fix borders
- Hide the question label if the Entity question is the only question on a screen

---

### Screenshots:
<img width="372" alt="Screenshot 2025-02-18 at 4 11 32 PM" src="https://github.com/user-attachments/assets/e00c059a-7a9a-4378-86eb-1bea1b9fd190" />

<img width="1313" alt="Screenshot 2025-02-18 at 4 11 25 PM" src="https://github.com/user-attachments/assets/6e7f7d10-ffcf-4198-a2d6-b565cb02f2fa" />

