### PR TITLE
fix(datatrak): entity filter comparator

### DIFF
--- a/packages/datatrak-web/src/database/entity/getEntityDescendants.ts
+++ b/packages/datatrak-web/src/database/entity/getEntityDescendants.ts
@@ -137,8 +137,8 @@ const buildEntityFilter = (params: GetEntityDescendantsParams) => {
     type,
     name: searchString
       ? {
-          comparator: 'ilike',
-          comparisonValue: `%${searchString}%`,
+          comparator: '=@',
+          comparisonValue: searchString,
         }
       : undefined,
     ...restOfFilter,


### PR DESCRIPTION
`=@` gets translated to `ilike` in `@tupaia/tsmodels/utils/entity/entityFilter`