### PR TITLE
doc: workaround for Boost installation issue

### DIFF
--- a/packages/auth/src/Authenticator.js
+++ b/packages/auth/src/Authenticator.js
@@ -1,7 +1,7 @@
 import randomToken from 'rand-token';
 import compareVersions from 'semver-compare';
 
-import { DatabaseError, UnauthenticatedError, UnverifiedError } from '@tupaia/utils';
+import { DatabaseError, requireEnv, UnauthenticatedError, UnverifiedError } from '@tupaia/utils';
 import { AccessPolicyBuilder } from './AccessPolicyBuilder';
 import { mergeAccessPolicies } from './mergeAccessPolicies';
 import { encryptPassword } from './utils';
@@ -43,7 +43,7 @@ export class Authenticator {
    * @param {{ username: string, secretKey: string }} apiClientCredentials
    */
   async authenticateApiClient({ username, secretKey }) {
-    const secretKeyHash = encryptPassword(secretKey, process.env.API_CLIENT_SALT);
+    const secretKeyHash = encryptPassword(secretKey, requireEnv('API_CLIENT_SALT'));
     const apiClient = await this.models.apiClient.findOne({
       username,
       secret_key_hash: secretKeyHash,

--- a/packages/meditrak-app/README.md
+++ b/packages/meditrak-app/README.md
@@ -1,69 +1,75 @@
-# Prerequisites
+# @tupaia/meditrak-app
+
+## Prerequisites
 
 - `nvm use`
-- `npm install -g watchman`
-- `npm install -g yarn`
+- `brew install watchman`
 - Run `npx react-native doctor` to see other requirements
 - First time starting `meditrak-app-new`? You must delete the old version of the app from the device.
 
-This is a new [**React Native**](https://reactnative.dev) project, bootstrapped using [`@react-native-community/cli`](https://github.com/react-native-community/cli).
+This is a [**React Native**](https://reactnative.dev) project, bootstrapped using [`@react-native-community/cli`](https://github.com/react-native-community/cli).
 
-# Getting Started
+## Getting Started
 
 > [!NOTE]
 > Make sure you have completed the React native [environment setup](https://reactnative.dev/docs/environment-setup) instructions till “Creating a new application” step, before proceeding.
 
-## Step 1: Start the Metro Server
+### Step 1: Start the Metro Server
 
 First, you will need to start **Metro**, the JavaScript bundler that ships with React Native.
 
-To start Metro, run the following command from the root of your React Native project:
-
 ```sh
-# using npm
-npm start
-
-# OR using Yarn
-yarn start
+yarn workspace @tupaia/meditrak-app run start
 ```
 
-## Step 2: Start your Application
+### Step 2: (iOS only) Install dependencies
 
-Let Metro bundler run in its own terminal. Open a new terminal from the root of your React Native project. Run the following command to start your Android or iOS app:
-
-### For Android
+From [`/packages/meditrak-app/ios/`](ios/):
 
 ```sh
-# using npm
-npm run android
-
-# OR using Yarn
-yarn android
+pod install
 ```
 
-### For iOS
+<details>
+<summary><h4>If you get <code>[!] Error installing boost</code> <code>Verification checksum was incorrect</code></h4></summary>
+Go to <code>/packages/meditrak-app/node_modules/react-native/third-party-podspecs/boost.podspec</code> and modify <code>spec.source</code> to point to <code>https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.bz2</code>:
 
-```bash
-# using npm
-npm run ios
+```pod
+  spec.source = { :http => 'https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.bz2',
+                  :sha256 => 'f0397ba6e982c4450f27bf32a2a83292aba035b827a5623a14636ea583318c41' }
+```
 
-# OR using Yarn
-yarn ios
+This happens because Boost (dependency of React Native) is no longer available from the server which hosted it when React 0.72 was released.
+This is [fixed in React Native 0.75](https://github.com/facebook/react-native/commit/d274826fecfbb67b1b534f4ce9b511a1393625f4) and newer; but older, legacy versions require a workaround like this.
+(See https://github.com/boostorg/boost/issues/843 and https://github.com/boostorg/boost/issues/996.)</details>
+
+### Step 3: Start your Application
+
+Let Metro bundler run in its own terminal. In a new terminal:
+
+```sh
+yarn workspace @tupaia/meditrak-app run android
+```
+
+or
+
+```sh
+yarn workspace @tupaia/meditrak-app run ios
 ```
 
 If everything is set up correctly, you should see your new app running in your Android Emulator or iOS Simulator shortly, provided you have set up your emulator/simulator correctly.
 
 This is **one** way to run your app; you can also run it directly from within Android Studio and Xcode respectively.
 
-## Step 3: Modifying your App
+### Step 4: Modifying your App
 
 Now that you have successfully run the app, let’s modify it.
 
 1. Open `App.tsx` in your text editor of choice and edit some lines.
 2. **Android**. Press the <kbd>R</kbd> key twice or “Reload” from the “Developer Menu” (<kbd>Ctrl</kbd> + <kbd>M</kbd> (on Windows and Linux) or ⌘M (on macOS)) to see your changes!\
-**iOS.** Hit ⌘R in your iOS Simulator to reload the app and see your changes!
+   **iOS.** Hit ⌘R in your iOS Simulator to reload the app and see your changes!
 
-## Congratulations! 🎉
+### Congratulations! 🎉
 
 You’ve successfully run and modified your React Native App. 🥳
 
@@ -72,11 +78,11 @@ You’ve successfully run and modified your React Native App. 🥳
 - If you want to add this new React Native code to an existing application, check out [Integration with Existing Apps](https://reactnative.dev/docs/integration-with-existing-apps).
 - If you’re curious to learn more about React Native, check out the [Introduction](https://reactnative.dev/docs/getting-started) to React Native.
 
-# Troubleshooting
+## Troubleshooting
 
 If you can’t get this to work, see [Troubleshooting](https://reactnative.dev/docs/troubleshooting).
 
-# Learn more
+## Learn more
 
 To learn more about React Native, take a look at the following resources:
 

--- a/packages/meditrak-app/ios/Podfile.lock
+++ b/packages/meditrak-app/ios/Podfile.lock
@@ -786,12 +786,12 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   AppCenter: a4070ec3d4418b5539067a51f57155012e486ebd
-  appcenter-analytics: fbeef54afe6fa91d3803dfd31499817baa81fec0
-  appcenter-core: e192ea8b373bebd3e44998882b43311078bd7dda
+  appcenter-analytics: fa7b1f2f87e9176bb33488c9a61179ec5b283ee6
+  appcenter-core: 3f5907606dfbf4ffe62cb7798210174c2608a7d9
   AppCenterReactNativeShared: 01df23849b1c3c6eb8c4049f54322635650e98f0
-  boost: 64032b9e9b938fda23325e68a3771f0fabf414dc
-  BugsnagReactNative: c681c456736c24344553f48013da8253eb00ee92
-  BVLinearGradient: 880f91a7854faff2df62518f0281afb1c60d49a3
+  boost: 7dcd2de282d72e344012f7d6564d024930a6a440
+  BugsnagReactNative: 1fa47c5ec12c9a610ebfaa86410500c3c8ee4885
+  BVLinearGradient: cb006ba232a1f3e4f341bb62c42d1098c284da70
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: 71803c074f6325f10b5ec891c443b6bbabef0ca7
@@ -805,39 +805,39 @@ SPEC CHECKSUMS:
   Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
   FlipperKit: 2efad7007d6745a3f95e4034d547be637f89d3f6
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: a1239c5c5b1018806c4f93e15aa57e6e39461a62
+  glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   hermes-engine: f6cf92a471053245614d9d8097736f6337d5b86c
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
-  RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
+  RCT-Folly: 8dc08ca5a393b48b1c523ab6220dfdcc0fe000ad
   RCTRequired: df81ab637d35fac9e6eb94611cfd20f0feb05455
   RCTTypeSafety: 4636e4a36c7c2df332bda6d59b19b41c443d4287
   React: e0cc5197a804031a6c53fb38483c3485fcb9d6f3
   React-callinvoker: 1a635856fe0c3d8b13fccd4ed7e76283b99b0868
-  React-Codegen: 78d61f981cccc68a771a598f71621cb7db14b04c
-  React-Core: 252f8e9ca5a4e91af9b9be58670846d662b1c49f
-  React-CoreModules: f8b9e91fac7bd5d18729ce961a4978c70b5031cc
-  React-cxxreact: 70284b32dcd367439d7dae84d9f72660544181b5
+  React-Codegen: ef4eae658851739a69ec955c9957b3f9b7d45558
+  React-Core: a4541fc5c759da408568cbf72253521fbfe40c7e
+  React-CoreModules: 8698a02b4b3a172e0b809bd1a2ed30540e1b60be
+  React-cxxreact: c9e823058d6cc8834da3bbdc7a06784db67fc222
   React-debug: ee33d7ba43766d9b10b32561527b57ccfbcb6bd1
-  React-hermes: 91f97ea2669dc5847e1f26c243aaad913319c570
-  React-jsi: bd68b7779746014f01ea72d1b738809e132d7f1e
-  React-jsiexecutor: ff70a72027dea5cc7d71cfcc6fad7f599f63987a
+  React-hermes: b46e650e7a0c948d382f989d9d03b574b90a50a7
+  React-jsi: db98891b5227986d8cc64a9f4f37a4be980be448
+  React-jsiexecutor: 7b950ed139738f2a446a9c0691ef0d07df3fb89e
   React-jsinspector: aef73cbd43b70675f572214d10fa438c89bf11ba
-  React-logger: 2e4aee3e11b3ec4fa6cfd8004610bbb3b8d6cca4
-  react-native-cameraroll: 121cab3d7fe2972d9a26ef40558d78d4053356a8
-  react-native-config: 86038147314e2e6d10ea9972022aa171e6b1d4d8
-  react-native-document-picker: 3599b238843369026201d2ef466df53f77ae0452
-  react-native-geolocation: ef66fb798d96284c6043f0b16c15d9d1d4955db4
-  react-native-image-picker: 2e2e82aba9b6a91a7c78f7d9afde341a2659c7b8
-  react-native-netinfo: fefd4e98d75cbdd6e85fc530f7111a8afdf2b0c5
-  react-native-safe-area-context: 7aa8e6d9d0f3100a820efb1a98af68aa747f9284
-  react-native-webview: 8fc09f66a1a5b16bbe37c3878fda27d5982bb776
-  React-NativeModulesApple: 797bc6078d566eef3fb3f74127e6e1d2e945a15f
+  React-logger: 984811296d6ce8fb1c1619cc8752c1029916d917
+  react-native-cameraroll: 928f9f1530d14123b983de728cb59e8787b440ba
+  react-native-config: 136f9755ccc991cc6438053a44363259ad4c7813
+  react-native-document-picker: a2e1577d26b9758ef3092e66f5d67f6e8c7454d9
+  react-native-geolocation: f0fa51740690633a1adb6222539166b484facefb
+  react-native-image-picker: 197ec356b2e16526610b3471c73ca6c884905a8f
+  react-native-netinfo: 58a62fc2fc7245875718b99ac9914c307e1523ca
+  react-native-safe-area-context: 9fdf214647353ab717139d164c9e1f163045eb1c
+  react-native-webview: 1d45f081bb200d0657097874317fa0d6149a2832
+  React-NativeModulesApple: d57608e52c875d2b952b68afd0d8f0543d690c3d
   React-perflogger: cd8886513f68e1c135a1e79d20575c6489641597
   React-RCTActionSheet: 726d2615ca62a77ce3e2c13d87f65379cdc73498
   React-RCTAnimation: 8f2716b881c37c64858e4ecee0f58bfa57ff9afd
-  React-RCTAppDelegate: d4a213f29e81682f6b9c7d22f62a2ccab6d125ae
-  React-RCTBlob: dfaa933231c3497915bbcc9d98fcff7b6b60582c
+  React-RCTAppDelegate: 961d059d21aa103a67293d25df1715683dbc1a66
+  React-RCTBlob: 92886e31e069db1997fc10a442df2a69979558ed
   React-RCTImage: 747e3d7b656a67470f9c234baedb8d41bbc4e745
   React-RCTLinking: 148332b5b0396b280b05534f7d168e560a3bbd5f
   React-RCTNetwork: 1d818121a8e678f064de663a6db7aaefc099e53c
@@ -846,24 +846,24 @@ SPEC CHECKSUMS:
   React-RCTVibration: 45372e61b35e96d16893540958d156675afbeb63
   React-rncore: a79d1cb3d6c01b358a8aa0b31ccc04ab5f0dbebc
   React-runtimeexecutor: 7e31e2bc6d0ecc83d4ba05eadc98401007abc10c
-  React-runtimescheduler: cc32add98c45c5df18436a6a52a7e1f6edec102c
-  React-utils: 7a9918a1ffdd39aba67835d42386f592ea3f8e76
-  ReactCommon: 91ece8350ebb3dd2be9cef662abd78b6948233c0
-  RealmJS: 578e16cf7c0b32c13a23b2df667b021bb3c36f1c
-  RNCAsyncStorage: c913ede1fa163a71cea118ed4670bbaaa4b511bb
-  RNDateTimePicker: 8fb39263b721223e095248acaf6f406d5b7f6713
-  RNDeviceInfo: bf8a32acbcb875f568217285d1793b0e8588c974
-  RNFS: 4ac0f0ea233904cb798630b3c077808c06931688
-  RNGestureHandler: 6e46dde1f87e5f018a54fe5d40cd0e0b942b49ee
-  RNLocalize: dbea38dcb344bf80ff18a1757b1becf11f70cae4
-  RNShare: 32e97adc8d8c97d4a26bcdd3c45516882184f8b6
-  RNSVG: d00c8f91c3cbf6d476451313a18f04d220d4f396
-  RNVectorIcons: ace237de89f1574ef3c963ae9d5da3bd6fbeb02a
+  React-runtimescheduler: ab7903607aad767fa6cd95feb910fb11501f9946
+  React-utils: 5b4df8692e966fd50e2d75c0f9659e176a292384
+  ReactCommon: 82a84765046cde44e4086a762a16a1ec5c3386ca
+  RealmJS: 13194c2e64c338cd821662a25b32f4cdb8f10ed3
+  RNCAsyncStorage: b934e5ab140257f25f5d67ded2464646731e4349
+  RNDateTimePicker: f56da0202e73cb1b02eefa3f8d045ae12183b5e6
+  RNDeviceInfo: 0fdf3a74396823838469394397d218fe159227f2
+  RNFS: 89de7d7f4c0f6bafa05343c578f61118c8282ed8
+  RNGestureHandler: f3902a2694346e4836112a2ef5524b3dcf408678
+  RNLocalize: 01b15a24a8f1856eeaeeb77f4179ccd88c117a73
+  RNShare: 729e789e672f91e43bfa6cfbb6e668b927bff15d
+  RNSVG: 4cab00c621b328a4a2fedaaedc15d8822216723e
+  RNVectorIcons: 9339ba0e0e2da46458a7b8fc278fe5f4a11b942d
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  VisionCamera: 3a1ba1518517f718d70486fdc4580723a6f2c891
+  VisionCamera: cdbfc29bde1c28a57c8f2926f5d44582fcf513fe
   Yoga: 86fed2e4d425ee4c6eab3813ba1791101ee153c6
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: 9d0921d206ad5368ab2b22815114d4a166126a49
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2


### PR DESCRIPTION
Ran into https://github.com/boostorg/boost/issues/996 [just over a year ago](https://beyondessential.slack.com/archives/C01MAA3NKM1/p1705276665873299?thread_ts=1705273683.276649&cid=C01MAA3NKM1) and the issue still affects us. It’s an issue React Native has fixed in newer versions, but for now just documenting a workaround until we bump the React Native or retire MediTrak in favour DataTrak.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved and restructured the Meditrak App README for clarity, updated setup commands, added iOS dependency installation steps, and included troubleshooting guidance.
- **Chores**
  - Updated internal handling of environment variables for authentication to improve reliability. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->