### PR TITLE
fix(serverUtils): RN-1723: duplicate “for” in permissions email

### DIFF
--- a/packages/server-utils/src/email/templates/content/permissionGranted.html
+++ b/packages/server-utils/src/email/templates/content/permissionGranted.html
@@ -1,7 +1,7 @@
 <div>
   <p>Hi {{userName}}</p>
   <p>
-    This is just to let you know that you've been added to the {{permissionGroupName}} access group
+    This is just to let you know that you’ve been added to the {{permissionGroupName}} access group
     for {{entityName}}.
   </p>
   <p>{{{description}}}</p>

--- a/packages/server-utils/src/email/templates/content/permissionGranted.html
+++ b/packages/server-utils/src/email/templates/content/permissionGranted.html
@@ -2,7 +2,7 @@
   <p>Hi {{userName}}</p>
   <p>
     This is just to let you know that you've been added to the {{permissionGroupName}} access group
-    for for {{entityName}}.
+    for {{entityName}}.
   </p>
   <p>{{{description}}}</p>
   <p>


### PR DESCRIPTION
## RN-1723

- One line change which removes a redundant duplicate "for" in Tupaia permission granted email
