### PR TITLE
fix(uiComponents): forwarding of `as` prop to `<SafeArea>`

### DIFF
--- a/packages/ui-components/src/components/SafeArea.tsx
+++ b/packages/ui-components/src/components/SafeArea.tsx
@@ -34,16 +34,23 @@ export const SafeArea = styled.div<{
   `;
 });
 
-export const SafeAreaColumn = (props: React.HTMLAttributes<HTMLDivElement>) => (
-  <SafeArea {...props} left right />
+export const SafeAreaColumn = ({
+  as,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof SafeArea>) => (
+  <SafeArea forwardedAs={as} {...props} left right />
 );
 
 /** @privateRemarks Consider setting `as="header"` */
-export const SafeAreaHeader = (props: React.HTMLAttributes<HTMLDivElement>) => (
-  <SafeArea {...props} top />
-);
+export const SafeAreaHeader = ({
+  as,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof SafeArea>) => <SafeArea forwardedAs={as} {...props} top />;
 
 /** @privateRemarks Consider setting `as="footer"` */
-export const SafeAreaFooter = (props: React.HTMLAttributes<HTMLDivElement>) => (
-  <SafeArea {...props} bottom />
+export const SafeAreaFooter = ({
+  as,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof SafeArea>) => (
+  <SafeArea forwardedAs={as} {...props} bottom />
 );


### PR DESCRIPTION
Turns out **styled-components**, by design, doesn’t forward the `as` prop:

https://github.com/styled-components/styled-components/issues/1981#issuecomment-548860710