### PR TITLE
fix: RN-1638: entity hierarchy build

### DIFF
--- a/packages/central-server/src/apiV2/GETHandler/GETHandler.js
+++ b/packages/central-server/src/apiV2/GETHandler/GETHandler.js
@@ -150,7 +150,7 @@ export class GETHandler extends CRUDHandler {
 
   async countRecords(criteria, { multiJoin }) {
     const options = { multiJoin }; // only the join option is required for count
-    return this.database.count(this.recordType, criteria, options);
+    return this.database.countFast(this.recordType, criteria, options);
   }
 
   async findRecords(criteria, options) {

--- a/packages/central-server/src/apiV2/GETHandler/GETHandler.js
+++ b/packages/central-server/src/apiV2/GETHandler/GETHandler.js
@@ -148,9 +148,9 @@ export class GETHandler extends CRUDHandler {
     };
   }
 
-  async countRecords(criteria, { multiJoin }) {
+  async countRecords(criteria, { multiJoin }, countFastOptions) {
     const options = { multiJoin }; // only the join option is required for count
-    return this.database.countFast(this.recordType, criteria, options);
+    return this.database.countFast(this.recordType, criteria, options, countFastOptions);
   }
 
   async findRecords(criteria, options) {

--- a/packages/central-server/src/apiV2/GETHandler/GETHandler.js
+++ b/packages/central-server/src/apiV2/GETHandler/GETHandler.js
@@ -148,9 +148,9 @@ export class GETHandler extends CRUDHandler {
     };
   }
 
-  async countRecords(criteria, { multiJoin }, countFastOptions) {
+  async countRecords(criteria, { multiJoin }) {
     const options = { multiJoin }; // only the join option is required for count
-    return this.database.countFast(this.recordType, criteria, options, countFastOptions);
+    return this.database.countFast(this.recordType, criteria, options);
   }
 
   async findRecords(criteria, options) {

--- a/packages/central-server/src/apiV2/dashboardVisualisations/GETDashboardVisualisations.js
+++ b/packages/central-server/src/apiV2/dashboardVisualisations/GETDashboardVisualisations.js
@@ -122,7 +122,7 @@ export class GETDashboardVisualisations extends GETHandler {
   }
 
   async countRecords(inputCriteria) {
-    return this.database.count(RECORDS.DASHBOARD_ITEM, parseCriteria(inputCriteria), {
+    return this.database.countFast(RECORDS.DASHBOARD_ITEM, parseCriteria(inputCriteria), {
       joinWith: 'report',
       joinCondition: ['dashboard_item.report_code', 'report.code'],
     });

--- a/packages/central-server/src/apiV2/mapOverlayVisualisations/GETMapOverlayVisualisations.js
+++ b/packages/central-server/src/apiV2/mapOverlayVisualisations/GETMapOverlayVisualisations.js
@@ -121,7 +121,7 @@ export class GETMapOverlayVisualisations extends GETHandler {
   }
 
   async countRecords(inputCriteria) {
-    return this.database.count(RECORDS.MAP_OVERLAY, parseCriteria(inputCriteria), {
+    return this.database.countFast(RECORDS.MAP_OVERLAY, parseCriteria(inputCriteria), {
       joinWith: 'report',
       joinCondition: ['map_overlay.report_code', 'report.code'],
     });

--- a/packages/central-server/src/apiV2/surveyResponses/GETSurveyResponses.js
+++ b/packages/central-server/src/apiV2/surveyResponses/GETSurveyResponses.js
@@ -1,11 +1,11 @@
+import { assertAnyPermissions, assertBESAdminAccess, hasBESAdminAccess } from '../../permissions';
 import { GETHandler } from '../GETHandler';
+import { getQueryOptionsForColumns } from '../GETHandler/helpers';
+import { assertEntityPermissions } from '../entities';
 import {
   assertSurveyResponsePermissions,
   createSurveyResponseDBFilter,
 } from './assertSurveyResponsePermissions';
-import { assertAnyPermissions, assertBESAdminAccess, hasBESAdminAccess } from '../../permissions';
-import { assertEntityPermissions } from '../entities';
-import { getQueryOptionsForColumns } from '../GETHandler/helpers';
 
 /**
  * Handles endpoints:
@@ -74,6 +74,6 @@ export class GETSurveyResponses extends GETHandler {
       this.defaultJoinType,
     );
 
-    return this.database.count(this.recordType, criteria, { multiJoin });
+    return this.database.countFast(this.recordType, criteria, { multiJoin });
   }
 }


### PR DESCRIPTION
## Release 2025-16 [regression issue 2](https://linear.app/bes/issue/RN-1638/release-2025-16-regression-testing#comment-9f7e1bfb)

> [!TIP]
>  Review this PR [commit-by-commit](https://github.com/beyondessential/tupaia/pull/6204/commits). Either of the last *two* commits are a valid approach, and I’m 50–50 on which one should get the go-head. Would appreciate reviewers’ input here 🙏 

The Admin Panel performance fix introduced by #6178 put a time limit on all calls to `TupaiaDatabase.count()`, which wrought havoc on how the entity hierarchy is built.

After discussing with Rohan and Chris, we decided this abort behaviour should be moved up the stack to **@tupaia/central-server** or **@tupaia/admin-panel-server**. The latter forwards `GET /surveyResponse` requests (with the slow `COUNT`) to the former, so this PR makes the change in **@tupaia/central-server**.

Two approaches:

- timeout (like that in #6178); or
- a [limited `COUNT`](https://pganalyze.com/blog/5mins-postgres-limited-count).

The second-to-last commit bf87bfa simply moves the fix from #6178 to affect only calls from Central Sever.

The last commit b80047b in this PR actually takes **both** approaches, taking the _faster_ of the two.

### Acknowledgements

Big thanks to @chris-bes for his debugging.