### PR TITLE
fix: support `POST /dashboardItems` to avoid long URIs

### DIFF
--- a/packages/api-client/src/connections/CentralApi.ts
+++ b/packages/api-client/src/connections/CentralApi.ts
@@ -82,6 +82,12 @@ export class CentralApi extends BaseApi {
     return this.connection.get(endpoint, stringifyParams(params));
   }
 
+  /**
+   * Use instead of {@link fetchResources} when the URI is unreasonably long to avoid
+   * `414 Request-URI Too Large`.
+   */
+  public fetchResourcesWithPost = this.createResource;
+
   public async createResource(
     endpoint: string,
     params: Record<string, unknown>,

--- a/packages/api-client/src/connections/mocks/MockCentralApi.ts
+++ b/packages/api-client/src/connections/mocks/MockCentralApi.ts
@@ -99,6 +99,7 @@ export class MockCentralApi implements CentralApiInterface {
       ),
     );
   }
+  public fetchResourcesWithPost = this.fetchResources;
   public createResource(
     endpoint: string,
     params: Record<string, unknown>,

--- a/packages/central-server/src/apiV2/GETHandler/GETHandler.js
+++ b/packages/central-server/src/apiV2/GETHandler/GETHandler.js
@@ -1,4 +1,4 @@
-import { isNotNullish, isNullish } from '@tupaia/tsutils';
+import { isNullish } from '@tupaia/tsutils';
 import { respond } from '@tupaia/utils';
 
 import { CRUDHandler } from '../CRUDHandler';

--- a/packages/central-server/src/apiV2/index.js
+++ b/packages/central-server/src/apiV2/index.js
@@ -267,6 +267,13 @@ apiV2.get('/landingPages/:recordId?', useRouteHandler(GETLandingPages));
 apiV2.get('/suggestSurveyCode', catchAsyncErrors(suggestSurveyCode));
 apiV2.get('/tasks/:recordId?', useRouteHandler(GETTasks));
 apiV2.get('/tasks/:parentRecordId/taskComments', useRouteHandler(GETTaskComments));
+
+/**
+ * Semantically a GET, but mechanically a POST, to bypass `414 Request-URI Too Large` error by
+ * putting params in request body.
+ */
+apiV2.post('/dashboardItems', useRouteHandler(GETDashboardRelations));
+
 /**
  * POST routes
  */

--- a/packages/tupaia-web-server/src/routes/DashboardsRoute.ts
+++ b/packages/tupaia-web-server/src/routes/DashboardsRoute.ts
@@ -107,17 +107,18 @@ export class DashboardsRoute extends Route<DashboardsRequest> {
       );
 
     // The dashboards themselves are fetched from central to ensure permission checking
-    const dashboardItems: DashboardItem[] = await ctx.services.central.fetchResources(
+
+    const dashboardItems: DashboardItem[] = await ctx.services.central.fetchResourcesWithPost(
       'dashboardItems',
+      { pageSize: DEFAULT_PAGE_SIZE }, // Override the default limit of 100 records
       {
+        // Potentially hundreds of dashboard items, hence POST method with body to avoid 414 error
         filter: {
           id: {
             comparator: 'IN',
             comparisonValue: dashboardRelations.map(dr => dr.child_id),
           },
         },
-        // Override the default limit of 100 records
-        pageSize: DEFAULT_PAGE_SIZE,
       },
     );
 

--- a/packages/utils/src/errors.js
+++ b/packages/utils/src/errors.js
@@ -193,6 +193,13 @@ export class Dhis2Error extends RespondingError {
   }
 }
 
+export class UnprocessableContentError extends RespondingError {
+  constructor(message) {
+    super(message, 422);
+    this.name = 'UnprocessableContentError';
+  }
+}
+
 export class CustomError extends RespondingError {
   constructor(jsonFields, extraJsonFields) {
     const json = {


### PR DESCRIPTION
### Issue #:

### Changes:

- Example

---

### Screenshots:
