### PR TITLE
refactor(datatrak): decompose sync status listener hooks

### DIFF
--- a/packages/datatrak-web/src/sync/ClientSyncManager.ts
+++ b/packages/datatrak-web/src/sync/ClientSyncManager.ts
@@ -18,12 +18,8 @@ import { ensure } from '@tupaia/tsutils';
 import { Project } from '@tupaia/types';
 import { remove, stream } from '../api';
 import { DatatrakDatabase } from '../database/DatatrakDatabase';
-import {
-  type DatatrakWebModelRegistry,
-  type ProcessStreamDataParams,
-  SYNC_EVENT_ACTIONS,
-  type SyncEvents,
-} from '../types';
+import type { DatatrakWebModelRegistry, ProcessStreamDataParams, SyncEvents } from '../types';
+import { SYNC_EVENT_ACTIONS } from '../types';
 import { formatFraction } from '../utils';
 import { getDeviceId } from './getDeviceId';
 import { getSyncTick } from './getSyncTick';

--- a/packages/datatrak-web/src/sync/syncStatus.ts
+++ b/packages/datatrak-web/src/sync/syncStatus.ts
@@ -161,3 +161,24 @@ export function useSyncError(): string | null {
 
   return message;
 }
+
+export function useSyncStatus() {
+  const isRequestingSync = useIsRequestingSync();
+  const isSyncing = useIsSyncing();
+  const isQueuing = useIsInSyncQueue();
+  const syncStage = useSyncStage();
+  const [progress, progressMessage] = useSyncProgress();
+  const errorMessage = useSyncError();
+  const lastSyncTime = useLastSyncTime();
+
+  return {
+    errorMessage,
+    isRequestingSync,
+    isSyncing,
+    isQueuing,
+    syncStage,
+    progress,
+    progressMessage,
+    lastSyncTime,
+  };
+}

--- a/packages/datatrak-web/src/sync/syncStatus.ts
+++ b/packages/datatrak-web/src/sync/syncStatus.ts
@@ -58,19 +58,21 @@ export function useIsSyncing(): boolean {
   const syncManager = useSyncContext()?.clientSyncManager;
   const [isSyncing, setIsSyncing] = useState(syncManager?.isSyncing ?? false);
 
-  const set = useCallback(() => setIsSyncing(true), []);
-  const unset = useCallback(() => setIsSyncing(false), []);
+  const update = useCallback(
+    () => setIsSyncing(syncManager?.isSyncing ?? false),
+    [syncManager?.isSyncing],
+  );
 
   useEffect(() => {
-    syncManager?.emitter?.on(SYNC_EVENT_ACTIONS.SYNC_IN_QUEUE, unset);
-    syncManager?.emitter?.on(SYNC_EVENT_ACTIONS.SYNC_STARTED, set);
-    syncManager?.emitter?.on(SYNC_EVENT_ACTIONS.SYNC_ENDED, unset);
+    syncManager?.emitter?.on(SYNC_EVENT_ACTIONS.SYNC_IN_QUEUE, update);
+    syncManager?.emitter?.on(SYNC_EVENT_ACTIONS.SYNC_STARTED, update);
+    syncManager?.emitter?.on(SYNC_EVENT_ACTIONS.SYNC_ENDED, update);
     return () => {
-      syncManager?.emitter?.off(SYNC_EVENT_ACTIONS.SYNC_IN_QUEUE, unset);
-      syncManager?.emitter?.off(SYNC_EVENT_ACTIONS.SYNC_STARTED, set);
-      syncManager?.emitter?.off(SYNC_EVENT_ACTIONS.SYNC_ENDED, unset);
+      syncManager?.emitter?.off(SYNC_EVENT_ACTIONS.SYNC_IN_QUEUE, update);
+      syncManager?.emitter?.off(SYNC_EVENT_ACTIONS.SYNC_STARTED, update);
+      syncManager?.emitter?.off(SYNC_EVENT_ACTIONS.SYNC_ENDED, update);
     };
-  }, [syncManager?.emitter, set, unset]);
+  }, [syncManager?.emitter, update]);
 
   return isSyncing;
 }

--- a/packages/datatrak-web/src/sync/syncStatus.ts
+++ b/packages/datatrak-web/src/sync/syncStatus.ts
@@ -1,0 +1,163 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { useSyncContext } from '../api/SyncContext';
+import { SYNC_EVENT_ACTIONS } from '../types';
+
+export function useIsRequestingSync(): boolean {
+  const syncManager = useSyncContext()?.clientSyncManager;
+  const [isRequestingSync, setIsRequestingSync] = useState(syncManager?.isRequestingSync ?? false);
+
+  const update = useCallback(
+    () => setIsRequestingSync(syncManager?.isRequestingSync ?? false),
+    [syncManager?.isRequestingSync],
+  );
+
+  useEffect(() => {
+    const eventTypes = [
+      SYNC_EVENT_ACTIONS.SYNC_REQUESTING,
+      SYNC_EVENT_ACTIONS.SYNC_IN_QUEUE,
+      SYNC_EVENT_ACTIONS.SYNC_STARTED,
+      SYNC_EVENT_ACTIONS.SYNC_ENDED,
+      SYNC_EVENT_ACTIONS.SYNC_ERROR,
+    ];
+    for (const type of eventTypes) syncManager?.emitter?.on(type, update);
+    return () => {
+      for (const type of eventTypes) syncManager?.emitter?.off(type, update);
+    };
+  }, [syncManager?.emitter, update]);
+
+  return isRequestingSync;
+}
+
+export function useIsInSyncQueue(): boolean {
+  const syncManager = useSyncContext()?.clientSyncManager;
+  const [isQueuing, setIsQueuing] = useState(syncManager?.isQueuing ?? false);
+
+  const update = useCallback(
+    () => setIsQueuing(syncManager?.isQueuing ?? false),
+    [syncManager?.isQueuing],
+  );
+
+  useEffect(() => {
+    syncManager?.emitter?.on(SYNC_EVENT_ACTIONS.SYNC_IN_QUEUE, update);
+    syncManager?.emitter?.on(SYNC_EVENT_ACTIONS.SYNC_STARTED, update);
+    syncManager?.emitter?.on(SYNC_EVENT_ACTIONS.SYNC_ENDED, update);
+    syncManager?.emitter?.on(SYNC_EVENT_ACTIONS.SYNC_ERROR, update);
+    return () => {
+      syncManager?.emitter?.off(SYNC_EVENT_ACTIONS.SYNC_IN_QUEUE, update);
+      syncManager?.emitter?.off(SYNC_EVENT_ACTIONS.SYNC_STARTED, update);
+      syncManager?.emitter?.off(SYNC_EVENT_ACTIONS.SYNC_ENDED, update);
+      syncManager?.emitter?.off(SYNC_EVENT_ACTIONS.SYNC_ERROR, update);
+    };
+  }, [syncManager?.emitter, update]);
+
+  return isQueuing;
+}
+
+export function useIsSyncing(): boolean {
+  const syncManager = useSyncContext()?.clientSyncManager;
+  const [isSyncing, setIsSyncing] = useState(syncManager?.isSyncing ?? false);
+
+  const set = useCallback(() => setIsSyncing(true), []);
+  const unset = useCallback(() => setIsSyncing(false), []);
+
+  useEffect(() => {
+    syncManager?.emitter?.on(SYNC_EVENT_ACTIONS.SYNC_IN_QUEUE, unset);
+    syncManager?.emitter?.on(SYNC_EVENT_ACTIONS.SYNC_STARTED, set);
+    syncManager?.emitter?.on(SYNC_EVENT_ACTIONS.SYNC_ENDED, unset);
+    return () => {
+      syncManager?.emitter?.off(SYNC_EVENT_ACTIONS.SYNC_IN_QUEUE, unset);
+      syncManager?.emitter?.off(SYNC_EVENT_ACTIONS.SYNC_STARTED, set);
+      syncManager?.emitter?.off(SYNC_EVENT_ACTIONS.SYNC_ENDED, unset);
+    };
+  }, [syncManager?.emitter, set, unset]);
+
+  return isSyncing;
+}
+
+export function useSyncStage(): number | null {
+  const syncManager = useSyncContext()?.clientSyncManager;
+  const [syncStage, setSyncStage] = useState(syncManager?.syncStage ?? null);
+
+  const update = useCallback(
+    () => setSyncStage(syncManager?.syncStage ?? null),
+    [syncManager?.syncStage],
+  );
+
+  useEffect(() => {
+    syncManager?.emitter?.on(SYNC_EVENT_ACTIONS.SYNC_STATE_CHANGED, update);
+    return () => void syncManager?.emitter?.off(SYNC_EVENT_ACTIONS.SYNC_STATE_CHANGED, update);
+  }, [syncManager?.emitter, update]);
+
+  return syncStage;
+}
+
+export function useSyncProgress(): [number | null, string | null] {
+  const syncManager = useSyncContext()?.clientSyncManager;
+
+  const [progress, setProgress] = useState(syncManager?.progress ?? null);
+  const [message, setMessage] = useState(syncManager?.progressMessage ?? null);
+
+  const update = useCallback(() => {
+    setProgress(syncManager?.progress ?? null);
+    setMessage(syncManager?.progressMessage ?? null);
+  }, [syncManager?.progress, syncManager?.progressMessage]);
+
+  useEffect(() => {
+    const eventTypes = [
+      SYNC_EVENT_ACTIONS.SYNC_REQUESTING,
+      SYNC_EVENT_ACTIONS.SYNC_IN_QUEUE,
+      SYNC_EVENT_ACTIONS.SYNC_STARTED,
+      SYNC_EVENT_ACTIONS.SYNC_STATE_CHANGED,
+      SYNC_EVENT_ACTIONS.SYNC_ENDED,
+    ];
+    for (const type of eventTypes) syncManager?.emitter?.on(type, update);
+    return () => {
+      for (const type of eventTypes) syncManager?.emitter?.off(type, update);
+    };
+  }, [syncManager?.emitter, update]);
+
+  return [progress, message];
+}
+
+export function useLastSyncTime(): Date | null {
+  const syncManager = useSyncContext()?.clientSyncManager;
+  const [lastSyncTime, setLastSyncTime] = useState<Date | null>(
+    syncManager?.lastSuccessfulSyncTime ?? null,
+  );
+
+  const update = useCallback(
+    () => setLastSyncTime(syncManager?.lastSuccessfulSyncTime ?? null),
+    [syncManager?.lastSuccessfulSyncTime],
+  );
+
+  useEffect(() => {
+    syncManager?.emitter?.on(SYNC_EVENT_ACTIONS.SYNC_STATE_CHANGED, update);
+    return () => void syncManager?.emitter?.off(SYNC_EVENT_ACTIONS.SYNC_STATE_CHANGED, update);
+  }, [syncManager?.emitter, update]);
+
+  return lastSyncTime;
+}
+
+export function useSyncError(): string | null {
+  const syncManager = useSyncContext()?.clientSyncManager;
+  const [message, setMessage] = useState<string | null>(syncManager?.errorMessage ?? null);
+
+  const update = useCallback(event => setMessage(event.error), []);
+  const clear = useCallback(() => setMessage(null), []);
+
+  useEffect(() => {
+    syncManager?.emitter?.on(SYNC_EVENT_ACTIONS.SYNC_REQUESTING, clear);
+    syncManager?.emitter?.on(SYNC_EVENT_ACTIONS.SYNC_IN_QUEUE, clear);
+    syncManager?.emitter?.on(SYNC_EVENT_ACTIONS.SYNC_STARTED, clear);
+    syncManager?.emitter?.on(SYNC_EVENT_ACTIONS.SYNC_ERROR, update);
+    return () => {
+      syncManager?.emitter?.off(SYNC_EVENT_ACTIONS.SYNC_REQUESTING, clear);
+      syncManager?.emitter?.off(SYNC_EVENT_ACTIONS.SYNC_IN_QUEUE, clear);
+      syncManager?.emitter?.off(SYNC_EVENT_ACTIONS.SYNC_STARTED, clear);
+      syncManager?.emitter?.off(SYNC_EVENT_ACTIONS.SYNC_ERROR, update);
+    };
+  }, [clear, syncManager?.emitter, update]);
+
+  return message;
+}

--- a/packages/datatrak-web/src/sync/syncStatus.ts
+++ b/packages/datatrak-web/src/sync/syncStatus.ts
@@ -1,30 +1,39 @@
-import { useCallback, useEffect, useState } from 'react';
+import type { Handler } from 'mitt';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useSyncContext } from '../api/SyncContext';
-import { SYNC_EVENT_ACTIONS } from '../types';
+import { SYNC_EVENT_ACTIONS, type SyncEvents } from '../types';
+
+const { SYNC_REQUESTING, SYNC_IN_QUEUE, SYNC_STARTED, SYNC_STATE_CHANGED, SYNC_ENDED, SYNC_ERROR } =
+  SYNC_EVENT_ACTIONS;
+
+export function useSyncEventListener<T extends keyof SyncEvents>(
+  eventType: T,
+  handler: Handler<SyncEvents[T]>,
+) {
+  const emitter = useSyncContext()?.clientSyncManager?.emitter;
+  useEffect(() => {
+    emitter?.on<T>(eventType, handler);
+    return () => {
+      emitter?.off<T>(eventType, handler);
+    };
+  }, [emitter, eventType, handler]);
+}
 
 export function useIsRequestingSync(): boolean {
   const syncManager = useSyncContext()?.clientSyncManager;
   const [isRequestingSync, setIsRequestingSync] = useState(syncManager?.isRequestingSync ?? false);
 
-  const update = useCallback(
+  const update: Handler = useCallback(
     () => setIsRequestingSync(syncManager?.isRequestingSync ?? false),
     [syncManager?.isRequestingSync],
   );
 
-  useEffect(() => {
-    const eventTypes = [
-      SYNC_EVENT_ACTIONS.SYNC_REQUESTING,
-      SYNC_EVENT_ACTIONS.SYNC_IN_QUEUE,
-      SYNC_EVENT_ACTIONS.SYNC_STARTED,
-      SYNC_EVENT_ACTIONS.SYNC_ENDED,
-      SYNC_EVENT_ACTIONS.SYNC_ERROR,
-    ];
-    for (const type of eventTypes) syncManager?.emitter?.on(type, update);
-    return () => {
-      for (const type of eventTypes) syncManager?.emitter?.off(type, update);
-    };
-  }, [syncManager?.emitter, update]);
+  useSyncEventListener(SYNC_REQUESTING, update);
+  useSyncEventListener(SYNC_IN_QUEUE, update);
+  useSyncEventListener(SYNC_STARTED, update);
+  useSyncEventListener(SYNC_ENDED, update);
+  useSyncEventListener(SYNC_ERROR, update);
 
   return isRequestingSync;
 }
@@ -33,23 +42,15 @@ export function useIsInSyncQueue(): boolean {
   const syncManager = useSyncContext()?.clientSyncManager;
   const [isQueuing, setIsQueuing] = useState(syncManager?.isQueuing ?? false);
 
-  const update = useCallback(
+  const update: Handler = useCallback(
     () => setIsQueuing(syncManager?.isQueuing ?? false),
     [syncManager?.isQueuing],
   );
 
-  useEffect(() => {
-    syncManager?.emitter?.on(SYNC_EVENT_ACTIONS.SYNC_IN_QUEUE, update);
-    syncManager?.emitter?.on(SYNC_EVENT_ACTIONS.SYNC_STARTED, update);
-    syncManager?.emitter?.on(SYNC_EVENT_ACTIONS.SYNC_ENDED, update);
-    syncManager?.emitter?.on(SYNC_EVENT_ACTIONS.SYNC_ERROR, update);
-    return () => {
-      syncManager?.emitter?.off(SYNC_EVENT_ACTIONS.SYNC_IN_QUEUE, update);
-      syncManager?.emitter?.off(SYNC_EVENT_ACTIONS.SYNC_STARTED, update);
-      syncManager?.emitter?.off(SYNC_EVENT_ACTIONS.SYNC_ENDED, update);
-      syncManager?.emitter?.off(SYNC_EVENT_ACTIONS.SYNC_ERROR, update);
-    };
-  }, [syncManager?.emitter, update]);
+  useSyncEventListener(SYNC_IN_QUEUE, update);
+  useSyncEventListener(SYNC_STARTED, update);
+  useSyncEventListener(SYNC_ENDED, update);
+  useSyncEventListener(SYNC_ERROR, update);
 
   return isQueuing;
 }
@@ -58,21 +59,14 @@ export function useIsSyncing(): boolean {
   const syncManager = useSyncContext()?.clientSyncManager;
   const [isSyncing, setIsSyncing] = useState(syncManager?.isSyncing ?? false);
 
-  const update = useCallback(
+  const update: Handler<undefined> = useCallback(
     () => setIsSyncing(syncManager?.isSyncing ?? false),
     [syncManager?.isSyncing],
   );
 
-  useEffect(() => {
-    syncManager?.emitter?.on(SYNC_EVENT_ACTIONS.SYNC_IN_QUEUE, update);
-    syncManager?.emitter?.on(SYNC_EVENT_ACTIONS.SYNC_STARTED, update);
-    syncManager?.emitter?.on(SYNC_EVENT_ACTIONS.SYNC_ENDED, update);
-    return () => {
-      syncManager?.emitter?.off(SYNC_EVENT_ACTIONS.SYNC_IN_QUEUE, update);
-      syncManager?.emitter?.off(SYNC_EVENT_ACTIONS.SYNC_STARTED, update);
-      syncManager?.emitter?.off(SYNC_EVENT_ACTIONS.SYNC_ENDED, update);
-    };
-  }, [syncManager?.emitter, update]);
+  useSyncEventListener(SYNC_IN_QUEUE, update);
+  useSyncEventListener(SYNC_STARTED, update);
+  useSyncEventListener(SYNC_ENDED, update);
 
   return isSyncing;
 }
@@ -81,15 +75,12 @@ export function useSyncStage(): number | null {
   const syncManager = useSyncContext()?.clientSyncManager;
   const [syncStage, setSyncStage] = useState(syncManager?.syncStage ?? null);
 
-  const update = useCallback(
+  const update: Handler = useCallback(
     () => setSyncStage(syncManager?.syncStage ?? null),
     [syncManager?.syncStage],
   );
 
-  useEffect(() => {
-    syncManager?.emitter?.on(SYNC_EVENT_ACTIONS.SYNC_STATE_CHANGED, update);
-    return () => void syncManager?.emitter?.off(SYNC_EVENT_ACTIONS.SYNC_STATE_CHANGED, update);
-  }, [syncManager?.emitter, update]);
+  useSyncEventListener(SYNC_STATE_CHANGED, update);
 
   return syncStage;
 }
@@ -100,24 +91,16 @@ export function useSyncProgress(): [number | null, string | null] {
   const [progress, setProgress] = useState(syncManager?.progress ?? null);
   const [message, setMessage] = useState(syncManager?.progressMessage ?? null);
 
-  const update = useCallback(() => {
+  const update: Handler = useCallback(() => {
     setProgress(syncManager?.progress ?? null);
     setMessage(syncManager?.progressMessage ?? null);
   }, [syncManager?.progress, syncManager?.progressMessage]);
 
-  useEffect(() => {
-    const eventTypes = [
-      SYNC_EVENT_ACTIONS.SYNC_REQUESTING,
-      SYNC_EVENT_ACTIONS.SYNC_IN_QUEUE,
-      SYNC_EVENT_ACTIONS.SYNC_STARTED,
-      SYNC_EVENT_ACTIONS.SYNC_STATE_CHANGED,
-      SYNC_EVENT_ACTIONS.SYNC_ENDED,
-    ];
-    for (const type of eventTypes) syncManager?.emitter?.on(type, update);
-    return () => {
-      for (const type of eventTypes) syncManager?.emitter?.off(type, update);
-    };
-  }, [syncManager?.emitter, update]);
+  useSyncEventListener(SYNC_REQUESTING, update);
+  useSyncEventListener(SYNC_IN_QUEUE, update);
+  useSyncEventListener(SYNC_STARTED, update);
+  useSyncEventListener(SYNC_STATE_CHANGED, update);
+  useSyncEventListener(SYNC_ENDED, update);
 
   return [progress, message];
 }
@@ -128,15 +111,12 @@ export function useLastSyncTime(): Date | null {
     syncManager?.lastSuccessfulSyncTime ?? null,
   );
 
-  const update = useCallback(
+  const update: Handler<SyncEvents[typeof SYNC_STATE_CHANGED]> = useCallback(
     () => setLastSyncTime(syncManager?.lastSuccessfulSyncTime ?? null),
     [syncManager?.lastSuccessfulSyncTime],
   );
 
-  useEffect(() => {
-    syncManager?.emitter?.on(SYNC_EVENT_ACTIONS.SYNC_STATE_CHANGED, update);
-    return () => void syncManager?.emitter?.off(SYNC_EVENT_ACTIONS.SYNC_STATE_CHANGED, update);
-  }, [syncManager?.emitter, update]);
+  useSyncEventListener(SYNC_STATE_CHANGED, update);
 
   return lastSyncTime;
 }
@@ -145,21 +125,16 @@ export function useSyncError(): string | null {
   const syncManager = useSyncContext()?.clientSyncManager;
   const [message, setMessage] = useState<string | null>(syncManager?.errorMessage ?? null);
 
-  const update = useCallback(event => setMessage(event.error), []);
-  const clear = useCallback(() => setMessage(null), []);
+  const clear: Handler<undefined> = useCallback(() => setMessage(null), []);
+  const update: Handler<SyncEvents[typeof SYNC_ERROR]> = useCallback(
+    event => setMessage(event.error),
+    [],
+  );
 
-  useEffect(() => {
-    syncManager?.emitter?.on(SYNC_EVENT_ACTIONS.SYNC_REQUESTING, clear);
-    syncManager?.emitter?.on(SYNC_EVENT_ACTIONS.SYNC_IN_QUEUE, clear);
-    syncManager?.emitter?.on(SYNC_EVENT_ACTIONS.SYNC_STARTED, clear);
-    syncManager?.emitter?.on(SYNC_EVENT_ACTIONS.SYNC_ERROR, update);
-    return () => {
-      syncManager?.emitter?.off(SYNC_EVENT_ACTIONS.SYNC_REQUESTING, clear);
-      syncManager?.emitter?.off(SYNC_EVENT_ACTIONS.SYNC_IN_QUEUE, clear);
-      syncManager?.emitter?.off(SYNC_EVENT_ACTIONS.SYNC_STARTED, clear);
-      syncManager?.emitter?.off(SYNC_EVENT_ACTIONS.SYNC_ERROR, update);
-    };
-  }, [clear, syncManager?.emitter, update]);
+  useSyncEventListener(SYNC_REQUESTING, clear);
+  useSyncEventListener(SYNC_IN_QUEUE, clear);
+  useSyncEventListener(SYNC_STARTED, clear);
+  useSyncEventListener(SYNC_ERROR, update);
 
   return message;
 }
@@ -173,14 +148,26 @@ export function useSyncStatus() {
   const errorMessage = useSyncError();
   const lastSyncTime = useLastSyncTime();
 
-  return {
-    errorMessage,
-    isRequestingSync,
-    isSyncing,
-    isQueuing,
-    syncStage,
-    progress,
-    progressMessage,
-    lastSyncTime,
-  };
+  return useMemo(
+    () => ({
+      errorMessage,
+      isRequestingSync,
+      isSyncing,
+      isQueuing,
+      syncStage,
+      progress,
+      progressMessage,
+      lastSyncTime,
+    }),
+    [
+      errorMessage,
+      isRequestingSync,
+      isSyncing,
+      isQueuing,
+      syncStage,
+      progress,
+      progressMessage,
+      lastSyncTime,
+    ],
+  );
 }

--- a/packages/datatrak-web/src/sync/syncStatus.ts
+++ b/packages/datatrak-web/src/sync/syncStatus.ts
@@ -80,6 +80,7 @@ export function useSyncStage(): number | null {
     [syncManager?.syncStage],
   );
 
+  useSyncEventListener(SYNC_STARTED, update);
   useSyncEventListener(SYNC_STATE_CHANGED, update);
 
   return syncStage;

--- a/packages/datatrak-web/src/views/Sync/LastSyncDate.tsx
+++ b/packages/datatrak-web/src/views/Sync/LastSyncDate.tsx
@@ -1,21 +1,40 @@
-import React, { HTMLAttributes } from 'react';
+import { formatDistance } from 'date-fns';
+import React, { HTMLAttributes, useEffect, useState } from 'react';
 import { SyncHeading } from './SyncHeading';
 import { SyncParagraph } from './SyncParagraph';
+
 interface LastSyncDateProps extends HTMLAttributes<HTMLDivElement> {
-  formattedLastSuccessfulSyncTime: React.ReactNode;
   lastSyncDate: Date | null;
 }
 
-export const LastSyncDate = ({
-  formattedLastSuccessfulSyncTime,
-  lastSyncDate,
-  ...props
-}: LastSyncDateProps) => {
+export function formatLastSuccessfulSyncTime(lastSuccessfulSyncTime: Date | null): React.ReactNode {
+  const formattedTimeString = lastSuccessfulSyncTime
+    ? formatDistance(lastSuccessfulSyncTime, new Date(), { addSuffix: true })
+    : '';
+
+  // Capitalize the first letter
+  return formattedTimeString.length > 0
+    ? formattedTimeString.charAt(0).toUpperCase() + formattedTimeString.slice(1)
+    : formattedTimeString;
+}
+
+export const LastSyncDate = ({ lastSyncDate, ...props }: LastSyncDateProps) => {
+  const [formattedDate, setFormattedDate] = useState<React.ReactNode>();
+
+  useEffect(() => {
+    // Refresh relatively formatted date
+    const interval = setInterval(
+      () => void setFormattedDate(formatLastSuccessfulSyncTime(lastSyncDate)),
+      1_000,
+    );
+    return () => void clearInterval(interval);
+  }, [lastSyncDate]);
+
   return (
     <div {...props}>
       <SyncHeading>Last successful sync</SyncHeading>
       <SyncParagraph>
-        <time dateTime={lastSyncDate?.toISOString()}>{formattedLastSuccessfulSyncTime}</time>
+        <time dateTime={lastSyncDate?.toISOString()}>{formattedDate}</time>
       </SyncParagraph>
     </div>
   );

--- a/packages/datatrak-web/src/views/Sync/LastSyncDate.tsx
+++ b/packages/datatrak-web/src/views/Sync/LastSyncDate.tsx
@@ -1,11 +1,8 @@
 import { formatDistance } from 'date-fns';
-import React, { HTMLAttributes, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { useLastSyncTime } from '../../sync/syncStatus';
 import { SyncHeading } from './SyncHeading';
 import { SyncParagraph } from './SyncParagraph';
-
-interface LastSyncDateProps extends HTMLAttributes<HTMLDivElement> {
-  lastSyncDate: Date | null;
-}
 
 export function formatLastSuccessfulSyncTime(lastSuccessfulSyncTime: Date | null): React.ReactNode {
   const formattedTimeString = lastSuccessfulSyncTime
@@ -18,23 +15,30 @@ export function formatLastSuccessfulSyncTime(lastSuccessfulSyncTime: Date | null
     : formattedTimeString;
 }
 
-export const LastSyncDate = ({ lastSyncDate, ...props }: LastSyncDateProps) => {
-  const [formattedDate, setFormattedDate] = useState<React.ReactNode>();
+export const LastSyncDate = (props: React.ComponentPropsWithRef<'div'>) => {
+  const lastSyncTime = useLastSyncTime();
+  const [formattedDate, setFormattedDate] = useState<React.ReactNode>(
+    formatLastSuccessfulSyncTime(lastSyncTime),
+  );
 
   useEffect(() => {
     // Refresh relatively formatted date
     const interval = setInterval(
-      () => void setFormattedDate(formatLastSuccessfulSyncTime(lastSyncDate)),
+      () => void setFormattedDate(formatLastSuccessfulSyncTime(lastSyncTime)),
       1_000,
     );
     return () => void clearInterval(interval);
-  }, [lastSyncDate]);
+  }, [lastSyncTime]);
 
   return (
     <div {...props}>
       <SyncHeading>Last successful sync</SyncHeading>
       <SyncParagraph>
-        <time dateTime={lastSyncDate?.toISOString()}>{formattedDate}</time>
+        {lastSyncTime ? (
+          <time dateTime={lastSyncTime.toISOString()}>{formattedDate}</time>
+        ) : (
+          'Never'
+        )}
       </SyncParagraph>
     </div>
   );

--- a/packages/datatrak-web/src/views/Sync/SyncPage.tsx
+++ b/packages/datatrak-web/src/views/Sync/SyncPage.tsx
@@ -8,15 +8,7 @@ import { ensure } from '@tupaia/tsutils';
 import { useSyncContext } from '../../api/SyncContext';
 import { Button } from '../../components';
 import { StickyMobileHeader } from '../../layout';
-import {
-  useIsInSyncQueue,
-  useIsRequestingSync,
-  useIsSyncing,
-  useLastSyncTime,
-  useSyncError,
-  useSyncProgress,
-  useSyncStage,
-} from '../../sync/syncStatus';
+import { useSyncStatus } from '../../sync/syncStatus';
 import { SYNC_EVENT_ACTIONS } from '../../types';
 import { useIsMobile } from '../../utils';
 import { LastSyncDate } from './LastSyncDate';
@@ -77,13 +69,16 @@ export const SyncPage = () => {
   const queryClient = useQueryClient();
 
   const [syncStarted, setSyncStarted] = useState<boolean>(syncManager.isSyncing);
-  const isRequestingSync = useIsRequestingSync();
-  const isSyncing = useIsSyncing();
-  const isQueuing = useIsInSyncQueue();
-  const syncStage = useSyncStage();
-  const [progress, progressMessage] = useSyncProgress();
-  const errorMessage = useSyncError();
-  const lastSyncTime = useLastSyncTime();
+  const {
+    errorMessage,
+    isRequestingSync,
+    isSyncing,
+    isQueuing,
+    syncStage,
+    progress,
+    progressMessage,
+    lastSyncTime,
+  } = useSyncStatus();
 
   const handler: Handler = useCallback(() => void setSyncStarted(true), []);
   useEffect(() => {

--- a/packages/datatrak-web/src/views/Sync/SyncPage.tsx
+++ b/packages/datatrak-web/src/views/Sync/SyncPage.tsx
@@ -77,7 +77,6 @@ export const SyncPage = () => {
     syncStage,
     progress,
     progressMessage,
-    lastSyncTime,
   } = useSyncStatus();
 
   const handler: Handler = useCallback(() => void setSyncStarted(true), []);
@@ -116,8 +115,7 @@ export const SyncPage = () => {
 
           {!isSyncing && !isRequestingSync && (
             <>
-              {Boolean(lastSyncTime) && <StyledLastSyncDate lastSyncDate={lastSyncTime} />}
-
+              <StyledLastSyncDate />
               <StyledButton onClick={manualSync}>Manual sync</StyledButton>
             </>
           )}


### PR DESCRIPTION
Previously, we looked at the event type to determine what `SetStateAction`s needed to be fired

This PR flips that around: look at what status we care about, and listen for the relevant event(s)

Bonus: Also exposes each property through its own hook