### PR TITLE
refactor: move permission assertions into @tupaia/access-policy

### DIFF
--- a/packages/access-policy/package.json
+++ b/packages/access-policy/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@tupaia/constants": "workspace:*",
+    "@tupaia/tsutils": "workspace:*",
     "@tupaia/utils": "workspace:*"
   }
 }

--- a/packages/access-policy/src/index.js
+++ b/packages/access-policy/src/index.js
@@ -2,7 +2,6 @@ export { AccessPolicy } from './AccessPolicy';
 export {
   allowNoPermissions,
   assertAdminPanelAccess,
-  assertAdminPanelAccessToCountry,
   assertAllPermissions,
   assertAnyPermissions,
   assertBESAdminAccess,

--- a/packages/access-policy/src/index.js
+++ b/packages/access-policy/src/index.js
@@ -1,2 +1,19 @@
 export { AccessPolicy } from './AccessPolicy';
-export * from './permissions';
+export {
+  allowNoPermissions,
+  assertAdminPanelAccess,
+  assertAdminPanelAccessToCountry,
+  assertAllPermissions,
+  assertAnyPermissions,
+  assertBESAdminAccess,
+  assertPermissionGroupAccess,
+  assertPermissionGroupsAccess,
+  assertVizBuilderAccess,
+  hasBESAdminAccess,
+  hasPermissionGroupAccess,
+  hasPermissionGroupsAccess,
+  hasSomePermissionGroupsAccess,
+  hasTupaiaAdminPanelAccess,
+  hasTupaiaAdminPanelAccessToCountry,
+  hasVizBuilderAccess,
+} from './permissions';

--- a/packages/access-policy/src/permissions.js
+++ b/packages/access-policy/src/permissions.js
@@ -150,5 +150,5 @@ export const assertPermissionGroupsAccess = (accessPolicy, permissionGroupNames)
   ) {
     return true;
   }
-  throw new PermissionsError(`You do not have access to all related permission groups`);
+  throw new PermissionsError(`Need access to ${permissionGroupNames.join(', ')}`);
 };

--- a/packages/access-policy/src/permissions.js
+++ b/packages/access-policy/src/permissions.js
@@ -101,7 +101,7 @@ export const assertAdminPanelAccessToCountry = async (accessPolicy, models, reco
   );
   if (!userHasAdminAccessToCountry) {
     throw new PermissionsError(
-      `Need Tupaia Admin Panel access to country '${entity.country_code}' to edit entity`,
+      `Need ${TUPAIA_ADMIN_PANEL_PERMISSION_GROUP} access to country ‘${entity.country_code}’ to edit entity ‘${entity.name}’`,
     );
   }
   return true;

--- a/packages/access-policy/src/permissions.js
+++ b/packages/access-policy/src/permissions.js
@@ -145,8 +145,8 @@ export const assertPermissionGroupAccess = (accessPolicy, permissionGroupName) =
  */
 export const assertPermissionGroupsAccess = (accessPolicy, permissionGroupNames) => {
   if (
-    hasPermissionGroupsAccess(accessPolicy, permissionGroupNames) ||
-    hasBESAdminAccess(accessPolicy)
+    hasBESAdminAccess(accessPolicy) ||
+    hasPermissionGroupsAccess(accessPolicy, permissionGroupNames)
   ) {
     return true;
   }

--- a/packages/access-policy/src/permissions.js
+++ b/packages/access-policy/src/permissions.js
@@ -7,14 +7,14 @@ import { PermissionsError } from '@tupaia/utils';
 
 /**
  * @typedef {import('./AccessPolicy').AccessPolicy} AccessPolicy
- * @typedef {(accessPolicy: AccessPolicy) => true} PermissionsAssertion
- * @typedef {(accessPolicy: AccessPolicy) => boolean} PermissionsChecker
+ * @typedef {(accessPolicy: AccessPolicy) => true} SimplePermissionsAssertion
+ * @typedef {(accessPolicy: AccessPolicy) => boolean} SimplePermissionsChecker
  * @typedef {string} PermissionGroupName
  */
 
 /**
  * Returns true all the time. This is for any route handlers that do not need permissions.
- * @type {PermissionsChecker}
+ * @returns {true}
  */
 export const allowNoPermissions = () => true;
 
@@ -23,6 +23,8 @@ export const allowNoPermissions = () => true;
  * @param {function[]} assertions Each permissions assertion should return `true` or throw a
  * {@link PermissionsError}
  * @param {string} errorMessage
+ * @returns {true}
+ * @throws {PermissionsError}
  */
 export const assertAllPermissions = (assertions, errorMessage) => async accessPolicy => {
   try {
@@ -38,6 +40,8 @@ export const assertAllPermissions = (assertions, errorMessage) => async accessPo
  * @param {function[]} assertions Each permissions assertion should return true or throw a
  * {@link PermissionsError}
  * @param {string} errorMessage
+ * @returns {true}
+ * @throws {PermissionsError}
  */
 export const assertAnyPermissions = (assertions, errorMessage) => async accessPolicy => {
   const combinedErrorMessages = ['One of the following conditions need to be satisfied:'];
@@ -54,62 +58,70 @@ export const assertAnyPermissions = (assertions, errorMessage) => async accessPo
   throw new PermissionsError(errorMessage || combinedErrorMessages.join('\n'));
 };
 
-/** @type {PermissionsChecker} */
+/** @type {SimplePermissionsChecker} */
 export const hasBESAdminAccess = accessPolicy =>
   accessPolicy.allowsSome(undefined, BES_ADMIN_PERMISSION_GROUP);
 
-/** @type {PermissionsChecker} */
+/** @type {SimplePermissionsChecker} */
 export const hasVizBuilderAccess = accessPolicy =>
   accessPolicy.allowsSome(undefined, VIZ_BUILDER_PERMISSION_GROUP);
 
 /**
- * @type {PermissionsChecker}
- * @param {PermissionGroupName}
+ * @param {AccessPolicy} accessPolicy
+ * @param {PermissionGroupName} permissionGroup
+ * @returns {boolean}
  */
 export const hasPermissionGroupAccess = (accessPolicy, permissionGroup) =>
   accessPolicy.allowsSome(undefined, permissionGroup);
 
 /**
  * Has access to all permission groups inputted
- * @type {PermissionsChecker}
- * @param {PermissionGroupName[]}
+ * @param {AccessPolicy} accessPolicy
+ * @param {PermissionGroupName[]} permissionGroups
+ * @returns {boolean}
  */
 export const hasPermissionGroupsAccess = (accessPolicy, permissionGroups) =>
   permissionGroups.every(pg => accessPolicy.allowsSome(undefined, pg));
 
-/** @type {PermissionsChecker} */
+/** @type {SimplePermissionsChecker} */
 export const hasSomePermissionGroupsAccess = (accessPolicy, permissionGroups) =>
   permissionGroups.some(pg => accessPolicy.allowsSome(undefined, pg));
 
-/** @type {PermissionsAssertion} */
+/** @type {SimplePermissionsAssertion} */
 export const assertBESAdminAccess = accessPolicy => {
   if (hasBESAdminAccess(accessPolicy)) return true;
   throw new PermissionsError(`Need ${BES_ADMIN_PERMISSION_GROUP} access`);
 };
 
-/** @type {PermissionsAssertion} */
+/** @type {SimplePermissionsAssertion} */
 export const assertVizBuilderAccess = accessPolicy => {
   if (hasVizBuilderAccess(accessPolicy)) return true;
   throw new PermissionsError(`Need ${VIZ_BUILDER_PERMISSION_GROUP} access`);
 };
 
-/** @type {PermissionsChecker} */
+/** @type {SimplePermissionsChecker} */
 export const hasTupaiaAdminPanelAccess = accessPolicy =>
   accessPolicy.allowsSome(undefined, TUPAIA_ADMIN_PANEL_PERMISSION_GROUP);
 
-/** @type {PermissionsChecker} */
+/**
+ * @param {AccessPolicy} accessPolicy
+ * @param {string} countryCode
+ * @returns {boolean}
+ */
 export const hasTupaiaAdminPanelAccessToCountry = (accessPolicy, countryCode) =>
   accessPolicy.allows(countryCode, TUPAIA_ADMIN_PANEL_PERMISSION_GROUP);
 
-/** @type {PermissionsAssertion} */
+/** @type {SimplePermissionsAssertion} */
 export const assertAdminPanelAccess = accessPolicy => {
   if (hasTupaiaAdminPanelAccess(accessPolicy)) return true;
   throw new PermissionsError(`Need ${TUPAIA_ADMIN_PANEL_PERMISSION_GROUP} access`);
 };
 
 /**
- * @type {PermissionsAssertion}
+ * @param {AccessPolicy} accessPolicy
  * @param {PermissionGroupName} permissionGroupName
+ * @returns {true}
+ * @throws {PermissionsError}
  */
 export const assertPermissionGroupAccess = (accessPolicy, permissionGroupName) => {
   if (hasPermissionGroupAccess(accessPolicy, permissionGroupName)) return true;
@@ -117,8 +129,10 @@ export const assertPermissionGroupAccess = (accessPolicy, permissionGroupName) =
 };
 
 /**
- * @type {PermissionsAssertion}
+ * @param {AccessPolicy} accessPolicy
  * @param {PermissionGroupName[]} permissionGroupNames
+ * @returns {true}
+ * @throws {PermissionsError}
  */
 export const assertPermissionGroupsAccess = (accessPolicy, permissionGroupNames) => {
   if (

--- a/packages/access-policy/src/permissions.js
+++ b/packages/access-policy/src/permissions.js
@@ -7,7 +7,15 @@ import { ensure } from '@tupaia/tsutils';
 import { PermissionsError } from '@tupaia/utils';
 
 /**
+ * @typedef {import('./AccessPolicy').AccessPolicy} AccessPolicy
+ * @typedef {(accessPolicy: AccessPolicy) => true} PermissionsAssertion
+ * @typedef {(accessPolicy: AccessPolicy) => boolean} PermissionsChecker
+ * @typedef {string} PermissionGroupName
+ */
+
+/**
  * Returns true all the time. This is for any route handlers that do not need permissions.
+ * @type {PermissionsChecker}
  */
 export const allowNoPermissions = () => true;
 
@@ -47,54 +55,63 @@ export const assertAnyPermissions = (assertions, errorMessage) => async accessPo
   throw new Error(errorMessage || combinedErrorMessages.join('\n'));
 };
 
-/**
- * @param {import('./AccessPolicy').AccessPolicy} accessPolicy
- * @returns {boolean}
- */
+/** @type {PermissionsChecker} */
 export const hasBESAdminAccess = accessPolicy =>
   accessPolicy.allowsSome(undefined, BES_ADMIN_PERMISSION_GROUP);
 
+/** @type {PermissionsChecker} */
 export const hasVizBuilderAccess = accessPolicy =>
   accessPolicy.allowsSome(undefined, VIZ_BUILDER_PERMISSION_GROUP);
 
+/**
+ * @type {PermissionsChecker}
+ * @param {PermissionGroupName}
+ */
 export const hasPermissionGroupAccess = (accessPolicy, permissionGroup) =>
   accessPolicy.allowsSome(undefined, permissionGroup);
 
-// has access to all permission groups inputted
+/**
+ * Has access to all permission groups inputted
+ * @type {PermissionsChecker}
+ * @param {PermissionGroupName[]}
+ */
 export const hasPermissionGroupsAccess = (accessPolicy, permissionGroups) =>
   permissionGroups.every(pg => accessPolicy.allowsSome(undefined, pg));
 
+/** @type {PermissionsChecker} */
 export const hasSomePermissionGroupsAccess = (accessPolicy, permissionGroups) =>
   permissionGroups.some(pg => accessPolicy.allowsSome(undefined, pg));
 
+/** @type {PermissionsAssertion} */
 export const assertBESAdminAccess = accessPolicy => {
-  if (hasBESAdminAccess(accessPolicy)) {
-    return true;
-  }
-
+  if (hasBESAdminAccess(accessPolicy)) return true;
   throw new Error(`Need ${BES_ADMIN_PERMISSION_GROUP} access`);
 };
 
+/** @type {PermissionsAssertion} */
 export const assertVizBuilderAccess = accessPolicy => {
-  if (hasVizBuilderAccess(accessPolicy)) {
-    return true;
-  }
-
+  if (hasVizBuilderAccess(accessPolicy)) return true;
   throw new Error(`Need ${VIZ_BUILDER_PERMISSION_GROUP} access`);
 };
 
+/** @type {PermissionsChecker} */
 export const hasTupaiaAdminPanelAccess = accessPolicy =>
   accessPolicy.allowsSome(undefined, TUPAIA_ADMIN_PANEL_PERMISSION_GROUP);
 
+/** @type {PermissionsChecker} */
 export const hasTupaiaAdminPanelAccessToCountry = (accessPolicy, countryCode) =>
   accessPolicy.allows(countryCode, TUPAIA_ADMIN_PANEL_PERMISSION_GROUP);
 
+/**
+ * @type {PermissionsAssertion}
+ * @param {ModelRegistry} models
+ * @param {string} recordId
+ */
 export const assertAdminPanelAccessToCountry = async (accessPolicy, models, recordId) => {
   const entity = ensure(
     await models.entity.findById(recordId),
     `No entity exists with ID ${recordId}`,
   );
-
   const userHasAdminAccessToCountry = accessPolicy.allows(
     entity.country_code,
     TUPAIA_ADMIN_PANEL_PERMISSION_GROUP,
@@ -107,22 +124,25 @@ export const assertAdminPanelAccessToCountry = async (accessPolicy, models, reco
   return true;
 };
 
+/** @type {PermissionsAssertion} */
 export const assertAdminPanelAccess = accessPolicy => {
-  if (hasTupaiaAdminPanelAccess(accessPolicy)) {
-    return true;
-  }
-
+  if (hasTupaiaAdminPanelAccess(accessPolicy)) return true;
   throw new PermissionsError(`Need ${TUPAIA_ADMIN_PANEL_PERMISSION_GROUP} access`);
 };
 
+/**
+ * @type {PermissionsAssertion}
+ * @param {PermissionGroupName} permissionGroupName
+ */
 export const assertPermissionGroupAccess = (accessPolicy, permissionGroupName) => {
-  if (hasPermissionGroupAccess(accessPolicy, permissionGroupName)) {
-    return true;
-  }
-
+  if (hasPermissionGroupAccess(accessPolicy, permissionGroupName)) return true;
   throw new PermissionsError(`Need ${permissionGroupName} access`);
 };
 
+/**
+ * @type {PermissionsAssertion}
+ * @param {PermissionGroupName[]} permissionGroupNames
+ */
 export const assertPermissionGroupsAccess = (accessPolicy, permissionGroupNames) => {
   if (
     hasPermissionGroupsAccess(accessPolicy, permissionGroupNames) ||
@@ -130,6 +150,5 @@ export const assertPermissionGroupsAccess = (accessPolicy, permissionGroupNames)
   ) {
     return true;
   }
-
   throw new Error(`You do not have access to all related permission groups`);
 };

--- a/packages/access-policy/src/permissions.js
+++ b/packages/access-policy/src/permissions.js
@@ -61,24 +61,11 @@ export const hasPermissionGroupAccess = (accessPolicy, permissionGroup) =>
   accessPolicy.allowsSome(undefined, permissionGroup);
 
 // has access to all permission groups inputted
-export const hasPermissionGroupsAccess = (accessPolicy, permissionGroups) => {
-  for (let i = 0; i < permissionGroups.length; i++) {
-    if (!accessPolicy.allowsSome(undefined, permissionGroups[i])) {
-      return false;
-    }
-  }
-  return true;
-};
+export const hasPermissionGroupsAccess = (accessPolicy, permissionGroups) =>
+  permissionGroups.every(pg => accessPolicy.allowsSome(undefined, pg));
 
-export const hasSomePermissionGroupsAccess = (accessPolicy, permissionGroups) => {
-  for (let i = 0; i < permissionGroups.length; i++) {
-    if (accessPolicy.allowsSome(undefined, permissionGroups[i])) {
-      return true;
-    }
-  }
-
-  return false;
-};
+export const hasSomePermissionGroupsAccess = (accessPolicy, permissionGroups) =>
+  permissionGroups.some(pg => accessPolicy.allowsSome(undefined, pg));
 
 export const assertBESAdminAccess = accessPolicy => {
   if (hasBESAdminAccess(accessPolicy)) {

--- a/packages/access-policy/src/permissions.js
+++ b/packages/access-policy/src/permissions.js
@@ -1,4 +1,55 @@
-import { BES_ADMIN_PERMISSION_GROUP } from '@tupaia/constants';
+import {
+  BES_ADMIN_PERMISSION_GROUP,
+  TUPAIA_ADMIN_PANEL_PERMISSION_GROUP,
+  VIZ_BUILDER_PERMISSION_GROUP,
+} from '@tupaia/constants';
+import { ensure } from '@tupaia/tsutils';
+import { PermissionsError } from '@tupaia/utils';
+
+/**
+ * Returns true all the time. This is for any route handlers that do not need permissions.
+ */
+export const allowNoPermissions = () => {
+  return true;
+};
+
+/**
+ * Returns true if all of the permissions assertions pass, or throws an error
+ * @param {function[]} assertions  Each permissions assertion should return true or throw an error
+ * @param {string} errorMessage
+ */
+export const assertAllPermissions = (assertions, errorMessage) => async accessPolicy => {
+  try {
+    for (let i = 0; i < assertions.length; i++) {
+      const assertion = assertions[i];
+      await assertion(accessPolicy);
+    }
+    return true;
+  } catch (e) {
+    throw new Error(errorMessage || e.message);
+  }
+};
+
+/**
+ * Returns true if any of the permissions assertions pass, or throws an error
+ * @param {function[]} assertions Each permissions assertion should return true or throw a
+ * {@link PermissionsError}
+ * @param {string} errorMessage
+ */
+export const assertAnyPermissions = (assertions, errorMessage) => async accessPolicy => {
+  const combinedErrorMessages = ['One of the following conditions need to be satisfied:'];
+
+  for (const assertion of assertions) {
+    try {
+      await assertion(accessPolicy);
+      return true;
+    } catch (e) {
+      combinedErrorMessages.push(e.message);
+      // swallow specific errors, in case any assertion returns true
+    }
+  }
+  throw new Error(errorMessage || combinedErrorMessages.join('\n'));
+};
 
 /**
  * @param {import('./AccessPolicy').AccessPolicy} accessPolicy
@@ -6,3 +57,96 @@ import { BES_ADMIN_PERMISSION_GROUP } from '@tupaia/constants';
  */
 export const hasBESAdminAccess = accessPolicy =>
   accessPolicy.allowsSome(undefined, BES_ADMIN_PERMISSION_GROUP);
+
+export const hasVizBuilderAccess = accessPolicy =>
+  accessPolicy.allowsSome(undefined, VIZ_BUILDER_PERMISSION_GROUP);
+
+export const hasPermissionGroupAccess = (accessPolicy, permissionGroup) =>
+  accessPolicy.allowsSome(undefined, permissionGroup);
+
+// has access to all permission groups inputted
+export const hasPermissionGroupsAccess = (accessPolicy, permissionGroups) => {
+  for (let i = 0; i < permissionGroups.length; i++) {
+    if (!accessPolicy.allowsSome(undefined, permissionGroups[i])) {
+      return false;
+    }
+  }
+  return true;
+};
+
+export const hasSomePermissionGroupsAccess = (accessPolicy, permissionGroups) => {
+  for (let i = 0; i < permissionGroups.length; i++) {
+    if (accessPolicy.allowsSome(undefined, permissionGroups[i])) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+export const assertBESAdminAccess = accessPolicy => {
+  if (hasBESAdminAccess(accessPolicy)) {
+    return true;
+  }
+
+  throw new Error(`Need ${BES_ADMIN_PERMISSION_GROUP} access`);
+};
+
+export const assertVizBuilderAccess = accessPolicy => {
+  if (hasVizBuilderAccess(accessPolicy)) {
+    return true;
+  }
+
+  throw new Error(`Need ${VIZ_BUILDER_PERMISSION_GROUP} access`);
+};
+
+export const hasTupaiaAdminPanelAccess = accessPolicy =>
+  accessPolicy.allowsSome(undefined, TUPAIA_ADMIN_PANEL_PERMISSION_GROUP);
+
+export const hasTupaiaAdminPanelAccessToCountry = (accessPolicy, countryCode) =>
+  accessPolicy.allows(countryCode, TUPAIA_ADMIN_PANEL_PERMISSION_GROUP);
+
+export const assertAdminPanelAccessToCountry = async (accessPolicy, models, recordId) => {
+  const entity = ensure(
+    await models.entity.findById(recordId),
+    `No entity exists with ID ${recordId}`,
+  );
+
+  const userHasAdminAccessToCountry = accessPolicy.allows(
+    entity.country_code,
+    TUPAIA_ADMIN_PANEL_PERMISSION_GROUP,
+  );
+  if (!userHasAdminAccessToCountry) {
+    throw new PermissionsError(
+      `Need Tupaia Admin Panel access to country '${entity.country_code}' to edit entity`,
+    );
+  }
+  return true;
+};
+
+export const assertAdminPanelAccess = accessPolicy => {
+  if (hasTupaiaAdminPanelAccess(accessPolicy)) {
+    return true;
+  }
+
+  throw new PermissionsError(`Need ${TUPAIA_ADMIN_PANEL_PERMISSION_GROUP} access`);
+};
+
+export const assertPermissionGroupAccess = (accessPolicy, permissionGroupName) => {
+  if (hasPermissionGroupAccess(accessPolicy, permissionGroupName)) {
+    return true;
+  }
+
+  throw new PermissionsError(`Need ${permissionGroupName} access`);
+};
+
+export const assertPermissionGroupsAccess = (accessPolicy, permissionGroupNames) => {
+  if (
+    hasPermissionGroupsAccess(accessPolicy, permissionGroupNames) ||
+    hasBESAdminAccess(accessPolicy)
+  ) {
+    return true;
+  }
+
+  throw new Error(`You do not have access to all related permission groups`);
+};

--- a/packages/access-policy/src/permissions.js
+++ b/packages/access-policy/src/permissions.js
@@ -3,7 +3,6 @@ import {
   TUPAIA_ADMIN_PANEL_PERMISSION_GROUP,
   VIZ_BUILDER_PERMISSION_GROUP,
 } from '@tupaia/constants';
-import { ensure } from '@tupaia/tsutils';
 import { PermissionsError } from '@tupaia/utils';
 
 /**
@@ -101,28 +100,6 @@ export const hasTupaiaAdminPanelAccess = accessPolicy =>
 /** @type {PermissionsChecker} */
 export const hasTupaiaAdminPanelAccessToCountry = (accessPolicy, countryCode) =>
   accessPolicy.allows(countryCode, TUPAIA_ADMIN_PANEL_PERMISSION_GROUP);
-
-/**
- * @type {PermissionsAssertion}
- * @param {ModelRegistry} models
- * @param {string} recordId
- */
-export const assertAdminPanelAccessToCountry = async (accessPolicy, models, recordId) => {
-  const entity = ensure(
-    await models.entity.findById(recordId),
-    `No entity exists with ID ${recordId}`,
-  );
-  const userHasAdminAccessToCountry = accessPolicy.allows(
-    entity.country_code,
-    TUPAIA_ADMIN_PANEL_PERMISSION_GROUP,
-  );
-  if (!userHasAdminAccessToCountry) {
-    throw new PermissionsError(
-      `Need ${TUPAIA_ADMIN_PANEL_PERMISSION_GROUP} access to country ‘${entity.country_code}’ to edit entity ‘${entity.name}’`,
-    );
-  }
-  return true;
-};
 
 /** @type {PermissionsAssertion} */
 export const assertAdminPanelAccess = accessPolicy => {

--- a/packages/access-policy/src/permissions.js
+++ b/packages/access-policy/src/permissions.js
@@ -30,7 +30,7 @@ export const assertAllPermissions = (assertions, errorMessage) => async accessPo
     for (const assertion of assertions) await assertion(accessPolicy);
     return true;
   } catch (e) {
-    throw new Error(errorMessage || e.message);
+    throw new PermissionsError(errorMessage || e.message);
   }
 };
 
@@ -52,7 +52,7 @@ export const assertAnyPermissions = (assertions, errorMessage) => async accessPo
       // swallow specific errors, in case any assertion returns true
     }
   }
-  throw new Error(errorMessage || combinedErrorMessages.join('\n'));
+  throw new PermissionsError(errorMessage || combinedErrorMessages.join('\n'));
 };
 
 /** @type {PermissionsChecker} */
@@ -85,13 +85,13 @@ export const hasSomePermissionGroupsAccess = (accessPolicy, permissionGroups) =>
 /** @type {PermissionsAssertion} */
 export const assertBESAdminAccess = accessPolicy => {
   if (hasBESAdminAccess(accessPolicy)) return true;
-  throw new Error(`Need ${BES_ADMIN_PERMISSION_GROUP} access`);
+  throw new PermissionsError(`Need ${BES_ADMIN_PERMISSION_GROUP} access`);
 };
 
 /** @type {PermissionsAssertion} */
 export const assertVizBuilderAccess = accessPolicy => {
   if (hasVizBuilderAccess(accessPolicy)) return true;
-  throw new Error(`Need ${VIZ_BUILDER_PERMISSION_GROUP} access`);
+  throw new PermissionsError(`Need ${VIZ_BUILDER_PERMISSION_GROUP} access`);
 };
 
 /** @type {PermissionsChecker} */
@@ -150,5 +150,5 @@ export const assertPermissionGroupsAccess = (accessPolicy, permissionGroupNames)
   ) {
     return true;
   }
-  throw new Error(`You do not have access to all related permission groups`);
+  throw new PermissionsError(`You do not have access to all related permission groups`);
 };

--- a/packages/access-policy/src/permissions.js
+++ b/packages/access-policy/src/permissions.js
@@ -9,21 +9,17 @@ import { PermissionsError } from '@tupaia/utils';
 /**
  * Returns true all the time. This is for any route handlers that do not need permissions.
  */
-export const allowNoPermissions = () => {
-  return true;
-};
+export const allowNoPermissions = () => true;
 
 /**
  * Returns true if all of the permissions assertions pass, or throws an error
- * @param {function[]} assertions  Each permissions assertion should return true or throw an error
+ * @param {function[]} assertions Each permissions assertion should return `true` or throw a
+ * {@link PermissionsError}
  * @param {string} errorMessage
  */
 export const assertAllPermissions = (assertions, errorMessage) => async accessPolicy => {
   try {
-    for (let i = 0; i < assertions.length; i++) {
-      const assertion = assertions[i];
-      await assertion(accessPolicy);
-    }
+    for (const assertion of assertions) await assertion(accessPolicy);
     return true;
   } catch (e) {
     throw new Error(errorMessage || e.message);

--- a/packages/central-server/src/permissions/assertions.js
+++ b/packages/central-server/src/permissions/assertions.js
@@ -1,151 +1,19 @@
-import { ensure } from '@tupaia/tsutils';
-import { PermissionsError } from '@tupaia/utils';
-import {
-  BES_ADMIN_PERMISSION_GROUP,
-  TUPAIA_ADMIN_PANEL_PERMISSION_GROUP,
-  VIZ_BUILDER_PERMISSION_GROUP,
-} from './constants';
-
-/**
- * Returns true all the time. This is for any route handlers that do not need permissions.
- */
-export const allowNoPermissions = () => {
-  return true;
-};
-
-/**
- * Returns true if all of the permissions assertions pass, or throws an error
- * @param {function[]} assertions  Each permissions assertion should return true or throw an error
- * @param {string} errorMessage
- */
-export const assertAllPermissions = (assertions, errorMessage) => async accessPolicy => {
-  try {
-    for (let i = 0; i < assertions.length; i++) {
-      const assertion = assertions[i];
-      await assertion(accessPolicy);
-    }
-    return true;
-  } catch (e) {
-    throw new Error(errorMessage || e.message);
-  }
-};
-
-/**
- * Returns true if any of the permissions assertions pass, or throws an error
- * @param {function[]} assertions Each permissions assertion should return true or throw a
- * {@link PermissionsError}
- * @param {string} errorMessage
- */
-export const assertAnyPermissions = (assertions, errorMessage) => async accessPolicy => {
-  const combinedErrorMessages = ['One of the following conditions need to be satisfied:'];
-
-  for (const assertion of assertions) {
-    try {
-      await assertion(accessPolicy);
-      return true;
-    } catch (e) {
-      combinedErrorMessages.push(e.message);
-      // swallow specific errors, in case any assertion returns true
-    }
-  }
-  throw new Error(errorMessage || combinedErrorMessages.join('\n'));
-};
-
-/**
- * @deprecated Use hasBESAdminAccess from @tupaia/access-policy instead
- */
-export const hasBESAdminAccess = accessPolicy =>
-  accessPolicy.allowsSome(undefined, BES_ADMIN_PERMISSION_GROUP);
-
-export const hasVizBuilderAccess = accessPolicy =>
-  accessPolicy.allowsSome(undefined, VIZ_BUILDER_PERMISSION_GROUP);
-
-export const hasPermissionGroupAccess = (accessPolicy, permissionGroup) =>
-  accessPolicy.allowsSome(undefined, permissionGroup);
-
-// has access to all permission groups inputted
-export const hasPermissionGroupsAccess = (accessPolicy, permissionGroups) => {
-  for (let i = 0; i < permissionGroups.length; i++) {
-    if (!accessPolicy.allowsSome(undefined, permissionGroups[i])) {
-      return false;
-    }
-  }
-  return true;
-};
-
-export const hasSomePermissionGroupsAccess = (accessPolicy, permissionGroups) => {
-  for (let i = 0; i < permissionGroups.length; i++) {
-    if (accessPolicy.allowsSome(undefined, permissionGroups[i])) {
-      return true;
-    }
-  }
-
-  return false;
-};
-
-export const assertBESAdminAccess = accessPolicy => {
-  if (hasBESAdminAccess(accessPolicy)) {
-    return true;
-  }
-
-  throw new Error(`Need ${BES_ADMIN_PERMISSION_GROUP} access`);
-};
-
-export const assertVizBuilderAccess = accessPolicy => {
-  if (hasVizBuilderAccess(accessPolicy)) {
-    return true;
-  }
-
-  throw new Error(`Need ${VIZ_BUILDER_PERMISSION_GROUP} access`);
-};
-
-export const hasTupaiaAdminPanelAccess = accessPolicy =>
-  accessPolicy.allowsSome(undefined, TUPAIA_ADMIN_PANEL_PERMISSION_GROUP);
-
-export const hasTupaiaAdminPanelAccessToCountry = (accessPolicy, countryCode) =>
-  accessPolicy.allows(countryCode, TUPAIA_ADMIN_PANEL_PERMISSION_GROUP);
-
-export const assertAdminPanelAccessToCountry = async (accessPolicy, models, recordId) => {
-  const entity = ensure(
-    await models.entity.findById(recordId),
-    `No entity exists with ID ${recordId}`,
-  );
-
-  const userHasAdminAccessToCountry = accessPolicy.allows(
-    entity.country_code,
-    TUPAIA_ADMIN_PANEL_PERMISSION_GROUP,
-  );
-  if (!userHasAdminAccessToCountry) {
-    throw new PermissionsError(
-      `Need Tupaia Admin Panel access to country '${entity.country_code}' to edit entity`,
-    );
-  }
-  return true;
-};
-
-export const assertAdminPanelAccess = accessPolicy => {
-  if (hasTupaiaAdminPanelAccess(accessPolicy)) {
-    return true;
-  }
-
-  throw new PermissionsError(`Need ${TUPAIA_ADMIN_PANEL_PERMISSION_GROUP} access`);
-};
-
-export const assertPermissionGroupAccess = (accessPolicy, permissionGroupName) => {
-  if (hasPermissionGroupAccess(accessPolicy, permissionGroupName)) {
-    return true;
-  }
-
-  throw new PermissionsError(`Need ${permissionGroupName} access`);
-};
-
-export const assertPermissionGroupsAccess = (accessPolicy, permissionGroupNames) => {
-  if (
-    hasPermissionGroupsAccess(accessPolicy, permissionGroupNames) ||
-    hasBESAdminAccess(accessPolicy)
-  ) {
-    return true;
-  }
-
-  throw new Error(`You do not have access to all related permission groups`);
-};
+/* Re-export for backward compatibility. Prefer importing directly from @tupaia/access-policy. */
+export {
+  allowNoPermissions,
+  assertAllPermissions,
+  assertAnyPermissions,
+  hasBESAdminAccess,
+  hasVizBuilderAccess,
+  hasPermissionGroupAccess,
+  hasPermissionGroupsAccess,
+  hasSomePermissionGroupsAccess,
+  assertBESAdminAccess,
+  assertVizBuilderAccess,
+  hasTupaiaAdminPanelAccess,
+  hasTupaiaAdminPanelAccessToCountry,
+  assertAdminPanelAccessToCountry,
+  assertAdminPanelAccess,
+  assertPermissionGroupAccess,
+  assertPermissionGroupsAccess,
+} from '@tupaia/access-policy';

--- a/packages/central-server/src/permissions/assertions.js
+++ b/packages/central-server/src/permissions/assertions.js
@@ -12,8 +12,29 @@ export {
   assertVizBuilderAccess,
   hasTupaiaAdminPanelAccess,
   hasTupaiaAdminPanelAccessToCountry,
-  assertAdminPanelAccessToCountry,
   assertAdminPanelAccess,
   assertPermissionGroupAccess,
   assertPermissionGroupsAccess,
 } from '@tupaia/access-policy';
+
+/**
+ * @type {PermissionsAssertion}
+ * @param {ModelRegistry} models
+ * @param {string} recordId
+ */
+export const assertAdminPanelAccessToCountry = async (accessPolicy, models, recordId) => {
+  const entity = ensure(
+    await models.entity.findById(recordId),
+    `No entity exists with ID ${recordId}`,
+  );
+  const userHasAdminAccessToCountry = accessPolicy.allows(
+    entity.country_code,
+    TUPAIA_ADMIN_PANEL_PERMISSION_GROUP,
+  );
+  if (!userHasAdminAccessToCountry) {
+    throw new PermissionsError(
+      `Need ${TUPAIA_ADMIN_PANEL_PERMISSION_GROUP} access to country ‘${entity.country_code}’ to edit entity ‘${entity.name}’`,
+    );
+  }
+  return true;
+};

--- a/packages/central-server/src/permissions/constants.js
+++ b/packages/central-server/src/permissions/constants.js
@@ -1,3 +1,6 @@
-export const BES_ADMIN_PERMISSION_GROUP = 'BES Admin';
-export const TUPAIA_ADMIN_PANEL_PERMISSION_GROUP = 'Tupaia Admin Panel';
-export const VIZ_BUILDER_PERMISSION_GROUP = 'Viz Builder User';
+/* Re-export for backward compatibility. Prefer importing directly from @tupaia/constants. */
+export {
+  BES_ADMIN_PERMISSION_GROUP,
+  TUPAIA_ADMIN_PANEL_PERMISSION_GROUP,
+  VIZ_BUILDER_PERMISSION_GROUP,
+} from '@tupaia/constants';

--- a/packages/constants/src/permission.ts
+++ b/packages/constants/src/permission.ts
@@ -18,3 +18,5 @@ export const API_CLIENT_PERMISSIONS = [
 ] as const;
 
 export const BES_ADMIN_PERMISSION_GROUP = 'BES Admin';
+export const TUPAIA_ADMIN_PANEL_PERMISSION_GROUP = 'Tupaia Admin Panel';
+export const VIZ_BUILDER_PERMISSION_GROUP = 'Viz Builder User';

--- a/yarn.lock
+++ b/yarn.lock
@@ -12109,6 +12109,7 @@ __metadata:
   dependencies:
     "@babel/eslint-parser": ^7.27.5
     "@tupaia/constants": "workspace:*"
+    "@tupaia/tsutils": "workspace:*"
     "@tupaia/utils": "workspace:*"
     eslint: ^7.32.0
     npm-run-all: ^4.1.5


### PR DESCRIPTION
> [!TIP]
> Review this PR [commit-by-commit](https://github.com/beyondessential/tupaia/pull/6469/commits)

Should be completely backward compatible with all existing usages


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves permission assertions/checkers into `@tupaia/access-policy`, re-exports them from central-server, and centralizes permission group constants in `@tupaia/constants`.
> 
> - **Access Policy**:
>   - **Permissions API**: Implements and exports `allowNoPermissions`, `assertAllPermissions`, `assertAnyPermissions`, `hasBESAdminAccess`, `hasVizBuilderAccess`, `hasPermissionGroupAccess`, `hasPermissionGroupsAccess`, `hasSomePermissionGroupsAccess`, `hasTupaiaAdminPanelAccess`, `hasTupaiaAdminPanelAccessToCountry`, and corresponding `assert*` helpers in `packages/access-policy/src/permissions.js`.
>   - **Exports**: Switch to explicit named exports from `src/index.js`.
> - **Central Server**:
>   - **Re-exports**: `src/permissions/assertions.js` now re-exports permission helpers from `@tupaia/access-policy` (keeps `assertAdminPanelAccessToCountry` locally with refined error message).
>   - **Constants**: `src/permissions/constants.js` re-exports `BES_ADMIN_PERMISSION_GROUP`, `TUPAIA_ADMIN_PANEL_PERMISSION_GROUP`, `VIZ_BUILDER_PERMISSION_GROUP` from `@tupaia/constants`.
> - **Constants Package**:
>   - Adds `TUPAIA_ADMIN_PANEL_PERMISSION_GROUP` and `VIZ_BUILDER_PERMISSION_GROUP` to `packages/constants/src/permission.ts`.
> - **Dependencies**:
>   - Adds `@tupaia/tsutils` to `@tupaia/access-policy`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b9df9cd19bd75398a8cbef81a8a95c7d76c705e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->