### PR TITLE
tweak(centralServer): warn when `assertCanImportSurveyResponses` sees unexpected nullish value

### DIFF
--- a/packages/central-server/src/apiV2/import/importSurveyResponses/assertCanImportSurveyResponses.js
+++ b/packages/central-server/src/apiV2/import/importSurveyResponses/assertCanImportSurveyResponses.js
@@ -1,4 +1,6 @@
 import { flattenDeep, groupBy, keyBy } from 'lodash';
+
+import { isNullish } from '@tupaia/tsutils';
 import { getUniqueEntries, reduceToDictionary } from '@tupaia/utils';
 import winston from '../../../log';
 
@@ -16,6 +18,10 @@ export const assertCanImportSurveyResponses = async (
       transactingModels.survey.findManyByColumn('code', surveyCodes),
     ]);
 
+    if (allEntities.some(isNullish)) {
+      winston.error('Unexpected nullish element in `allEntities`', { allEntities });
+    }
+
     const codeToSurvey = keyBy(surveys, 'code');
     const surveyPermissionGroupIds = surveys.map(s => s.permission_group_id);
     const surveyPermissionGroups =
@@ -24,12 +30,24 @@ export const assertCanImportSurveyResponses = async (
 
     for (const [surveyCode, entityCodes] of Object.entries(entitiesBySurveyCode)) {
       const survey = codeToSurvey[surveyCode];
+
+      if (isNullish(survey)) {
+        winston.error(`Unexpected nullish survey (code '${surveyCode}')`, { codeToSurvey });
+      }
+
       const responseEntities = allEntities.filter(e => entityCodes.includes(e.code));
       const surveyResponseCountryCodes = [...new Set(responseEntities.map(e => e.country_code))];
       const surveyResponseCountries = await transactingModels.country.findManyByColumn(
         'code',
         surveyResponseCountryCodes,
       );
+
+      if (surveyResponseCountries.some(isNullish)) {
+        winston.error('Unexpected nullish element in `surveyResponseCountries`', {
+          surveyResponseCountries,
+        });
+      }
+
       if (surveyResponseCountries.length !== surveyResponseCountryCodes.length) {
         const expected = surveyResponseCountryCodes;
         const actual = surveyResponseCountries.map(c => c.code);
@@ -46,6 +64,11 @@ export const assertCanImportSurveyResponses = async (
         if (survey.country_ids?.length && !survey.country_ids.includes(surveyResponseCountry.id)) {
           const surveyCountries = await transactingModels.country.findManyById(survey.country_ids);
           const entities = entitiesByCountryCode[surveyResponseCountry.code];
+
+          if (entities.some(isNullish)) {
+            winston.error('Unexpected nullish element in `entities`', { entities });
+          }
+
           const entityCodesString = entities.map(e => e.code).join(', ');
           const surveyCountryNamesString = surveyCountries.map(s => s.name).join(', ');
           throw new Error(


### PR DESCRIPTION
## [MediTrak sync support issue](https://beyondessential.slack.com/archives/C01JD93J4E6/p1753157306408759)

Troubling, long-lived bug that is known to self-resolve (but not in a timely fashion).

