### PR TITLE
fix(datatrak): binary question with default options

### DIFF
--- a/packages/datatrak-web/src/features/Questions/BinaryQuestion.tsx
+++ b/packages/datatrak-web/src/features/Questions/BinaryQuestion.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+
 import { SurveyQuestionInputProps } from '../../types';
+import { isNonEmptyArray } from '../../utils';
 import { RadioQuestion } from './RadioQuestion';
 
 export const BinaryQuestion = ({ options = [], ...props }: SurveyQuestionInputProps) => {

--- a/packages/datatrak-web/src/features/Questions/BinaryQuestion.tsx
+++ b/packages/datatrak-web/src/features/Questions/BinaryQuestion.tsx
@@ -3,7 +3,7 @@ import { SurveyQuestionInputProps } from '../../types';
 import { RadioQuestion } from './RadioQuestion';
 
 export const BinaryQuestion = ({ options = [], ...props }: SurveyQuestionInputProps) => {
-  const questionOptions = Array.isArray(options)
+  const questionOptions = isNonEmptyArray(options)
     ? options
     : [
         {

--- a/packages/datatrak-web/src/utils/index.ts
+++ b/packages/datatrak-web/src/utils/index.ts
@@ -7,5 +7,6 @@ export {
   setTaskFilterSetting,
 } from './taskFilterSettings';
 export { errorToast, infoToast, successToast } from './toast';
+export { isEmptyArray, isNonEmptyArray } from './typeGuards';
 export { useIsMobileMediaQuery as useIsMobile } from './useIsMobileMediaQuery';
 export { useFromLocation } from './useLocationState';

--- a/packages/datatrak-web/src/utils/typeGuards.ts
+++ b/packages/datatrak-web/src/utils/typeGuards.ts
@@ -1,0 +1,7 @@
+export function isEmptyArray(val: unknown): val is [] {
+  return Array.isArray(val) && val.length === 0;
+}
+
+export function isNonEmptyArray<T = unknown>(val: unknown): val is [T, ...T[]] {
+  return Array.isArray(val) && val.length > 0;
+}

--- a/packages/datatrak-web/src/utils/typeGuards.ts
+++ b/packages/datatrak-web/src/utils/typeGuards.ts
@@ -1,3 +1,8 @@
+/*
+ * Duplicated from @tupaia/tsutils, which cannot (currently!) be used as a dependency of our front-end
+ * packages due some incompatibilities with its transitive dependencies (as of May 2024).
+ */
+
 export function isEmptyArray(val: unknown): val is [] {
   return Array.isArray(val) && val.length === 0;
 }

--- a/packages/tsutils/src/typeGuards.ts
+++ b/packages/tsutils/src/typeGuards.ts
@@ -1,6 +1,8 @@
 export const isDefined = <T>(value: T): value is Exclude<T, undefined> => value !== undefined;
 
-export const isNullish = (val: unknown): val is null | undefined => val == null;
+export function isNullish(val: unknown): val is null | undefined {
+  return val === null || val === undefined;
+}
 
 export const isNotNullish = <T>(val: T): val is NonNullable<T> => val !== undefined && val !== null;
 

--- a/packages/tsutils/src/typeGuards.ts
+++ b/packages/tsutils/src/typeGuards.ts
@@ -1,5 +1,7 @@
 export const isDefined = <T>(value: T): value is Exclude<T, undefined> => value !== undefined;
 
+export const isNullish = (val: unknown): val is null | undefined => val == null;
+
 export const isNotNullish = <T>(val: T): val is NonNullable<T> => val !== undefined && val !== null;
 
 export function assertIsNotNullish<T>(val: T): asserts val is NonNullable<T> {
@@ -15,3 +17,11 @@ export const ensure = <T>(val: T) => {
 
 export const isObject = (val: unknown): val is Record<string, unknown> =>
   typeof val === 'object' && val !== null && !Array.isArray(val);
+
+export function isEmptyArray(val: unknown): val is [] {
+  return Array.isArray(val) && val.length === 0;
+}
+
+export function isNonEmptyArray<T = unknown>(val: unknown): val is [T, ...T[]] {
+  return Array.isArray(val) && val.length > 0;
+}


### PR DESCRIPTION
#6112 introduced a semantic check that an object is an array, but the code change wasn’t 100% equivalent

This PR fixes that