### PR TITLE
fix(sync): RN-1717: Fix advisory lock causing db connection pool exhaustion

### DIFF
--- a/packages/database/src/core/BaseDatabase.js
+++ b/packages/database/src/core/BaseDatabase.js
@@ -222,7 +222,7 @@ export class BaseDatabase {
         return; // Lock acquired successfully
       }
 
-      // Wait before retrying (with jitter to avoid thundering herd)
+      // Wait before retrying
       await sleep(retryDelayMs);
     }
 

--- a/packages/database/src/core/BaseDatabase.js
+++ b/packages/database/src/core/BaseDatabase.js
@@ -198,7 +198,7 @@ export class BaseDatabase {
    * Uses pg_try_advisory_xact_lock with retry to prevent indefinite blocking
    * that can exhaust the connection pool.
    *
-   * @param {number} lockKeyInt numeric key for the lock (bigint)
+   * @param {number} lockKeyInt numeric key for the lock
    * @param {object} [options]
    * @param {number} [options.maxRetries=43200] Maximum number of retry attempts (default 12 hours)
    * @param {number} [options.retryDelayMs=1000] Delay between retries in milliseconds

--- a/packages/database/src/core/BaseDatabase.js
+++ b/packages/database/src/core/BaseDatabase.js
@@ -9,7 +9,7 @@ import autobind from 'react-autobind';
 import winston from 'winston';
 
 import { hashStringToInt } from '@tupaia/tsutils';
-import { getEnvVarOrDefault, NotImplementedError } from '@tupaia/utils';
+import { getEnvVarOrDefault, NotImplementedError, sleep } from '@tupaia/utils';
 import { SCHEMA_NAMES } from './constants';
 import { generateId } from './utilities';
 import {
@@ -191,14 +191,62 @@ export class BaseDatabase {
   }
 
   /**
+   * Acquires an advisory lock by numeric key for the current transaction.
+   * Lock will be immediately released once the transaction ends.
+   * (https://www.postgresql.org/docs/current/explicit-locking.html#ADVISORY-LOCKS)
+   *
+   * Uses pg_try_advisory_xact_lock with retry to prevent indefinite blocking
+   * that can exhaust the connection pool.
+   *
+   * @param {number} lockKeyInt numeric key for the lock (bigint)
+   * @param {object} [options]
+   * @param {number} [options.maxRetries=43200] Maximum number of retry attempts (default 12 hours)
+   * @param {number} [options.retryDelayMs=1000] Delay between retries in milliseconds
+   * @param {string} [options.lockDescription] Description for error messages
+   */
+  async acquireAdvisoryLockByKey(lockKeyInt, options = {}) {
+    const {
+      maxRetries = 60 * 60 * 12,
+      retryDelayMs = 1000,
+      lockDescription = lockKeyInt,
+    } = options;
+
+    for (let attempt = 0; attempt < maxRetries; attempt++) {
+      // Use pg_try_advisory_xact_lock which returns immediately with true/false
+      const [{ pg_try_advisory_xact_lock: acquired }] = await this.executeSql(
+        'SELECT pg_try_advisory_xact_lock(?)',
+        [lockKeyInt],
+      );
+
+      if (acquired) {
+        return; // Lock acquired successfully
+      }
+
+      // Wait before retrying (with jitter to avoid thundering herd)
+      await sleep(retryDelayMs);
+    }
+
+    throw new Error(
+      `Failed to acquire advisory lock "${lockDescription}" after ${maxRetries} attempts (${(maxRetries * retryDelayMs) / 1000}s timeout)`,
+    );
+  }
+
+  /**
    * Acquires an advisory lock for the current transaction
    * Lock will be immediately released once the transaction ends
    * (https://www.postgresql.org/docs/current/explicit-locking.html#ADVISORY-LOCKS)
+   *
    * @param {string} lockKey unique identifier key for the lock
+   * @param {object} [options]
+   * @param {number} [options.maxRetries=43200] Maximum number of retry attempts (default 12 hours)
+   * @param {number} [options.retryDelayMs=1000] Delay between retries in milliseconds
    */
-  async acquireAdvisoryLock(lockKey) {
+  async acquireAdvisoryLock(lockKey, options = {}) {
     const lockKeyInt = hashStringToInt(lockKey); // Locks require bigint key, so must convert key to int
-    return await this.executeSql('SELECT pg_advisory_xact_lock(?)', [lockKeyInt]);
+    return await this.acquireAdvisoryLockByKey(lockKeyInt, {
+      ...options,
+      lockDescription: lockKey,
+    });
   }
 
   /**

--- a/packages/sync/src/utils/waitForPendingEditsUsingSyncTick.ts
+++ b/packages/sync/src/utils/waitForPendingEditsUsingSyncTick.ts
@@ -5,8 +5,13 @@ import type { BaseDatabase } from '@tupaia/database';
 // transactions that involve a create/update of a record have finished
 export const waitForPendingEditsUsingSyncTick = async <
   DatabaseT extends BaseDatabase = BaseDatabase,
-  ReturnT = unknown,
 >(
   database: DatabaseT,
   syncTick: number,
-) => await database.executeSql<ReturnT>('SELECT pg_advisory_xact_lock(:syncTick);', { syncTick });
+  options: { maxRetries?: number; retryDelayMs?: number } = {},
+) => {
+  await database.acquireAdvisoryLockByKey(syncTick, {
+    ...options,
+    lockDescription: `pending edits (syncTick: ${syncTick})`,
+  });
+};


### PR DESCRIPTION
### Changes:
**Issue**: DB connection pool sometimes exhausts and throw (especially after importing entities and sync)
```
16|sync-server  | 2026-02-12T01:10:14: error: Knex: Timeout acquiring a connection. The pool is probably full. Are you missing a .transacting(trx) call? {"name":"KnexTimeoutError","stack":"KnexTimeoutError: Knex: Timeout acquiring a connection. The pool is probably full. Are you missing a .transacting(trx) call?\n    at Client_PG.acquireConnection (/home/ubuntu/tupaia/node_modules/knex/lib/client.js:332:26)\n    at async Runner.ensureConnection (/home/ubuntu/tupaia/node_modules/knex/lib/execution/runner.js:305:28)\n    at async Runner.run (/home/ubuntu/tupaia/node_modules/knex/lib/execution/runner.js:30:19)","timestamp":"2026-02-12T01:10:14.453Z"}
```

**Cause:**
In tupaia, as I understand, we’ve been using `pg_advisory_xact_lock` for not letting change handlers stepping on each other. The disadvantage of this is it holds a database connection the entire time it’s waiting. That wasn’t really an issue before as change handlers transactions can finish quite quickly and I don’t think they can step on each other.

However, sync also uses `pg_advisory_xact_lock` in a few places. With change handlers and sync combined running at the same time, they can hold the total of 10 active db connections for a while and exhaust the db connection pool.

**Fix:**
The fix I can think of for this is: instead of using `pg_advisory_xact_lock` , use `pg_try_advisory_xact_lock` . The difference between these is, `pg_try_advisory_xact_lock` checks and returns the result (true/false), and releases the connection immediately, while the other one will be waiting indefinitely until it is true. So what we can do is keep polling `pg_try_advisory_xact_lock` (with sleep 1000ms in between each poll) until it is true.

