### PR TITLE
refactor `buildNonInternalDependencies`

### DIFF
--- a/scripts/bash/buildNonInternalDependencies.sh
+++ b/scripts/bash/buildNonInternalDependencies.sh
@@ -1,16 +1,10 @@
-#!/bin/bash -ex
+#!/usr/bin/env bash
 
-PACKAGES="report-server admin-panel-server central-server data-table-server datatrak-web datatrak-web-server entity-server lesmis lesmis-server meditrak-app-server psss psss-server web-config-server tupaia-web tupaia-web-server"
+set -ex
 
-CONCURRENT_BUILD_BATCH_SIZE=1
-
-build_commands=()
-build_prefixes=()
-
-# Build dependencies
-for PACKAGE in $PACKAGES; do
-    build_commands+=("\"yarn workspace @tupaia/${PACKAGE} build\"")
-    build_prefixes+=("${PACKAGE},")
-done
-
-eval "yarn concurrently -m $CONCURRENT_BUILD_BATCH_SIZE --names \"${build_prefixes[*]}\" -k ${build_commands[*]}"
+yarn workspaces foreach \
+    --parallel \
+    --verbose \
+    --jobs unlimited \
+    --include '@tupaia/{admin-panel-server,central-server,data-table-server,datatrak-web,datatrak-web-server,entity-server,lesmis,lesmis-server,meditrak-app-server,psss,psss-server,report-server,tupaia-web,tupaia-web-server,web-config-server}' \
+    run build


### PR DESCRIPTION
Delegates concurrent building of multiple packages to `yarn workspaces`

On an Apple Silicon M4 chip, halves the build time (~90 s → ~45 s)