### PR TITLE
ci: avoid unnecessary builds with `yarn workspaces foreach`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -184,7 +184,7 @@ jobs:
           cache: yarn
       - run: corepack enable yarn
       - run: SKIP_BUILD_INTERNAL_DEPENDENCIES=true yarn install
-      - run: yarn build:internal-dependencies
+      - run: yarn workspaces foreach --recursive --parallel --topological --from @tupaia/${{ matrix.package }} run build
       - run: yarn workspace @tupaia/${{ matrix.package }} setup-test || echo "No setup needed"
       - run: yarn workspace @tupaia/${{ matrix.package }} test
 

--- a/packages/expression-parser/package.json
+++ b/packages/expression-parser/package.json
@@ -22,6 +22,7 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
+    "@tupaia/utils": "workspace:*",
     "date-fns": "^2.16.1",
     "lodash.startcase": "^4.4.0",
     "mathjs": "^11.11.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10246,6 +10246,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@tupaia/expression-parser@workspace:packages/expression-parser"
   dependencies:
+    "@tupaia/utils": "workspace:*"
     date-fns: ^2.16.1
     lodash.startcase: ^4.4.0
     mathjs: ^11.11.0


### PR DESCRIPTION
Just build the regular dependencies (“regular” as in no dev dependencies) of each package when running tests, rather than all internal dependencies

Back-of-the-napkin calculation suggests this saves 40–50 GHA minutes in a full CI run