### PR TITLE
fix: RN-1657: suppress Waka in survey response exports

### DIFF
--- a/packages/datatrak-web/index.html
+++ b/packages/datatrak-web/index.html
@@ -38,31 +38,17 @@
       content="Data collection and visualisation for the most remote settings in the world"
     />
 
-    <% if (process.env.REACT_APP_DEPLOYMENT_NAME === 'master' ||
-    process.env.REACT_APP_DEPLOYMENT_NAME === 'main' || process.env.REACT_APP_DEPLOYMENT_NAME ===
-    'production') { %>
-    <!-- Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-P5KF6SLGKR"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-      gtag('js', new Date());
-      gtag('config', 'G-P5KF6SLGKR');
-    </script>
-    <!-- End Google Analytics -->
-
+    <% if (true) { %>
     <!-- Start of bes-support Zendesk Widget script -->
-    <script type="text/javascript">
+    <script type="text/javascript" defer>
       const ua = navigator.userAgent.toLowerCase();
       const platform = navigator.platform.toLowerCase();
       const platformName = ua.match(/ip(?:ad|od|hone)/)
         ? 'ios'
         : (ua.match(/(?:webos|android)/) || platform.match(/mac|win|linux/) || ['other'])[0];
       const isMobile = /ios|android|webos/.test(platformName);
-
-      if (!isMobile) {
+      const isExport = window.location.pathname.startsWith('/export/');
+      if (!isMobile && !isExport) {
         const script = document.createElement('script');
         script.id = 'ze-snippet';
         script.src =

--- a/packages/datatrak-web/index.html
+++ b/packages/datatrak-web/index.html
@@ -22,6 +22,7 @@
       crossorigin
     />
     <% } %>
+    <link rel="preconnect" href="https://tupaia.s3.ap-southeast-2.amazonaws.com" crossorigin />
 
     <!-- Open Graph for shared links -->
     <meta property="og:title" content="Tupaia DataTrak" />

--- a/packages/datatrak-web/index.html
+++ b/packages/datatrak-web/index.html
@@ -38,16 +38,32 @@
       content="Data collection and visualisation for the most remote settings in the world"
     />
 
-    <% if (true) { %>
+    <% if (process.env.REACT_APP_DEPLOYMENT_NAME === 'master' ||
+    process.env.REACT_APP_DEPLOYMENT_NAME === 'main' || process.env.REACT_APP_DEPLOYMENT_NAME ===
+    'production') { %>
+    <!-- Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-P5KF6SLGKR"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag('js', new Date());
+      gtag('config', 'G-P5KF6SLGKR');
+    </script>
+    <!-- End Google Analytics -->
     <!-- Start of bes-support Zendesk Widget script -->
     <script type="text/javascript" defer>
       const ua = navigator.userAgent.toLowerCase();
-      const platform = navigator.platform.toLowerCase();
       const platformName = ua.match(/ip(?:ad|od|hone)/)
         ? 'ios'
-        : (ua.match(/(?:webos|android)/) || platform.match(/mac|win|linux/) || ['other'])[0];
+        : (ua.match(/(?:webos|android)/) ||
+            navigator.platform.toLowerCase().match(/mac|win|linux/) || ['other'])[0];
       const isMobile = /ios|android|webos/.test(platformName);
-      const isExport = window.location.pathname.startsWith('/export/');
+
+      const EXPORT_SURVEY_RESPONSE = '/export/';
+      const isExport = window.location.pathname.startsWith(EXPORT_SURVEY_RESPONSE);
+
       if (!isMobile && !isExport) {
         const script = document.createElement('script');
         script.id = 'ze-snippet';

--- a/packages/datatrak-web/src/views/ExportSurveyResponsePage/ExportSurveyResponsePage.tsx
+++ b/packages/datatrak-web/src/views/ExportSurveyResponsePage/ExportSurveyResponsePage.tsx
@@ -21,16 +21,16 @@ const Header = styled.div`
 `;
 
 const ProjectLogo = styled.img`
-  max-height: 4rem;
-  max-width: 5rem;
-  width: auto;
+  height: 4rem;
+  object-fit: contain;
+  width: 5rem;
 `;
 
 const SurveyResponseDetailsWrapper = styled.div`
   font-weight: ${({ theme }) => theme.typography.fontWeightMedium};
   > * {
     font-size: 0.75rem;
-    text-align: right;
+    text-align: end;
   }
 `;
 

--- a/packages/datatrak-web/src/views/ExportSurveyResponsePage/ExportSurveyResponsePage.tsx
+++ b/packages/datatrak-web/src/views/ExportSurveyResponsePage/ExportSurveyResponsePage.tsx
@@ -81,6 +81,7 @@ export const ExportSurveyResponsePage = () => {
         <ProjectLogo
           src={survey?.project?.logoUrl || '/tupaia-logo-dark.svg'}
           alt={survey?.project?.name}
+          crossOrigin=""
         />
         <SurveyResponseDetailsWrapper>
           <SurveyTitle>

--- a/packages/datatrak-web/src/views/LandingPage/ActivityFeedSection/ActivityFeedMarkdownItem.tsx
+++ b/packages/datatrak-web/src/views/LandingPage/ActivityFeedSection/ActivityFeedMarkdownItem.tsx
@@ -20,7 +20,7 @@ const Heading = styled(Typography)`
   margin-bottom: 0.4rem;
 `;
 
-const Image = styled.img`
+const Image = styled.img.attrs({ crossOrigin: '' })`
   height: 10rem;
   width: auto;
   max-width: 100%;


### PR DESCRIPTION
## Issue RN-1657

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Suppresses the Zendesk widget on export pages, adds cross-origin handling for images, and makes minor performance/style tweaks.
> 
> - **Web (index.html)**:
>   - Suppress Zendesk widget on export routes by checking `window.location.pathname` prefix `'/export/'`.
>   - Defer Zendesk script loading and refine platform detection.
>   - Add `preconnect` to `https://tupaia.s3.ap-southeast-2.amazonaws.com`.
> - **Export Survey Response** (`ExportSurveyResponsePage.tsx`):
>   - Set project logo `crossOrigin=""` and adjust sizing (`height`, `width`, `object-fit`).
>   - Use `text-align: end` in details wrapper.
> - **Activity Feed** (`ActivityFeedMarkdownItem.tsx`):
>   - Add `crossOrigin` to rendered images.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6700d0d1c6a1333b2c2f5aebb007da7638fe5037. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->