### PR TITLE
tweak(datatrak): hide Smart App Banner, don’t open DataTrak links in MediTrak

### DIFF
--- a/packages/datatrak-web/index.html
+++ b/packages/datatrak-web/index.html
@@ -26,9 +26,6 @@
       content="Data collection and visualisation for the most remote settings in the world"
     />
 
-    <!-- Smart App Banner on iOS -->
-    <meta name="apple-itunes-app" content="app-id=1245053537" />
-
     <% if (process.env.REACT_APP_DEPLOYMENT_NAME === 'master' ||
     process.env.REACT_APP_DEPLOYMENT_NAME === 'main' || process.env.REACT_APP_DEPLOYMENT_NAME ===
     'production') { %>

--- a/packages/datatrak-web/public/.well-known/apple-app-site-association
+++ b/packages/datatrak-web/public/.well-known/apple-app-site-association
@@ -1,22 +1,4 @@
 {
-  "applinks": {
-    "apps": [],
-    "details": [
-      {
-        "appIDs": ["352QMCKRKJ.com.tupaia.meditrak"],
-        "components": [
-          { "/": "/account-settings/*", "exclude": true },
-          { "/": "/forgot-password/*", "exclude": true },
-          { "/": "/reports/*", "exclude": true },
-          { "/": "/reset-password/*", "exclude": true },
-          { "/": "/verify-email/*", "exclude": true },
-          { "/": "/verify-email-resend/*", "exclude": true },
-          { "/": "/tasks/*", "exclude": true },
-          { "/": "/*" }
-        ]
-      }
-    ]
-  },
   "webcredentials": {
     "apps": ["352QMCKRKJ.com.tupaia.meditrak"]
   }

--- a/packages/meditrak-app/ios/TupaiaMediTrak/TupaiaMediTrak.entitlements
+++ b/packages/meditrak-app/ios/TupaiaMediTrak/TupaiaMediTrak.entitlements
@@ -4,7 +4,6 @@
 <dict>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:datatrak.tupaia.org</string>
 		<string>webcredentials:datatrak.tupaia.org</string>
 		<string>webcredentials:tupaia.org</string>
 	</array>


### PR DESCRIPTION
## [RN-1479 QA Issue 11](https://linear.app/bes/issue/RN-1479/set-up-pwa-for-installation#comment-1783910f)

Keeps `webcredentials` association so iOS knows to let people autofill login credentials in MediTrak with DataTrak credentials