### PR TITLE
fix(utils): handle null RegExp match in `requireEnv` error

### DIFF
--- a/packages/utils/src/requireEnv.js
+++ b/packages/utils/src/requireEnv.js
@@ -1,13 +1,14 @@
 const getCurrentPackage = () => {
-  const [, packageName] = process.cwd().match(/packages\/([^\\/]+)$/);
-  return packageName ? `@tupaia/${packageName}` : '';
+  const cwd = process.cwd();
+  const packageName = cwd.match(/packages\/([^\\/]+)$/)?.[1];
+  return packageName ? `@tupaia/${packageName}` : `<unknown package> (${cwd})`;
 };
 
 export const requireEnv = variable => {
   const value = process.env[variable];
   if (value === undefined) {
     throw new Error(
-      `Could not load env variable '${variable}', required in ${getCurrentPackage()} `,
+      `Could not load env variable '${variable}', required in ${getCurrentPackage()}`,
     );
   }
   return value;


### PR DESCRIPTION
Avoids this error from intercepting the the one we’re actually trying to throw

```
TypeError: Invalid attempt to destructure non-iterable instance.
```