### PR TITLE
fix(a11y): don’t autofocus

### DIFF
--- a/packages/datatrak-web/src/views/AccountSettingsPage/PersonalDetailsSection/PersonalDetailsForm.tsx
+++ b/packages/datatrak-web/src/views/AccountSettingsPage/PersonalDetailsSection/PersonalDetailsForm.tsx
@@ -102,7 +102,6 @@ export const PersonalDetailsForm = () => {
       <StyledFieldset disabled={isSubmitting || isLoading}>
         <FormInput
           autoComplete="given-name"
-          autoFocus
           id="firstName"
           Input={StyledTextField}
           inputProps={{ enterKeyHint: 'next' }}


### PR DESCRIPTION
We can blame intern me for this one

_Generally_, accessibility-wise, not a great idea to autofocus a form field because it robs the user of their opportunity to get a sense of what the page is first (for example, from semantic headings)

For many users, especially on desktop, this is largely a non-issue. But especially on mobile, it brings up the virtual keyboard which obscures half the screen. This feels a bit silly, especially because the user might not even want to change their personal details. (There are several other forms on this page!)