### PR TITLE
fix(datatrakWeb): RN-1808: graceful database startup

### DIFF
--- a/packages/datatrak-web/src/api/DatabaseContext.tsx
+++ b/packages/datatrak-web/src/api/DatabaseContext.tsx
@@ -25,7 +25,11 @@ export const DatabaseProvider = ({ children }: { children: Readonly<React.ReactN
     init();
 
     return () => {
-      modelsInstance?.closeDatabaseConnections();
+      modelsInstance?.closeDatabaseConnections().catch((err: unknown) => {
+        // Graceful recovery: avoid unhandled rejection when closing mid-sync or in environments
+        // (e.g. browser) where connection pool cleanup may fail (e.g. timeout.close is not a function)
+        console.warn('Database cleanup on unmount:', err);
+      });
     };
   }, []);
 

--- a/packages/datatrak-web/src/api/DatabaseContext.tsx
+++ b/packages/datatrak-web/src/api/DatabaseContext.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useEffect, useState } from 'react';
+import winston from 'winston';
 
 import { FullPageLoader } from '@tupaia/ui-components';
-
 import { createDatabase } from '../database/createDatabase';
 import { DatatrakWebModelRegistry } from '../types';
 
@@ -28,7 +28,7 @@ export const DatabaseProvider = ({ children }: { children: Readonly<React.ReactN
       modelsInstance?.closeDatabaseConnections().catch((err: unknown) => {
         // Graceful recovery: avoid unhandled rejection when closing mid-sync or in environments
         // (e.g. browser) where connection pool cleanup may fail (e.g. timeout.close is not a function)
-        console.warn('Database cleanup on unmount:', err);
+        winston.warn('Database cleanup on unmount:', err);
       });
     };
   }, []);

--- a/packages/datatrak-web/src/api/SyncContext.tsx
+++ b/packages/datatrak-web/src/api/SyncContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, ReactNode, useContext, useEffect, useState } from 'react';
+import React, { createContext, ReactNode, useContext, useEffect, useMemo, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 
 import { FullPageLoader } from '@tupaia/ui-components';
@@ -37,11 +37,13 @@ export const SyncProvider = ({ children }: { children: ReactNode }) => {
     }
   }, [isLoggedIn, isOfflineFirst, clientSyncManager]);
 
-  if (!clientSyncManager && isLoggedIn) {
+  const value = useMemo(() => ({ clientSyncManager }), [clientSyncManager]);
+
+  if (!value.clientSyncManager && isLoggedIn) {
     return <FullPageLoader message="Setting up sync…" />;
   }
 
-  return <SyncContext.Provider value={{ clientSyncManager }}>{children}</SyncContext.Provider>;
+  return <SyncContext.Provider value={value}>{children}</SyncContext.Provider>;
 };
 
 export const useSyncContext = (): SyncContextType | null => {

--- a/packages/datatrak-web/src/database/DatatrakDatabase.ts
+++ b/packages/datatrak-web/src/database/DatatrakDatabase.ts
@@ -1,6 +1,7 @@
 import { types } from '@electric-sql/pglite';
 import type { Knex } from 'knex';
 import ClientPgLite from 'knex-pglite';
+import winston from 'winston';
 
 import { BaseDatabase } from '@tupaia/database';
 import { getConnectionConfig } from './getConnectionConfig';
@@ -52,7 +53,7 @@ export class DatatrakDatabase extends BaseDatabase {
     try {
       await super.closeConnections();
     } catch (err) {
-      console.warn('DatatrakDatabase.closeConnections:', err);
+      winston.warn('DatatrakDatabase.closeConnections:', err);
     }
   }
 }

--- a/packages/datatrak-web/src/database/DatatrakDatabase.ts
+++ b/packages/datatrak-web/src/database/DatatrakDatabase.ts
@@ -41,4 +41,18 @@ export class DatatrakDatabase extends BaseDatabase {
       transactionConfig,
     );
   }
+
+  /**
+   * @override
+   * Browser-safe close: knex’s pool destroy can throw in the browser (e.g. timeout.close is not
+   * a function when the pool uses Node-style timers). Swallow errors so reload/unmount doesn’t
+   * leave unhandled rejections; the next load will get a fresh connection anyway.
+   */
+  override async closeConnections(): Promise<void> {
+    try {
+      await super.closeConnections();
+    } catch (err) {
+      console.warn('DatatrakDatabase.closeConnections:', err);
+    }
+  }
 }

--- a/packages/datatrak-web/src/views/Sync/SyncPage.tsx
+++ b/packages/datatrak-web/src/views/Sync/SyncPage.tsx
@@ -73,34 +73,36 @@ export function formatlastSuccessfulSyncTime(lastSuccessfulSyncTime: Date | null
 
 export const SyncPage = () => {
   const syncContext = useSyncContext();
-  const clientSyncManager = syncContext?.clientSyncManager ?? null;
-
+  const syncManager = syncContext?.clientSyncManager ?? null;
   const isMobile = useIsMobile();
-
-  // Sync context may not be ready yet after reload (e.g. mid-sync); show loader until we have a manager
-  if (!clientSyncManager) {
-    return <FullPageLoader message="Setting up sync…" />;
-  }
-
-  const syncManager = clientSyncManager;
   const navigate = useNavigate();
   const queryClient = useQueryClient();
 
-  const [syncStarted, setSyncStarted] = useState<boolean>(syncManager.isSyncing);
-  const [errorMessage, setErrorMessage] = useState<string | null>(syncManager.errorMessage);
-  const [isRequestingSync, setIsRequestingSync] = useState<boolean>(syncManager.isRequestingSync);
-  const [isSyncing, setIsSyncing] = useState<boolean>(syncManager.isSyncing);
-  const [isQueuing, setIsQueuing] = useState<boolean>(syncManager.isQueuing);
-  const [syncStage, setSyncStage] = useState<number | null>(syncManager.syncStage);
-  const [progress, setProgress] = useState<number | null>(syncManager.progress);
-  const [progressMessage, setProgressMessage] = useState<string | null>(
-    syncManager.progressMessage,
-  );
+  const [syncStarted, setSyncStarted] = useState<boolean | undefined>(syncManager?.isSyncing);
+  const [errorMessage, setErrorMessage] = useState<string | null | undefined>(syncManager?.errorMessage);
+  const [isRequestingSync, setIsRequestingSync] = useState<boolean | undefined>(syncManager?.isRequestingSync);
+  const [isSyncing, setIsSyncing] = useState<boolean | undefined>(syncManager?.isSyncing);
+  const [isQueuing, setIsQueuing] = useState<boolean | undefined>(syncManager?.isQueuing);
+  const [syncStage, setSyncStage] = useState<number | null | undefined>(syncManager?.syncStage);
+  const [progress, setProgress] = useState<number | null | undefined>(syncManager?.progress);
+  const [progressMessage, setProgressMessage] = useState<string | null>(null);
   const [formattedLastSuccessfulSyncTime, setFormattedLastSuccessfulSyncTime] = useState<string>(
-    formatlastSuccessfulSyncTime(syncManager.lastSuccessfulSyncTime),
+    '',
   );
 
   useEffect(() => {
+    if (!syncManager) return;
+    setSyncStarted(syncManager.isSyncing);
+    setErrorMessage(syncManager.errorMessage);
+    setIsRequestingSync(syncManager.isRequestingSync);
+    setIsSyncing(syncManager.isSyncing);
+    setIsQueuing(syncManager.isQueuing);
+    setSyncStage(syncManager.syncStage);
+    setProgress(syncManager.progress);
+    setProgressMessage(syncManager.progressMessage);
+    setFormattedLastSuccessfulSyncTime(
+      formatlastSuccessfulSyncTime(syncManager.lastSuccessfulSyncTime),
+    );
     const handler = (action, data): void => {
       switch (action) {
         case SYNC_EVENT_ACTIONS.SYNC_REQUESTING:
@@ -144,7 +146,7 @@ export const SyncPage = () => {
         case SYNC_EVENT_ACTIONS.SYNC_ERROR:
           setIsRequestingSync(false);
           setIsQueuing(false);
-          setErrorMessage(data.error);
+          setErrorMessage(data?.error );
           break;
         default:
           break;
@@ -157,6 +159,7 @@ export const SyncPage = () => {
   }, [syncManager]);
 
   useEffect(() => {
+    if (!syncManager) return;
     const interval = setInterval(() => {
       setFormattedLastSuccessfulSyncTime(
         formatlastSuccessfulSyncTime(syncManager.lastSuccessfulSyncTime),
@@ -165,14 +168,19 @@ export const SyncPage = () => {
     return () => {
       clearInterval(interval);
     };
-  }, []);
+  }, [syncManager]);
 
   const manualSync = useCallback(() => {
-    syncManager.triggerUrgentSync(queryClient);
+    syncManager?.triggerUrgentSync(queryClient);
   }, [syncManager, queryClient]);
 
   const syncFinishedSuccessfully =
     syncStarted && !isSyncing && !isQueuing && !errorMessage && !isRequestingSync;
+
+  // Sync context may not be ready yet after reload (e.g. mid-sync); show loader until we have a manager
+  if (!syncManager) {
+    return <FullPageLoader message="Setting up sync…" />;
+  }
 
   return (
     <Wrapper>

--- a/packages/datatrak-web/src/views/Sync/SyncPage.tsx
+++ b/packages/datatrak-web/src/views/Sync/SyncPage.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { formatDistance } from 'date-fns';
 import { useQueryClient } from '@tanstack/react-query';
 
-import { ensure } from '@tupaia/tsutils';
+import { FullPageLoader } from '@tupaia/ui-components';
 
 import { Button } from '../../components';
 import { StickyMobileHeader } from '../../layout';
@@ -72,10 +72,17 @@ export function formatlastSuccessfulSyncTime(lastSuccessfulSyncTime: Date | null
 }
 
 export const SyncPage = () => {
-  const { clientSyncManager } = useSyncContext() || {};
-  const syncManager = ensure(clientSyncManager);
+  const syncContext = useSyncContext();
+  const clientSyncManager = syncContext?.clientSyncManager ?? null;
 
   const isMobile = useIsMobile();
+
+  // Sync context may not be ready yet after reload (e.g. mid-sync); show loader until we have a manager
+  if (!clientSyncManager) {
+    return <FullPageLoader message="Setting up sync…" />;
+  }
+
+  const syncManager = clientSyncManager;
   const navigate = useNavigate();
   const queryClient = useQueryClient();
 


### PR DESCRIPTION
To be completely honest, I don’t 100% understand why this fix works—I left it completely to Cursor. Empirically, it works.

## Prompt

```
When I sync during the `saveIncomingSnapshotChanges` phase of datatrak-web’s sync ( @sync/src/utils/saveIncomingChanges.ts:167-210), then reload datatrak-web, I expect the database to simply revert back to its last consistent and legal state because we use database transactions to save synced changes

However, if I reload mid-sync, I instead get these errors in the console:

typeGuards.ts:15 Uncaught UnexpectedNullishValueError: Expected non-nullish value, but got null
    at assertIsNotNullish (typeGuards.ts:15:11)
    at ensure (typeGuards.ts:20:3)
    at SyncPage (SyncPage.tsx:76:23)
installHook.js:1 The above error occurred in the <SyncPage> component:
    in SyncPage (at Routes.tsx:92)
    in Outlet (at PrivateRoute.tsx:82)
    in PrivateRoute (at Routes.tsx:64)
    in Outlet (at MainPageLayout.tsx:69)
    in div (created by styled.div)
    in styled.div (at MainPageLayout.tsx:67)
    in MainPageLayout (at Routes.tsx:61)
    in Routes (at Routes.tsx:57)
    in Routes (at App.tsx:12)
    in RedirectErrorHandler (at App.tsx:11)
    in Router (created by BrowserRouter)
    in BrowserRouter (at App.tsx:10)
    in CurrentUserContextProvider (at AppProviders.tsx:75)
    in SyncProvider (at AppProviders.tsx:74)
    in DatabaseProvider (at AppProviders.tsx:73)
    in SnackbarProvider2 (at AppProviders.tsx:88)
    in QueryClientProvider (at AppProviders.tsx:86)
    in ThemeProvider (at AppProviders.tsx:85)
    in ThemeProvider (at AppProviders.tsx:84)
    in StylesProvider (at AppProviders.tsx:83)
    in AppProviders (at App.tsx:9)
    in App (at main.tsx:9)

Consider adding an error boundary to your tree to customize error handling behavior.
Visit https://fb.me/react-error-boundaries to learn more about error boundaries.

typeGuards.ts:15 Uncaught (in promise) UnexpectedNullishValueError: Expected non-nullish value, but got null
    at assertIsNotNullish (typeGuards.ts:15:11)
    at ensure (typeGuards.ts:20:3)
    at SyncPage (SyncPage.tsx:76:23)
chunk-NRSSLNYT.js?v=3f6adf96:851 Uncaught (in promise) TypeError: timeout.close is not a function
    at DatatrakDatabase.closeConnections (BaseDatabase.js:156:34)
    at ModelRegistry.closeDatabaseConnections (ModelRegistry.js?t=1772144502954:37:27)
    at DatabaseContext.tsx:28:23


Please determine the source of this issue, and come up with an elegant way for the IndexedDB to gracefully recover when the datatak-web front-end first loads. I am not sure if this issue is happening with IndexedDB, pglite, knex, or in the React layer.

@datatrak-web/src/api/SyncContext.tsx may be relevant if it’s an issue within React
```