### PR TITLE
Release 2025-23

### DIFF
--- a/packages/auth/src/__tests__/userAuth.test.js
+++ b/packages/auth/src/__tests__/userAuth.test.js
@@ -1,9 +1,11 @@
 import jwt from 'jsonwebtoken';
-import { createBasicHeader, createBearerHeader } from '@tupaia/utils';
+
+import { createBasicHeader, createBearerHeader, requireEnv } from '@tupaia/utils';
+
 import {
-  getUserAndPassFromBasicAuth,
-  getTokenClaimsFromBearerAuth,
   constructAccessToken,
+  getTokenClaimsFromBearerAuth,
+  getUserAndPassFromBasicAuth,
 } from '../userAuth';
 
 describe('userAuth', () => {
@@ -48,9 +50,7 @@ describe('userAuth', () => {
     });
 
     it('throws error when decrypting expired token', async () => {
-      const accessToken = jwt.sign({ test: 'test' }, process.env.JWT_SECRET, {
-        expiresIn: 0,
-      });
+      const accessToken = jwt.sign({ test: 'test' }, requireEnv('JWT_SECRET'), { expiresIn: 0 });
       const authHeader = createBearerHeader(accessToken);
 
       return expect(() => getTokenClaimsFromBearerAuth(authHeader)).toThrow(

--- a/packages/auth/src/security.js
+++ b/packages/auth/src/security.js
@@ -1,6 +1,8 @@
 import jwt from 'jsonwebtoken';
 import randomize from 'randomatic';
 
+import { requireEnv } from '@tupaia/utils';
+
 export function generateSecretKey() {
   return randomize('*', 20);
 }
@@ -32,5 +34,5 @@ export const extractRefreshTokenFromReq = req => {
   }
 
   const jwtToken = getJwtToken(authHeader);
-  return jwt.verify(jwtToken, process.env.JWT_SECRET).refreshToken;
+  return jwt.verify(jwtToken, requireEnv('JWT_SECRET')).refreshToken;
 };

--- a/packages/auth/src/userAuth.js
+++ b/packages/auth/src/userAuth.js
@@ -1,5 +1,7 @@
 import jwt from 'jsonwebtoken';
-import { UnauthenticatedError } from '@tupaia/utils';
+
+import { UnauthenticatedError, requireEnv } from '@tupaia/utils';
+
 import { getJwtToken } from './security';
 
 const ACCESS_TOKEN_EXPIRY_SECONDS = 15 * 60; // User's access expires every 15 mins
@@ -18,7 +20,7 @@ export const constructAccessToken = ({ userId, apiClientUserId }) => {
   }
 
   // Generate JWT
-  return jwt.sign(jwtPayload, process.env.JWT_SECRET, {
+  return jwt.sign(jwtPayload, requireEnv('JWT_SECRET'), {
     expiresIn: ACCESS_TOKEN_EXPIRY_SECONDS,
   });
 };
@@ -47,7 +49,7 @@ export function getTokenClaimsFromBearerAuth(authHeader) {
 export function getTokenClaims(jwtToken) {
   let tokenClaims = {};
   try {
-    tokenClaims = jwt.verify(jwtToken, process.env.JWT_SECRET);
+    tokenClaims = jwt.verify(jwtToken, requireEnv('JWT_SECRET'));
   } catch (error) {
     if (error.name === 'TokenExpiredError') {
       throw new UnauthenticatedError('Authorization token has expired, please log in again');

--- a/packages/central-server/src/apiV2/authenticate/authenticate.js
+++ b/packages/central-server/src/apiV2/authenticate/authenticate.js
@@ -140,11 +140,11 @@ export async function authenticate(req, res) {
       permissionGroups: permissionGroupsByCountryId,
     });
 
-    // Reset rate limiting on successful authorisation
-    await consecutiveFailsRateLimiter.resetFailedAttempts(req);
-    await bruteForceRateLimiter.resetFailedAttempts(req);
-
     respond(res, authorizationObject, 200);
+
+    // Reset rate limiting on successful authorisation, no need to block response by awaiting though 
+    consecutiveFailsRateLimiter.resetFailedAttempts(req);
+    bruteForceRateLimiter.resetFailedAttempts(req);
   } catch (authError) {
     if (authError.statusCode === 401) {
       // Record failed login attempt to rate limiter

--- a/packages/central-server/src/apiV2/export/exportSurveyResponses/exportResponsesToFile.js
+++ b/packages/central-server/src/apiV2/export/exportSurveyResponses/exportResponsesToFile.js
@@ -243,7 +243,7 @@ export async function exportResponsesToFile(
     );
 
     // Add any questions that are in survey responses but no longer in the survey
-    const allQuestionIds = getUniqueEntries(answers.map(a => a['question.id']).flat());
+    const allQuestionIds = getUniqueEntries(answers.flatMap(a => a['question.id']));
     const validQuestionIds = questions.map(q => q.id);
     const outdatedQuestionIds = allQuestionIds.filter(id => !validQuestionIds.includes(id));
     const outdatedQuestions = await models.question.find({ id: outdatedQuestionIds });

--- a/packages/central-server/src/apiV2/import/importSurveyResponses/SurveyResponseUpdatePersistor.js
+++ b/packages/central-server/src/apiV2/import/importSurveyResponses/SurveyResponseUpdatePersistor.js
@@ -104,15 +104,14 @@ export class SurveyResponseUpdatePersistor {
             ({ newSurveyResponse }) => newSurveyResponse,
           );
           const newAnswers = batchOfCreates
-            .map(({ answers }) =>
+            .flatMap(({ answers }) =>
               answers.upserts.map(({ surveyResponseId, questionId, type, text }) => ({
                 survey_response_id: surveyResponseId,
                 question_id: questionId,
                 type,
                 text,
               })),
-            )
-            .flat();
+            );
           await transactingModels.surveyResponse.createMany(newSurveyResponses);
           await transactingModels.answer.createMany(newAnswers);
         });

--- a/packages/central-server/src/apiV2/import/importSurveyResponses/assertCanImportSurveyResponses.js
+++ b/packages/central-server/src/apiV2/import/importSurveyResponses/assertCanImportSurveyResponses.js
@@ -92,8 +92,7 @@ export const assertCanSubmitSurveyResponses = async (accessPolicy, models, surve
 
   const entitiesUpserted = surveyResponses
     .filter(sr => !!sr.entities_upserted)
-    .map(sr => sr.entities_upserted)
-    .flat();
+    .flatMap(sr => sr.entities_upserted);
 
   for (const response of surveyResponses) {
     const entityCode = await getEntityCodeFromSurveyResponseChange(

--- a/packages/central-server/src/apiV2/import/importSurveyResponses/assertCanImportSurveyResponses.js
+++ b/packages/central-server/src/apiV2/import/importSurveyResponses/assertCanImportSurveyResponses.js
@@ -1,5 +1,6 @@
 import { flattenDeep, groupBy, keyBy } from 'lodash';
 import { getUniqueEntries, reduceToDictionary } from '@tupaia/utils';
+import winston from '../../../log';
 
 export const assertCanImportSurveyResponses = async (
   accessPolicy,
@@ -8,50 +9,60 @@ export const assertCanImportSurveyResponses = async (
 ) => {
   const allEntityCodes = flattenDeep(Object.values(entitiesBySurveyCode));
   const surveyCodes = Object.keys(entitiesBySurveyCode);
-  const allEntities = await models.entity.findManyByColumn('code', allEntityCodes);
-  const surveys = await models.survey.findManyByColumn('code', surveyCodes);
-  const codeToSurvey = keyBy(surveys, 'code');
-  const surveyPermissionGroupIds = surveys.map(s => s.permission_group_id);
-  const surveyPermissionGroups = await models.permissionGroup.findManyById(
-    surveyPermissionGroupIds,
-  );
-  const idToPermissionGroupName = reduceToDictionary(surveyPermissionGroups, 'id', 'name');
 
-  for (const entry of Object.entries(entitiesBySurveyCode)) {
-    const [surveyCode, entityCodes] = entry;
-    const survey = codeToSurvey[surveyCode];
-    const responseEntities = allEntities.filter(e => entityCodes.includes(e.code));
-    const surveyResponseCountryCodes = [...new Set(responseEntities.map(e => e.country_code))];
-    const surveyResponseCountries = await models.country.findManyByColumn(
-      'code',
-      surveyResponseCountryCodes,
-    );
-    if (surveyResponseCountries.length !== surveyResponseCountryCodes.length) {
-      throw new Error(`Could not find all countries`, surveyResponseCountryCodes);
-    }
-    const entitiesByCountryCode = groupBy(responseEntities, 'country_code');
+  await models.wrapInReadOnlyTransaction(async transactingModels => {
+    const [allEntities, surveys] = await Promise.all([
+      transactingModels.entity.findManyByColumn('code', allEntityCodes),
+      transactingModels.survey.findManyByColumn('code', surveyCodes),
+    ]);
 
-    for (const surveyResponseCountry of surveyResponseCountries) {
-      // Check if the country of the submitted survey response(s) matches with the survey countries.
-      if (survey.country_ids?.length && !survey.country_ids.includes(surveyResponseCountry.id)) {
-        const surveyCountries = await models.country.findManyById(survey.country_ids);
-        const entities = entitiesByCountryCode[surveyResponseCountry.code];
-        const entityCodesString = entities.map(e => e.code).join(', ');
-        const surveyCountryNamesString = surveyCountries.map(s => s.name).join(', ');
+    const codeToSurvey = keyBy(surveys, 'code');
+    const surveyPermissionGroupIds = surveys.map(s => s.permission_group_id);
+    const surveyPermissionGroups =
+      await transactingModels.permissionGroup.findManyById(surveyPermissionGroupIds);
+    const idToPermissionGroupName = reduceToDictionary(surveyPermissionGroups, 'id', 'name');
+
+    for (const [surveyCode, entityCodes] of Object.entries(entitiesBySurveyCode)) {
+      const survey = codeToSurvey[surveyCode];
+      const responseEntities = allEntities.filter(e => entityCodes.includes(e.code));
+      const surveyResponseCountryCodes = [...new Set(responseEntities.map(e => e.country_code))];
+      const surveyResponseCountries = await transactingModels.country.findManyByColumn(
+        'code',
+        surveyResponseCountryCodes,
+      );
+      if (surveyResponseCountries.length !== surveyResponseCountryCodes.length) {
+        const expected = surveyResponseCountryCodes;
+        const actual = surveyResponseCountries.map(c => c.code);
+        const difference = actual.filter(c => !expected.includes(c));
         throw new Error(
-          `Some survey response(s) are submitted against entity code(s) (${entityCodesString}) that do not belong to the countries (${surveyCountryNamesString}) of the survey '${survey.name}' (${survey.code})`,
+          `Couldn’t find the following countries: ${difference.join(', ')}`,
+          surveyResponseCountryCodes,
         );
       }
+      const entitiesByCountryCode = groupBy(responseEntities, 'country_code');
 
-      // Now check if users have permission group access to the survey response's country
-      const permissionGroup = idToPermissionGroupName[survey.permission_group_id];
-      if (!accessPolicy.allows(surveyResponseCountry.code, permissionGroup)) {
-        throw new Error(
-          `Need ${permissionGroup} access to ${surveyResponseCountry.name} to import the survey response(s)`,
-        );
+      for (const surveyResponseCountry of surveyResponseCountries) {
+        // Check if the country of the submitted survey response(s) matches with the survey countries.
+        if (survey.country_ids?.length && !survey.country_ids.includes(surveyResponseCountry.id)) {
+          const surveyCountries = await transactingModels.country.findManyById(survey.country_ids);
+          const entities = entitiesByCountryCode[surveyResponseCountry.code];
+          const entityCodesString = entities.map(e => e.code).join(', ');
+          const surveyCountryNamesString = surveyCountries.map(s => s.name).join(', ');
+          throw new Error(
+            `Some survey response(s) are submitted against entity code(s) (${entityCodesString}) that do not belong to the countries (${surveyCountryNamesString}) of the survey '${survey.name}' (${survey.code})`,
+          );
+        }
+
+        // Now check if users have permission group access to the survey response's country
+        const permissionGroup = idToPermissionGroupName[survey.permission_group_id];
+        if (!accessPolicy.allows(surveyResponseCountry.code, permissionGroup)) {
+          throw new Error(
+            `Need ${permissionGroup} access to ${surveyResponseCountry.name} to import the survey response(s)`,
+          );
+        }
       }
     }
-  }
+  });
 
   return true;
 };
@@ -68,7 +79,7 @@ const getEntityCodeFromSurveyResponseChange = async (models, surveyResponse, ent
     const newEntity = entitiesUpserted.find(e => e.id === surveyResponse.entity_id);
     if (newEntity) {
       const parentEntity = await models.entity.findById(newEntity.parent_id);
-      return parentEntity.code;
+      return parentEntity?.code;
     }
     const entity = await models.entity.findById(surveyResponse.entity_id);
     return entity.code;
@@ -87,26 +98,25 @@ export const assertCanSubmitSurveyResponses = async (accessPolicy, models, surve
 
   // Pre-fetch unique surveys
   const surveyIds = getUniqueEntries(surveyResponses.map(sr => sr.survey_id));
-  const surveys = await models.survey.findManyById(surveyIds);
-  const surveyCodesById = reduceToDictionary(surveys, 'id', 'code');
 
-  const entitiesUpserted = surveyResponses
-    .filter(sr => !!sr.entities_upserted)
-    .flatMap(sr => sr.entities_upserted);
+  await models.wrapInReadOnlyTransaction(async transactingModels => {
+    const surveys = await transactingModels.survey.findManyById(surveyIds);
+    const surveyCodesById = reduceToDictionary(surveys, 'id', 'code');
 
-  for (const response of surveyResponses) {
-    const entityCode = await getEntityCodeFromSurveyResponseChange(
-      models,
-      response,
-      entitiesUpserted,
-    );
-    const surveyCode = surveyCodesById[response.survey_id];
+    const entitiesUpserted = surveyResponses
+      .filter(sr => !!sr.entities_upserted)
+      .flatMap(sr => sr.entities_upserted);
 
-    if (!entitiesBySurveyCode[surveyCode]) {
-      entitiesBySurveyCode[surveyCode] = [];
+    for (const response of surveyResponses) {
+      const entityCode = await getEntityCodeFromSurveyResponseChange(
+        transactingModels,
+        response,
+        entitiesUpserted,
+      );
+      const surveyCode = surveyCodesById[response.survey_id];
+      (entitiesBySurveyCode[surveyCode] ??= []).push(entityCode);
     }
-    entitiesBySurveyCode[surveyCode].push(entityCode);
-  }
+  });
 
   return assertCanImportSurveyResponses(accessPolicy, models, entitiesBySurveyCode);
 };

--- a/packages/central-server/src/apiV2/userAccounts/assertUserAccountPermissions.js
+++ b/packages/central-server/src/apiV2/userAccounts/assertUserAccountPermissions.js
@@ -94,8 +94,7 @@ ${accessibleCountryCodes
   const parameters = [
     ...accessibleCountryCodes,
     ...accessibleCountryCodes
-      .map(countryCode => [countryCode, ...permissionsByCountryCode[countryCode]])
-      .flat(),
+      .flatMap(countryCode => [countryCode, ...permissionsByCountryCode[countryCode]]),
   ];
   return { sql, parameters };
 };

--- a/packages/central-server/src/permissions/assertions.js
+++ b/packages/central-server/src/permissions/assertions.js
@@ -22,6 +22,7 @@ export const assertAllPermissions = (assertions, errorMessage) => async accessPo
       const assertion = assertions[i];
       await assertion(accessPolicy);
     }
+    return true;
   } catch (e) {
     throw new Error(errorMessage || e.message);
   }

--- a/packages/central-server/src/tests/apiV2/GETSurveyScreenComponents.test.js
+++ b/packages/central-server/src/tests/apiV2/GETSurveyScreenComponents.test.js
@@ -57,7 +57,7 @@ describe('Permissions checker for GETSurveyScreenComponents', async () => {
     ]);
 
     surveyIds = surveyModels.map(sm => sm.survey.id);
-    const screenComponents = surveyModels.map(sm => sm.surveyScreenComponents).flat(1);
+    const screenComponents = surveyModels.flatMap(sm => sm.surveyScreenComponents);
     screenComponentIds = screenComponents.map(sc => sc.id);
     filterString = `filter={"id":{"comparator":"in","comparisonValue":["${screenComponentIds.join(
       '","',

--- a/packages/central-server/src/tests/apiV2/import/importSurveyResponses/importSurveyResponses.fixtures.js
+++ b/packages/central-server/src/tests/apiV2/import/importSurveyResponses/importSurveyResponses.fixtures.js
@@ -172,15 +172,14 @@ export const createSurveyResponses = async (models, responsesBySurvey) => {
   const surveyCodeToId = reduceToDictionary(surveys, 'code', 'id');
 
   const responseRecords = Object.entries(responsesBySurvey)
-    .map(([surveyCode, responses]) =>
+    .flatMap(([surveyCode, responses]) =>
       responses.map(({ id, entityCode }) => ({
         id,
         survey_id: surveyCodeToId[surveyCode],
         user_id: user.id,
         entity_id: entityCodeToId[entityCode],
       })),
-    )
-    .flat();
+    );
 
   await findOrCreateRecords(models, { surveyResponse: responseRecords });
 };

--- a/packages/data-table-server/src/__tests__/dataTableService/services/EventsDataTableService.test.ts
+++ b/packages/data-table-server/src/__tests__/dataTableService/services/EventsDataTableService.test.ts
@@ -82,7 +82,7 @@ const fetchFakeEvents = (
 const fetchFakeDataGroup = (dataGroupCode: string) => {
   const eventsForDataGroup = TEST_EVENTS[dataGroupCode] || [];
   const dataElements = Array.from(
-    new Set(eventsForDataGroup.map(({ dataValues }) => Object.keys(dataValues)).flat()),
+    new Set(eventsForDataGroup.flatMap(({ dataValues }) => Object.keys(dataValues))),
   ).map(dataElement => ({ code: dataElement, name: dataElement }));
   return { code: dataGroupCode, name: dataGroupCode, dataElements };
 };

--- a/packages/database/src/ModelRegistry.js
+++ b/packages/database/src/ModelRegistry.js
@@ -104,6 +104,15 @@ export class ModelRegistry {
     }, transactionConfig);
   }
 
+  /**
+   * @param {(models: TupaiaDatabase) => Promise<void>} wrappedFunction
+   * @param {Knex.TransactionConfig} [transactionConfig]
+   * @returns {Promise} A promise (return value of `knex.transaction()`).
+   */
+  wrapInReadOnlyTransaction(wrappedFunction, transactionConfig = {}) {
+    return this.wrapInTransaction(wrappedFunction, { ...transactionConfig, readOnly: true });
+  }
+
   getTypesToSyncWithMeditrak() {
     return Object.values(this)
       .filter(({ meditrakConfig }) => meditrakConfig)

--- a/packages/database/src/TupaiaDatabase.js
+++ b/packages/database/src/TupaiaDatabase.js
@@ -228,6 +228,15 @@ export class TupaiaDatabase {
     );
   }
 
+  /**
+   * @param {(models: TupaiaDatabase) => Promise<void>} wrappedFunction
+   * @param {Knex.TransactionConfig} [transactionConfig]
+   * @returns {Promise} A promise (return value of `knex.transaction()`).
+   */
+  wrapInReadOnlyTransaction(wrappedFunction, transactionConfig = {}) {
+    return this.wrapInTransaction(wrappedFunction, { ...transactionConfig, readOnly: true });
+  }
+
   async fetchSchemaForTable(databaseRecord) {
     await this.waitUntilConnected();
     return this.connection(databaseRecord).columnInfo();

--- a/packages/database/src/migrations/20201117053359-AddPsssWoWIncreaseIndicators-modifies-data.js
+++ b/packages/database/src/migrations/20201117053359-AddPsssWoWIncreaseIndicators-modifies-data.js
@@ -120,14 +120,13 @@ exports.up = async function (db) {
 };
 
 exports.down = async function (db) {
-  const codes = CONDITION_CODES.map(condition => [
+  const codes = CONDITION_CODES.flatMap(condition => [
     psssCode('Total_Cases', condition),
     psssCode('Site_Average', condition, true),
     psssCode('Site_Average', condition, false),
     psssCode('WoW_Increase', condition, true),
     psssCode('WoW_Increase', condition, false),
   ])
-    .flat()
     .concat(psssCode('Total_Sites_Reported'));
 
   await db.runSql(`DELETE FROM indicator WHERE code IN (${arrayToDbString(codes)})`);

--- a/packages/database/src/migrations/20201125021221-AddPsssAlertThresholdIndicators-modifies-data.js
+++ b/packages/database/src/migrations/20201125021221-AddPsssAlertThresholdIndicators-modifies-data.js
@@ -109,12 +109,12 @@ exports.up = async function (db) {
 };
 
 exports.down = async function (db) {
-  const codes = CONDITION_CODES.map(condition => [
+  const codes = CONDITION_CODES.flatMap(condition => [
     psssCode('Alert_Threshold_Level', condition, true),
     psssCode('Alert_Threshold_Level', condition, false),
     psssCode('Alert_Threshold_Crossed', condition, true),
     psssCode('Alert_Threshold_Crossed', condition, false),
-  ]).flat();
+  ]);
 
   await db.runSql(`DELETE FROM indicator WHERE code IN (${arrayToDbString(codes)})`);
   await db.runSql(`DELETE FROM data_source WHERE code IN (${arrayToDbString(codes)})`);

--- a/packages/database/src/migrations/20210629111111-02-MigrateCurrentDashboardsToNewDashboards-modifies-data.js
+++ b/packages/database/src/migrations/20210629111111-02-MigrateCurrentDashboardsToNewDashboards-modifies-data.js
@@ -181,7 +181,7 @@ const migrateLinkedDashboardReports = async db => {
         organisationUnitLevelOrder.indexOf(d2.organisationLevel),
     );
     const combinedDashboardReports = [
-      ...new Set(sortedDashboardGroups.map(d => d.dashboardReports).flat()),
+      ...new Set(sortedDashboardGroups.flatMap(d => d.dashboardReports)),
     ];
 
     for (let i = 0; i < combinedDashboardReports.length; i++) {
@@ -224,8 +224,7 @@ const migrateLinkedDashboardReports = async db => {
         ...new Set(
           sortedDashboardGroups
             .filter(d => d.dashboardReports.includes(dashboardReportId))
-            .map(d => d.projectCodes)
-            .flat(),
+            .flatMap(d => d.projectCodes),
         ),
       ];
       const userGroups = [

--- a/packages/database/src/migrations/20210812035000-AddSomeUsefulLESMISIndicators-modifies-data.js
+++ b/packages/database/src/migrations/20210812035000-AddSomeUsefulLESMISIndicators-modifies-data.js
@@ -17,7 +17,7 @@ exports.setup = function (options, seedLink) {
 };
 
 const sumSchoolCounts = (level, types) => {
-  const dataElements = types.map(x => [`nosch_type${x}_public`, `nosch_type${x}_private`]).flat();
+  const dataElements = types.flatMap(x => [`nosch_type${x}_public`, `nosch_type${x}_private`]);
 
   return {
     id: generateId(),

--- a/packages/database/src/migrations/20210812035022-ICTAmenitiesAvailability-modifies-data.js
+++ b/packages/database/src/migrations/20210812035022-ICTAmenitiesAvailability-modifies-data.js
@@ -28,9 +28,9 @@ const ENTITY_LEVEL_MAP = {
 const REPORT_CONFIG = entityLevel => ({
   fetch: {
     dataElements: [
-      ...EDUCATION_LEVELS.map(educationLevel =>
+      ...EDUCATION_LEVELS.flatMap(educationLevel =>
         AMENITIES.map(amenity => `amenity_${entityLevel}_${educationLevel}_${amenity}`),
-      ).flat(),
+      ),
       'nosch_ece',
       'nosch_pe',
       'nosch_se',

--- a/packages/database/src/migrations/20210825230542-LESMISProvinceNationalDropOutRates-modifies-data.js
+++ b/packages/database/src/migrations/20210825230542-LESMISProvinceNationalDropOutRates-modifies-data.js
@@ -43,12 +43,11 @@ const DATA_ELEMENT_TRANSLATIONS = {
 const generateReportConfig = (entityLevel, educationLevel) => ({
   fetch: {
     dataElements: Object.keys(DATA_ELEMENT_TRANSLATIONS[educationLevel])
-      .map(grade => [
+      .flatMap(grade => [
         `dor_${entityLevel}_${grade}_m`,
         `dor_${entityLevel}_${grade}_f`,
         `dor_${entityLevel}_${grade}_t`,
-      ])
-      .flat(),
+      ]),
     aggregations: [
       {
         type: 'MOST_RECENT',

--- a/packages/database/src/migrations/20211201090124-MergeFlutrackingResponses-modifies-data.js
+++ b/packages/database/src/migrations/20211201090124-MergeFlutrackingResponses-modifies-data.js
@@ -82,7 +82,7 @@ const mergeAnswersInResponseGroup = (responses, answersByResponseId) => {
 };
 
 const selectAnswersForResponseGroups = async (db, responseGroups) => {
-  const responseIds = responseGroups.map(group => group.map(r => r.id)).flat();
+  const responseIds = responseGroups.flatMap(group => group.map(r => r.id));
   const { rows: answers } = await db.runSql(`
     select * from answer where survey_response_id IN (${arrayToDbString(responseIds)});
   `);
@@ -95,8 +95,8 @@ const processResponseGroups = async (db, responseGroupBatch) => {
     mergeAnswersInResponseGroup(responseGroup, answerByResponseId),
   );
 
-  const responseIdsToDelete = mergeData.map(r => r.responseIdsToDelete).flat();
-  const answersToCreate = mergeData.map(d => d.answersToCreate).flat();
+  const responseIdsToDelete = mergeData.flatMap(r => r.responseIdsToDelete);
+  const answersToCreate = mergeData.flatMap(d => d.answersToCreate);
   await deleteResponses(db, responseIdsToDelete);
   await createAnswers(db, answersToCreate);
 };

--- a/packages/database/src/migrations/20220520141700-UpdateDataElementPermissionsFromVisuals-modifies-data.js
+++ b/packages/database/src/migrations/20220520141700-UpdateDataElementPermissionsFromVisuals-modifies-data.js
@@ -104,8 +104,7 @@ exports.up = async function (db) {
     );
 
     const jointPermissionGroups = dashboardRelations
-      .map(rel => rel.permission_groups)
-      .flat()
+      .flatMap(rel => rel.permission_groups)
       .concat(mapOverlays.map(map => map.permission_group));
 
     if (jointPermissionGroups.length <= 0) {

--- a/packages/database/src/migrations/20230222233428-RewriteVizsUsedDataElementCodeToName-modifies-schema.js
+++ b/packages/database/src/migrations/20230222233428-RewriteVizsUsedDataElementCodeToName-modifies-schema.js
@@ -106,7 +106,7 @@ exports.up = async function (db) {
     };
 
     let newTransform = transform
-      .map(t => {
+      .flatMap(t => {
         if (JSON.stringify(t).includes('dataElementCodeToName(')) {
           if (report.code === PALAU_MATRIX_REPORT_CODE) {
             return [
@@ -127,8 +127,7 @@ exports.up = async function (db) {
           ];
         }
         return [t];
-      })
-      .flat();
+      });
 
     if (report.code === PALAU_MATRIX_REPORT_CODE) {
       newTransform = newTransform.concat([orderColumnsByDate]);

--- a/packages/database/src/modelClasses/MapOverlay.js
+++ b/packages/database/src/modelClasses/MapOverlay.js
@@ -25,11 +25,10 @@ export class MapOverlayModel extends DatabaseModel {
       },
     );
     const measureCodes = overlays
-      .map(({ code: overlayCode, linked_measures: linkedMeasures }) => [
+      .flatMap(({ code: overlayCode, linked_measures: linkedMeasures }) => [
         overlayCode,
         ...(linkedMeasures !== null ? linkedMeasures : []),
-      ])
-      .flat();
+      ]);
 
     const measureResults = await this.findMeasuresWithLegacyInfo({
       'map_overlay.code': measureCodes,

--- a/packages/devops/scripts/deployment-aws/buildDeployablePackages.sh
+++ b/packages/devops/scripts/deployment-aws/buildDeployablePackages.sh
@@ -21,13 +21,6 @@ chmod 755 node_modules/@babel/cli/bin/babel.js
 # packages' dists are not rebuilt. This will be fixed by changing to a single yarn:build command in a future PR.
 yarn build:internal-dependencies
 
-if ! bw --version; then
-    echo "Bad Bitwarden CLI version installed (probably 2025.5). Replacing with 2025.4..."
-    npm uninstall --global @bitwarden/cli
-    npm install --global @bitwarden/cli@2025.4.0
-    echo "Bitwarden CLI $(bw --version) is installed"
-fi
-
 # Inject environment variables from Bitwarden
 BW_CLIENTID="$("$DIR/fetchParameterStoreValue.sh" BW_CLIENTID)"
 BW_CLIENTSECRET="$("$DIR/fetchParameterStoreValue.sh" BW_CLIENTSECRET)"

--- a/packages/devops/scripts/deployment-aws/setupGoldMaster.sh
+++ b/packages/devops/scripts/deployment-aws/setupGoldMaster.sh
@@ -1,7 +1,15 @@
-#!/bin/bash -le
+#!/usr/bin/env bash
+# setupGoldMaster.sh is used by EC2 Image Builder to pre-bake a Tupaia AMI. To deploy changes:
+#
+#   1. Upload the latest version Amazon S3 → Buckets → tupaia_devops.
+#   2. Optionally, go to EC2 Image Builder → Image pipelines → Tupaia Gold Master and run the
+#      pipeline. Left alone, this will happen automatically according to the image pipeline’s build
+#      schedule. Do this step if you need changes to take effect immediately.
+#
+# REMARK
+#   The version of setup.sh invoked by this script is always from the default branch.
 
-# This script is used by Amazon Image Builder to pre-bake a Tupaia AMI
-# To deploy changes, upload the latest to the S3 bucket "tupaia_devops"
+set -e
 
 # clone our repo
 cd /home/ubuntu

--- a/packages/devops/scripts/deployment-common/setup.sh
+++ b/packages/devops/scripts/deployment-common/setup.sh
@@ -1,7 +1,24 @@
-#!/bin/bash -le
+#!/usr/bin/env bash
+# This script is invoked by setupGoldMaster.sh, which is used by EC2 Image Builder to pre-bake a
+# Tupaia AMI.
+#
+# DEPLOYING CHANGES
+#   Unlike setupGoldMaster.sh, the “live” version of this file lives in version control, and doesn’t
+#   need to be uploaded to Amazon S3. To deploy changes:
+#
+#   1. Merge changes into the default branch.
+#   2. Optionally, go to EC2 Image Builder → Image pipelines → Tupaia Gold Master and run the
+#      pipeline. Left alone, this will happen automatically according to the image pipeline’s build
+#      schedule. Do this step if you need changes to take effect immediately.
+#
+# REMARK
+#   The EC2 Image Builder image pipeline always invokes the version of this script from the default
+#   branch, regardless of whether you’ll be deploying from a feature branch.
+#
+# SEE ALSO
+#   packages/devops/scripts/deployment-aws/setupGoldMaster.sh
 
-# This script is used by Amazon Image Builder to pre-bake a Tupaia AMI
-# To deploy changes, upload the latest to the S3 bucket "tupaia_devops"
+set -e
 
 HOME_DIR=/home/ubuntu
 TUPAIA_DIR=$HOME_DIR/tupaia
@@ -11,21 +28,18 @@ cd $HOME_DIR
 sudo apt-get update
 
 # install nginx and add h5bp config
-if ! command -v nginx &> /dev/null
-then
+if ! command -v nginx &>/dev/null; then
+  echo 'nginx not installed. Installing...'
   sudo apt-get install -yqq nginx
-  git clone https://github.com/h5bp/server-configs-nginx.git
-  cd ./server-configs-nginx
-  git checkout tags/2.0.0
-  cd ..
+
+  git clone --branch 2.0.0 --depth 1 https://github.com/h5bp/server-configs-nginx.git
   sudo cp -R ./server-configs-nginx/h5bp/ /etc/nginx/
   rm -rf server-configs-nginx
 
   # Add the nginx user (www-data) to the ubuntu group to give it access to the tupaia code
   sudo usermod -a -G ubuntu www-data
-else
-  echo "nginx already installed, skipping"
 fi
+nginx -v
 
 # install psql for use when installing mv refresh in the db
 sudo apt-get install -yqq postgresql-client
@@ -35,11 +49,11 @@ sudo apt-get --no-install-recommends -yqq install \
   bash-completion \
   build-essential \
   cmake \
-  libcurl4  \
-  libcurl4-openssl-dev  \
-  libssl-dev  \
+  libcurl4 \
+  libcurl4-openssl-dev \
+  libssl-dev \
   libxml2 \
-  libxml2-dev  \
+  libxml2-dev \
   libssl3 \
   pkg-config \
   ca-certificates \
@@ -86,13 +100,12 @@ sudo apt-get -yqq install \
   wget \
   xdg-utils
 
-
 # install node and yarn
 if ! command -v node &>/dev/null; then
-  echo "nvm not installed. Installing..."
+  echo 'nvm not installed. Installing...'
   curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
   export NVM_DIR="$HOME/.nvm"
-  [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+  [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
   nvm install $(sudo cat "$TUPAIA_DIR/.nvmrc")
   npm install --global yarn
 fi

--- a/packages/indicators/src/Builder/AnalyticArithmeticBuilder/AnalyticArithmeticBuilder.ts
+++ b/packages/indicators/src/Builder/AnalyticArithmeticBuilder/AnalyticArithmeticBuilder.ts
@@ -100,13 +100,12 @@ export class AnalyticArithmeticBuilder extends Builder {
     const analyticsByElement = groupBy(analytics, 'dataElement');
 
     return Object.entries(analyticsByElement)
-      .map(([element, analyticsForElement]) => {
+      .flatMap(([element, analyticsForElement]) => {
         const aggregationList = this.config.aggregation[element];
         return this.api
           .getAggregator()
           .aggregateAnalytics(analyticsForElement, aggregationList, fetchOptions.period);
-      })
-      .flat();
+      });
   };
 
   private buildAnalyticClusters = (analytics: Analytic[]) => {

--- a/packages/meditrak-app-server/src/__tests__/__integration__/sync/pullChanges/fixtures.ts
+++ b/packages/meditrak-app-server/src/__tests__/__integration__/sync/pullChanges/fixtures.ts
@@ -188,13 +188,12 @@ export const findRecordsWithPermissions = (
           countryIdsWithAccess.some(cid => survey.country_ids.includes(cid))) &&
         permissionGroupIdsWithAccess.some(pgid => survey.permission_group_id === pgid),
     )
-    .map(({ survey, surveyScreen, surveyScreenComponents, questions }) => [
+    .flatMap(({ survey, surveyScreen, surveyScreenComponents, questions }) => [
       { type: 'survey', record: survey },
       { type: 'survey_screen', record: surveyScreen },
       ...surveyScreenComponents.map(r => ({ type: 'survey_screen_component', record: r })),
       ...questions.map(r => ({ type: 'question', record: r })),
-    ])
-    .flat();
+    ]);
 
   const allRecords = [
     ...countryRecords,

--- a/packages/report-server/src/__tests__/reportBuilder/transform/fetchData/fetchData.test.ts
+++ b/packages/report-server/src/__tests__/reportBuilder/transform/fetchData/fetchData.test.ts
@@ -172,7 +172,7 @@ describe('fetchData', () => {
       ];
 
       const resultTable = existingTable
-        .map(row => {
+        .flatMap(row => {
           const matchingAnalytics = fetchedAnalytics.filter(
             analytic =>
               analytic.dataElement === row.question_code &&
@@ -184,8 +184,7 @@ describe('fetchData', () => {
           }
 
           return matchingAnalytics.map(analytic => ({ ...row, ...analytic }));
-        })
-        .flat();
+        });
 
       const received = await transform(TransformTable.fromRows(existingTable));
       expect(received).toStrictEqual(TransformTable.fromRows(resultTable));

--- a/packages/report-server/src/reportBuilder/context/detectDependencies.ts
+++ b/packages/report-server/src/reportBuilder/context/detectDependencies.ts
@@ -12,15 +12,13 @@ import { ContextDependency } from './types';
 const detectDependenciesFromExpressions = (expressions: string[]) => {
   const parser = new TransformParser();
   const functions = expressions
-    .map(calcExpression => {
+    .flatMap(calcExpression => {
       return parser.getFunctions(calcExpression);
-    })
-    .flat();
+    });
 
   const dependencies = Object.entries(contextFunctionDependencies)
     .filter(([fnName]) => functions.includes(fnName))
-    .map(([, fnDependencies]) => fnDependencies)
-    .flat();
+    .flatMap(([, fnDependencies]) => fnDependencies);
 
   return getUniqueEntries(dependencies);
 };
@@ -28,8 +26,7 @@ const detectDependenciesFromExpressions = (expressions: string[]) => {
 const detectDependenciesFromAliasTransforms = (aliasTransforms: string[]) => {
   const dependencies = Object.entries(contextAliasDependencies)
     .filter(([fnName]) => aliasTransforms.includes(fnName))
-    .map(([, aliasDependencies]) => aliasDependencies)
-    .flat();
+    .flatMap(([, aliasDependencies]) => aliasDependencies);
 
   return getUniqueEntries(dependencies);
 };

--- a/packages/report-server/src/reportBuilder/output/functions/matrix/matrixBuilder.ts
+++ b/packages/report-server/src/reportBuilder/output/functions/matrix/matrixBuilder.ts
@@ -85,7 +85,7 @@ export class MatrixBuilder {
       ? getRemainingFieldsFromRows(includeFields, excludeFields)
       : [];
 
-    const allFields = includeFields.map(field => (field === '*' ? remainingFields : field)).flat();
+    const allFields = includeFields.flatMap(field => (field === '*' ? remainingFields : field));
 
     assignColumnSetToMatrixData(allFields);
   }

--- a/packages/report-server/src/reportBuilder/transform/functions/fetchData/createJoin.ts
+++ b/packages/report-server/src/reportBuilder/transform/functions/fetchData/createJoin.ts
@@ -17,22 +17,20 @@ export const createJoin = (joinConfig?: { tableColumn: string; newDataColumn: st
   const tableRowsByJoinColumn = groupBy(tableRows, createKey(tableColumns));
   const newDataRowsByJoinColumn = groupBy(newDataRows, createKey(newDataColumns));
   const jointRows = Object.entries(tableRowsByJoinColumn)
-    .map(([joinColumnValue, tableRowsForValue]) => {
+    .flatMap(([joinColumnValue, tableRowsForValue]) => {
       const newDataRowsForValue = newDataRowsByJoinColumn[joinColumnValue];
       if (!newDataRowsForValue) {
         return tableRowsForValue;
       }
 
       return tableRowsForValue
-        .map(tableRowForValue =>
+        .flatMap(tableRowForValue =>
           newDataRowsForValue.map(newDataRowForValue => ({
             ...tableRowForValue,
             ...newDataRowForValue,
           })),
-        )
-        .flat();
-    })
-    .flat();
+        );
+    });
 
   return jointRows;
 };

--- a/packages/report-server/src/reportBuilder/transform/functions/fetchData/fetchData.ts
+++ b/packages/report-server/src/reportBuilder/transform/functions/fetchData/fetchData.ts
@@ -51,7 +51,7 @@ const fetchData = async (table: TransformTable, params: FetchParams, context: Co
   }
 
   const existingColumns = table.getColumns();
-  const newColumns = Array.from(new Set(newRows.map(Object.keys).flat())).filter(
+  const newColumns = Array.from(new Set(newRows.flatMap(Object.keys))).filter(
     column => !existingColumns.includes(column),
   );
 

--- a/packages/report-server/src/reportBuilder/transform/functions/gatherColumns.ts
+++ b/packages/report-server/src/reportBuilder/transform/functions/gatherColumns.ts
@@ -22,7 +22,7 @@ const gatherColumns = (table: TransformTable, params: GatherColumnsParams) => {
 
   const newRowData = table
     .getRows()
-    .map(row => {
+    .flatMap(row => {
       const keptData: Row = Object.fromEntries(
         columnsToKeep.map(columnName => [columnName, row[columnName]]),
       );
@@ -32,8 +32,7 @@ const gatherColumns = (table: TransformTable, params: GatherColumnsParams) => {
         value: row[columnName],
         columnName,
       }));
-    })
-    .flat();
+    });
 
   return new TransformTable(newColumnNames, newRowData);
 };

--- a/packages/report-server/src/reportBuilder/transform/table/TransformTable.ts
+++ b/packages/report-server/src/reportBuilder/transform/table/TransformTable.ts
@@ -22,7 +22,7 @@ export class TransformTable {
    * into a TransformTable
    */
   public static fromRows(rowObjects: Row[], columnOrder?: string[]) {
-    const columnsInRows = columnOrder || Array.from(new Set(rowObjects.map(Object.keys).flat()));
+    const columnsInRows = columnOrder || Array.from(new Set(rowObjects.flatMap(Object.keys)));
     return new TransformTable(columnsInRows, rowObjects);
   }
 

--- a/packages/server-boilerplate/src/utils/forwardRequest.ts
+++ b/packages/server-boilerplate/src/utils/forwardRequest.ts
@@ -1,7 +1,10 @@
 import { NextFunction, Request, Response } from 'express';
 import { IncomingMessage, ServerResponse } from 'http';
 import { createProxyMiddleware, fixRequestBody } from 'http-proxy-middleware';
+import winston from 'winston';
+
 import { AuthHandler } from '@tupaia/api-client';
+
 import { RequiresSessionAuthHandler } from '../orchestrator';
 
 type AuthHandlerProvider = (req: Request) => AuthHandler;
@@ -39,7 +42,7 @@ export const forwardRequest = (
 
   const proxyMiddleware = createProxyMiddleware(proxyOptions);
   return async (req: Request, res: Response, next: NextFunction) => {
-    console.log(`forwarding ${req.originalUrl} to ${target}`);
+    winston.info(`Forwarding ${req.originalUrl} to ${target}`);
     try {
       const authHandler = authHandlerProvider(req);
       req.headers.authorization = await authHandler.getAuthHeader();

--- a/packages/ui-chart-components/src/components/Axes/YAxes.tsx
+++ b/packages/ui-chart-components/src/components/Axes/YAxes.tsx
@@ -91,7 +91,7 @@ const renderYAxisLabel = (
 
 const flattenValues = (data?: any[], dataKeys?: string[]) => {
   if (!data) return [];
-  return data?.map(item => dataKeys?.map(key => item[key])).flat();
+  return data?.flatMap(item => dataKeys?.map(key => item[key]));
 };
 
 /**

--- a/packages/ui-chart-components/src/utils/parseChartConfig.ts
+++ b/packages/ui-chart-components/src/utils/parseChartConfig.ts
@@ -145,7 +145,7 @@ const createDynamicConfig = (
   data: ChartData[],
 ) => {
   // Just find keys. Doesn't include keys which end in _metadata.
-  const dataKeys = data.map(dataKey => Object.keys(dataKey).filter(isDataKey)).flat();
+  const dataKeys = data.flatMap(dataKey => Object.keys(dataKey).filter(isDataKey));
   const keys = new Set(dataKeys);
 
   // Add config to each key

--- a/packages/web-config-server/src/apiV1/RouteHandler.js
+++ b/packages/web-config-server/src/apiV1/RouteHandler.js
@@ -85,7 +85,7 @@ export class RouteHandler {
       ({ exceptions }) => !exceptions,
     );
 
-    const excludedTypes = frontendExcludedWithoutExceptions.map(({ types }) => types).flat();
+    const excludedTypes = frontendExcludedWithoutExceptions.flatMap(({ types }) => types);
 
     await Promise.all(
       frontendExcludedWithExceptions.map(async ({ types, exceptions }) => {

--- a/packages/web-config-server/src/apiV1/dataBuilders/generic/table/tableOfDataValues/tableOfPercentagesOfValueCounts.js
+++ b/packages/web-config-server/src/apiV1/dataBuilders/generic/table/tableOfDataValues/tableOfPercentagesOfValueCounts.js
@@ -6,8 +6,7 @@ class TableOfPercentagesOfValueCountsBuilder extends TableOfDataValuesBuilder {
   buildDataElementCodes() {
     const dataElementCodes = this.config.cells
       .flat()
-      .map(cell => cell.numerator.dataValues.concat(cell.denominator.dataValues))
-      .flat();
+      .flatMap(cell => cell.numerator.dataValues.concat(cell.denominator.dataValues));
     return [...new Set(dataElementCodes)];
   }
 

--- a/packages/web-config-server/src/apiV1/dataBuilders/generic/table/tableOfEvents.js
+++ b/packages/web-config-server/src/apiV1/dataBuilders/generic/table/tableOfEvents.js
@@ -56,8 +56,7 @@ class TableOfEventsBuilder extends DataBuilder {
     }
     return Object.entries(columns)
       .filter(([key]) => !isMetadataKey(key))
-      .map(([key, config]) => [key, ...(config?.additionalData || [])])
-      .flat();
+      .flatMap(([key, config]) => [key, ...(config?.additionalData || [])]);
   }
 
   async fetchEvents() {

--- a/packages/web-config-server/src/apiV1/dataBuilders/modules/covid-samoa/valueAndPercentageByDataValueByFlightDate.js
+++ b/packages/web-config-server/src/apiV1/dataBuilders/modules/covid-samoa/valueAndPercentageByDataValueByFlightDate.js
@@ -60,7 +60,7 @@ export class ValueAndPercentageByDataValueByFlightDate extends DataBuilder {
     const { rows: rowsConfig, cells } = this.config;
     const useDynamicRows = rowsConfig === '$allValues';
     const rowHeaders = useDynamicRows
-      ? this.getDataValueSet(flights.map(f => f.events).flat(), cells[0])
+      ? this.getDataValueSet(flights.flatMap(f => f.events), cells[0])
       : rowsConfig;
     const dataValues = useDynamicRows ? rowHeaders.map(rowheader => [cells[0], rowheader]) : cells;
     const rows = rowHeaders.map((rowHeader, rowIndex) => {

--- a/packages/web-config-server/src/apiV1/dataBuilders/modules/fetp/countIndividualsByDistrict.js
+++ b/packages/web-config-server/src/apiV1/dataBuilders/modules/fetp/countIndividualsByDistrict.js
@@ -30,7 +30,7 @@ export const countIndividualsByDistrict = async ({
 
   const rows = districts
     .sort(compare)
-    .map(district => {
+    .flatMap(district => {
       const districtCount = individuals.filter(i => i.parent_id == district.id).length;
       const childDistricts = subDistricts.filter(
         subDistrict => subDistrict.parent_id == district.id,
@@ -52,8 +52,7 @@ export const countIndividualsByDistrict = async ({
       };
       const category = { category: district.name, CountColumn: totalCount };
       return [districtCountRow, ...childRows, category];
-    })
-    .flat();
+    });
   const returnData = {
     columns: [{ key: 'CountColumn', title: dataBuilderConfig.columns[0] }],
     rows,

--- a/scripts/bash/ansiControlSequences.sh
+++ b/scripts/bash/ansiControlSequences.sh
@@ -28,8 +28,9 @@ export CLEAR_LINE="\033[2K${CURSOR_START_OF_LINE}"
 
 # Select graphic rendition (SGR) parameters
 
-# Print colour only if outputting to a terminal, and NO_COLOR is unset (see https://no-color.org)
-if [[ ! -t 1 || $NO_COLOR != '' ]]; then
+# Print colour only if outputting to an interactive terminal that supports it, and NO_COLOR is unset
+# See https://clig.dev/#output and https://no-color.org
+if [[ ! -t 1 || $TERM = dumb || -n $NO_COLOR ]]; then
 	export RESET=''
 	export BOLD=''
 	export UNDERLINE=''

--- a/scripts/bash/buildPackagesByGlob.sh
+++ b/scripts/bash/buildPackagesByGlob.sh
@@ -6,7 +6,6 @@ DIR=$(dirname "$0")
 source "$DIR/ansiControlSequences.sh"
 
 # One flag and one “real” argument expected (except in the case of --help)
-ARG_COUNT=${#@}
 FLAG=$1
 GLOB=$2
 
@@ -70,7 +69,7 @@ assert_expected_arguments() {
 		exit 1
 	fi
 
-	if (($ARG_COUNT > 2)); then
+	if (($# > 2)); then
 		echo -en "${BOLD}${YELLOW}Too many arguments:${RESET} ${BLUE}$@${RESET}. "
 		echo 'Did you forget to escape (or quote) your glob? Example usage:'
 		echo

--- a/scripts/bash/downloadEnvironmentVariables.sh
+++ b/scripts/bash/downloadEnvironmentVariables.sh
@@ -39,6 +39,7 @@ cleanup() {
     echo
     echo -e "${BLUE}==>️${RESET} ${BOLD}Logging out of Bitwarden${RESET}"
     bw logout
+    echo
 
     # Clean up detritus on macOS
     # macOS and Ubuntu’s interfaces for sed are slightly different. In this script, we use it in a

--- a/scripts/bash/downloadEnvironmentVariables.sh
+++ b/scripts/bash/downloadEnvironmentVariables.sh
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
 set -e +x # Do not output commands in this script, as some would show credentials in plain text
 
-DEPLOYMENT_NAME=$1
 DIR=$(dirname "$0")
-REPO_ROOT=$(realpath "$DIR/../..")
+"$DIR/requireCommands.sh" bw jq
+
 . "$DIR/ansiControlSequences.sh"
+DEPLOYMENT_NAME=$1
+REPO_ROOT=$(realpath "$DIR/../..")
 
 # Log into Bitwarden
-if [[ ! $(bw login --check) ]]; then
-    if [[ -v BW_CLIENTID && -v BW_CLIENTSECRET ]]; then
+if ! bw login --check &>/dev/null; then
+    if [[ -v BW_CLIENTID && -v BW_CLIENTSECRET && -v BW_PASSWORD ]]; then
         # See https://bitwarden.com/help/personal-api-key
         echo -e "${BLUE}==>️${RESET} ${BOLD}Logging into Bitwarden using API key${RESET}"
         bw login --apikey
@@ -27,11 +29,27 @@ if [[ ! $(bw login --check) ]]; then
 
     else
         # Automated environment
-        echo -e "${BOLD}${RED}Login credentials for Bitwarden are missing.${RESET} Please ensure BW_CLIENTID and BW_CLIENTSECRET environment variables are set."
-        echo -e "See ${MAGENTA}https://bitwarden.com/help/personal-api-key${RESET}"
+        echo -e "${BOLD}${RED}Login credentials for Bitwarden are missing.${RESET} Ensure BW_CLIENTID, BW_CLIENTSECRET and BW_PASSWORD environment variables are set." >&2
+        echo -e "See ${MAGENTA}https://bitwarden.com/help/personal-api-key${RESET}" >&2
         exit 1
     fi
 fi
+
+cleanup() {
+    echo
+    echo -e "${BLUE}==>️${RESET} ${BOLD}Logging out of Bitwarden${RESET}"
+    bw logout
+
+    # Clean up detritus on macOS
+    # macOS and Ubuntu’s interfaces for sed are slightly different. In this script, we use it in a
+    # way that’s compatible to both (by not supplying a suffix for the -i flag), but this causes
+    # macOS to generate backup files which we don’t need.
+    if [[ $(uname) = 'Darwin' ]]; then
+        rm -f "$REPO_ROOT"/env/*.env-e "$REPO_ROOT"/packages/*/.env-e
+    fi
+}
+
+trap cleanup EXIT
 
 # Unlock Bitwarden vault
 if [[ ! -t 1 && ! -v BW_PASSWORD ]]; then
@@ -112,16 +130,3 @@ for file_name in "$REPO_ROOT"/env/*.env.example; do
     package_name=$(basename "$file_name" '.env.example')
     load_env_file_from_bw "$package_name" "$REPO_ROOT/env" "$package_name"
 done
-
-# Log out of Bitwarden
-echo
-echo -e "${BLUE}==>️${RESET} ${BOLD}Logging out of Bitwarden${RESET}"
-bw logout
-
-# Clean up detritus on macOS
-# macOS and Ubuntu’s interfaces for sed are slightly different. In this script, we use it in a way
-# that’s compatible to both (by not supplying a suffix for the -i flag), but this causes macOS to
-# generate backup files which we don’t need.
-if [[ $(uname) = 'Darwin' ]]; then
-    rm -f "$DIR"/../../env/*.env-e "$DIR"/../../packages/*/.env-e
-fi

--- a/scripts/bash/requireCommands.sh
+++ b/scripts/bash/requireCommands.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Asserts that all of the passed arguments are available as shell commands. On success, exits with
+# code 0 and outputs nothing. On failure, prints a summary of which commands are available (and
+# their paths), and which commands couldn’t be found.
+#
+# EXAMPLE USAGE
+#   path/to/requireCommands.sh echo jq python3
+#
+# EXAMPLE OUTPUT
+#   ✓  echo     shell builtin
+#   ×  jq       not found
+#   ✓  python3  /opt/homebrew/bin/python3
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+. "$script_dir/ansiControlSequences.sh"
+
+if (($# == 0)); then
+	this_script=$(basename "${BASH_SOURCE[0]}")
+	echo -en "${BOLD}${YELLOW}Missing arguments.${RESET} " >&2
+	echo -e "${BOLD}$this_script${RESET} was called with no arguments, which does nothing. Example usage:" >&2
+	echo >&2
+	echo -e "  ${GREEN}path/to/$this_script ${BLUE}readarray python3 yarn${RESET}" >&2
+	exit 2
+fi
+
+readarray -t required < <(printf "%s\n" "$@" | sort)
+
+any_missing=0
+for cmd in "${required[@]}"; do
+	if ! command -v "$cmd" >/dev/null; then
+		any_missing=1
+		break
+	fi
+done
+
+# Short-circuit with silent output on success
+if ((any_missing == 0)); then
+	exit 0
+fi
+
+# Subsequent outputs to stderr
+exec 1>&2
+
+summary='' # Table in CSV format
+for cmd in "${required[@]}"; do
+	if executable=$(command -v "$cmd"); then
+		if [[ $(type -t "$cmd") = builtin ]]; then
+			executable='shell builtin'
+		fi
+		summary+="${BOLD}${GREEN}✓${RESET},"
+		summary+="${BOLD}${cmd}${RESET},"
+		summary+="${GREEN}${executable}${RESET}\n"
+	else
+		summary+="${BOLD}${RED}×${RESET},"
+		summary+="${BOLD}${cmd}${RESET},"
+		summary+="${RED}not found${RESET}\n"
+	fi
+done
+
+echo -e "${BOLD}${RED}Missing commands.${RESET} To run this script, ensure the following commands are available:"
+echo
+echo -e "$summary" |
+	column -t -s , | # Pretty print CSV as table
+	sed 's/^/  /'    # Indent by two wordspaces
+
+exit 1


### PR DESCRIPTION
## Manual release steps

_None_

## Features ⭐

- RN-1544: DataTrak now also supports Entity questions configured with `allowScanQrCode`
- RN-1468: Refreshed design for viewing tasks in DataTrak mobile

## Tweaks ⚖️

- RN-1460: Preparatory code for ‘Detect current location’ workflow in DataTrak
- no-issue: DataTrak web app now pre-caches more image and file types in preparation for offline support

## Bug fixes 🐛

- RN-1663: Fixed issue preventing logins in MediTrak
- no-issue: Added support for `congo (the)` as country with code `CG`

## Infrastructure and maintenance 🛠️

- RN-1653: Building internal dependencies is now a bit faster (thanks to `yarn workspaces foreach`)
- no-issue: refactored out a magic string for code maintainability, deleted some unused code (#6185, #6230)
- no-issue: Updated `.env.example` files
- no-issue: Avoid Bitwarden CLI 2025.5 (#6255 and #6255)
