### PR TITLE
fix(datatrak): RN-1585: hide entity select list subtitles when redundant

### DIFF
--- a/packages/datatrak-web/src/features/EntitySelector/EntitySelector.tsx
+++ b/packages/datatrak-web/src/features/EntitySelector/EntitySelector.tsx
@@ -149,7 +149,7 @@ export const EntitySelector = ({
               invalid={invalid}
               required={required}
               inputProps={{
-                ['aria-labelledby']: showLegend && !label ? 'entity-selector-legend' : undefined,
+                'aria-labelledby': showLegend && !label ? 'entity-selector-legend' : undefined,
               }}
             />
           )}

--- a/packages/datatrak-web/src/features/EntitySelector/ResultsList.tsx
+++ b/packages/datatrak-web/src/features/EntitySelector/ResultsList.tsx
@@ -128,7 +128,7 @@ export const ResultsList = ({
           onSelect={onSelect}
           variant="borderless"
           noResultsMessage={noResultsMessage}
-          subTitle={!searchValue ? 'All' : undefined}
+          subTitle={showRecentEntities && !searchValue ? 'All' : null}
         />
       </SubListWrapper>
     </ListWrapper>

--- a/packages/ui-components/src/components/SelectList/SelectList.tsx
+++ b/packages/ui-components/src/components/SelectList/SelectList.tsx
@@ -81,7 +81,7 @@ interface SelectListProps {
     component?: React.ElementType;
   };
   noResultsMessage?: string;
-  subTitle?: string;
+  subTitle?: string | null;
 }
 
 export const SelectList = ({
@@ -92,7 +92,7 @@ export const SelectList = ({
   variant = 'fullBorder',
   labelProps = {},
   noResultsMessage = 'No items to display',
-  subTitle = '',
+  subTitle,
 }: SelectListProps) => {
   return (
     <Wrapper>


### PR DESCRIPTION
### Issue [RN-1585 Issue 6](https://linear.app/bes/issue/RN-1585/regression-testing-release-2025-08#comment-30aacf97)