### PR TITLE
fix(tupaiaWebServer): long URI from `useDashboards` (band-aid fix)

### DIFF
--- a/packages/devops/configs/nginx-template/servers.template.conf
+++ b/packages/devops/configs/nginx-template/servers.template.conf
@@ -418,6 +418,8 @@ server {
   include /etc/nginx/default.d/*.conf;
   include /etc/nginx/h5bp/basic.conf;
 
+  large_client_header_buffers 4 16k;
+
   location / {
               proxy_pass http://localhost:8100;
               proxy_set_header Host $host;


### PR DESCRIPTION
### RN-1713: Fix large `GET` request URIs from tupaia-web-server

A more robust, permanent solution is underway on branch `rn-1713-long-uri-alt`, but that involves some nontrivial code changes. This is a quick solution, but

- increases memory usage;
- just kicks the can down the road; and
- an 8 KB URI really is unreasonably long

I plan to reverse this change once the permanent solution is in place