### PR TITLE
fix(datatrak): use dynamic viewport units

### DIFF
--- a/packages/datatrak-web/src/features/Questions/GeolocateQuestion/MapModal/Map.tsx
+++ b/packages/datatrak-web/src/features/Questions/GeolocateQuestion/MapModal/Map.tsx
@@ -56,8 +56,8 @@ const Wrapper = styled.div`
   }
 
   ${({ theme }) => theme.breakpoints.down('sm')} {
-    margin-top: 1rem;
-    height: calc(100vh - ${PAGE_PADDING}px);
+    margin-block-start: 1rem;
+    block-size: calc(100dvb - ${PAGE_PADDING}px);
   }
 `;
 

--- a/packages/datatrak-web/src/features/Questions/GeolocateQuestion/MapModal/MapModal.tsx
+++ b/packages/datatrak-web/src/features/Questions/GeolocateQuestion/MapModal/MapModal.tsx
@@ -15,15 +15,15 @@ const Heading = styled(Typography).attrs({
 `;
 
 const Container = styled.div`
-  width: 80vw;
-  max-width: 100%;
+  inline-size: 80dvi;
+  max-inline-size: 100%;
   ${({ theme }) => theme.breakpoints.down('sm')} {
-    margin-top: -1rem;
+    margin-block-start: -1rem;
   }
 
   ${({ theme }) => theme.breakpoints.up('md')} {
-    max-width: 75rem;
-    padding: 0 1.5rem;
+    max-inline-size: 75rem;
+    padding-inline: 1.5rem;
   }
 `;
 
@@ -31,8 +31,8 @@ const ButtonGroup = styled.div`
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  margin-top: 1.8rem;
-  width: 100%;
+  margin-block-start: 1.8rem;
+  inline-size: 100%;
 `;
 
 type Geolocation = {

--- a/packages/datatrak-web/src/layout/BackgroundPageLayout.tsx
+++ b/packages/datatrak-web/src/layout/BackgroundPageLayout.tsx
@@ -17,7 +17,7 @@ export const Background = styled.div<{
   min-height: ${props => {
     // Need to add 1px offset to account for the negative margin when hiding the header border
     const offset = props.$hideBorder ? `${HEADER_HEIGHT} + 1px` : HEADER_HEIGHT;
-    return `calc(100vh - ${offset})`;
+    return `calc(100dvb - ${offset})`;
   }};
   display: flex;
   margin-top: ${props => (props.$hideBorder ? '-1px' : 0)};

--- a/packages/datatrak-web/src/layout/TasksLayout.tsx
+++ b/packages/datatrak-web/src/layout/TasksLayout.tsx
@@ -5,7 +5,7 @@ import { PageContainer as BasePageContainer } from '../components';
 import { HEADER_HEIGHT, TITLE_BAR_HEIGHT } from '../constants';
 
 const HeaderLessFullHeightContainer = styled.div`
-  height: calc(100vh - ${HEADER_HEIGHT} - ${TITLE_BAR_HEIGHT});
+  block-size: calc(100dvb - ${HEADER_HEIGHT} - ${TITLE_BAR_HEIGHT});
   display: flex;
   flex-direction: column;
 `;

--- a/packages/datatrak-web/src/layout/UserMenu/DrawerMenu.tsx
+++ b/packages/datatrak-web/src/layout/UserMenu/DrawerMenu.tsx
@@ -14,7 +14,7 @@ const Drawer = styled(MuiDrawer)`
 `;
 
 const Paper = styled(MuiPaper)`
-  min-width: 70vw;
+  min-inline-size: 70dvi;
   border-radius: 0;
   padding: 0 1rem;
   ${({ theme }) => theme.breakpoints.up('sm')} {
@@ -40,7 +40,7 @@ const CloseButton = styled(IconButton).attrs({
   color: 'default',
   disableRipple: true,
 })`
-    color: ${({ theme }) => theme.palette.text.primary};
+  color: ${({ theme }) => theme.palette.text.primary};
   padding: 0.8rem;
 `;
 

--- a/packages/datatrak-web/src/views/LandingPage/ActivityFeedSection/MobileActivityFeed.tsx
+++ b/packages/datatrak-web/src/views/LandingPage/ActivityFeedSection/MobileActivityFeed.tsx
@@ -28,7 +28,7 @@ const InfiniteListWrapper = styled.div`
   display: flex;
   overflow: hidden;
   flex-direction: column;
-  max-height: calc(100vh - ${HEADER_HEIGHT});
+  max-block-size: calc(100dvb - ${HEADER_HEIGHT});
   background-color: ${({ theme }) => theme.palette.background.default};
 `;
 

--- a/packages/datatrak-web/src/views/OfflinePage.tsx
+++ b/packages/datatrak-web/src/views/OfflinePage.tsx
@@ -8,7 +8,7 @@ import { HEADER_HEIGHT } from '../constants';
 const Container = styled.div`
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  block-size: 100dvb;
 `;
 
 const HeaderContainer = styled.header`

--- a/packages/datatrak-web/src/views/SurveyPage.tsx
+++ b/packages/datatrak-web/src/views/SurveyPage.tsx
@@ -19,9 +19,9 @@ import { successToast, useBeforeUnload, useIsMobile } from '../utils';
 const PageWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  height: 100%;
+  block-size: 100%;
   .MuiBox-root {
-    height: 100%; // this is to fix the loader causing a scrollbar
+    block-size: 100%; // this is to fix the loader causing a scrollbar
   }
   ${({ theme }) => theme.breakpoints.down('sm')} {
     .MuiContainer-root:has(&) {
@@ -38,16 +38,16 @@ const SurveyScreenContainer = styled.div<{
   overflow: ${({ $scrollable }) => ($scrollable ? 'auto' : 'hidden')};
   align-items: flex-start;
 
-  height: 100vh;
-  width: 100%;
+  block-size: 100dvb;
+  inline-size: 100%;
   ${({ theme }) => theme.breakpoints.up('md')} {
-    height: ${({ $hasToolbar }) =>
+    block-size: ${({ $hasToolbar }) =>
       $hasToolbar
-        ? `calc(100vh - ${HEADER_HEIGHT} - ${TITLE_BAR_HEIGHT})`
-        : `calc(100vh - ${HEADER_HEIGHT})`};
-    margin-left: -1.25rem;
-    padding-top: ${({ $scrollable }) => ($scrollable ? '0' : '2rem')};
-    padding-bottom: 2rem;
+        ? `calc(100dvb - ${HEADER_HEIGHT} - ${TITLE_BAR_HEIGHT})`
+        : `calc(100dvb - ${HEADER_HEIGHT})`};
+    margin-inline-start: -1.25rem;
+    padding-block-start: ${({ $scrollable }) => ($scrollable ? '0' : '2rem')};
+    padding-block-end: 2rem;
   }
 `;
 


### PR DESCRIPTION
`vh`, `vw`, `vb` and `vi` units have proven a bit problematic for browsers where the viewport size isn’t fixed, often behaving as their _large_ counterparts (`lvh`, `lvw`, `lvb` and `lvi`), which leads to unwanted overflow when we want an element to exactly fit the viewport.

The _dynamic_ version of these viewport units (same but with a `d` prefix) has been baseline since 2023; and is more appropriate in these cases.

This PR makes small semantic changes to prefer logical properties where appropriate, but is otherwise a pure refactor—no behavioural changes

***

This issue came out of testing for #6030 (see [this Linear thread](https://linear.app/bes/issue/RN-1528/welcome-screen-and-very-short-tutorial-for-datatrak#comment-51f95bf5)). I fixed the offending style in that PR, but this carries the fix to the rest of DataTrak