### PR TITLE
deps: RN-1761: bump body-parser 1.18 → 1.20.3

### DIFF
--- a/packages/central-server/package.json
+++ b/packages/central-server/package.json
@@ -42,7 +42,7 @@
     "@tupaia/utils": "workspace:*",
     "adm-zip": "^0.5.5",
     "api-error-handler": "^1.0.0",
-    "body-parser": "^1.18.3",
+    "body-parser": "^1.20.3",
     "case": "^1.6.3",
     "compare-versions": "^6.1.0",
     "cors": "^2.8.5",

--- a/packages/server-boilerplate/package.json
+++ b/packages/server-boilerplate/package.json
@@ -33,7 +33,7 @@
     "@tupaia/types": "workspace:*",
     "@tupaia/utils": "workspace:*",
     "api-error-handler": "^1.0.0",
-    "body-parser": "^1.18.3",
+    "body-parser": "^1.20.3",
     "client-sessions": "^0.8.0",
     "cors": "^2.8.5",
     "express": "^4.19.2",

--- a/packages/web-config-server/package.json
+++ b/packages/web-config-server/package.json
@@ -33,7 +33,7 @@
     "@tupaia/tsutils": "workspace:*",
     "@tupaia/types": "workspace:*",
     "@tupaia/utils": "workspace:*",
-    "body-parser": "^1.18.2",
+    "body-parser": "^1.20.3",
     "case": "^1.6.3",
     "client-sessions": "^0.8.0",
     "compression": "^1.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12210,7 +12210,7 @@ __metadata:
     "@tupaia/utils": "workspace:*"
     adm-zip: ^0.5.5
     api-error-handler: ^1.0.0
-    body-parser: ^1.18.3
+    body-parser: ^1.20.3
     case: ^1.6.3
     chai: ^4.1.2
     chai-as-promised: ^7.1.1
@@ -12871,7 +12871,7 @@ __metadata:
     "@types/jest": ^29.5.14
     "@types/supertest": ^2.0.11
     api-error-handler: ^1.0.0
-    body-parser: ^1.18.3
+    body-parser: ^1.20.3
     client-sessions: ^0.8.0
     cors: ^2.8.5
     express: ^4.19.2
@@ -13223,7 +13223,7 @@ __metadata:
     "@tupaia/types": "workspace:*"
     "@tupaia/utils": "workspace:*"
     babel-plugin-module-resolver: ^4.0.0
-    body-parser: ^1.18.2
+    body-parser: ^1.20.3
     case: ^1.6.3
     client-sessions: ^0.8.0
     compression: ^1.7.2
@@ -16755,21 +16755,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"body-parser@npm:^1.18.2, body-parser@npm:^1.18.3":
-  version: 1.19.0
-  resolution: "body-parser@npm:1.19.0"
+"body-parser@npm:^1.20.3":
+  version: 1.20.3
+  resolution: "body-parser@npm:1.20.3"
   dependencies:
-    bytes: 3.1.0
-    content-type: ~1.0.4
+    bytes: 3.1.2
+    content-type: ~1.0.5
     debug: 2.6.9
-    depd: ~1.1.2
-    http-errors: 1.7.2
+    depd: 2.0.0
+    destroy: 1.2.0
+    http-errors: 2.0.0
     iconv-lite: 0.4.24
-    on-finished: ~2.3.0
-    qs: 6.7.0
-    raw-body: 2.4.0
-    type-is: ~1.6.17
-  checksum: 490231b4c89bbd43112762f7ba8e5342c174a6c9f64284a3b0fcabf63277e332f8316765596f1e5b15e4f3a6cf0422e005f4bb3149ed3a224bb025b7a36b9ac1
+    on-finished: 2.4.1
+    qs: 6.13.0
+    raw-body: 2.5.2
+    type-is: ~1.6.18
+    unpipe: 1.0.0
+  checksum: 1a35c59a6be8d852b00946330141c4f142c6af0f970faa87f10ad74f1ee7118078056706a05ae3093c54dabca9cd3770fa62a170a85801da1a4324f04381167d
   languageName: node
   linkType: hard
 
@@ -17085,13 +17087,6 @@ __metadata:
   version: 3.0.0
   resolution: "bytes@npm:3.0.0"
   checksum: a2b386dd8188849a5325f58eef69c3b73c51801c08ffc6963eddc9be244089ba32d19347caf6d145c86f315ae1b1fc7061a32b0c1aa6379e6a719090287ed101
-  languageName: node
-  linkType: hard
-
-"bytes@npm:3.1.0":
-  version: 3.1.0
-  resolution: "bytes@npm:3.1.0"
-  checksum: 7c3b21c5d9d44ed455460d5d36a31abc6fa2ce3807964ba60a4b03fd44454c8cf07bb0585af83bfde1c5cc2ea4bbe5897bc3d18cd15e0acf25a3615a35aba2df
   languageName: node
   linkType: hard
 
@@ -24212,19 +24207,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-errors@npm:1.7.2":
-  version: 1.7.2
-  resolution: "http-errors@npm:1.7.2"
-  dependencies:
-    depd: ~1.1.2
-    inherits: 2.0.3
-    setprototypeof: 1.1.1
-    statuses: ">= 1.5.0 < 2"
-    toidentifier: 1.0.0
-  checksum: 5534b0ae08e77f5a45a2380f500e781f6580c4ff75b816cb1f09f99a290b57e78a518be6d866db1b48cca6b052c09da2c75fc91fb16a2fe3da3c44d9acbb9972
-  languageName: node
-  linkType: hard
-
 "http-errors@npm:2.0.0, http-errors@npm:^2.0.0":
   version: 2.0.0
   resolution: "http-errors@npm:2.0.0"
@@ -24644,13 +24626,6 @@ __metadata:
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 4a48a733847879d6cf6691860a6b1e3f0f4754176e4d71494c41f3475553768b10f84b5ce1d40fbd0e34e6bfbb864ee35858ad4dd2cf31e02fc4a154b724d7f1
-  languageName: node
-  linkType: hard
-
-"inherits@npm:2.0.3":
-  version: 2.0.3
-  resolution: "inherits@npm:2.0.3"
-  checksum: 78cb8d7d850d20a5e9a7f3620db31483aa00ad5f722ce03a55b110e5a723539b3716a3b463e2b96ce3fe286f33afc7c131fa2f91407528ba80cea98a7545d4c0
   languageName: node
   linkType: hard
 
@@ -33006,10 +32981,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:6.7.0":
-  version: 6.7.0
-  resolution: "qs@npm:6.7.0"
-  checksum: dfd5f6adef50e36e908cfa70a6233871b5afe66fbaca37ecc1da352ba29eb2151a3797991948f158bb37fccde51bd57845cb619a8035287bfc24e4591172c347
+"qs@npm:6.13.0":
+  version: 6.13.0
+  resolution: "qs@npm:6.13.0"
+  dependencies:
+    side-channel: ^1.0.6
+  checksum: e9404dc0fc2849245107108ce9ec2766cde3be1b271de0bf1021d049dc5b98d1a2901e67b431ac5509f865420a7ed80b7acb3980099fe1c118a1c5d2e1432ad8
   languageName: node
   linkType: hard
 
@@ -33171,18 +33148,6 @@ __metadata:
   version: 5.0.3
   resolution: "rate-limiter-flexible@npm:5.0.3"
   checksum: 2cf9edb7f887470cd5849bb7d2645d77953719a693d2f98afe38bc6e6af9976832b3ff6cd01469743a7105c5bcfe3122f7ba0300bb34fba3d97a4773326920d2
-  languageName: node
-  linkType: hard
-
-"raw-body@npm:2.4.0":
-  version: 2.4.0
-  resolution: "raw-body@npm:2.4.0"
-  dependencies:
-    bytes: 3.1.0
-    http-errors: 1.7.2
-    iconv-lite: 0.4.24
-    unpipe: 1.0.0
-  checksum: 6343906939e018c6e633a34a938a5d6d1e93ffcfa48646e00207d53b418e941953b521473950c079347220944dc75ba10e7b3c08bf97e3ac72c7624882db09bb
   languageName: node
   linkType: hard
 
@@ -38675,7 +38640,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-is@npm:^1.6.16, type-is@npm:^1.6.18, type-is@npm:^1.6.4, type-is@npm:~1.6.17, type-is@npm:~1.6.18":
+"type-is@npm:^1.6.16, type-is@npm:^1.6.18, type-is@npm:^1.6.4, type-is@npm:~1.6.18":
   version: 1.6.18
   resolution: "type-is@npm:1.6.18"
   dependencies:


### PR DESCRIPTION
## RN-1761

Fixes https://github.com/beyondessential/tupaia/security/dependabot/322

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrade body-parser to ^1.20.3 in central-server, server-boilerplate, and web-config-server with corresponding yarn.lock updates.
> 
> - **Dependencies**:
>   - **body-parser**: Upgrade to `^1.20.3` in `packages/central-server/package.json`, `packages/server-boilerplate/package.json`, and `packages/web-config-server/package.json`.
>   - **Lockfile updates**: Refresh `yarn.lock` to new transitive versions (e.g., `bytes@3.1.2`, `qs@6.13.0`, `http-errors@2.0.0`, `depd@2.0.0`, `destroy@1.2.0`, `on-finished@2.4.1`, `type-is@1.6.18`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f520846819692acbe8e3d1399c68f28c4de518c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->