### PR TITLE
db(entityTypes): MAUI-5937: add `spare_part` entity type

### DIFF
--- a/packages/database/src/migrations/20251003065208-AddSparePartEntityType-modifies-schema.js
+++ b/packages/database/src/migrations/20251003065208-AddSparePartEntityType-modifies-schema.js
@@ -5,23 +5,23 @@ var type;
 var seed;
 
 /**
-  * We receive the dbmigrate dependency from dbmigrate initially.
-  * This enables us to not have to rely on NODE_PATH.
-  */
-exports.setup = function(options, seedLink) {
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
   dbm = options.dbmigrate;
   type = dbm.dataType;
   seed = seedLink;
 };
 
-exports.up = function(db) {
+exports.up = function (db) {
   return db.runSql("ALTER TYPE public.entity_type ADD VALUE IF NOT EXISTS 'spare_part';");
 };
 
-exports.down = function(db) {
+exports.down = function (db) {
   return null;
 };
 
 exports._meta = {
-  "version": 1
+  version: 1,
 };

--- a/packages/database/src/migrations/20251003065208-AddSparePartEntityType-modifies-schema.js
+++ b/packages/database/src/migrations/20251003065208-AddSparePartEntityType-modifies-schema.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function(db) {
+  return db.runSql("ALTER TYPE public.entity_type ADD VALUE IF NOT EXISTS 'spare_part';");
+};
+
+exports.down = function(db) {
+  return null;
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/packages/types/src/schemas/schemas.ts
+++ b/packages/types/src/schemas/schemas.ts
@@ -84731,6 +84731,7 @@ export const EntityTypeEnumSchema = {
 		"project",
 		"repair_request",
 		"school",
+		"spare_part",
 		"sub_catchment",
 		"sub_district",
 		"sub_facility",

--- a/packages/types/src/types/models.ts
+++ b/packages/types/src/types/models.ts
@@ -1897,6 +1897,7 @@ export enum EntityTypeEnum {
   'policy' = 'policy',
   'kiuar_facility' = 'kiuar_facility',
   'kiuar_area' = 'kiuar_area',
+  'spare_part' = 'spare_part',
 }
 export enum DataTableType {
   'analytics' = 'analytics',


### PR DESCRIPTION
### Issue #: MAUI-5937

### Changes:

- Addition of spare_part entity type


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `spare_part` entity type across DB enum and TypeScript schemas/enums.
> 
> - **Database**:
>   - Migration `packages/database/src/migrations/20251003065208-AddSparePartEntityType-modifies-schema.js` adds `'spare_part'` to `public.entity_type` enum.
> - **Types**:
>   - Add `'spare_part'` to `EntityTypeEnum` in `packages/types/src/types/models.ts`.
>   - Include `'spare_part'` in entity type schema list in `packages/types/src/schemas/schemas.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b65bd975f7433a4bd6adb5355c0cdcf12d31cf79. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->