### PR TITLE
deps: RN-1761: bump decode-uri-component 0.2.0 → 0.4.1

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -19531,9 +19531,9 @@ __metadata:
   linkType: hard
 
 "decode-uri-component@npm:^0.2.0":
-  version: 0.2.0
-  resolution: "decode-uri-component@npm:0.2.0"
-  checksum: f3749344ab9305ffcfe4bfe300e2dbb61fc6359e2b736812100a3b1b6db0a5668cba31a05e4b45d4d63dbf1a18dfa354cd3ca5bb3ededddabb8cd293f4404f94
+  version: 0.4.1
+  resolution: "decode-uri-component@npm:0.4.1"
+  checksum: 0473924860986fb6ca19ee65a2af13e08801b4f3660475b058500ea8479ed715c919884a026b6bf4296dbb640d3cea74fadf45490b2439152fc548271d0201ec
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## RN-1761

Fixes https://github.com/beyondessential/tupaia/security/dependabot/194

Changeling suggests no changes that would be breaking for us: https://github.com/SamVerschueren/decode-uri-component/releases

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps `decode-uri-component` from `0.2.0` to `0.4.1` in `yarn.lock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da283a0a6506e0fa7ba841192cfa36f340f3a4db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->