### PR TITLE
feat(map): enable arbitrary Material UI icons in map overlays

### DIFF
--- a/packages/types/src/types/models-extra/mapOverlay.ts
+++ b/packages/types/src/types/models-extra/mapOverlay.ts
@@ -105,6 +105,10 @@ export enum IconKey {
   HIDDEN = 'hidden',
 }
 
+// Extended type that allows both predefined IconKey values and arbitrary strings
+// This enables the use of any Material UI icon key while maintaining type safety for predefined icons
+export type IconKeyOrString = IconKey | string;
+
 export enum ScaleType {
   PERFORMANCE = 'performance',
   PERFORMANCE_DESC = 'performanceDesc',
@@ -321,8 +325,10 @@ export type IconMapOverlayConfig = BaseMapOverlayConfig & {
 
   /**
    * @description Which icon to display for this map overlay
+   * Can be one of the predefined IconKey values or any valid Material UI icon name
+   * Examples: IconKey.PIN, 'Pets', 'Home', 'LocalHospital', etc.
    */
-  icon: IconKey;
+  icon: IconKeyOrString;
 };
 
 export type RadiusMapOverlayConfig = BaseMapOverlayConfig & {


### PR DESCRIPTION
- Add IconKeyOrString type to accept both predefined IconKey values and arbitrary strings
- Update IconMapOverlayConfig to support any Material UI icon name
- Implement dynamic Material UI icon loading with caching
- Update getMarkerForOption and getMarkerForValue to handle string icon keys
- Maintain backward compatibility with existing predefined icons
- Enable usage of any Material UI icon (e.g. 'Pets', 'Home', 'LocalHospital') in map overlay configurations

### Issue #:

### Changes:

- Example

---

### Screenshots:
