### PR TITLE
refactor(centralServer): more efficient `SurveyResponseVariablesExtractor.getSurveys` filtering

### DIFF
--- a/packages/central-server/src/apiV2/utilities/SurveyResponseVariablesExtractor.js
+++ b/packages/central-server/src/apiV2/utilities/SurveyResponseVariablesExtractor.js
@@ -1,4 +1,7 @@
+import { QUERY_CONJUNCTIONS } from '@tupaia/database';
 import { ValidationError } from '@tupaia/utils';
+
+const { AND, OR } = QUERY_CONJUNCTIONS;
 
 /**
  * A function that extracts `country`, `countryId`, 'entities', 'surveyResponse' and 'surveys' from a database
@@ -79,10 +82,9 @@ export class SurveyResponseVariablesExtractor {
       };
       if (countryId) {
         // Fetch surveys where country_ids is empty (enabled in all countries) or contains countryId
-        // eslint-disable-next-line no-underscore-dangle
-        surveyFindConditions._and_ = {
+        surveyFindConditions[AND] = {
           country_ids: '{}',
-          _or_: {
+          [OR]: {
             country_ids: { comparator: '@>', comparisonValue: [countryId] },
           },
         };
@@ -90,10 +92,12 @@ export class SurveyResponseVariablesExtractor {
       surveys = await this.models.survey.find(surveyFindConditions);
     } else {
       // No specific surveyId passed in, so export all surveys that apply to this country
-      const allSurveys = await this.models.survey.all();
-      surveys = allSurveys.filter(
-        survey => survey.country_ids.length === 0 || survey.country_ids.includes(countryId),
-      );
+      surveys = await this.models.survey.find({
+        country_ids: '{}',
+        [OR]: {
+          country_ids: { comparator: '@>', comparisonValue: [countryId] },
+        },
+      });
     }
     if (!surveys || surveys.length < 1) {
       throw new ValidationError('Survey not found. Please check permissions');

--- a/packages/central-server/src/apiV2/utilities/SurveyResponseVariablesExtractor.js
+++ b/packages/central-server/src/apiV2/utilities/SurveyResponseVariablesExtractor.js
@@ -67,6 +67,15 @@ export class SurveyResponseVariablesExtractor {
   }
 
   async getSurveys(surveyId, surveyCodes, countryId) {
+    const isEnabledInCountryFilter = countryId
+      ? {
+          country_ids: '{}', // empty country_ids means enabled in all countries
+          [OR]: {
+            country_ids: { comparator: '@>', comparisonValue: [countryId] },
+          },
+        }
+      : { country_ids: '{}' };
+
     let surveys;
     if (surveyId) {
       // A surveyId of interest passed in, only export that
@@ -81,23 +90,12 @@ export class SurveyResponseVariablesExtractor {
         },
       };
       if (countryId) {
-        // Fetch surveys where country_ids is empty (enabled in all countries) or contains countryId
-        surveyFindConditions[AND] = {
-          country_ids: '{}',
-          [OR]: {
-            country_ids: { comparator: '@>', comparisonValue: [countryId] },
-          },
-        };
+        surveyFindConditions[AND] = isEnabledInCountryFilter;
       }
       surveys = await this.models.survey.find(surveyFindConditions);
     } else {
       // No specific surveyId passed in, so export all surveys that apply to this country
-      surveys = await this.models.survey.find({
-        country_ids: '{}',
-        [OR]: {
-          country_ids: { comparator: '@>', comparisonValue: [countryId] },
-        },
-      });
+      surveys = await this.models.survey.find(isEnabledInCountryFilter);
     }
     if (!surveys || surveys.length < 1) {
       throw new ValidationError('Survey not found. Please check permissions');


### PR DESCRIPTION
### 🦸 Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->


<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>625bb1f</u></sup><!-- /BUGBOT_STATUS -->