### PR TITLE
fix(tupaiaWeb): RN-1716: browser history abuse

### DIFF
--- a/packages/tupaia-web/src/Routes.tsx
+++ b/packages/tupaia-web/src/Routes.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
 import { Navigate, Route, Routes as RouterRoutes, useLocation } from 'react-router-dom';
+import { useUser } from './api/queries';
+import { LoadingScreen } from './components';
+import { DEFAULT_URL, MAP_OVERLAY_EXPORT_ROUTE, MODAL_ROUTES, ROUTE_STRUCTURE } from './constants';
+import { Dashboard } from './features';
+import { MainLayout } from './layout';
+import { gaEvent, useEntityLink } from './utils';
 import {
   DashboardPDFExport,
   LandingPage,
@@ -7,12 +13,6 @@ import {
   ProjectPage,
   Unsubscribe,
 } from './views';
-import { Dashboard } from './features';
-import { MODAL_ROUTES, DEFAULT_URL, ROUTE_STRUCTURE, MAP_OVERLAY_EXPORT_ROUTE } from './constants';
-import { useUser } from './api/queries';
-import { MainLayout } from './layout';
-import { LoadingScreen } from './components';
-import { gaEvent, useEntityLink } from './utils';
 
 const HomeRedirect = () => {
   const { isLoggedIn, data } = useUser();
@@ -35,8 +35,9 @@ const HomeRedirect = () => {
  * Redirect to the dashboardGroupName of the project if a dashboard name is not provided
  */
 const ProjectPageDashboardRedirect = () => {
-  const url = useEntityLink();
-  return <Navigate to={url} replace />;
+  const to = useEntityLink();
+  if (to === undefined) return null;
+  return <Navigate to={to} replace />;
 };
 
 const UserPageRedirect = ({ modal }: { modal: MODAL_ROUTES }) => {

--- a/packages/tupaia-web/src/utils/useEntityLink.ts
+++ b/packages/tupaia-web/src/utils/useEntityLink.ts
@@ -8,20 +8,19 @@ import { useProject } from '../api/queries';
 export const useEntityLink = (entityCode?: string): Partial<Path> | undefined => {
   const { hash, search } = useLocation();
   const { projectCode, entityCode: entityCodeParam } = useParams();
-  const { data: project } = useProject(projectCode);
+  const { data: project, isFetched } = useProject(projectCode);
 
   // If entityCode is not provided, use the one from the URL
   const newEntityCode = entityCode || entityCodeParam;
-  const dashboardGroupName = project?.dashboardGroupName
-    ? encodeURIComponent(project.dashboardGroupName)
-    : '';
+  const dashboardGroupName =
+    isFetched && project?.dashboardGroupName ? project.dashboardGroupName : '';
 
   return useMemo(() => {
-    if (!projectCode || !newEntityCode || !dashboardGroupName) return undefined;
+    if (!projectCode || !newEntityCode || !isFetched) return undefined;
     return {
       hash,
-      pathname: `/${projectCode}/${newEntityCode}/${dashboardGroupName}`,
+      pathname: `/${projectCode}/${newEntityCode}/${encodeURIComponent(dashboardGroupName)}`,
       search,
     };
-  }, [dashboardGroupName, hash, newEntityCode, projectCode, search]);
+  }, [dashboardGroupName, hash, isFetched, newEntityCode, projectCode, search]);
 };

--- a/packages/tupaia-web/src/utils/useEntityLink.ts
+++ b/packages/tupaia-web/src/utils/useEntityLink.ts
@@ -1,6 +1,6 @@
+import { useMemo } from 'react';
 import { Path, useLocation, useParams } from 'react-router-dom';
 import { useProject } from '../api/queries';
-import { useMemo } from 'react';
 
 /**
  * @returns `undefined` if and only if the eventual return value is pending.

--- a/packages/tupaia-web/src/utils/useEntityLink.ts
+++ b/packages/tupaia-web/src/utils/useEntityLink.ts
@@ -1,18 +1,27 @@
-import { useLocation, useParams } from 'react-router-dom';
+import { Path, useLocation, useParams } from 'react-router-dom';
 import { useProject } from '../api/queries';
+import { useMemo } from 'react';
 
-export const useEntityLink = (entityCode?: string) => {
-  const location = useLocation();
+/**
+ * @returns `undefined` if and only if the eventual return value is pending.
+ */
+export const useEntityLink = (entityCode?: string): Partial<Path> | undefined => {
+  const { hash, search } = useLocation();
   const { projectCode, entityCode: entityCodeParam } = useParams();
   const { data: project } = useProject(projectCode);
 
   // If entityCode is not provided, use the one from the URL
   const newEntityCode = entityCode || entityCodeParam;
+  const dashboardGroupName = project?.dashboardGroupName
+    ? encodeURIComponent(project.dashboardGroupName)
+    : '';
 
-  return {
-    ...location,
-    pathname: `/${projectCode}/${newEntityCode}/${
-      project?.dashboardGroupName ? encodeURIComponent(project.dashboardGroupName) : ''
-    }`,
-  };
+  return useMemo(() => {
+    if (!projectCode || !newEntityCode || !dashboardGroupName) return undefined;
+    return {
+      hash,
+      pathname: `/${projectCode}/${newEntityCode}/${dashboardGroupName}`,
+      search,
+    };
+  }, [dashboardGroupName, hash, newEntityCode, projectCode, search]);
 };


### PR DESCRIPTION
## RN-1716

`<Navigate>` was being called with a prop that changes under its feed hundreds of times, causing `history.replaceState()` to be called many times.

This was causing browsers to throttle or block calls.