### PR TITLE
tweak(datatrak): smarter default `TLocalContext` in `useDatabaseQuery` query function

### DIFF
--- a/packages/datatrak-web/src/api/queries/useDatabaseQuery.ts
+++ b/packages/datatrak-web/src/api/queries/useDatabaseQuery.ts
@@ -20,13 +20,11 @@ interface GlobalQueryContext {
   user: CurrentUser;
 }
 
-interface LocalContext {
-  readonly [key: string]: unknown;
-}
+export interface ContextualQueryFunctionContext extends QueryFunctionContext, GlobalQueryContext {}
 
 // Enhanced QueryFunction type that receives extra context
-interface ContextualQueryFn<TData> {
-  (context: QueryFunctionContext & GlobalQueryContext & LocalContext): Promise<TData>;
+interface ContextualQueryFn<TData = unknown> {
+  (context: ContextualQueryFunctionContext): TData | Promise<TData>;
 }
 
 // Main function with same signature as useQuery
@@ -35,7 +33,7 @@ export function useDatabaseQuery<
   TError = unknown,
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
-  TLocalContext extends LocalContext = LocalContext,
+  TLocalContext = unknown,
 >(
   queryKey: TQueryKey,
   queryFn: ContextualQueryFn<TQueryFnData>,

--- a/packages/datatrak-web/src/api/queries/useDatabaseQuery.ts
+++ b/packages/datatrak-web/src/api/queries/useDatabaseQuery.ts
@@ -20,7 +20,14 @@ interface GlobalQueryContext {
   user: CurrentUser;
 }
 
-export interface ContextualQueryFunctionContext extends QueryFunctionContext, GlobalQueryContext {}
+interface LocalContext {
+  readonly [key: string]: unknown;
+}
+
+export interface ContextualQueryFunctionContext
+  extends QueryFunctionContext,
+    GlobalQueryContext,
+    LocalContext {}
 
 // Enhanced QueryFunction type that receives extra context
 interface ContextualQueryFn<TData = unknown> {
@@ -33,7 +40,7 @@ export function useDatabaseQuery<
   TError = unknown,
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
-  TLocalContext = unknown,
+  TLocalContext extends LocalContext = {},
 >(
   queryKey: TQueryKey,
   queryFn: ContextualQueryFn<TQueryFnData>,


### PR DESCRIPTION
After working with it a bit, I think defining `LocalContext` as a `Record<string, unknown>` caused more issues than it solved.

- I tried using generics so that consumers could declare a local context type, but since we attach the `GlobalContext` as well as TanStack’s `QueryFunctionContext`, we end up having to pass through heaps of type arguments which made devX a bit miserable.
- Just defaulting it to `{}` instead of `LocalContext`
- `useDatabase` query doesn’t need to know about the input param type in that much detail. It just needs to call it and know what the return type is. This code change maintains all that.

When defining query functions, we _can_ explicitly type its context parameter to extend this new `ContextualQueryFunctionContext`; but it will also happen through type inference for free.