### PR TITLE
tweak: reusable `<SafeArea>` component

### DIFF
--- a/packages/datatrak-web/src/components/PageContainer.tsx
+++ b/packages/datatrak-web/src/components/PageContainer.tsx
@@ -25,21 +25,23 @@ export const SafeArea = styled.div<{
   right?: boolean;
 }>(props => {
   return css`
+    --safe-area-min-padding-y: 1rem;
+    --safe-area-min-padding-x: 1.25rem;
     ${props.top &&
     css`
-      padding-top: max(env(safe-area-inset-top, 0), 1rem);
+      padding-top: max(env(safe-area-inset-top, 0), var(--safe-area-min-padding-y));
     `}
     ${props.bottom &&
     css`
-      padding-bottom: max(env(safe-area-inset-bottom, 0), 1rem);
+      padding-bottom: max(env(safe-area-inset-bottom, 0), var(--safe-area-min-padding-y));
     `}
     ${props.left &&
     css`
-      padding-left: max(env(safe-area-inset-left, 0), 1.25rem);
+      padding-left: max(env(safe-area-inset-left, 0), var(--safe-area-min-padding-x));
     `}
     ${props.right &&
     css`
-      padding-right: max(env(safe-area-inset-right, 0), 1.25rem);
+      padding-right: max(env(safe-area-inset-right, 0), var(--safe-area-min-padding-x));
     `}
   `;
 });

--- a/packages/datatrak-web/src/components/PageContainer.tsx
+++ b/packages/datatrak-web/src/components/PageContainer.tsx
@@ -1,6 +1,5 @@
 import { Container } from '@material-ui/core';
-import React from 'react';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 
 /**
  * @deprecated
@@ -17,43 +16,3 @@ export const PageContainer = styled(Container).attrs({
   padding-right: max(env(safe-area-inset-right, 0), 1.25rem);
   position: relative;
 `;
-
-export const SafeArea = styled.div<{
-  top?: boolean;
-  bottom?: boolean;
-  left?: boolean;
-  right?: boolean;
-}>(props => {
-  return css`
-    --safe-area-min-padding-y: 1rem;
-    --safe-area-min-padding-x: 1.25rem;
-    ${props.top &&
-    css`
-      padding-top: max(env(safe-area-inset-top, 0), var(--safe-area-min-padding-y));
-    `}
-    ${props.bottom &&
-    css`
-      padding-bottom: max(env(safe-area-inset-bottom, 0), var(--safe-area-min-padding-y));
-    `}
-    ${props.left &&
-    css`
-      padding-left: max(env(safe-area-inset-left, 0), var(--safe-area-min-padding-x));
-    `}
-    ${props.right &&
-    css`
-      padding-right: max(env(safe-area-inset-right, 0), var(--safe-area-min-padding-x));
-    `}
-  `;
-});
-
-export const SafeAreaColumn = (props: React.HTMLAttributes<HTMLDivElement>) => (
-  <SafeArea {...props} left right />
-);
-
-export const SafeAreaHeader = (props: React.HTMLAttributes<HTMLDivElement>) => (
-  <SafeArea {...props} top />
-);
-
-export const SafeAreaFooter = (props: React.HTMLAttributes<HTMLDivElement>) => (
-  <SafeArea {...props} bottom />
-);

--- a/packages/datatrak-web/src/components/PageContainer.tsx
+++ b/packages/datatrak-web/src/components/PageContainer.tsx
@@ -3,10 +3,10 @@ import styled from 'styled-components';
 
 /**
  * @deprecated
- * Consider using {@link SafeArea} or {@link SafeAreaColumn} instead, augmenting it with
- * {@link styled} as needed. This component sets `flex` and `position` values, which are easier to
- * work with when set by the consumer. This component remains for backward compatibility, and will
- * be removed in the future.
+ * Consider using `SafeArea` or `SafeAreaColumn` from @tupaia/ui-components instead, augmenting it
+ * with {@link styled} as needed. This component sets `flex` and `position` values, which are easier
+ * to work with when set by the consumer. This component remains for backward compatibility, and
+ * will be removed in the future.
  */
 export const PageContainer = styled(Container).attrs({
   maxWidth: false,

--- a/packages/datatrak-web/src/components/PageContainer.tsx
+++ b/packages/datatrak-web/src/components/PageContainer.tsx
@@ -1,6 +1,14 @@
 import { Container } from '@material-ui/core';
-import styled from 'styled-components';
+import React from 'react';
+import styled, { css } from 'styled-components';
 
+/**
+ * @deprecated
+ * Consider using {@link SafeArea} or {@link SafeAreaColumn} instead, augmenting it with
+ * {@link styled} as needed. This component sets `flex` and `position` values, which are easier to
+ * work with when set by the consumer. This component remains for backward compatibility, and will
+ * be removed in the future.
+ */
 export const PageContainer = styled(Container).attrs({
   maxWidth: false,
 })`
@@ -9,3 +17,41 @@ export const PageContainer = styled(Container).attrs({
   padding-right: max(env(safe-area-inset-right, 0), 1.25rem);
   position: relative;
 `;
+
+export const SafeArea = styled.div<{
+  top?: boolean;
+  bottom?: boolean;
+  left?: boolean;
+  right?: boolean;
+}>(props => {
+  return css`
+    ${props.top &&
+    css`
+      padding-top: max(env(safe-area-inset-top, 0), 1rem);
+    `}
+    ${props.bottom &&
+    css`
+      padding-bottom: max(env(safe-area-inset-bottom, 0), 1rem);
+    `}
+    ${props.left &&
+    css`
+      padding-left: max(env(safe-area-inset-left, 0), 1.25rem);
+    `}
+    ${props.right &&
+    css`
+      padding-right: max(env(safe-area-inset-right, 0), 1.25rem);
+    `}
+  `;
+});
+
+export const SafeAreaColumn = (props: React.HTMLAttributes<HTMLDivElement>) => (
+  <SafeArea {...props} left right />
+);
+
+export const SafeAreaHeader = (props: React.HTMLAttributes<HTMLDivElement>) => (
+  <SafeArea {...props} top />
+);
+
+export const SafeAreaFooter = (props: React.HTMLAttributes<HTMLDivElement>) => (
+  <SafeArea {...props} bottom />
+);

--- a/packages/datatrak-web/src/components/index.ts
+++ b/packages/datatrak-web/src/components/index.ts
@@ -1,7 +1,13 @@
 // Exporting these first to avoid issues with circular references
 export * from './Icons';
 export { Modal } from './Modal';
-export { PageContainer } from './PageContainer';
+export {
+  PageContainer,
+  SafeArea,
+  SafeAreaColumn,
+  SafeAreaFooter,
+  SafeAreaHeader,
+} from './PageContainer';
 
 export { Autocomplete, QuestionAutocomplete } from './Autocomplete';
 export { Button } from './Button';

--- a/packages/datatrak-web/src/components/index.ts
+++ b/packages/datatrak-web/src/components/index.ts
@@ -1,13 +1,7 @@
 // Exporting these first to avoid issues with circular references
 export * from './Icons';
 export { Modal } from './Modal';
-export {
-  PageContainer,
-  SafeArea,
-  SafeAreaColumn,
-  SafeAreaFooter,
-  SafeAreaHeader,
-} from './PageContainer';
+export { PageContainer } from './PageContainer';
 
 export { Autocomplete, QuestionAutocomplete } from './Autocomplete';
 export { Button } from './Button';

--- a/packages/datatrak-web/src/layout/CentredLayout.tsx
+++ b/packages/datatrak-web/src/layout/CentredLayout.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { Outlet } from 'react-router';
 import styled from 'styled-components';
+
+import { SafeArea } from '@tupaia/ui-components';
+
 import { HEADER_HEIGHT } from '../constants';
-import { SafeArea } from '../components';
 
 const Wrapper = styled(SafeArea).attrs({
   bottom: true,

--- a/packages/datatrak-web/src/layout/CentredLayout.tsx
+++ b/packages/datatrak-web/src/layout/CentredLayout.tsx
@@ -2,13 +2,19 @@ import React from 'react';
 import { Outlet } from 'react-router';
 import styled from 'styled-components';
 import { HEADER_HEIGHT } from '../constants';
+import { SafeArea } from '../components';
 
-const Wrapper = styled.div`
+const Wrapper = styled(SafeArea).attrs({
+  bottom: true,
+  left: true,
+  right: true,
+})`
+  align-items: center;
+  block-size: calc(100dvb - 2 * ${HEADER_HEIGHT});
   display: flex;
   justify-content: center;
-  align-items: center;
-  height: calc(100vh - 2 * ${HEADER_HEIGHT});
-  padding: 1rem 0;
+  padding-top: 1rem;
+
   form p,
   form a,
   .MuiTypography-root.MuiFormControlLabel-label {

--- a/packages/ui-components/src/components/SafeArea.tsx
+++ b/packages/ui-components/src/components/SafeArea.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import styled, { css } from 'styled-components';
 
-/** @see https://developer.mozilla.org/en-US/docs/Web/CSS/env */
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/CSS/env
+ * @privateRemarks Using absolute properties because safe-area-inset-*
+ * [has no logical equivalents](https://github.com/w3c/csswg-drafts/issues/6379).
+ */
 export const SafeArea = styled.div<{
   top?: boolean;
   bottom?: boolean;

--- a/packages/ui-components/src/components/SafeArea.tsx
+++ b/packages/ui-components/src/components/SafeArea.tsx
@@ -34,10 +34,12 @@ export const SafeAreaColumn = (props: React.HTMLAttributes<HTMLDivElement>) => (
   <SafeArea {...props} left right />
 );
 
+/** @privateRemarks Consider setting `as="header"` */
 export const SafeAreaHeader = (props: React.HTMLAttributes<HTMLDivElement>) => (
   <SafeArea {...props} top />
 );
 
+/** @privateRemarks Consider setting `as="footer"` */
 export const SafeAreaFooter = (props: React.HTMLAttributes<HTMLDivElement>) => (
   <SafeArea {...props} bottom />
 );

--- a/packages/ui-components/src/components/SafeArea.tsx
+++ b/packages/ui-components/src/components/SafeArea.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import styled, { css } from 'styled-components';
+
+/** @see https://developer.mozilla.org/en-US/docs/Web/CSS/env */
+export const SafeArea = styled.div<{
+  top?: boolean;
+  bottom?: boolean;
+  left?: boolean;
+  right?: boolean;
+}>(props => {
+  return css`
+    --safe-area-min-padding-y: 1rem;
+    --safe-area-min-padding-x: 1.25rem;
+    ${props.top &&
+    css`
+      padding-top: max(env(safe-area-inset-top, 0), var(--safe-area-min-padding-y));
+    `}
+    ${props.bottom &&
+    css`
+      padding-bottom: max(env(safe-area-inset-bottom, 0), var(--safe-area-min-padding-y));
+    `}
+    ${props.left &&
+    css`
+      padding-left: max(env(safe-area-inset-left, 0), var(--safe-area-min-padding-x));
+    `}
+    ${props.right &&
+    css`
+      padding-right: max(env(safe-area-inset-right, 0), var(--safe-area-min-padding-x));
+    `}
+  `;
+});
+
+export const SafeAreaColumn = (props: React.HTMLAttributes<HTMLDivElement>) => (
+  <SafeArea {...props} left right />
+);
+
+export const SafeAreaHeader = (props: React.HTMLAttributes<HTMLDivElement>) => (
+  <SafeArea {...props} top />
+);
+
+export const SafeAreaFooter = (props: React.HTMLAttributes<HTMLDivElement>) => (
+  <SafeArea {...props} bottom />
+);

--- a/packages/ui-components/src/components/SafeArea.tsx
+++ b/packages/ui-components/src/components/SafeArea.tsx
@@ -3,7 +3,7 @@ import styled, { css } from 'styled-components';
 
 /**
  * @see https://developer.mozilla.org/en-US/docs/Web/CSS/env
- * @privateRemarks Using absolute properties because safe-area-inset-*
+ * @privateRemarks Using absolute properties because `safe-area-inset-*`
  * [has no logical equivalents](https://github.com/w3c/csswg-drafts/issues/6379).
  */
 export const SafeArea = styled.div<{

--- a/packages/ui-components/src/components/index.ts
+++ b/packages/ui-components/src/components/index.ts
@@ -32,6 +32,7 @@ export * from './PasswordStrengthBar';
 export * from './ProfileButton';
 export * from './QrCode';
 export * from './ReferenceTooltip';
+export * from './SafeArea';
 export * from './SplitButton';
 export * from './Table';
 export * from './Toast';


### PR DESCRIPTION
`<PageContainer>` was doing a similar job to the new `<SafeAreaColumn>`, but its use of `flex` and `position` was a bit heavy-handed. I often need to override it with `flex: initial; position: initial;`, polluting the cascade.

The idea behind this component is to dedupe instances of `max(env())`

I don’t have an elegant solution for `calc(env() + x)`, though, as `x` is more likely to change