### PR TITLE
fix(datatrak): RN-1585: text field colour contrast

### DIFF
--- a/packages/ui-components/src/components/Inputs/TextField.tsx
+++ b/packages/ui-components/src/components/Inputs/TextField.tsx
@@ -87,6 +87,7 @@ const StyledTextField = styled(MuiTextField)<{ $focusColor?: Property.Color }>`
 
   /* Override MaterialUI which hides the placeholder due to conflict with its floating labels */
   &&&& .MuiInputBase-input::placeholder {
+    color: inherit;
     opacity: 55% !important;
   }
 


### PR DESCRIPTION
### Issue [RN-1585 Issue 1](https://linear.app/bes/issue/RN-1585/regression-testing-release-2025-08#comment-f9dc8f48)
