### PR TITLE
refactor: use `Number` namespace

### DIFF
--- a/packages/admin-panel-server/src/routes/FetchHierarchyEntitiesRoute.ts
+++ b/packages/admin-panel-server/src/routes/FetchHierarchyEntitiesRoute.ts
@@ -42,7 +42,7 @@ export class FetchHierarchyEntitiesRoute extends Route<FetchHierarchyEntitiesReq
 
     // If pageSize is provided, return only the first n entities
     if (pageSize) {
-      return flattenedDescendants.slice(0, parseInt(pageSize, 10));
+      return flattenedDescendants.slice(0, Number.parseInt(pageSize, 10));
     }
     return flattenedDescendants;
   }

--- a/packages/admin-panel/src/VizBuilderApp/components/PreviewOptions/DateRangeField.jsx
+++ b/packages/admin-panel/src/VizBuilderApp/components/PreviewOptions/DateRangeField.jsx
@@ -55,7 +55,7 @@ export const DateRangeField = () => {
     new Date(date.setMinutes(date.getMinutes() - date.getTimezoneOffset()));
 
   const convertDateToIsoString = date => {
-    if (!date || isNaN(new Date(date).getTime())) return null;
+    if (!date || Number.isNaN(new Date(date).getTime())) return null;
     const correctedDate = shiftEpoch(date);
 
     // Slice to discard timestamp, keeping only "yyyy-mm-dd"

--- a/packages/admin-panel/src/table/actions.js
+++ b/packages/admin-panel/src/table/actions.js
@@ -94,8 +94,8 @@ const refreshDataWithDebounce = debounce(
       };
       const response = await api.get(endpoint, queryParameters);
       const linkHeader = parseLinkHeader(response.headers.get('Link'));
-      const totalRecords = parseInt(response.headers.get('X-Total-Count'), 10);
-      const lastPageNumber = parseInt(linkHeader.last.page, 10);
+      const totalRecords = Number.parseInt(response.headers.get('X-Total-Count'), 10);
+      const lastPageNumber = Number.parseInt(linkHeader.last.page, 10);
 
       dispatch({
         type: DATA_FETCH_SUCCESS,

--- a/packages/central-server/src/apiV2/GETHandler/helpers.js
+++ b/packages/central-server/src/apiV2/GETHandler/helpers.js
@@ -3,7 +3,7 @@ import { ValidationError } from '@tupaia/utils';
 import { getApiUrl, resourceToRecordType } from '../../utilities';
 
 export const generateLinkHeader = (resource, pageString, lastPage, originalQueryParameters) => {
-  const currentPage = parseInt(pageString, 10);
+  const currentPage = Number.parseInt(pageString, 10);
 
   const getUrlForPage = page => getApiUrl(resource, { ...originalQueryParameters, page });
 

--- a/packages/central-server/src/apiV2/import/importSurveyResponses/importSurveyResponses.js
+++ b/packages/central-server/src/apiV2/import/importSurveyResponses/importSurveyResponses.js
@@ -276,9 +276,8 @@ export async function importSurveyResponses(req, res) {
             checkIsCellEmpty(answerValue) &&
             IMPORT_BEHAVIOURS[importMode].shouldFillEmptyAnswer
           ) {
-            const { dataTime, answerTextsByQuestionId } = await getExistingResponseData(
-              columnIndex,
-            );
+            const { dataTime, answerTextsByQuestionId } =
+              await getExistingResponseData(columnIndex);
             // Use data from an existing response to fill the empty answer
             return isDateAnswer(rowType) ? dataTime : answerTextsByQuestionId?.[questionId];
           }
@@ -516,7 +515,7 @@ function getDateStringForColumn(sheet, columnIndex) {
   const date = isInExportFormat
     ? moment(dateString, EXPORT_DATE_FORMAT).toDate()
     : moment(dateString).toDate();
-  if (isNaN(date.getTime())) {
+  if (Number.isNaN(date.getTime())) {
     throw new ImportValidationError(`Invalid date ${dateString}`);
   }
   return stripTimezoneFromDate(date);

--- a/packages/central-server/src/apiV2/import/importSurveys/Validator/ConfigValidator/ArithmeticConfigValidator.js
+++ b/packages/central-server/src/apiV2/import/importSurveys/Validator/ConfigValidator/ArithmeticConfigValidator.js
@@ -28,15 +28,12 @@ export class ArithmeticConfigValidator extends CalculatedConfigValidator {
    * @param {*} rowIndex
    */
   getDefaultValuesValidators(rowIndex) {
-    const existIfQuestionsInFormulaAreOptional = this.hasContentIfQuestionsInFormulaAreOptional(
-      rowIndex,
-    );
-    const defaultValuesPointToOtherQuestions = this.constructDefaultValuesPointToOtherQuestions(
-      rowIndex,
-    );
-    const defaultValuesProvidedForAllOptionalQuestions = this.constructDefaultValuesProvidedForAllOptionalQuestions(
-      rowIndex,
-    );
+    const existIfQuestionsInFormulaAreOptional =
+      this.hasContentIfQuestionsInFormulaAreOptional(rowIndex);
+    const defaultValuesPointToOtherQuestions =
+      this.constructDefaultValuesPointToOtherQuestions(rowIndex);
+    const defaultValuesProvidedForAllOptionalQuestions =
+      this.constructDefaultValuesProvidedForAllOptionalQuestions(rowIndex);
     const defaultValuesAreNumeric = this.defaultValuesAreNumeric();
 
     return [
@@ -52,15 +49,12 @@ export class ArithmeticConfigValidator extends CalculatedConfigValidator {
    * @param {*} rowIndex
    */
   getValueTranslationValidators(rowIndex) {
-    const existIfQuestionsInFormulaAreNonNumeric = this.hasContentIfQuestionsInFormulaAreNonNumeric(
-      rowIndex,
-    );
-    const valueTranslationPointToOtherQuestions = this.constructValueTranslationPointsToOtherQuestions(
-      rowIndex,
-    );
-    const valueTranslationProvidedForAllNonNumericQuestions = this.constructTranslationProvidedForAllNonNumericQuestions(
-      rowIndex,
-    );
+    const existIfQuestionsInFormulaAreNonNumeric =
+      this.hasContentIfQuestionsInFormulaAreNonNumeric(rowIndex);
+    const valueTranslationPointToOtherQuestions =
+      this.constructValueTranslationPointsToOtherQuestions(rowIndex);
+    const valueTranslationProvidedForAllNonNumericQuestions =
+      this.constructTranslationProvidedForAllNonNumericQuestions(rowIndex);
     const valueTranslationsAreNumeric = this.valueTranslationsAreNumeric();
 
     return [
@@ -184,7 +178,7 @@ export class ArithmeticConfigValidator extends CalculatedConfigValidator {
 
       for (const defaultValuePair of defaultValues) {
         const [code, defaultValue] = splitStringOn(defaultValuePair, ':');
-        if (isNaN(defaultValue)) {
+        if (Number.isNaN(defaultValue)) {
           throw new ValidationError(
             `Default values must be numeric. Found non numeric value '${defaultValue}'`,
           );
@@ -245,7 +239,7 @@ export class ArithmeticConfigValidator extends CalculatedConfigValidator {
       const valueTranslation = splitStringOnComma(value);
       for (const translation of valueTranslation) {
         const [code, translatedValue] = splitStringOn(translation, ':');
-        if (isNaN(translatedValue)) {
+        if (Number.isNaN(translatedValue)) {
           throw new ValidationError(
             `Translated values must be numeric. Found non numeric value '${translatedValue}'`,
           );

--- a/packages/central-server/src/apiV2/import/importSurveys/constructQuestionValidators.js
+++ b/packages/central-server/src/apiV2/import/importSurveys/constructQuestionValidators.js
@@ -187,7 +187,7 @@ export const constructQuestionValidators = models => ({
               }
               break;
             case 'Number':
-              if (!answers.every(answer => !isNaN(answer))) {
+              if (!answers.every(answer => !Number.isNaN(answer))) {
                 throw new Error(
                   'All answers in the visibility criteria for a number question should be numbers',
                 );

--- a/packages/central-server/src/apiV2/import/importSurveys/importSurveyQuestions.js
+++ b/packages/central-server/src/apiV2/import/importSurveys/importSurveyQuestions.js
@@ -462,5 +462,5 @@ function processValidationCriteriaValue(value) {
   if (valueTranslations[value] !== undefined) {
     return valueTranslations[value];
   }
-  return parseFloat(value);
+  return Number.parseFloat(value);
 }

--- a/packages/central-server/src/apiV2/meditrakApp/changesMetadata.js
+++ b/packages/central-server/src/apiV2/meditrakApp/changesMetadata.js
@@ -22,6 +22,6 @@ export async function changesMetadata(req, res) {
     select: 'count(*)',
   });
   const queryResult = await query.executeOnDatabase(models.database);
-  const changeCount = parseInt(queryResult[0].count);
+  const changeCount = Number.parseInt(queryResult[0].count);
   respond(res, { changeCount, countries, permissionGroups });
 }

--- a/packages/central-server/src/apiV2/meditrakApp/countChanges/LegacyCountChangesHandler.js
+++ b/packages/central-server/src/apiV2/meditrakApp/countChanges/LegacyCountChangesHandler.js
@@ -88,7 +88,7 @@ export class LegacyCountChangesHandler {
       [refreshToken, since, apiRequestLogId],
     );
 
-    return parseInt(count, 10);
+    return Number.parseInt(count, 10);
   }
 
   /**
@@ -142,7 +142,7 @@ export class LegacyCountChangesHandler {
       { select: 'count(*)' },
     );
     const result = await dbQuery.executeOnDatabase(models.database);
-    const changesCount = parseInt(result[0].count);
+    const changesCount = Number.parseInt(result[0].count);
 
     return changesCount > 0;
   }
@@ -168,7 +168,7 @@ export class LegacyCountChangesHandler {
     await this.handleSetUp();
     const { query } = await buildMeditrakSyncQuery(this.req, { select: 'count(*)' });
     const queryResult = await query.executeOnDatabase(this.req.models.database);
-    const changeCount = parseInt(queryResult[0].count);
+    const changeCount = Number.parseInt(queryResult[0].count);
     respond(this.res, { changeCount });
   }
 }

--- a/packages/central-server/src/apiV2/meditrakApp/countChanges/countChanges.js
+++ b/packages/central-server/src/apiV2/meditrakApp/countChanges/countChanges.js
@@ -9,7 +9,7 @@ const handleNonLegacyRequest = async (req, res) => {
   const { models } = req;
   const { query } = await buildMeditrakSyncQuery(req, { select: 'count(*)' });
   const queryResult = await query.executeOnDatabase(models.database);
-  const changeCount = parseInt(queryResult[0].count);
+  const changeCount = Number.parseInt(queryResult[0].count);
   respond(res, { changeCount });
 };
 

--- a/packages/central-server/src/apiV2/meditrakApp/getSocialFeed.js
+++ b/packages/central-server/src/apiV2/meditrakApp/getSocialFeed.js
@@ -29,7 +29,7 @@ export const getSocialFeed = async (req, res) => {
     page = 0,
     numberPerPage = DEFAULT_NUMBER_PER_PAGE,
   } = query;
-  const pageNumber = parseInt(page, 10);
+  const pageNumber = Number.parseInt(page, 10);
 
   await req.assertPermissions(allowNoPermissions);
 

--- a/packages/central-server/src/apiV2/meditrakApp/meditrakSync/meditrakSyncQuery.js
+++ b/packages/central-server/src/apiV2/meditrakApp/meditrakSync/meditrakSyncQuery.js
@@ -68,11 +68,11 @@ export const selectFromClause = select => `
 
 export const extractSinceValue = req => {
   const { since = 0 } = req.query;
-  if (isNaN(since)) {
+  if (Number.isNaN(since)) {
     throw new ValidationError("The 'since' parameter must be a number.");
   }
 
-  return parseFloat(since);
+  return Number.parseFloat(since);
 };
 
 export const getModifiers = (sort, limit, offset) => {

--- a/packages/central-server/src/hooks/utilities.js
+++ b/packages/central-server/src/hooks/utilities.js
@@ -28,7 +28,7 @@ export async function getHookAnswerValues(surveyResponse, baseHookName, defaultF
 
 export function parseCoordinates(answerText) {
   const { latitude, longitude } = JSON.parse(answerText);
-  if (Number.isNaN(parseFloat(latitude)) || Number.isNaN(parseFloat(longitude))) {
+  if (Number.isNaN(Number.parseFloat(latitude)) || Number.isNaN(Number.parseFloat(longitude))) {
     throw new Error(`Invalid coordinate data: ${answer.text}`);
   }
 

--- a/packages/data-api/src/__tests__/testFetchAnalytics.test.ts
+++ b/packages/data-api/src/__tests__/testFetchAnalytics.test.ts
@@ -43,7 +43,7 @@ const getAnalyticsFromResponses = (
         analytics.push({
           dataElement: questionCode,
           organisationUnit: r.entityCode,
-          value: isNaN(answer as any) ? answer : parseFloat(answer),
+          value: Number.isNaN(answer as any) ? answer : Number.parseFloat(answer),
           period: dateStringToPeriod(r.data_time, periodType),
         });
       });
@@ -260,7 +260,8 @@ describe('fetchAnalytics()', () => {
       `${Number(
         responses
           .reduce(
-            (sum, { answers }) => sum + (answers[answerCode] ? parseFloat(answers[answerCode]) : 0),
+            (sum, { answers }) =>
+              sum + (answers[answerCode] ? Number.parseFloat(answers[answerCode]) : 0),
             0,
           )
           .toFixed(1),

--- a/packages/data-api/src/__tests__/testFetchEvents.test.ts
+++ b/packages/data-api/src/__tests__/testFetchEvents.test.ts
@@ -24,7 +24,7 @@ const getEventsFromResponses = (
       .reduce(
         (values, [code, answer]) => ({
           ...values,
-          [code]: isNaN(answer as any) ? answer : parseFloat(answer),
+          [code]: Number.isNaN(answer as any) ? answer : Number.parseFloat(answer),
         }),
         {},
       ),

--- a/packages/data-api/src/utils.ts
+++ b/packages/data-api/src/utils.ts
@@ -1,7 +1,7 @@
 export const sanitizeMetadataValue = (value: string, type: string) => {
   switch (type) {
     case 'Number': {
-      const sanitizedValue = parseFloat(value);
+      const sanitizedValue = Number.parseFloat(value);
       return Number.isNaN(sanitizedValue) ? '' : sanitizedValue;
     }
     case 'Binary':
@@ -22,7 +22,7 @@ export const sanitizeAnalyticsTableValue = (value: string, type: string) => {
     case 'Checkbox':
     case 'Arithmetic':
     case 'Number': {
-      const sanitizedValue = parseFloat(value);
+      const sanitizedValue = Number.parseFloat(value);
       return Number.isNaN(sanitizedValue) ? '' : sanitizedValue;
     }
     default:

--- a/packages/data-broker/src/services/dhis/builders/sanitizeValue.ts
+++ b/packages/data-broker/src/services/dhis/builders/sanitizeValue.ts
@@ -3,7 +3,7 @@ import { ValueType } from '../types';
 
 export const sanitizeValue = (value: string | number, valueType?: ValueType): string | number => {
   if (valueType === NUMBER) {
-    const sanitizedValue = parseFloat(value as string);
+    const sanitizedValue = Number.parseFloat(value as string);
     return Number.isNaN(sanitizedValue) ? '' : sanitizedValue;
   }
 

--- a/packages/data-broker/src/services/dhis/translators/parseValueForDhis.ts
+++ b/packages/data-broker/src/services/dhis/translators/parseValueForDhis.ts
@@ -35,7 +35,7 @@ export function parseValueForDhis(value: string, valueType: ValueType) {
       // in future, this should be removed
       if (value === 'Yes') return '1';
       if (value === 'No') return '0';
-      return parseFloat(value).toString();
+      return Number.parseFloat(value).toString();
 
     // booleans
     case BOOLEAN:

--- a/packages/data-lake-api/src/__tests__/fetchAnalytics.test.ts
+++ b/packages/data-lake-api/src/__tests__/fetchAnalytics.test.ts
@@ -13,7 +13,7 @@ const formatAnalytics = (inputAnalytics: Analytic[]) =>
     organisationUnit: entity_code,
     dataElement: data_element_code,
     period: dateStringToPeriod(date, 'DAY'),
-    value: isNaN(value as any) ? value : parseFloat(value),
+    value: Number.isNaN(value as any) ? value : Number.parseFloat(value),
   }));
 
 describe('fetchAnalytics', () => {

--- a/packages/data-lake-api/src/__tests__/fetchEvents.test.ts
+++ b/packages/data-lake-api/src/__tests__/fetchEvents.test.ts
@@ -23,7 +23,7 @@ const getEventsFromAnalytics = (analytics: Analytic[], dataElementsToInclude: st
         .reduce(
           (values, { data_element_code, value }) => ({
             ...values,
-            [data_element_code]: isNaN(value as any) ? value : parseFloat(value),
+            [data_element_code]: Number.isNaN(value as any) ? value : Number.parseFloat(value),
           }),
           {},
         ),

--- a/packages/data-lake-api/src/sanitizeAnalyticsTableValue.ts
+++ b/packages/data-lake-api/src/sanitizeAnalyticsTableValue.ts
@@ -7,7 +7,7 @@ export const sanitizeAnalyticsTableValue = (value: string, type: string) => {
     case 'Binary':
     case 'Checkbox':
     case 'Number': {
-      const sanitizedValue = parseFloat(value);
+      const sanitizedValue = Number.parseFloat(value);
       return Number.isNaN(sanitizedValue) ? '' : sanitizedValue;
     }
     default:

--- a/packages/database/src/TupaiaDatabase.js
+++ b/packages/database/src/TupaiaDatabase.js
@@ -328,7 +328,7 @@ export class TupaiaDatabase {
   async count(recordType, where, options) {
     // If just a simple query without options, use the more efficient knex count method
     const result = await this.find(recordType, where, options, QUERY_METHODS.COUNT);
-    return parseInt(result[0].count, 10);
+    return Number.parseInt(result[0].count, 10);
   }
 
   async create(recordType, record, where) {

--- a/packages/database/src/modelClasses/DataServiceSyncGroup.js
+++ b/packages/database/src/modelClasses/DataServiceSyncGroup.js
@@ -57,7 +57,7 @@ export class DataServiceSyncGroupRecord extends DatabaseRecord {
       [this.id],
     );
 
-    return parseInt(count);
+    return Number.parseInt(count);
   }
 
   async getLatestLogs(limit = 100, offset = 0) {

--- a/packages/database/src/runPostMigration.js
+++ b/packages/database/src/runPostMigration.js
@@ -52,7 +52,7 @@ export const runPostMigration = async driver => {
   const { rows: postgisExtension } = await driver.runSql(`
     SELECT COUNT(1) FROM pg_extension WHERE extname = 'postgis';
   `);
-  if (!parseInt(postgisExtension[0].count, 10)) {
+  if (!Number.parseInt(postgisExtension[0].count, 10)) {
     throw new Error(
       "PostGIS extension is required. Install the binaries and run 'CREATE EXTENSION postgis;' in postgres to install it.",
     );

--- a/packages/datatrak-web-server/src/routes/ActivityFeedRoute.ts
+++ b/packages/datatrak-web-server/src/routes/ActivityFeedRoute.ts
@@ -49,8 +49,8 @@ export class ActivityFeedRoute extends Route<ActivityFeedRequest> {
     const { query, models, accessPolicy } = this.req;
     const { page: queryPage, pageLimit: queryPageLimit, projectId } = query;
 
-    const page = queryPage ? parseInt(queryPage, 10) : 0;
-    const pageLimit = queryPageLimit ? parseInt(queryPageLimit, 10) : NUMBER_PER_PAGE;
+    const page = queryPage ? Number.parseInt(queryPage, 10) : 0;
+    const pageLimit = queryPageLimit ? Number.parseInt(queryPageLimit, 10) : NUMBER_PER_PAGE;
 
     const pinned = page === 0 ? await this.getPinnedItem() : undefined;
 

--- a/packages/datatrak-web/src/features/Questions/GeolocateQuestion/LatLongFields.tsx
+++ b/packages/datatrak-web/src/features/Questions/GeolocateQuestion/LatLongFields.tsx
@@ -29,7 +29,7 @@ export const LatLongFields = ({
   const handleChange = (e: ChangeEvent<{}>, field: string) => {
     setGeolocation({
       ...geolocation,
-      [field]: parseFloat((e.target as HTMLInputElement).value),
+      [field]: Number.parseFloat((e.target as HTMLInputElement).value),
       accuracy: 'N/A',
     });
   };

--- a/packages/datatrak-web/src/features/Questions/GeolocateQuestion/MapModal/Map.tsx
+++ b/packages/datatrak-web/src/features/Questions/GeolocateQuestion/MapModal/Map.tsx
@@ -75,8 +75,8 @@ export const Map = ({ lat, lng, setCoordinates, tileSet, onChangeTileSet }: MapP
   // round coordinates to 4 decimal places before setting them - any less and the coordinates are not very accurate
   const onUpdateCoordinates = ({ lat, lng }: LatLngLiteral) => {
     setCoordinates({
-      lat: parseFloat(lat.toFixed(4)),
-      lng: parseFloat(lng.toFixed(4)),
+      lat: Number.parseFloat(lat.toFixed(4)),
+      lng: Number.parseFloat(lng.toFixed(4)),
     });
   };
   return (

--- a/packages/datatrak-web/src/features/Survey/SurveyContext/SurveyContext.tsx
+++ b/packages/datatrak-web/src/features/Survey/SurveyContext/SurveyContext.tsx
@@ -49,7 +49,7 @@ export const SurveyContext = ({ children, surveyCode, countryCode }) => {
   const [primaryEntityCode] = useState(primaryEntityCodeParam);
   const [state, dispatch] = useReducer(surveyReducer, defaultContext);
   const params = useParams<SurveyParams>();
-  const screenNumber = params.screenNumber ? parseInt(params.screenNumber!, 10) : null;
+  const screenNumber = params.screenNumber ? Number.parseInt(params.screenNumber!, 10) : null;
   const { data: survey } = useSurvey(surveyCode);
   const isResponseScreen = !!urlSearchParams.get('responseId');
   const isResubmitReviewScreen = !!useMatch(ROUTES.SURVEY_RESUBMIT_REVIEW);

--- a/packages/datatrak-web/src/features/Survey/SurveyContext/utils.ts
+++ b/packages/datatrak-web/src/features/Survey/SurveyContext/utils.ts
@@ -104,7 +104,7 @@ const getArithmeticDependantAnswer = (questionId, answer, valueTranslation, defa
   }
   // return raw answer if it's a number, else 0 (e.g. if no valueTranslation provided for the question and this specific answer when answer is non-numeric)
   if (answer !== undefined && answer !== null && answer !== '') {
-    return isNaN(answer) ? 0 : answer; // return raw answer
+    return Number.isNaN(answer) ? 0 : answer; // return raw answer
   }
 
   return defaultValues[questionId] !== undefined ? defaultValues[questionId] : 0; // No answer found, return the default answer
@@ -135,7 +135,7 @@ const getArithmeticResult = (
   // Evaluate the expression
   expressionParser.setAll(values);
 
-  const result = !isNaN(expressionParser.evaluate(formula))
+  const result = !Number.isNaN(expressionParser.evaluate(formula))
     ? Math.round(expressionParser.evaluate(formula) * 1000) / 1000 // Round to 3 decimal places
     : 0;
 

--- a/packages/datatrak-web/src/features/Survey/useSurveyRouting.ts
+++ b/packages/datatrak-web/src/features/Survey/useSurveyRouting.ts
@@ -29,14 +29,14 @@ export const useSurveyRouting = numberOfScreens => {
 
   const getNextPath = () => {
     if (isReview) return null;
-    if (params.screenNumber && parseInt(params.screenNumber) === numberOfScreens) {
+    if (params.screenNumber && Number.parseInt(params.screenNumber) === numberOfScreens) {
       const REVIEW_PATH = isResubmit ? ROUTES.SURVEY_RESUBMIT_REVIEW : ROUTES.SURVEY_REVIEW;
       return {
         ...location,
         pathname: generatePath(REVIEW_PATH, params),
       };
     }
-    return getScreenPath(parseInt(params.screenNumber ?? '1') + 1);
+    return getScreenPath(Number.parseInt(params.screenNumber ?? '1') + 1);
   };
 
   const getPreviousPath = () => {
@@ -48,7 +48,7 @@ export const useSurveyRouting = numberOfScreens => {
             ...location,
             pathname: generatePath(ROUTES.SURVEY_SELECT),
           };
-    return getScreenPath(parseInt(params.screenNumber) - 1);
+    return getScreenPath(Number.parseInt(params.screenNumber) - 1);
   };
 
   return {

--- a/packages/datatrak-web/src/features/Survey/useValidationResolver.ts
+++ b/packages/datatrak-web/src/features/Survey/useValidationResolver.ts
@@ -6,7 +6,7 @@ import { getAllSurveyComponents, useSurveyForm } from '.';
 
 const transformNumberValue = (value: string | number, originalValue: string | number) => {
   // This is a workaround for yup not handling empty number fields (https://github.com/jquense/yup/issues/298)
-  return originalValue === '' || isNaN(originalValue as number) ? null : value;
+  return originalValue === '' || Number.isNaN(originalValue as number) ? null : value;
 };
 
 const getBaseSchema = (type: QuestionType) => {
@@ -81,7 +81,7 @@ const getValidationSchema = (screenComponents?: SurveyScreenComponent[]) => {
               // Show the required message when the user has not entered a location at all
               if (
                 (!value?.latitude && !value?.longitude) ||
-                (isNaN(value.latitude) && isNaN(value.longitude))
+                (Number.isNaN(value.latitude) && Number.isNaN(value.longitude))
               )
                 return 'Required';
               // Otherwise show the invalid location message
@@ -90,8 +90,8 @@ const getValidationSchema = (screenComponents?: SurveyScreenComponent[]) => {
             value =>
               value?.latitude &&
               value?.longitude &&
-              !isNaN(value.latitude) &&
-              !isNaN(value.longitude),
+              !Number.isNaN(value.latitude) &&
+              !Number.isNaN(value.longitude),
           );
         }
       }

--- a/packages/datatrak-web/src/features/Tasks/TasksTable/TasksTable.tsx
+++ b/packages/datatrak-web/src/features/Tasks/TasksTable/TasksTable.tsx
@@ -49,9 +49,9 @@ export const useTasksTable = () => {
   const { projectId } = useCurrentUserContext();
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const page = parseInt(searchParams.get('page') || '0', 10);
+  const page = Number.parseInt(searchParams.get('page') || '0', 10);
 
-  const pageSize = parseInt(searchParams.get('pageSize') || '20', 10);
+  const pageSize = Number.parseInt(searchParams.get('pageSize') || '20', 10);
   const URLSortBy = searchParams.get('sortBy');
   const sortBy = URLSortBy ? JSON.parse(URLSortBy) : [];
 

--- a/packages/entity-server/src/routes/hierarchy/middleware/filter.ts
+++ b/packages/entity-server/src/routes/hierarchy/middleware/filter.ts
@@ -68,7 +68,7 @@ const formatComparisonValue = (value: Value, operator: Operator) => {
 };
 
 const formatValue = <T extends keyof EntityFilterQuery>(field: T, value: string) =>
-  isNumericField(field) ? parseFloat(value) : value;
+  isNumericField(field) ? Number.parseFloat(value) : value;
 
 const convertValueToAdvancedCriteria = (
   field: keyof EntityFilterQuery,

--- a/packages/indicators/src/Builder/helpers.ts
+++ b/packages/indicators/src/Builder/helpers.ts
@@ -54,7 +54,7 @@ export const convertBooleanToNumber = (
 };
 
 export const isValidIndicatorValue = (value: string | number) =>
-  typeof value === 'string' || isFinite(value); // Should be either string, finite number or boolean as a number
+  typeof value === 'string' || Number.isFinite(value); // Should be either string, finite number or boolean as a number
 
 export const replaceDataValuesWithDefaults = (
   dataValues: DataValues,

--- a/packages/meditrak-app-server/src/routes/sync/pullChanges/meditrakSyncQuery.ts
+++ b/packages/meditrak-app-server/src/routes/sync/pullChanges/meditrakSyncQuery.ts
@@ -52,9 +52,9 @@ export const extractSinceValue = (req: Request) => {
 
   if (typeof since === 'number') return since;
 
-  const parsedSince = parseFloat(since as string);
+  const parsedSince = Number.parseFloat(since as string);
 
-  if (isNaN(parsedSince)) {
+  if (Number.isNaN(parsedSince)) {
     throw new ValidationError("The 'since' parameter must be a number.");
   }
 

--- a/packages/meditrak-app/app/assessment/selectors.jsx
+++ b/packages/meditrak-app/app/assessment/selectors.jsx
@@ -1,20 +1,14 @@
-import {
-  ExpressionParser,
-  BooleanExpressionParser,
-} from '@tupaia/expression-parser';
-import {checkAnswerPreconditionsAreMet} from './helpers';
+import { ExpressionParser, BooleanExpressionParser } from '@tupaia/expression-parser';
+import { checkAnswerPreconditionsAreMet } from './helpers';
 
 const expressionParser = new ExpressionParser();
 const booleanExpressionParser = new BooleanExpressionParser();
 
-export const getSurveyScreenIndex = state =>
-  state.assessment.currentScreenIndex;
+export const getSurveyScreenIndex = state => state.assessment.currentScreenIndex;
 
-export const getCurrentScreen = state =>
-  getSurveyScreen(state, getSurveyScreenIndex(state));
+export const getCurrentScreen = state => getSurveyScreen(state, getSurveyScreenIndex(state));
 
-export const getSurveyScreen = (state, screenIndex) =>
-  getScreens(state)[screenIndex];
+export const getSurveyScreen = (state, screenIndex) => getScreens(state)[screenIndex];
 
 export const getScreens = state => state.assessment.screens || [];
 
@@ -39,7 +33,7 @@ export const getErrorMessageForScreen = (state, screenIndex) => {
 };
 
 const checkQuestionIsVisible = (answers, visibilityCriteria) => {
-  const {hidden} = visibilityCriteria;
+  const { hidden } = visibilityCriteria;
   return !hidden && checkAnswerPreconditionsAreMet(answers, visibilityCriteria);
 };
 
@@ -47,21 +41,15 @@ export const getSurveyScreenQuestions = (state, screenIndex) => {
   // Build questions to display, filtering out follow up questions if enabling answer not given
   const questions = [];
   getSurveyScreen(state, screenIndex).components.forEach((component, index) => {
-    const {
-      questionId,
-      visibilityCriteria,
-      questionLabel,
-      detailLabel,
-      validationCriteria,
-    } = component;
+    const { questionId, visibilityCriteria, questionLabel, detailLabel, validationCriteria } =
+      component;
 
     const question = {
       id: questionId,
       ...getQuestion(state, questionId),
       componentIndex: index,
       visibilityCriteria,
-      checkVisibility: answers =>
-        checkQuestionIsVisible(answers, visibilityCriteria),
+      checkVisibility: answers => checkQuestionIsVisible(answers, visibilityCriteria),
       validationCriteria,
     };
 
@@ -83,58 +71,44 @@ export const getValidQuestions = (state, questions, validatedScreens) => {
     curr.components.forEach(component => {
       components[component.questionId] = component.visibilityCriteria;
     });
-    return {...prev, ...components};
+    return { ...prev, ...components };
   }, {});
 
   return Object.values(questions).filter(question =>
-    checkAnswerPreconditionsAreMet(
-      answers,
-      visibilityCriteriaByQuestion[question.id],
-    ),
+    checkAnswerPreconditionsAreMet(answers, visibilityCriteriaByQuestion[question.id]),
   );
 };
 
-export const getSelectedCountryId = ({country}) => country.selectedCountryId;
+export const getSelectedCountryId = ({ country }) => country.selectedCountryId;
 
 // Whether a given survey can repeat, i.e. be done again and again within a single facility on a
 // single date. If no surveyId passed in, will assume the current survey being completed
-export const getCanSurveyRepeat = (
-  {assessment},
-  surveyId = assessment.surveyId,
-) => assessment.surveys[surveyId] && assessment.surveys[surveyId].canRepeat;
+export const getCanSurveyRepeat = ({ assessment }, surveyId = assessment.surveyId) =>
+  assessment.surveys[surveyId] && assessment.surveys[surveyId].canRepeat;
 
 // The name of a survey. If no surveyId passed in, will assume the current survey being completed
-export const getSurveyName = ({assessment}, surveyId = assessment.surveyId) =>
+export const getSurveyName = ({ assessment }, surveyId = assessment.surveyId) =>
   assessment.surveys[surveyId].name;
 
 export const getQuestionState = (state, screenIndex, componentIndex) => {
-  const component = getSurveyScreen(state, screenIndex).components[
-    componentIndex
-  ];
+  const component = getSurveyScreen(state, screenIndex).components[componentIndex];
   return {
     ...component,
     answer: getAnswerForQuestion(state, component.questionId),
   };
 };
 
-export const getQuestion = (state, questionId) =>
-  state.assessment.questions[questionId];
+export const getQuestion = (state, questionId) => state.assessment.questions[questionId];
 
 export const getAnswers = state => state.assessment.answers;
 
-export const getAnswerForQuestion = (state, questionId) =>
-  getAnswers(state)[questionId];
+export const getAnswerForQuestion = (state, questionId) => getAnswers(state)[questionId];
 
 export const getArithmeticResult = (state, arithmeticQuestionId) => {
-  const {config} = getQuestion(state, arithmeticQuestionId);
+  const { config } = getQuestion(state, arithmeticQuestionId);
 
   const {
-    arithmetic: {
-      formula,
-      valueTranslation = {},
-      defaultValues = {},
-      answerDisplayText = '',
-    },
+    arithmetic: { formula, valueTranslation = {}, defaultValues = {}, answerDisplayText = '' },
   } = config;
 
   const values = {};
@@ -143,21 +117,16 @@ export const getArithmeticResult = (state, arithmeticQuestionId) => {
   const getArithmeticAnswer = questionId => {
     const answer = getAnswerForQuestion(state, questionId);
 
-    if (
-      valueTranslation[questionId] &&
-      valueTranslation[questionId][answer] !== undefined
-    ) {
+    if (valueTranslation[questionId] && valueTranslation[questionId][answer] !== undefined) {
       return valueTranslation[questionId][answer]; // return translated answer if there's any
     }
     // return raw answer if it's a number, else 0 (e.g. if no valueTranslation provided for the question and this specific answer when answer is non-numeric)
     if (answer !== undefined && answer !== null && answer !== '') {
-      return isNaN(answer) ? 0 : answer; // return raw answer
+      return Number.isNaN(answer) ? 0 : answer; // return raw answer
     }
 
     // return default answer if there's no answer
-    return defaultValues[questionId] !== undefined
-      ? defaultValues[questionId]
-      : 0; // No answer found, return the default answer
+    return defaultValues[questionId] !== undefined ? defaultValues[questionId] : 0; // No answer found, return the default answer
   };
 
   // Setting up scope values.
@@ -168,7 +137,7 @@ export const getArithmeticResult = (state, arithmeticQuestionId) => {
 
   // Evaluate the expression
   expressionParser.setAll(values);
-  const result = !isNaN(expressionParser.evaluate(formula))
+  const result = !Number.isNaN(expressionParser.evaluate(formula))
     ? Math.round(expressionParser.evaluate(formula) * 1000) / 1000 // Round to 3 decimal places
     : 0;
   expressionParser.clearScope();
@@ -176,15 +145,9 @@ export const getArithmeticResult = (state, arithmeticQuestionId) => {
   let translatedAnswerDisplayText = answerDisplayText;
   questionIds.forEach(questionId => {
     const answer = values[`$${questionId}`];
-    translatedAnswerDisplayText = translatedAnswerDisplayText.replace(
-      questionId,
-      answer,
-    );
+    translatedAnswerDisplayText = translatedAnswerDisplayText.replace(questionId, answer);
   });
-  translatedAnswerDisplayText = translatedAnswerDisplayText.replace(
-    '$result',
-    result,
-  );
+  translatedAnswerDisplayText = translatedAnswerDisplayText.replace('$result', result);
 
   return {
     answerDisplayText: translatedAnswerDisplayText,
@@ -193,19 +156,18 @@ export const getArithmeticResult = (state, arithmeticQuestionId) => {
 };
 
 export const getConditionResult = (state, conditionQuestionId) => {
-  const {config} = getQuestion(state, conditionQuestionId);
+  const { config } = getQuestion(state, conditionQuestionId);
   const {
-    condition: {conditions},
+    condition: { conditions },
   } = config;
-  const checkConditionMet = ({formula, defaultValues = {}}) => {
+  const checkConditionMet = ({ formula, defaultValues = {} }) => {
     const values = {};
     const variables = booleanExpressionParser.getVariables(formula);
 
     variables.forEach(questionIdVariable => {
       const questionId = questionIdVariable.replace(/^\$/, ''); // Remove the first $ prefix
       const answer = getAnswerForQuestion(state, questionId);
-      const defaultValue =
-        defaultValues[questionId] !== undefined ? defaultValues[questionId] : 0; // 0 is the last resort
+      const defaultValue = defaultValues[questionId] !== undefined ? defaultValues[questionId] : 0; // 0 is the last resort
       const value = answer !== undefined ? answer : defaultValue;
       values[questionIdVariable] = value;
     });

--- a/packages/meditrak-app/app/assessment/validation.jsx
+++ b/packages/meditrak-app/app/assessment/validation.jsx
@@ -1,10 +1,10 @@
 // Validators return null if there is no error, or a string representing the error message
 const answerValidators = {
-  isNumber: answer => (isNaN(parseFloat(answer)) ? 'Must be a number' : null),
+  isNumber: answer => (Number.isNaN(Number.parseFloat(answer)) ? 'Must be a number' : null),
   min: (answer, minimumValue) =>
-    parseFloat(answer) < minimumValue ? `The minimum value is ${minimumValue}` : null,
+    Number.parseFloat(answer) < minimumValue ? `The minimum value is ${minimumValue}` : null,
   max: (answer, maximumValue) =>
-    parseFloat(answer) > maximumValue ? `The maximum value is ${maximumValue}` : null,
+    Number.parseFloat(answer) > maximumValue ? `The maximum value is ${maximumValue}` : null,
 };
 
 export const validateAnswer = (validationCriteria, answer) => {

--- a/packages/meditrak-app/app/sync/Synchroniser.jsx
+++ b/packages/meditrak-app/app/sync/Synchroniser.jsx
@@ -1,7 +1,7 @@
-import {Scheduler} from 'sussol-utilities';
+import { Scheduler } from 'sussol-utilities';
 
-import {LogBox} from 'react-native';
-import {ChangeQueue} from './ChangeQueue';
+import { LogBox } from 'react-native';
+import { ChangeQueue } from './ChangeQueue';
 import {
   setSyncProgress,
   setSyncProgressMessage,
@@ -15,8 +15,8 @@ import {
   LATEST_SERVER_SYNC_TIMESTAMP,
   PERMISSION_GROUPS_SYNCED,
 } from '../settings';
-import {loadSocialFeedLatest} from '../social';
-import {getSyncMigrations} from './syncMigrations';
+import { loadSocialFeedLatest } from '../social';
+import { getSyncMigrations } from './syncMigrations';
 
 LogBox.ignoreLogs(['Setting a timer']);
 
@@ -221,13 +221,13 @@ export class Synchroniser {
 
     // Get batch of outgoing changes and send them
     const changes = await this.changeQueue.nextWithinThreshold(this.batchSize);
-    const {requestDuration} = await this.pushChanges(changes.map(({payload}) => payload));
+    const { requestDuration } = await this.pushChanges(changes.map(({ payload }) => payload));
 
     // Run any post-change cleanup
-    await this.cleanupChangesAfterPush(changes.map(({change}) => change));
+    await this.cleanupChangesAfterPush(changes.map(({ change }) => change));
 
     // Take the successfully sent batch of changes off the queue requiring sync
-    this.changeQueue.use(changes.map(({change}) => change));
+    this.changeQueue.use(changes.map(({ change }) => change));
 
     const batchCount = changes.length;
 
@@ -270,7 +270,7 @@ export class Synchroniser {
     setProgress(this.synchroniserProgress);
 
     // Get a batch of changes and integrate them
-    const {changes, requestDuration} = await this.getIncomingChanges(since, numberChangesPulled);
+    const { changes, requestDuration } = await this.getIncomingChanges(since, numberChangesPulled);
     if (!changes || changes.length === 0) {
       throw new Error(`Expected ${total - numberChangesPulled} more changes, but received none`);
     }
@@ -280,7 +280,7 @@ export class Synchroniser {
     // Save the current timestamp we are in sync with on the server
     const latestChangeTimestamp = changes.reduce(
       (currentLatestTimestamp, change) => Math.max(change.timestamp, currentLatestTimestamp),
-      parseFloat(this.getLastSyncTime()),
+      Number.parseFloat(this.getLastSyncTime()),
     );
     this.database.setSetting(LATEST_SERVER_SYNC_TIMESTAMP, latestChangeTimestamp);
 
@@ -318,7 +318,7 @@ export class Synchroniser {
     if (responseJson.error && responseJson.error.length > 0) {
       throw new Error(responseJson.error);
     }
-    const {changeCount, countries, permissionGroups} = responseJson;
+    const { changeCount, countries, permissionGroups } = responseJson;
     if (
       typeof changeCount !== 'number' ||
       !Array.isArray(countries) ||
@@ -326,7 +326,7 @@ export class Synchroniser {
     ) {
       throw new Error('Unexpected response from server');
     }
-    return {changeCount, countries, permissionGroups};
+    return { changeCount, countries, permissionGroups };
   }
 
   /**

--- a/packages/meditrak-app/app/sync/syncMigrations.jsx
+++ b/packages/meditrak-app/app/sync/syncMigrations.jsx
@@ -54,13 +54,13 @@ const migrations = {
 export const getSyncMigrations = async database => {
   const currentMigrationVersion = (await database.getSetting(DATABASE_SYNC_MIGRATION_VERSION)) || 0;
   const availableMigrationVersions = Object.keys(migrations)
-    .map(version => parseInt(version, 10))
+    .map(version => Number.parseInt(version, 10))
     .sort(
       (versionA, versionB) =>
         // Sort in ascending order
         versionA - versionB,
     )
-    .filter(version => version > parseInt(currentMigrationVersion, 10));
+    .filter(version => version > Number.parseInt(currentMigrationVersion, 10));
   const hasNeverSynced = await !database.getSetting(LATEST_SERVER_SYNC_TIMESTAMP);
   if (hasNeverSynced) {
     // No need to migrate anything as it will do initial sync, jump the migration version up

--- a/packages/report-server/src/reportBuilder/transform/functions/insertColumns.ts
+++ b/packages/report-server/src/reportBuilder/transform/functions/insertColumns.ts
@@ -47,10 +47,10 @@ const insertColumns = (table: TransformTable, params: InsertColumnsParams, conte
   }));
 
   // Drop, then re-insert the original skipped rows
-  const rowsToDrop = Object.keys(skippedRows).map(rowIndexString => parseInt(rowIndexString));
+  const rowsToDrop = Object.keys(skippedRows).map(Number.parseInt);
   const rowReinserts = Object.entries(skippedRows).map(([rowIndexString, row]) => ({
     row,
-    index: parseInt(rowIndexString),
+    index: Number.parseInt(rowIndexString),
   }));
 
   return table.upsertColumns(columnUpserts).dropRows(rowsToDrop).insertRows(rowReinserts);

--- a/packages/report-server/src/reportBuilder/transform/functions/updateColumns.ts
+++ b/packages/report-server/src/reportBuilder/transform/functions/updateColumns.ts
@@ -56,10 +56,12 @@ const updateColumns = (table: TransformTable, params: UpdateColumnsParams, conte
   }));
 
   // Drop, then re-insert the original skipped rows
-  const rowsToDrop = Object.keys(skippedRows).map(rowIndexString => parseInt(rowIndexString));
+  const rowsToDrop = Object.keys(skippedRows).map(rowIndexString =>
+    Number.parseInt(rowIndexString),
+  );
   const rowReinserts = Object.entries(skippedRows).map(([rowIndexString, row]) => ({
     row,
-    index: parseInt(rowIndexString),
+    index: Number.parseInt(rowIndexString),
   }));
 
   return table

--- a/packages/server-boilerplate/src/utils/emailAfterTimeout.ts
+++ b/packages/server-boilerplate/src/utils/emailAfterTimeout.ts
@@ -79,7 +79,7 @@ export const emailAfterTimeout =
       next();
       return;
     }
-    const timeout = parseInt(respondWithEmailTimeout, 10);
+    const timeout = Number.parseInt(respondWithEmailTimeout, 10);
     if (Number.isNaN(timeout)) {
       throw new Error('respondWithEmailTimeout must be a number');
     }

--- a/packages/server-boilerplate/src/utils/forwardRequest.ts
+++ b/packages/server-boilerplate/src/utils/forwardRequest.ts
@@ -11,7 +11,7 @@ const defaultAuthHandlerProvider = (req: Request) => new RequiresSessionAuthHand
 const stripVersionFromPath = (path: string) => {
   if (path.startsWith('/v')) {
     const secondSlashIndex = path.indexOf('/', 2);
-    const version = parseFloat(path.substring(2, secondSlashIndex));
+    const version = Number.parseFloat(path.substring(2, secondSlashIndex));
     return path.replace(`/v${version}`, '');
   }
   return path;

--- a/packages/tupaia-web-server/src/routes/EntitiesRoute.ts
+++ b/packages/tupaia-web-server/src/routes/EntitiesRoute.ts
@@ -33,7 +33,7 @@ const FILTER_PARSERS = {
   },
   generational_distance: (filterVal: string) => ({
     comparator: '<=',
-    comparisonValue: parseInt(filterVal),
+    comparisonValue: Number.parseInt(filterVal),
   }),
 };
 const parseFilter = (filter: Record<string, any>): Record<string, any> =>

--- a/packages/tupaia-web/src/features/Visuals/View/SingleDate.tsx
+++ b/packages/tupaia-web/src/features/Visuals/View/SingleDate.tsx
@@ -28,7 +28,7 @@ interface SingleDateProps {
 
 const formatDate = (value: string) => {
   const date = new Date(value);
-  if (!value || isNaN(date.getTime())) return 'Not yet assessed';
+  if (!value || Number.isNaN(date.getTime())) return 'Not yet assessed';
   return date.toDateString();
 };
 

--- a/packages/tupaia-web/src/utils/getTopBarHeight.ts
+++ b/packages/tupaia-web/src/utils/getTopBarHeight.ts
@@ -11,7 +11,7 @@ const envBannerIsVisible = () => {
 };
 export const getMobileTopBarHeight = () => {
   if (envBannerIsVisible()) {
-    const height = parseInt(TOP_BAR_HEIGHT_MOBILE) + ENV_BANNER_HEIGHT;
+    const height = Number.parseInt(TOP_BAR_HEIGHT_MOBILE) + ENV_BANNER_HEIGHT;
     return `${height}px`;
   }
   return TOP_BAR_HEIGHT_MOBILE;
@@ -19,7 +19,7 @@ export const getMobileTopBarHeight = () => {
 
 export const getTopBarHeight = () => {
   if (envBannerIsVisible()) {
-    const height = parseInt(TOP_BAR_HEIGHT) + ENV_BANNER_HEIGHT;
+    const height = Number.parseInt(TOP_BAR_HEIGHT) + ENV_BANNER_HEIGHT;
     return `${height}px`;
   }
   return TOP_BAR_HEIGHT;

--- a/packages/tupaia-web/src/views/MapOverlayPDFExport.tsx
+++ b/packages/tupaia-web/src/views/MapOverlayPDFExport.tsx
@@ -114,7 +114,7 @@ const useExportParams = () => {
   const tileset = urlSearchParams.get('tileset') ?? initialTileSet.url;
   const urlCenter = urlSearchParams.get('center');
   const urlZoom = urlSearchParams.get('zoom');
-  const zoom = urlZoom ? parseInt(urlZoom) : 5;
+  const zoom = urlZoom ? Number.parseInt(urlZoom) : 5;
   const center = urlCenter ? JSON.parse(urlCenter) : undefined;
   const urlHiddenValues = urlSearchParams.get('hiddenValues');
   const hiddenValues = urlHiddenValues ? JSON.parse(urlHiddenValues) : undefined;

--- a/packages/ui-chart-components/src/components/Charts/PieChart.tsx
+++ b/packages/ui-chart-components/src/components/Charts/PieChart.tsx
@@ -144,7 +144,7 @@ export const PieChart = ({
     data
       ?.filter(({ value }) => {
         if (typeof value === 'number') return value > 0;
-        return parseFloat(value) > 0;
+        return Number.parseFloat(value) > 0;
       })
       .map(item => {
         const { name, ...otherKeyValues } = item;

--- a/packages/ui-chart-components/src/utils/parseChartConfig.ts
+++ b/packages/ui-chart-components/src/utils/parseChartConfig.ts
@@ -125,9 +125,9 @@ const sortChartConfigByLegendOrder = (chartConfig: LooseObject) => {
   return Object.entries(chartConfig)
     .sort(defaultSort)
     .sort(([, cfg1], [, cfg2]) => {
-      if (isNaN(cfg1.legendOrder) && isNaN(cfg2.legendOrder)) return 0;
-      if (isNaN(cfg1.legendOrder)) return 1;
-      if (isNaN(cfg2.legendOrder)) return -1;
+      if (Number.isNaN(cfg1.legendOrder) && Number.isNaN(cfg2.legendOrder)) return 0;
+      if (Number.isNaN(cfg1.legendOrder)) return 1;
+      if (Number.isNaN(cfg2.legendOrder)) return -1;
       return cfg1.legendOrder - cfg2.legendOrder;
     })
     .reduce(

--- a/packages/ui-components/src/components/DataTable/useDataTableExport.tsx
+++ b/packages/ui-components/src/components/DataTable/useDataTableExport.tsx
@@ -36,7 +36,7 @@ export const useDataTableExport = (
             tableColumns.map(col => {
               const value = row.values[col.id];
               // check for strings that are not stringified numbers, including dates and percentages
-              if (typeof value === 'string' && isNaN(Number(value))) return value;
+              if (typeof value === 'string' && Number.isNaN(Number(value))) return value;
               // only parse the value if it is not a boolean (as this means it is definitely meant to be a number)
               const num = value && typeof value !== 'boolean' ? Number(value) : value;
 

--- a/packages/ui-components/src/components/Editor/SqlEditor.tsx
+++ b/packages/ui-components/src/components/Editor/SqlEditor.tsx
@@ -25,10 +25,10 @@ const AceEditor = styled(BaseAceEditor).attrs({
   // font-size set by fontSize prop
   line-height: 1.5;
 
-  /* 
+  /*
    * Prevent caret drift in some browsers, including Safari.
-   * 
-   * Ace uses CSS properties to calculate the width of characters and lines, which determines where 
+   *
+   * Ace uses CSS properties to calculate the width of characters and lines, which determines where
    * the caret should appear. However, when a font style isn’t provided by the font files, and the
    * browser attempts to synthesize it, this can cause the caret to lag behind or lead ahead of the
    * actual insertion point.
@@ -103,7 +103,7 @@ export const SqlEditor = ({
       //   "Expecting '(', 'NUMERIC', 'IDENTIFIER', 'STRING', 'EXPONENT_NU...",
       // ];
       const errors = (e as Error).message.split('\n');
-      const rowNum = parseInt(errors[0].split(' ')[4].replace(':', ''));
+      const rowNum = Number.parseInt(errors[0].split(' ')[4].replace(':', ''));
       if (errors[1].startsWith('...')) {
         errors[1] = errors[1].substring(3);
         errors[2] = errors[2].substring(3);

--- a/packages/ui-components/src/components/Matrix/MatrixLegend.tsx
+++ b/packages/ui-components/src/components/Matrix/MatrixLegend.tsx
@@ -42,7 +42,7 @@ const convertConditionToText = (condition: PresentationOptionCondition['conditio
   if (typeof condition === 'object') {
     const values = Object.values(condition);
 
-    const isNumberRange = values.every(value => !isNaN(parseInt(String(value), 10)));
+    const isNumberRange = values.every(value => !Number.isNaN(Number.parseInt(String(value), 10)));
     if (isNumberRange) {
       return convertNumberRangeToText(condition);
     }

--- a/packages/ui-components/src/components/Matrix/utils.ts
+++ b/packages/ui-components/src/components/Matrix/utils.ts
@@ -35,7 +35,7 @@ const CONDITION_CHECK_METHOD = {
   '=': (value: any, filterValue: ConditionValue) => {
     // Make sure we are comparing the same types
     if (typeof filterValue === 'number') {
-      return parseFloat(value) === filterValue;
+      return Number.parseFloat(value) === filterValue;
     }
     return value === filterValue;
   },
@@ -72,7 +72,7 @@ const getPresentationOptionFromCondition = (
 
           if (operator !== '=') {
             // If operator is not '=' then we need to parse the value to a number
-            parsedValue = parseFloat(parsedValue);
+            parsedValue = Number.parseFloat(parsedValue);
           }
 
           return checkConditionMethod

--- a/packages/ui-components/src/components/Table/TablePaginator.jsx
+++ b/packages/ui-components/src/components/Table/TablePaginator.jsx
@@ -77,7 +77,7 @@ export const TablePaginator = React.memo(
 
     const handleChangeRowsPerPage = useCallback(
       event => {
-        const newRowsPerPage = parseInt(event.target.value, 10);
+        const newRowsPerPage = Number.parseInt(event.target.value, 10);
         if (onChangeRowsPerPage) onChangeRowsPerPage(newRowsPerPage);
       },
       [onChangeRowsPerPage],

--- a/packages/ui-map-components/src/components/Markers/CircleProportionMarker.tsx
+++ b/packages/ui-map-components/src/components/Markers/CircleProportionMarker.tsx
@@ -15,7 +15,7 @@ export const CircleProportionMarker = React.memo(
     if ((coordinates as number[])?.length !== 2) return null;
 
     const AREA_MULTIPLIER = 100; // just tuned by hand
-    const numberValue = parseFloat(String(radius)) || 0;
+    const numberValue = Number.parseFloat(String(radius)) || 0;
     const area = Math.max(numberValue, 1) * AREA_MULTIPLIER;
 
     const displayRadius = Math.sqrt(area / Math.PI);

--- a/packages/ui-map-components/src/components/Markers/MeasureMarker.tsx
+++ b/packages/ui-map-components/src/components/Markers/MeasureMarker.tsx
@@ -6,7 +6,7 @@ import { MarkerProps } from '../../types';
 export const MeasureMarker = React.memo((props: MarkerProps) => {
   const { icon, radius = 0 } = props;
 
-  if (radius !== undefined && parseInt(String(radius), 10) === 0) {
+  if (radius !== undefined && Number.parseInt(String(radius), 10) === 0) {
     if (icon) {
       // we have an icon, so don't render the radius at all
       return <IconMarker {...props} />;

--- a/packages/ui-map-components/src/utils/markerColors.ts
+++ b/packages/ui-map-components/src/utils/markerColors.ts
@@ -33,7 +33,7 @@ export function resolveSpectrumColour(
   max: number | string, // the highest number or a string representing latest date in a range
   noDataColour?: string, // css hsl string, e.g. `hsl(value, 100%, 50%)` for null value
 ): string {
-  if (value === null || isNaN(value)) return noDataColour || HEATMAP_UNKNOWN_COLOR;
+  if (value === null || Number.isNaN(value)) return noDataColour || HEATMAP_UNKNOWN_COLOR;
 
   let valueToColor: (value: number | null, ...args: any[]) => string;
   if (scaleColorScheme) {
@@ -87,7 +87,7 @@ export function getPerformanceHeatmapColor(
 }
 
 const getTimeProportion = (value: number | null, min: string, max: string) => {
-  if (!value || !isNaN(value)) return null;
+  if (!value || !Number.isNaN(value)) return null;
   const range = moment(max).diff(min, 'days');
   const valueAsMoment = moment(value);
   const ageOfSample = moment(max).diff(valueAsMoment, 'days');
@@ -101,7 +101,7 @@ export function getTimeHeatmapColor(
   value: number | null, // Number in range [0..1] representing percentage
   noDataColour?: string,
 ): string {
-  if (value === null || isNaN(value)) return noDataColour || HEATMAP_UNKNOWN_COLOR;
+  if (value === null || Number.isNaN(value)) return noDataColour || HEATMAP_UNKNOWN_COLOR;
   return `hsl(${100 - Math.floor(value * 100)}, 100%, 50%)`;
 }
 

--- a/packages/ui-map-components/src/utils/markerFormats.ts
+++ b/packages/ui-map-components/src/utils/markerFormats.ts
@@ -381,7 +381,7 @@ export const calculateRadiusScaleFactor = (measureData: MeasureData[]) => {
   // (this needs to happen here instead of inside the circle marker component
   // because it needs to operate on the dataset level, not the datapoint level)
   const maxRadius = measureData
-    .map(d => parseInt(d.radius as string, 10) || 1)
+    .map(d => Number.parseInt(d.radius as string, 10) || 1)
     .reduce((state, current) => Math.max(state, current), 0);
   return maxRadius < MAX_ALLOWED_RADIUS ? 1 : (1 / maxRadius) * MAX_ALLOWED_RADIUS;
 };
@@ -389,5 +389,5 @@ export const calculateRadiusScaleFactor = (measureData: MeasureData[]) => {
 // Take a measureData array where the [key]: value is a number
 // and filters NaN values (e.g. undefined).
 export function flattenNumericalMeasureData(measureData: MeasureData[], key: string) {
-  return measureData.map(v => parseFloat(v[key])).filter(x => !isNaN(x));
+  return measureData.map(v => Number.parseFloat(v[key])).filter(x => !Number.isNaN(x));
 }

--- a/packages/utils/src/formatDataValueByType.js
+++ b/packages/utils/src/formatDataValueByType.js
@@ -16,17 +16,17 @@ export const VALUE_TYPES = {
 const currency = value => numeral(value).format('$0.00a');
 
 const fraction = (value, { total }) => {
-  if (isNaN(total)) return 'No data';
+  if (Number.isNaN(total)) return 'No data';
   return `${String(value)}/${String(total)}`;
 };
 
 const fractionAndPercentage = (value, { numerator, denominator }) => {
-  if (isNaN(value)) return value;
+  if (Number.isNaN(value)) return value;
   return `${numerator}/${denominator} = ${percentage(value)}`;
 };
 
 const numberAndPercentage = (value, { numerator, denominator }) => {
-  if (isNaN(value)) return value;
+  if (Number.isNaN(value)) return value;
   const percentage = (numerator / denominator) * 100;
   return `${value} (${percentage === 0 ? 0 : percentage.toFixed(1)}%)`;
 };
@@ -41,7 +41,7 @@ const text = value => String(value);
 const boolean = value => value > 0;
 
 const percentage = value => {
-  if (isNaN(value)) {
+  if (Number.isNaN(value)) {
     return value;
   }
 

--- a/packages/utils/src/period/period.js
+++ b/packages/utils/src/period/period.js
@@ -130,7 +130,7 @@ export const isValidPeriod = period => typeof period === 'string' && !!periodToT
 export const comparePeriods = (periodA, periodB) => {
   const dayPeriodA = convertToPeriod(periodA, DAY);
   const dayPeriodB = convertToPeriod(periodB, DAY);
-  return parseInt(dayPeriodA, 10) - parseInt(dayPeriodB, 10);
+  return Number.parseInt(dayPeriodA, 10) - Number.parseInt(dayPeriodB, 10);
 };
 
 export const isFuturePeriod = period => comparePeriods(period, getCurrentPeriod(DAY)) > 0;

--- a/packages/utils/src/validation/validatorFunctions.js
+++ b/packages/utils/src/validation/validatorFunctions.js
@@ -50,7 +50,7 @@ export const takesDateForm = value => {
 };
 
 export const isNumber = value => {
-  if (isNaN(value)) {
+  if (Number.isNaN(value)) {
     throw new ValidationError(`Should contain a number instead of ${value}`);
   }
 };

--- a/packages/web-config-server/src/apiV1/dataBuilders/generic/compose/composePercentagesPerPeriod.js
+++ b/packages/web-config-server/src/apiV1/dataBuilders/generic/compose/composePercentagesPerPeriod.js
@@ -68,7 +68,7 @@ export const composePercentagesPerPeriod = async (config, aggregator, dhisApi) =
 
     Object.entries(percentageParts).forEach(([dataKey, { numerator, denominator }]) => {
       const fraction = divideValues(numerator, denominator);
-      if (!isNaN(fraction)) {
+      if (!Number.isNaN(fraction)) {
         newDataItem[dataKey] = fraction;
         newDataItem[`${dataKey}_metadata`] = { numerator, denominator };
       }

--- a/packages/web-config-server/src/apiV1/dataBuilders/generic/count/countDataElement10kPax.js
+++ b/packages/web-config-server/src/apiV1/dataBuilders/generic/count/countDataElement10kPax.js
@@ -33,11 +33,11 @@ class CountDataElement10kPaxBuilder extends DataBuilder {
     if (population !== 0) {
       addRow(population, 'Population');
       const partialDoctors = totalOfDoctors / population;
-      addRow(parseFloat(partialDoctors * 10000).toFixed(2), 'Doctors/10,000 pop');
+      addRow(Number.parseFloat(partialDoctors * 10000).toFixed(2), 'Doctors/10,000 pop');
       const partialNurses = totalOfNurses / population;
-      addRow(parseFloat(partialNurses * 10000).toFixed(2), 'Nurses/10,000 pop');
+      addRow(Number.parseFloat(partialNurses * 10000).toFixed(2), 'Nurses/10,000 pop');
       const partialFacilities = numberOperational / population;
-      addRow(parseFloat(partialFacilities * 10000).toFixed(2), 'Facilities/10,000 pop');
+      addRow(Number.parseFloat(partialFacilities * 10000).toFixed(2), 'Facilities/10,000 pop');
     }
     return { data: returnData };
   }

--- a/packages/web-config-server/src/apiV1/dataBuilders/generic/count/countOperationalFacilitiesByType.js
+++ b/packages/web-config-server/src/apiV1/dataBuilders/generic/count/countOperationalFacilitiesByType.js
@@ -54,12 +54,12 @@ class CountOperationalFacilitiesByTypeBuilder extends DataBuilder {
       if (isMultipleCountries) {
         return {
           type: pluraliseFacilityType(translateCategoryCodeToFacilityType(facility.category_code)),
-          level: parseInt(facility.category_code, 10),
+          level: Number.parseInt(facility.category_code, 10),
         };
       }
       return {
         type: pluraliseFacilityType(facility.type_name),
-        level: parseFloat(facility.type),
+        level: Number.parseFloat(facility.type),
       };
     };
     const facilityTypeAndLevelByCode = {};

--- a/packages/web-config-server/src/apiV1/dataBuilders/generic/percentage/percentagesPerPeriod.js
+++ b/packages/web-config-server/src/apiV1/dataBuilders/generic/percentage/percentagesPerPeriod.js
@@ -150,7 +150,7 @@ const percentagesPerPeriod = async (
     data: Object.keys(percentagesByPeriod)
       .sort()
       .map(periodTimestamp => {
-        const timestamp = parseInt(periodTimestamp, 10);
+        const timestamp = Number.parseInt(periodTimestamp, 10);
         const dataForPeriod = {
           name: timestampToPeriodName(timestamp, periodType),
           timestamp,

--- a/packages/web-config-server/src/apiV1/dataBuilders/generic/table/tableOfDataValues/TotalCalculator.js
+++ b/packages/web-config-server/src/apiV1/dataBuilders/generic/table/tableOfDataValues/TotalCalculator.js
@@ -131,7 +131,7 @@ export class TotalCalculator {
         const cell = this.tableConfig.cells[row][column];
         const cellVal =
           cell && !TotalCalculator.isTotalKey(cell) ? this.valuesByCell[cell] : undefined;
-        total += isNaN(cellVal) ? 0 : cellVal;
+        total += Number.isNaN(cellVal) ? 0 : cellVal;
       }
     }
 

--- a/packages/web-config-server/src/apiV1/dataBuilders/generic/table/tableOfEvents.js
+++ b/packages/web-config-server/src/apiV1/dataBuilders/generic/table/tableOfEvents.js
@@ -164,7 +164,7 @@ class TableOfEventsBuilder extends DataBuilder {
     const totals = {};
     Object.entries(this.config.columns).forEach(([key, { shouldShowTotal }]) => {
       if (shouldShowTotal) {
-        totals[key] = rows.reduce((total, row) => total + parseFloat(row[key]), 0);
+        totals[key] = rows.reduce((total, row) => total + Number.parseFloat(row[key]), 0);
       }
     });
 

--- a/packages/web-config-server/src/apiV1/dataBuilders/helpers/divideValues.js
+++ b/packages/web-config-server/src/apiV1/dataBuilders/helpers/divideValues.js
@@ -8,7 +8,7 @@ const FRACTION_TYPE_TO_FUNC = {
 
 export const divideValues = (numerator, denominator, fractionType = 'percentage') => {
   const isNumeratorValid = numerator || numerator === 0;
-  const isDenominatorValid = denominator && parseFloat(denominator) !== 0;
+  const isDenominatorValid = denominator && Number.parseFloat(denominator) !== 0;
 
   if (!isNumeratorValid || !isDenominatorValid) {
     return NO_DATA_AVAILABLE;

--- a/packages/web-config-server/src/apiV1/measureBuilders/composePercentagePerOrgUnit.js
+++ b/packages/web-config-server/src/apiV1/measureBuilders/composePercentagePerOrgUnit.js
@@ -54,7 +54,7 @@ export const composePercentagePerOrgUnit = async (
 
     const fraction = divideValues(numeratorValue, denominatorValue, fractionType);
 
-    if (!isNaN(fraction)) {
+    if (!Number.isNaN(fraction)) {
       fractionsByOrgUnit[orgUnit] = {
         ...denominatorsByOrgUnit[orgUnit],
         [dataElementCode]: fraction,

--- a/packages/web-config-server/src/apiV1/utils/fetchIndicatorValues/buildAnalyticsFromDhisAggregatedAnalytics.js
+++ b/packages/web-config-server/src/apiV1/utils/fetchIndicatorValues/buildAnalyticsFromDhisAggregatedAnalytics.js
@@ -28,7 +28,7 @@ const DIMENSION_TYPES = {
  */
 const sanitizeValue = (value, valueType) => {
   if (valueType === 'NUMBER') {
-    const sanitizedValue = parseFloat(value);
+    const sanitizedValue = Number.parseFloat(value);
     return Number.isNaN(sanitizedValue) ? '' : sanitizedValue;
   }
 


### PR DESCRIPTION
Pure find & replace of legacy globals that ES2015 moved into the `Number` namespace.

- https://biomejs.dev/linter/rules/use-number-namespace/
- https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-number-properties.md

e.g. `(?<!Number\.)isFinite\(` → `Number.isInteger`