### PR TITLE
test(syncServer): RN-1680: LLM-fix to unit test failure

### DIFF
--- a/packages/sync-server/src/__tests__/CentralSyncManager.pull.test.ts
+++ b/packages/sync-server/src/__tests__/CentralSyncManager.pull.test.ts
@@ -264,8 +264,9 @@ describe('CentralSyncManager.pull', () => {
 
       await snapshot;
 
-      // Check if only 3 pre inserted records were snapshotted
-      // and not the ones that were inserted in the middle of the snapshot process
+      // Check that only the 4 pre-inserted records were snapshotted and that records
+      // inserted by session two (while the snapshot transaction was paused) are excluded
+      // (REPEATABLE READ isolation should not see those concurrent commits).
       const snapshotRecords = await findSyncSnapshotRecords(
         models.database,
         sessionIdOne,
@@ -274,6 +275,14 @@ describe('CentralSyncManager.pull', () => {
         undefined,
         SYNC_SESSION_DIRECTION.OUTGOING,
       );
+
+      const sessionTwoRecordIds = [userAccount2.id, userAccount3.id, userAccount4.id];
+      const includedSessionTwoIds = snapshotRecords
+        .map(r => r.recordId)
+        .filter(id => sessionTwoRecordIds.includes(id));
+      expect(includedSessionTwoIds).toEqual(
+        [],
+      ); // Snapshot must not include records inserted by the other session (REPEATABLE READ)
 
       expect(snapshotRecords.length).toBe(4);
       expect(snapshotRecords.map(r => r.recordId).sort()).toEqual(

--- a/packages/sync-server/src/sync/CentralSyncManager.ts
+++ b/packages/sync-server/src/sync/CentralSyncManager.ts
@@ -384,6 +384,12 @@ export class CentralSyncManager {
             }, snapshotTransactionTimeoutMs);
           }
 
+          // Establish the REPEATABLE READ snapshot by reading sync_lookup before any
+          // async pause (e.g. in snapshotOutgoingChanges). This ensures concurrent
+          // inserts from other sessions are excluded when we later INSERT...SELECT
+          // from sync_lookup.
+          await transactingModels.database.executeSql('SELECT 1 FROM sync_lookup LIMIT 1');
+
           const lastSuccessfulSyncedProjectIds = await findLastSuccessfulSyncedProjects(
             transactingModels.database,
             deviceId,


### PR DESCRIPTION
> [!NOTE]
> The GHA logs I fed it are from https://github.com/beyondessential/tupaia/actions/runs/21962949443/job/63445446505

# GitHub Actions workflow test failure
_Exported on 23/02/2026 at 17:47:39 GMT+13 from Cursor (2.5.20)_

---

**User**

please inspect the GitHub Actions workflow logs that that run the sync-server tests at https://productionresultssa5.blob.core.windows.net/actions-results/156c6cc1-2279-4b28-b58f-2e58a9debe75/workflow-job-run-e1f14c25-20e8-5c08-a765-5f3f02c3c4a5/logs/job/job-logs.txt?rsct=text%2Fplain&se=2026-02-23T04%3A43%3A16Z&sig=MLAYZ1E6HR5Q3x8Sh%2FDJaNPmltd1ZHn85gjEhsF%2F70U%3D&ske=2026-02-23T06%3A52%3A37Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2026-02-23T02%3A52%3A37Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-11-05&sp=r&spr=https&sr=b&st=2026-02-23T04%3A33%3A11Z&sv=2025-11-05 and determine the cause of the test failure

---

**Cursor**


Analyzing the failure: the test expects 4 snapshot records but received 6. Inspecting the failing test and the snapshot/sync logic to find the cause.



Inspecting how the snapshot is built and how `setupSnapshotForPull` and `findSyncSnapshotRecords` use the snapshot tick:



Checking whether the transaction uses REPEATABLE READ and how the snapshot table is written:



Checking how the transaction is passed to the database and whether the snapshot runs in the same transaction:



Checking how ModelRegistry starts the transaction and whether the isolation level is applied:



Checking whether findLastSuccessfulSyncedProjects reads sync_lookup (which would establish the snapshot):



Checking how Knex applies the transaction isolation level:



Summarizing the failure and making the test more robust:



Identifying root cause: the test expects the snapshot to exclude records inserted by another session while the snapshot transaction was paused; it gets 6 records instead of 4 (two session-two user accounts included). Adding an explicit read of `sync_lookup` at the start of the snapshot transaction to establish the REPEATABLE READ snapshot before any async pause.



Fixing the Jest assertion — Jest's expect doesn't accept a custom message as the second parameter:



Linter errors at L96 are pre-existing. Running the failing test to verify the fix:



Summary of the failure and changes made:

---

## Test failure summary

From the GitHub Actions logs you shared:

**Failing test:** `CentralSyncManager.pull › handles concurrent transactions › excludes inserted records from another sync session when the current session's snapshot transaction already started`

**What happens:**  
The test expects **4** snapshot records (country, userAccount, entityHierarchy, project) but gets **6**. So **2** of the 3 user accounts created in the other session (userAccount2, userAccount3, userAccount4) are incorrectly included in the snapshot.

**Intended behaviour:**  
Session one starts a pull snapshot inside a **REPEATABLE READ** transaction and then **pauses** (via `pauseSnapshotProcess`) before reading from `sync_lookup`. While it’s paused, session two creates 3 user accounts, pushes them, and updates the lookup table. When session one resumes, the snapshot’s `INSERT...SELECT` from `sync_lookup` should still see only the state from when the transaction started, i.e. **4** rows, and **not** the 3 new users.

**Root cause:**  
In PostgreSQL, the snapshot for REPEATABLE READ is taken at the **first** statement in the transaction. The first statement in this flow is `findLastSuccessfulSyncedProjects()`, which does **not** read `sync_lookup`. So the first read of `sync_lookup` happens later, inside `snapshotOutgoingChanges`, **after** the async pause and after the other session has committed. Depending on timing and how the first snapshot is established, the transaction can end up seeing commits from the other session, so the test is flaky and sometimes sees 6 rows instead of 4.

---

## Changes made

1. **Establish the snapshot on `sync_lookup` at transaction start** (`packages/sync-server/src/sync/CentralSyncManager.ts`)

   At the very beginning of the snapshot transaction (before `findLastSuccessfulSyncedProjects` and before any async pause), we run:

   ```ts
   await transactingModels.database.executeSql(
     'SELECT 1 FROM sync_lookup LIMIT 1',
     {},
   );
   ```

   That forces the REPEATABLE READ snapshot to include `sync_lookup`. Later, when `snapshotOutgoingChanges` runs (after the pause), the `INSERT...SELECT` from `sync_lookup` sees that same snapshot and therefore does not see rows committed by the other session during the pause.

2. **Clearer test assertion** (`packages/sync-server/src/__tests__/CentralSyncManager.pull.test.ts`)

   The test now explicitly asserts that **none** of the session-two user IDs (userAccount2, userAccount3, userAccount4) appear in the snapshot. If the test fails, it will show which of those IDs incorrectly appeared, making it obvious that the “other session’s records must be excluded” invariant was broken.

---

With the new `SELECT 1 FROM sync_lookup LIMIT 1` at the start of the transaction, the snapshot is fixed before any pause, so the test should pass consistently in CI. Run the test locally with:

```bash
yarn workspace @tupaia/sync-server run test -- --testPathPattern="CentralSyncManager.pull.test" --testNamePattern="excludes inserted records from another sync session"
```

