### PR TITLE
feat(permissions): RN-1519: separate data table read and edit permissions 

### DIFF
--- a/packages/central-server/src/apiV2/externalDatabaseConnections/GETExternalDatabaseConnections.js
+++ b/packages/central-server/src/apiV2/externalDatabaseConnections/GETExternalDatabaseConnections.js
@@ -1,6 +1,24 @@
-import { GETHandler } from '../GETHandler';
+import { assertIsNotNullish } from '@tupaia/tsutils';
 import { assertBESAdminAccess, hasBESAdminAccess } from '../../permissions';
+import { GETHandler } from '../GETHandler';
 import { getPermissionListWithWildcard } from '../utilities';
+
+export async function hasExternalDatabaseConnectionPermissions(
+  accessPolicy,
+  models,
+  externalDatabaseConnectionId,
+) {
+  const [connection, userPermissions] = await Promise.all([
+    models.externalDatabaseConnection.findById(externalDatabaseConnectionId),
+    getPermissionListWithWildcard(accessPolicy),
+  ]);
+  assertIsNotNullish(
+    connection,
+    `No external database connection exists with ID ${externalDatabaseConnectionId}`,
+  );
+
+  return connection.permission_groups.some(code => userPermissions.includes(code));
+}
 
 export class GETExternalDatabaseConnections extends GETHandler {
   permissionsFilteredInternally = true;

--- a/packages/database/src/modelClasses/DataTable.js
+++ b/packages/database/src/modelClasses/DataTable.js
@@ -1,3 +1,5 @@
+import { ensure } from '@tupaia/tsutils';
+import { DataTableType } from '@tupaia/types';
 import { DatabaseModel } from '../DatabaseModel';
 import { DatabaseRecord } from '../DatabaseRecord';
 import { RECORDS } from '../records';
@@ -17,7 +19,19 @@ export class DataTableModel extends DatabaseModel {
     return DataTableRecord;
   }
 
-  /** @returns {Promise<import('@tupaia/types').DataTableType[]>} */
+  async getExternalDatabaseConnection() {
+    if (this.type !== DataTableType.sql) return null;
+    const code = ensure(
+      this.config.externalDatabaseConnectionCode,
+      `Data table ${this.id}’s config is missing required property externalDatabaseConnectionCode`,
+    );
+    return ensure(
+      await this.otherModels.externalDatabaseConnection.findOne({ code }),
+      `Couldn’t find external database connection for data table ${this.id} (expected external database connection with code ${code})`,
+    );
+  }
+
+  /** @returns {Promise<DataTableType[]>} */
   async getDataTableTypes() {
     const dataTableTypes = await this.database.executeSql(
       'SELECT unnest(enum_range(NULL::data_table_type)) AS type;',

--- a/packages/tsutils/src/typeGuards.ts
+++ b/packages/tsutils/src/typeGuards.ts
@@ -6,14 +6,14 @@ export function isNullish(val: unknown): val is null | undefined {
 
 export const isNotNullish = <T>(val: T): val is NonNullable<T> => val !== undefined && val !== null;
 
-export function assertIsNotNullish<T>(val: T): asserts val is NonNullable<T> {
-  if (!isNotNullish(val)) {
-    throw new Error(`Expected value to be defined, but got ${val}`);
+export function assertIsNotNullish<T>(val: T, message?: string): asserts val is NonNullable<T> {
+  if (isNullish(val)) {
+    throw new UnexpectedNullishValueError(message ?? `Expected non-nullish value, but got ${val}`);
   }
 }
 
-export const ensure = <T>(val: T) => {
-  assertIsNotNullish(val);
+export const ensure = <T>(val: T, message?: string): NonNullable<T> => {
+  assertIsNotNullish(val, message);
   return val;
 };
 
@@ -40,4 +40,11 @@ export function isPrimitive(val: unknown): val is Primitive {
     typeof val === 'bigint' ||
     typeof val === 'symbol'
   );
+}
+
+class UnexpectedNullishValueError extends Error {
+  constructor(message?: string) {
+    super(message);
+    this.name = 'UnexpectedNullishValueError';
+  }
 }


### PR DESCRIPTION
## RN-1519

- `data_table.permission_groups` determines whether that record can be READ by a user. (**Viz Builder User** permission is also required.)
- But to EDIT a `data_table` with `type = "sql"`, the user must have access to the relevant `external_database_connection`.
- No one (except ***BES Admin**) may edit other types of `data_table`s