### PR TITLE
fix(datatrak): RN-1490: offline submission of entity-creating survey submissions

### DIFF
--- a/packages/database/src/core/modelClasses/Survey/Survey.js
+++ b/packages/database/src/core/modelClasses/Survey/Survey.js
@@ -20,7 +20,13 @@ export class SurveyRecord extends DatabaseRecord {
    * @returns {Promise<import('../DataGroup').DataGroupRecord>} data group for survey
    */
   async dataGroup() {
-    return await this.otherModels.dataGroup.findById(this.data_group_id);
+    const dataGroupId =
+      this.data_group_id ??
+      (await this.model.findById(this.id, { columns: ['data_group_id'] })).data_group_id;
+    return ensure(
+      await this.otherModels.dataGroup.findById(dataGroupId),
+      `Couldn’t find data group for survey ${this.id} (expected data group with ID ${dataGroupId})`,
+    );
   }
 
   /**


### PR DESCRIPTION
## [RN-1490 Issue 16](https://linear.app/bes/issue/RN-1490/offline-survey-submission#comment-805210e3)

`upsertEntities()` internally accesses a survey’s data group, but this doesn’t currently exist in the client databasese