### PR TITLE
repo: `build:nonlegacy` script for actively maintained package subtree

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "build": "yarn workspaces foreach -ptv --jobs unlimited --exclude tupaia run build",
     "build:from": "./scripts/bash/buildPackagesByGlob.sh --from",
     "build:only": "./scripts/bash/buildPackagesByGlob.sh --only",
+    "build:nonlegacy": "yarn run build:from \"{admin-panel*,datatrak*,tupaia*,{central,data-table,entity,report,sync,web-config}-server}\"",
     "build:internal-dependencies": "./scripts/bash/buildInternalDependencies.sh",
     "build:non-internal-dependencies": "./scripts/bash/buildNonInternalDependencies.sh",
     "build:admin-panel": "yarn workspace @tupaia/admin-panel build",


### PR DESCRIPTION
`yarn run build`, but excluding packages used only by LESMIS and PSSS server stacks.

Really just intended for local dev use; save about 30% in build time.

CI still checks full build.