### PR TITLE
feat(datatrak): RN-1479: enable web app in production

### DIFF
--- a/packages/datatrak-web/index.html
+++ b/packages/datatrak-web/index.html
@@ -72,12 +72,7 @@
     <!-- End of bes-support Zendesk Widget script -->
     <% } %>
 
-    <!-- Temporarily disable PWA on production environments -->
-    <% if (process.env.REACT_APP_DEPLOYMENT_NAME !== 'master' &&
-    process.env.REACT_APP_DEPLOYMENT_NAME !== 'main' && process.env.REACT_APP_DEPLOYMENT_NAME !==
-    'production') { %>
-      <link rel="manifest" id="manifest" href="/manifest.json"/>
-    <% } %>
+    <link rel="manifest" id="manifest" href="/manifest.json" />
 
     <link rel="icon" href="/favicon.ico" />
     <link rel="icon" href="/favicon.svg" sizes="any" type="image/svg+xml" />


### PR DESCRIPTION
RN-1479 has actually already been released, but we disabled the web app in production

Arose from [this comment in RN-1479](https://linear.app/bes/issue/RN-1479/set-up-pwa-for-installation#comment-0de3f89c)
