### PR TITLE
fix(datatrak): incorrect forwarding of `useQueryOptions.enabled` when no options provided

### DIFF
--- a/packages/datatrak-web/src/api/queries/useProjectEntities.ts
+++ b/packages/datatrak-web/src/api/queries/useProjectEntities.ts
@@ -30,7 +30,7 @@ export const useProjectEntities = (
     getEntityDescendants,
     {
       ...useQueryOptions,
-      enabled: !!projectCode && useQueryOptions?.enabled,
+      enabled: !!projectCode && (useQueryOptions?.enabled ?? true),
       placeholderData: [] as DatatrakWebEntityDescendantsRequest.ResBody,
     },
   );

--- a/packages/datatrak-web/src/api/queries/useSurveyResponse.ts
+++ b/packages/datatrak-web/src/api/queries/useSurveyResponse.ts
@@ -11,7 +11,7 @@ export const useSurveyResponse = (
     () => get(`surveyResponse/${surveyResponseId}`),
     {
       ...useQueryOptions,
-      enabled: !!surveyResponseId && useQueryOptions?.enabled,
+      enabled: !!surveyResponseId && (useQueryOptions?.enabled ?? true),
     },
   );
 };


### PR DESCRIPTION
If no `useQueryOptions.enabled` value is explicitly is provided, the chain evaluates `undefined`, which is falsy

But `enabled` should default to true to preserve `useQuery`’s out-of-the-box behaviour