### PR TITLE
fix(centralServer): make parser actually parse

### DIFF
--- a/packages/central-server/src/hooks/utilities.js
+++ b/packages/central-server/src/hooks/utilities.js
@@ -28,7 +28,7 @@ export async function getHookAnswerValues(surveyResponse, baseHookName, defaultF
 
 export function parseCoordinates(answerText) {
   const { latitude, longitude } = JSON.parse(answerText);
-  if (Number.isNaN(parseFloat(latitude)) || Number.isNaN(parseFloat(longitude))) {
+  if (Number.isNaN(Number.parseFloat(latitude)) || Number.isNaN(Number.parseFloat(longitude))) {
     throw new Error(`Invalid coordinate data: ${answerText}`);
   }
 

--- a/packages/central-server/src/hooks/utilities.js
+++ b/packages/central-server/src/hooks/utilities.js
@@ -27,8 +27,12 @@ export async function getHookAnswerValues(surveyResponse, baseHookName, defaultF
 }
 
 export function parseCoordinates(answerText) {
-  const { latitude, longitude } = JSON.parse(answerText);
-  if (Number.isNaN(Number.parseFloat(latitude)) || Number.isNaN(Number.parseFloat(longitude))) {
+  const answer = JSON.parse(answerText);
+
+  const latitude = Number.parseFloat(answer.latitude);
+  const longitude = Number.parseFloat(answer.longitude);
+
+  if (Number.isNaN(latitude) || Number.isNaN(longitude)) {
     throw new Error(`Invalid coordinate data: ${answerText}`);
   }
 

--- a/packages/central-server/src/hooks/utilities.js
+++ b/packages/central-server/src/hooks/utilities.js
@@ -29,7 +29,7 @@ export async function getHookAnswerValues(surveyResponse, baseHookName, defaultF
 export function parseCoordinates(answerText) {
   const { latitude, longitude } = JSON.parse(answerText);
   if (Number.isNaN(parseFloat(latitude)) || Number.isNaN(parseFloat(longitude))) {
-    throw new Error(`Invalid coordinate data: ${answer.text}`);
+    throw new Error(`Invalid coordinate data: ${answerText}`);
   }
 
   return { latitude, longitude };


### PR DESCRIPTION
From this comment: https://github.com/beyondessential/tupaia/pull/6325#discussion_r2221176732

[`ST_GeomFromGeoJSON` docs](https://postgis.net/docs/ST_GeomFromGeoJSON.html) suggest it expects stringified numeric values, but current implementation just checks the input _is parseable_ and discards the parsed values.