### PR TITLE
Osc 25 email validation only required

### DIFF
--- a/packages/central-server/src/apiV2/userAccounts/RegisterUserAccounts.js
+++ b/packages/central-server/src/apiV2/userAccounts/RegisterUserAccounts.js
@@ -26,7 +26,7 @@ export class RegisterUserAccounts extends CreateUserAccounts {
     const fieldValidators = {
       firstName: [fieldHasContent],
       lastName: [fieldHasContent],
-      emailAddress: [fieldHasContent, isEmail],
+      emailAddress: [fieldHasContent], // , isEmail
       password: [fieldHasContent],
       passwordConfirm: [fieldHasContent],
       contactNumber: contactNumber ? [hasNoAlphaLetters] : [],

--- a/packages/lesmis/src/components/Forms/LoginForm.jsx
+++ b/packages/lesmis/src/components/Forms/LoginForm.jsx
@@ -69,10 +69,10 @@ export const LoginForm = () => {
         helperText={errors.email?.message}
         inputRef={register({
           required: 'Required',
-          pattern: {
-            value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
-            message: 'invalid email address',
-          },
+          // pattern: {
+          //   value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
+          //   message: 'invalid email address',
+          // },
         })}
       />
       <TextField

--- a/packages/lesmis/src/components/Forms/RegisterForm.jsx
+++ b/packages/lesmis/src/components/Forms/RegisterForm.jsx
@@ -111,10 +111,10 @@ export const RegisterForm = () => {
           helperText={errors?.emailAddress?.message}
           inputRef={register({
             required: 'Required',
-            pattern: {
-              value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
-              message: 'invalid email address',
-            },
+            // pattern: {
+            //   value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
+            //   message: 'invalid email address',
+            // },
           })}
         />
         <TextField

--- a/packages/psss/src/containers/Forms/LoginForm.jsx
+++ b/packages/psss/src/containers/Forms/LoginForm.jsx
@@ -47,10 +47,10 @@ const LoginFormComponent = ({ user, onLogin, isLoading, isError, error }) => {
         helperText={errors.email && errors.email.message}
         inputRef={register({
           required: 'Required',
-          pattern: {
-            value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
-            message: 'invalid email address',
-          },
+          // pattern: {
+          //   value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
+          //   message: 'invalid email address',
+          // },
         })}
       />
       <TextField

--- a/packages/tupaia-web/src/constants/constants.ts
+++ b/packages/tupaia-web/src/constants/constants.ts
@@ -9,7 +9,7 @@ export const PROJECT_ACCESS_TYPES = {
 export const FORM_FIELD_VALIDATION = {
   EMAIL: {
     pattern: {
-      value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
+      value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i, // Case-insensitive regex for email validation
       message: 'Invalid email address',
     },
   },

--- a/packages/tupaia-web/src/constants/constants.ts
+++ b/packages/tupaia-web/src/constants/constants.ts
@@ -8,10 +8,10 @@ export const PROJECT_ACCESS_TYPES = {
 
 export const FORM_FIELD_VALIDATION = {
   EMAIL: {
-    pattern: {
-      value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i, // Case-insensitive regex for email validation
-      message: 'Invalid email address',
-    },
+    // pattern: {
+    //   value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i, // Case-insensitive regex for email validation
+    //   message: 'Invalid email address',
+    // },
   },
   PASSWORD: {
     minLength: { value: 8, message: 'Must be at least 8 characters long' },

--- a/packages/ui-components/src/constants.js
+++ b/packages/ui-components/src/constants.js
@@ -3,10 +3,10 @@ export const DAY_MONTH_YEAR_DATE_FORMAT = 'dd/MM/yyyy';
 
 export const FORM_FIELD_VALIDATION = {
   EMAIL: {
-    pattern: {
-      value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
-      message: 'Invalid email',
-    },
+    // pattern: {
+    //   value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
+    //   message: 'Invalid email',
+    // },
     required: {
       value: true,
       message: '*Required',

--- a/packages/utils/src/validation/validatorFunctions.js
+++ b/packages/utils/src/validation/validatorFunctions.js
@@ -80,10 +80,10 @@ export const hasNoAlphaLetters = value => {
 };
 
 export const isEmail = value => {
-  if (!validator.isEmail(value.toString())) {
-    // Coerce to string before checking with validator
-    throw new ValidationError('Not a valid email address');
-  }
+  // if (!validator.isEmail(value.toString())) {
+  //   // Coerce to string before checking with validator
+  //   throw new ValidationError('Not a valid email address');
+  // }
 };
 
 export const isHexColor = value => {


### PR DESCRIPTION
### Issue #:

### Changes:
 **Commented out the email regex validation across your codebase while keeping the required validation**
1. Frontend Constants Files
2. Login Forms
3. Registration Forms
4. Backend Validation
Email field is still required - users must enter something in the email field
Email regex validation is disabled - users can enter any text without symbol/format restrictions
