### PR TITLE
fix(datatrak): fire query functions even when offline

### DIFF
--- a/packages/datatrak-web/src/AppProviders.tsx
+++ b/packages/datatrak-web/src/AppProviders.tsx
@@ -33,8 +33,12 @@ const defaultQueryClient = new QueryClient({
     onError: handleError,
   }),
   defaultOptions: {
+    mutations: {
+      networkMode: 'offlineFirst',
+    },
     queries: {
       keepPreviousData: false,
+      networkMode: 'offlineFirst',
       refetchOnWindowFocus: false,
       retry: false,
       staleTime: 1000 * 60 * 5, // 5 minutes

--- a/packages/datatrak-web/src/api/queries/useDatabaseMutation.ts
+++ b/packages/datatrak-web/src/api/queries/useDatabaseMutation.ts
@@ -55,7 +55,6 @@ export function useDatabaseMutation<
 
   return useMutation<TData, TError, TVariables, TContext>({
     mutationFn: wrappedMutationFn,
-    networkMode: 'always',
     ...reactQueryOptions,
   });
 }

--- a/packages/datatrak-web/src/api/queries/useDatabaseQuery.ts
+++ b/packages/datatrak-web/src/api/queries/useDatabaseQuery.ts
@@ -66,7 +66,6 @@ export function useDatabaseQuery<
   return useQuery<TQueryFnData, TError, TData, TQueryKey>({
     queryKey,
     queryFn: wrappedQueryFn,
-    networkMode: 'always',
     ...queryOptions,
   });
 }


### PR DESCRIPTION
By default, TanStack Query pauses queries when offline; but some of our query functions now hit a local IndexedDB so this does more harm than good.


https://tanstack.com/query/v4/docs/framework/react/guides/network-mode