### PR TITLE
fix: globally avoid Bitwarden CLI 2025.5.0

### DIFF
--- a/packages/devops/scripts/deployment-common/setup.sh
+++ b/packages/devops/scripts/deployment-common/setup.sh
@@ -111,7 +111,7 @@ if ! command -v bw &>/dev/null; then
   echo 'Bitwarden CLI not installed. Installing...'
   # Avoid 2025.5.0, which has a known issue. See https://github.com/bitwarden/clients/issues/14995
   npm install --global '@bitwarden/cli@<2025.5.0 || >2025.5.0'
-elif ! bw --version; then
+elif ! bw --version &>/dev/null; then
   echo "Bad Bitwarden CLI version installed (probably 2025.5.0). Replacing with '<2025.5.0 || >2025.5.0'..."
   npm uninstall --global @bitwarden/cli
   npm install --global '@bitwarden/cli@<2025.5.0 || >2025.5.0'

--- a/packages/devops/scripts/deployment-common/setup.sh
+++ b/packages/devops/scripts/deployment-common/setup.sh
@@ -111,6 +111,10 @@ if ! command -v bw &>/dev/null; then
   echo 'Bitwarden CLI not installed. Installing...'
   # Avoid 2025.5.0, which has a known issue. See https://github.com/bitwarden/clients/issues/14995
   npm install --global '@bitwarden/cli@<2025.5.0 || >2025.5.0'
+elif ! bw --version; then
+  echo "Bad Bitwarden CLI version installed (probably 2025.5.0). Replacing with '<2025.5.0 || >2025.5.0'..."
+  npm uninstall --global @bitwarden/cli
+  npm install --global '@bitwarden/cli@<2025.5.0 || >2025.5.0'
 fi
 echo "Bitwarden CLI $(bw --version) is installed"
 

--- a/packages/devops/scripts/deployment-common/setup.sh
+++ b/packages/devops/scripts/deployment-common/setup.sh
@@ -88,36 +88,31 @@ sudo apt-get -yqq install \
 
 
 # install node and yarn
-if ! command -v node &> /dev/null
-then
-  echo "Installing nvm"
+if ! command -v node &>/dev/null; then
+  echo "nvm not installed. Installing..."
   curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
   export NVM_DIR="$HOME/.nvm"
   [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
   nvm install $(sudo cat "$TUPAIA_DIR/.nvmrc")
   npm install --global yarn
-else
-  echo "nvm already installed, skipping"
 fi
+echo "nvm $(nvm --version) is installed"
 
 # install pm2
-if ! command -v pm2 &> /dev/null
-then
-  echo "Installing pm2"
+if ! command -v pm2 &>/dev/null; then
+  echo 'PM2 not installed. Installing...'
   npm install --global pm2
   pm2 install pm2-logrotate
-else
-  echo "pm2 already installed, skipping"
 fi
+echo "PM2 $(pm2 --version) is installed"
 
 # install bitwarden
-if ! command -v bw &> /dev/null
-then
-  echo "Installing bitwarden-cli"
-  npm install --global @bitwarden/cli
-else
-  echo "bitwarden-cli already installed, skipping"
+if ! command -v bw &>/dev/null; then
+  echo 'Bitwarden CLI not installed. Installing...'
+  # Avoid 2025.5.0, which has a known issue. See https://github.com/bitwarden/clients/issues/14995
+  npm install --global '@bitwarden/cli@<2025.5.0 || >2025.5.0'
 fi
+echo "Bitwarden CLI $(bw --version) is installed"
 
 LOGS_DIR=$HOME_DIR/logs
 # Create a directory for logs to go


### PR DESCRIPTION
Previous fix is fine for branches off **dev**, but it didn’t occur to me that **baseline-** branches are still affected

This change will need to be applied to AWS once passed review