### PR TITLE
fix(datatrak): RN-1619: text clipping in Dashboard tiles

### DIFF
--- a/packages/datatrak-web/src/components/Tile.tsx
+++ b/packages/datatrak-web/src/components/Tile.tsx
@@ -12,12 +12,10 @@ const Wrapper = styled(Paper).attrs({
 })`
   align-items: stretch;
   border-radius: 0.625rem;
-  display: block flex;
-  flex-direction: column;
+  display: grid;
   font-size: 0.875rem;
   font-weight: 400;
   gap: 0.25rem 0.5rem;
-  inline-size: 14.75rem;
   justify-content: flex-start;
   line-height: 1.45;
   min-block-size: fit-content;
@@ -41,8 +39,12 @@ const Wrapper = styled(Paper).attrs({
       background-color: ${theme.palette.primaryHover};
     }
 
-    ${theme.breakpoints.up('lg')} {
-      flex-direction: row;
+    ${theme.breakpoints.down('sm')} {
+      grid-template-columns: 100%;
+      inline-size: 14.75rem;
+    }
+    ${theme.breakpoints.up('md')} {
+      grid-template-columns: auto minmax(0, 1fr);
       inline-size: 100%;
     }
   `}
@@ -84,10 +86,6 @@ const TrailingIconGroup = styled(IconGroup)`
   align-self: flex-end;
 `;
 
-const BodyWrapper = styled.div`
-  flex-grow: 1;
-`;
-
 const Heading = styled(Typography).attrs({ variant: 'h3' })`
   color: ${({ theme }) => theme.palette.text.primary};
   font-size: 1rem;
@@ -115,7 +113,7 @@ export const Tile = ({
   trailingIcons,
   ...props
 }: TileProps) => {
-  const Body = useIsMobile() ? Fragment : BodyWrapper;
+  const Body = useIsMobile() ? Fragment : 'div';
   return (
     <Wrapper {...props}>
       <Header>


### PR DESCRIPTION
Looks like a previous merge of **dev** into an epic branch went bad and we lost this fix.

Took the opportunity to refactor to use `grid` layout, as `flex` worked but wasn’t semantically appropriate anyway