### PR TITLE
fix: RN-1309: migrate API clients to Argon2

### DIFF
--- a/packages/auth/src/Authenticator.js
+++ b/packages/auth/src/Authenticator.js
@@ -81,9 +81,7 @@ export class Authenticator {
    * @returns {Promise<boolean>} `true` if and only if the client is authenticated and migrated to
    * Argon2.
    * @see `@tupaia/database/migrations/20250701000000-argon2-passwords-modifies-schema.js`
-   * @privateRemarks This method should be called no more than once per API client. Once all API
-   * clients have been migrated to Argon2, remove this method (and drop the `secret_key_hash_old`
-   * column).
+   * @privateRemarks This method should be called no more than once per API client.
    */
   async #verifyApiClientWithSha256(apiClient, secretKey) {
     const hash = apiClient.secret_key_hash.replace('$sha256+argon2id$', '$argon2id$');
@@ -93,10 +91,7 @@ export class Authenticator {
     if (isVerified) {
       // Migrate to Argon2
       const argon2Hash = await encryptPassword(secretKey);
-      await apiClient.model.updateById(apiClient.id, {
-        secret_key_hash: argon2Hash,
-        secret_key_hash_old: null,
-      });
+      await apiClient.model.updateById(apiClient.id, { secret_key_hash: argon2Hash });
     }
 
     return isVerified;

--- a/packages/auth/src/Authenticator.js
+++ b/packages/auth/src/Authenticator.js
@@ -58,9 +58,7 @@ export class Authenticator {
         : await verifyPassword(secretKey, apiClient.secret_key_hash);
 
       if (!isVerified) {
-        throw new UnauthenticatedError(
-          `Incorrect username or secret for API client ${apiClient.username}`,
-        );
+        throw new UnauthenticatedError(`Couldn’t authenticate API client ${apiClient.username}`);
       }
 
       const user = await apiClient.getUser();

--- a/packages/central-server/src/database/models/User.js
+++ b/packages/central-server/src/database/models/User.js
@@ -50,7 +50,7 @@ export class UserModel extends CommonUserModel {
       'position',
       'mobile_number',
       'password_hash',
-      'password_salt',
+      'legacy_password_salt',
       'verified_email',
       'profile_image',
       'primary_platform',

--- a/packages/central-server/src/tests/apiV2/authenticate/authenticate.test.js
+++ b/packages/central-server/src/tests/apiV2/authenticate/authenticate.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
-import sinon from 'sinon';
 import Chance from 'chance';
+import sinon from 'sinon';
 
 import {
   encryptPassword,
@@ -9,7 +9,7 @@ import {
   verifyPassword,
 } from '@tupaia/auth';
 import { findOrCreateDummyCountryEntity, findOrCreateDummyRecord } from '@tupaia/database';
-import { createBasicHeader } from '@tupaia/utils';
+import { createBasicHeader, randomEmail, randomString } from '@tupaia/utils';
 
 import { BruteForceRateLimiter } from '../../../apiV2/authenticate/BruteForceRateLimiter';
 import { ConsecutiveFailsRateLimiter } from '../../../apiV2/authenticate/ConsecutiveFailsRateLimiter';
@@ -32,12 +32,13 @@ configureEnv();
 const sandbox = sinon.createSandbox();
 
 const chance = new Chance();
-const randomPassword = () => chance.string({ length: 10 }); // We require min length of 8
+
 const randomSalt = () =>
   `${chance.string({ length: 22, pool: 'abcdefghijklmnopqrstuvwxyz0123456789+/' })}==`;
+
 const randomCredentials = () => ({
-  email: chance.email(),
-  password: randomPassword(),
+  email: randomEmail(),
+  password: randomString(),
   salt: randomSalt(),
 });
 
@@ -45,8 +46,8 @@ const app = new TestableApp();
 const { models } = app;
 const { VERIFIED } = models.user.emailVerifiedStatuses;
 
-const userAccountPassword = randomPassword();
-const apiClientSecret = randomPassword();
+const userAccountPassword = randomString();
+const apiClientSecret = randomString();
 
 let userAccount;
 let apiClientUserAccount;

--- a/packages/central-server/src/tests/apiV2/authenticate/authenticate.test.js
+++ b/packages/central-server/src/tests/apiV2/authenticate/authenticate.test.js
@@ -167,8 +167,7 @@ describe('Authenticate', function () {
       last_name: chance.last(),
       email: email,
       password_hash: combiHash,
-      password_hash_old: sha256Hash,
-      password_salt: salt,
+      legacy_password_salt: salt,
       verified_email: VERIFIED,
     });
 
@@ -202,8 +201,7 @@ describe('Authenticate', function () {
       last_name: chance.last(),
       email,
       password_hash: combiHash,
-      password_hash_old: sha256Hash,
-      password_salt: salt,
+      legacy_password_salt: salt,
       verified_email: VERIFIED,
     });
 

--- a/packages/central-server/src/tests/apiV2/import/importSurveyResponses/testPermissions.js
+++ b/packages/central-server/src/tests/apiV2/import/importSurveyResponses/testPermissions.js
@@ -143,7 +143,6 @@ export const testPermissions = async () => {
         name: 'Test User',
         email: 'testuser@tupaia.org',
         password_hash: 'hash',
-        password_salt: 'salt',
       },
     );
 

--- a/packages/central-server/src/tests/apiV2/requestPasswordReset.test.js
+++ b/packages/central-server/src/tests/apiV2/requestPasswordReset.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { createBearerHeader, randomEmail } from '@tupaia/utils';
+import { createBearerHeader, randomEmail, randomString } from '@tupaia/utils';
 
 import { configureEnv } from '../../configureEnv';
 import { getAuthorizationHeader, TestableApp } from '../testUtilities';
@@ -83,7 +83,7 @@ describe('Reset Password', () => {
         'No user object returned by repeated one time login',
       );
 
-      const password = chance.string({ length: 12 });
+      const password = randomString();
       const changePassword = await app.post('me/changePassword', {
         headers: {
           Authorization: createBearerHeader(accessToken),

--- a/packages/central-server/src/tests/apiV2/requestPasswordReset.test.js
+++ b/packages/central-server/src/tests/apiV2/requestPasswordReset.test.js
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
 
-import { createBearerHeader, randomEmail, randomString } from '@tupaia/utils';
+import { createBearerHeader, randomEmail } from '@tupaia/utils';
 
-import { getAuthorizationHeader, TestableApp } from '../testUtilities';
 import { configureEnv } from '../../configureEnv';
+import { getAuthorizationHeader, TestableApp } from '../testUtilities';
 
 configureEnv();
 
@@ -83,7 +83,7 @@ describe('Reset Password', () => {
         'No user object returned by repeated one time login',
       );
 
-      const password = randomString();
+      const password = chance.string({ length: 12 });
       const changePassword = await app.post('me/changePassword', {
         headers: {
           Authorization: createBearerHeader(accessToken),

--- a/packages/database/src/__tests__/changeHandlers/AnalyticsRefresher.fixtures.js
+++ b/packages/database/src/__tests__/changeHandlers/AnalyticsRefresher.fixtures.js
@@ -68,7 +68,7 @@ const USER = [
     name: 'Test User',
     email: 'testuser@tupaia.org',
     password_hash: 'hash',
-    password_salt: 'salt',
+    legacy_password_salt: 'salt',
   },
 ];
 

--- a/packages/database/src/migrations/20250701000000-argon2-passwords-modifies-schema.js
+++ b/packages/database/src/migrations/20250701000000-argon2-passwords-modifies-schema.js
@@ -54,8 +54,7 @@ exports.up = async function (db) {
     );
   }
 
-  await migrateUserAccounts();
-  await migrateApiClients();
+  await Promise.all([migrateUserAccounts(), migrateApiClients()]);
 
   // Preserve legacy salt for a given user so we can still authenticate them.
   // Once a user is migrated to Argon2, we set their legacy salt to NULL.

--- a/packages/database/src/migrations/20250701000000-argon2-passwords-modifies-schema.js
+++ b/packages/database/src/migrations/20250701000000-argon2-passwords-modifies-schema.js
@@ -16,29 +16,49 @@ exports.setup = function (options, seedLink) {
   seed = seedLink;
 };
 
+/**
+ * Use Argon2 to hash existing SHA-256 hash, replacing standard '$argon2id$' prefix with
+ * '$sha256+argon2id$' to track which users have truly migrated to Argon2
+ */
+async function flaggedHash(sha256Hash) {
+  const argon2Hash = await hash(sha256Hash);
+  return argon2Hash.replace('$argon2id$', '$sha256+argon2id$');
+}
+
 exports.up = async function (db) {
   await db.runSql(`
-    ALTER TABLE user_account
-    RENAME COLUMN password_hash TO password_hash_old;
+    ALTER TABLE user_account RENAME COLUMN password_hash TO password_hash_old;
     ALTER TABLE user_account ALTER COLUMN password_hash_old DROP NOT NULL;
     ALTER TABLE user_account ALTER COLUMN password_salt DROP NOT NULL;
+    ALTER TABLE user_account ADD COLUMN password_hash text;
 
-    ALTER TABLE user_account
-    ADD COLUMN password_hash TEXT;
+    ALTER TABLE api_client RENAME COLUMN secret_key_hash TO secret_key_hash_old;
+    ALTER TABLE api_client ALTER COLUMN secret_key_hash_old DROP NOT NULL;
+    ALTER TABLE api_client ADD COLUMN secret_key_hash text;
   `);
-  const users = await db.runSql('SELECT id, password_hash_old FROM user_account');
 
-  // Use Argon2 to hash existing SHA-256 hash, replacing standard '$argon2id$' prefix with
-  // '$sha256+argon2id$' to track which users have truly migrated to Argon2
+  const [users, apiClients] = await Promise.all([
+    db.runSql('SELECT id, password_hash_old FROM user_account'),
+    db.runSql('SELECT id, secret_key_hash_old FROM api_client'),
+  ]);
+
   await Promise.all(
     users.rows.map(async user => {
       const { id, password_hash_old } = user;
-      const hashedValue = (await hash(password_hash_old)).replace(
-        '$argon2id$',
-        '$sha256+argon2id$',
-      );
+      const migratedHash = await flaggedHash(password_hash_old);
       await db.runSql('UPDATE user_account SET password_hash = $1 WHERE id = $2', [
-        hashedValue,
+        migratedHash,
+        id,
+      ]);
+    }),
+  );
+
+  await Promise.all(
+    apiClients.rows.map(async apiClient => {
+      const { id, secret_key_hash_old } = apiClient;
+      const migratedHash = await flaggedHash(secret_key_hash_old);
+      await db.runSql('UPDATE api_client SET secret_key_hash = $1 WHERE id = $2', [
+        migratedHash,
         id,
       ]);
     }),
@@ -46,6 +66,7 @@ exports.up = async function (db) {
 
   await db.runSql(`
     ALTER TABLE user_account ALTER COLUMN password_hash SET NOT NULL;
+    ALTER TABLE api_client ALTER COLUMN secret_key_hash SET NOT NULL;
   `);
 };
 

--- a/packages/database/src/modelClasses/ApiClient.js
+++ b/packages/database/src/modelClasses/ApiClient.js
@@ -5,6 +5,19 @@ import { RECORDS } from '../records';
 
 export class ApiClientRecord extends DatabaseRecord {
   static databaseRecord = RECORDS.API_CLIENT;
+  static #legacyHashPrefix = '$sha256+argon2id$';
+
+  /**
+   * A legacy hash is:
+   * - A SHA-256 hash…
+   * - …further hashed with Argon2…
+   * - …prefixed with `$sha256+argon2id$` instead of `$argon2id$`.
+   *
+   * @see `@tupaia/database/migrations/20250701000000-argon2-passwords-modifies-schema.js`
+   */
+  get hasLegacySecretKeyHash() {
+    return this.secret_key_hash.startsWith(ApiClientRecord.#legacyHashPrefix);
+  }
 
   async getUser() {
     const userId = this.user_account_id;

--- a/packages/server-boilerplate/src/utils/initialiseApiClient.ts
+++ b/packages/server-boilerplate/src/utils/initialiseApiClient.ts
@@ -146,9 +146,9 @@ export const initialiseApiClient = async (
     });
     await upsertPermissions({
       models: transactingModels,
-      userAccountId: userAccountId,
+      userAccountId,
       permissions,
     });
-    winston.info(`Initialised API Client: ${API_CLIENT_NAME}`);
+    winston.info(`Initialised API client: ${API_CLIENT_NAME}`);
   });
 };

--- a/packages/server-boilerplate/src/utils/initialiseApiClient.ts
+++ b/packages/server-boilerplate/src/utils/initialiseApiClient.ts
@@ -66,7 +66,6 @@ const upsertApiClient = async ({
       {
         secret_key_hash: secretKeyHash,
         user_account_id: userAccountId,
-        secret_key_hash_old: null,
       },
     );
     return;

--- a/packages/server-boilerplate/src/utils/initialiseApiClient.ts
+++ b/packages/server-boilerplate/src/utils/initialiseApiClient.ts
@@ -66,6 +66,7 @@ const upsertApiClient = async ({
       {
         secret_key_hash: secretKeyHash,
         user_account_id: userAccountId,
+        secret_key_hash_old: null,
       },
     );
     return;

--- a/packages/types/src/schemas/schemas.ts
+++ b/packages/types/src/schemas/schemas.ts
@@ -41614,6 +41614,9 @@ export const ApiClientSchema = {
 		"secret_key_hash": {
 			"type": "string"
 		},
+		"secret_key_hash_old": {
+			"type": "string"
+		},
 		"user_account_id": {
 			"type": "string"
 		},
@@ -41633,6 +41636,9 @@ export const ApiClientCreateSchema = {
 	"type": "object",
 	"properties": {
 		"secret_key_hash": {
+			"type": "string"
+		},
+		"secret_key_hash_old": {
 			"type": "string"
 		},
 		"user_account_id": {
@@ -41656,6 +41662,9 @@ export const ApiClientUpdateSchema = {
 			"type": "string"
 		},
 		"secret_key_hash": {
+			"type": "string"
+		},
+		"secret_key_hash_old": {
 			"type": "string"
 		},
 		"user_account_id": {

--- a/packages/types/src/schemas/schemas.ts
+++ b/packages/types/src/schemas/schemas.ts
@@ -41614,9 +41614,6 @@ export const ApiClientSchema = {
 		"secret_key_hash": {
 			"type": "string"
 		},
-		"secret_key_hash_old": {
-			"type": "string"
-		},
 		"user_account_id": {
 			"type": "string"
 		},
@@ -41636,9 +41633,6 @@ export const ApiClientCreateSchema = {
 	"type": "object",
 	"properties": {
 		"secret_key_hash": {
-			"type": "string"
-		},
-		"secret_key_hash_old": {
 			"type": "string"
 		},
 		"user_account_id": {
@@ -41662,9 +41656,6 @@ export const ApiClientUpdateSchema = {
 			"type": "string"
 		},
 		"secret_key_hash": {
-			"type": "string"
-		},
-		"secret_key_hash_old": {
 			"type": "string"
 		},
 		"user_account_id": {
@@ -84116,16 +84107,13 @@ export const UserAccountSchema = {
 		"last_name": {
 			"type": "string"
 		},
+		"legacy_password_salt": {
+			"type": "string"
+		},
 		"mobile_number": {
 			"type": "string"
 		},
 		"password_hash": {
-			"type": "string"
-		},
-		"password_hash_old": {
-			"type": "string"
-		},
-		"password_salt": {
 			"type": "string"
 		},
 		"position": {
@@ -84198,16 +84186,13 @@ export const UserAccountCreateSchema = {
 		"last_name": {
 			"type": "string"
 		},
+		"legacy_password_salt": {
+			"type": "string"
+		},
 		"mobile_number": {
 			"type": "string"
 		},
 		"password_hash": {
-			"type": "string"
-		},
-		"password_hash_old": {
-			"type": "string"
-		},
-		"password_salt": {
 			"type": "string"
 		},
 		"position": {
@@ -84281,16 +84266,13 @@ export const UserAccountUpdateSchema = {
 		"last_name": {
 			"type": "string"
 		},
+		"legacy_password_salt": {
+			"type": "string"
+		},
 		"mobile_number": {
 			"type": "string"
 		},
 		"password_hash": {
-			"type": "string"
-		},
-		"password_hash_old": {
-			"type": "string"
-		},
-		"password_salt": {
 			"type": "string"
 		},
 		"position": {

--- a/packages/types/src/types/models.ts
+++ b/packages/types/src/types/models.ts
@@ -158,20 +158,17 @@ export interface AnswerUpdate {
 export interface ApiClient {
   'id': string;
   'secret_key_hash': string;
-  'secret_key_hash_old'?: string | null;
   'user_account_id'?: string | null;
   'username': string;
 }
 export interface ApiClientCreate {
   'secret_key_hash': string;
-  'secret_key_hash_old'?: string | null;
   'user_account_id'?: string | null;
   'username': string;
 }
 export interface ApiClientUpdate {
   'id'?: string;
   'secret_key_hash'?: string;
-  'secret_key_hash_old'?: string | null;
   'user_account_id'?: string | null;
   'username'?: string;
 }
@@ -1653,10 +1650,9 @@ export interface UserAccount {
   'gender'?: string | null;
   'id': string;
   'last_name'?: string | null;
+  'legacy_password_salt'?: string | null;
   'mobile_number'?: string | null;
   'password_hash': string;
-  'password_hash_old'?: string | null;
-  'password_salt'?: string | null;
   'position'?: string | null;
   'preferences': UserAccountPreferences;
   'primary_platform'?: PrimaryPlatform | null;
@@ -1670,10 +1666,9 @@ export interface UserAccountCreate {
   'first_name'?: string | null;
   'gender'?: string | null;
   'last_name'?: string | null;
+  'legacy_password_salt'?: string | null;
   'mobile_number'?: string | null;
   'password_hash': string;
-  'password_hash_old'?: string | null;
-  'password_salt'?: string | null;
   'position'?: string | null;
   'preferences'?: UserAccountPreferences;
   'primary_platform'?: PrimaryPlatform | null;
@@ -1688,10 +1683,9 @@ export interface UserAccountUpdate {
   'gender'?: string | null;
   'id'?: string;
   'last_name'?: string | null;
+  'legacy_password_salt'?: string | null;
   'mobile_number'?: string | null;
   'password_hash'?: string;
-  'password_hash_old'?: string | null;
-  'password_salt'?: string | null;
   'position'?: string | null;
   'preferences'?: UserAccountPreferences;
   'primary_platform'?: PrimaryPlatform | null;

--- a/packages/types/src/types/models.ts
+++ b/packages/types/src/types/models.ts
@@ -158,17 +158,20 @@ export interface AnswerUpdate {
 export interface ApiClient {
   'id': string;
   'secret_key_hash': string;
+  'secret_key_hash_old'?: string | null;
   'user_account_id'?: string | null;
   'username': string;
 }
 export interface ApiClientCreate {
   'secret_key_hash': string;
+  'secret_key_hash_old'?: string | null;
   'user_account_id'?: string | null;
   'username': string;
 }
 export interface ApiClientUpdate {
   'id'?: string;
   'secret_key_hash'?: string;
+  'secret_key_hash_old'?: string | null;
   'user_account_id'?: string | null;
   'username'?: string;
 }

--- a/packages/utils/src/testUtilities/randomData.js
+++ b/packages/utils/src/testUtilities/randomData.js
@@ -6,8 +6,8 @@ export function randomEmail() {
   return chance.email({ domain: 'tupaia.org' });
 }
 
-export function randomString() {
-  return chance.string({ length: 7 });
+export function randomString(length = 10) {
+  return chance.string({ length });
 }
 
 export function randomIntBetween(min, max) {


### PR DESCRIPTION
### RN-1303

- Updates the migration from #5872 to immediately discard legacy hashes, not preserving them in `password_hash_old`
- Adds similar migration logic for API clients
- fixes last few unit tests broken by this stack