### PR TITLE
feat(datatrak): RN-1810: Add delete draft confirmation modal

### DIFF
--- a/packages/datatrak-web/src/components/SmallModal.tsx
+++ b/packages/datatrak-web/src/components/SmallModal.tsx
@@ -7,6 +7,10 @@ import { Button, Modal } from '.';
 const Wrapper = styled.div`
   width: 25rem;
   max-width: 100%;
+
+  .MuiTypography-root.MuiTypography-body1 {
+    font-size: 0.875rem;
+  }
   ${({ theme }) => theme.breakpoints.up('sm')} {
     padding: 0 2rem 1rem;
   }
@@ -28,7 +32,9 @@ const Heading = styled(Typography).attrs({
   variant: 'h2',
   align: 'center',
 })`
-  margin-bottom: 1rem;
+  &.MuiTypography-root {
+    margin-bottom: 1rem;
+  }
 `;
 
 const ModalButton = styled(Button).attrs({

--- a/packages/datatrak-web/src/views/LandingPage/DraftSurveysSection/DeleteDraftModal.tsx
+++ b/packages/datatrak-web/src/views/LandingPage/DraftSurveysSection/DeleteDraftModal.tsx
@@ -15,8 +15,6 @@ export const DeleteDraftModal = ({
   onDelete,
   isLoading,
 }: DeleteDraftModalProps) => {
-  if (!isOpen) return null;
-
   return (
     <SmallModal
       open

--- a/packages/datatrak-web/src/views/LandingPage/DraftSurveysSection/DeleteDraftModal.tsx
+++ b/packages/datatrak-web/src/views/LandingPage/DraftSurveysSection/DeleteDraftModal.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Typography } from '@material-ui/core';
+import { SmallModal } from '../../../components';
+
+interface DeleteDraftModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onDelete: () => void;
+  isLoading: boolean;
+}
+
+export const DeleteDraftModal = ({
+  isOpen,
+  onClose,
+  onDelete,
+  isLoading,
+}: DeleteDraftModalProps) => {
+  if (!isOpen) return null;
+
+  return (
+    <SmallModal
+      open
+      onClose={onClose}
+      title="Delete draft"
+      primaryButton={{
+        label: 'Delete draft',
+        onClick: onDelete,
+      }}
+      secondaryButton={{
+        label: 'Cancel',
+        onClick: onClose,
+      }}
+      isLoading={isLoading}
+    >
+      <Typography align="center">
+        Are you sure you would like to delete this saved draft?
+      </Typography>
+    </SmallModal>
+  );
+};

--- a/packages/datatrak-web/src/views/LandingPage/DraftSurveysSection/DeleteDraftModal.tsx
+++ b/packages/datatrak-web/src/views/LandingPage/DraftSurveysSection/DeleteDraftModal.tsx
@@ -17,7 +17,7 @@ export const DeleteDraftModal = ({
 }: DeleteDraftModalProps) => {
   return (
     <SmallModal
-      open
+      open={isOpen}
       onClose={onClose}
       title="Delete draft"
       primaryButton={{

--- a/packages/datatrak-web/src/views/LandingPage/DraftSurveysSection/DraftSurveyTile.tsx
+++ b/packages/datatrak-web/src/views/LandingPage/DraftSurveysSection/DraftSurveyTile.tsx
@@ -10,17 +10,46 @@ import { DeleteDraftModal } from './DeleteDraftModal';
 
 type DraftSurvey = DatatrakWebSurveyResponseDraftsRequest.DraftSurveyResponse;
 
-const StyledActionsMenu = styled(ActionsMenu)`
-  position: absolute;
-  top: 50%;
-  right: 0;
-  transform: translateY(-50%);
-  z-index: 1;
+const Wrapper = styled.div`
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+
+  ${({ theme }) => theme.breakpoints.down('sm')} {
+    flex: 1;
+
+    > span {
+      flex: 1;
+
+      > a.MuiButtonBase-root {
+        width: 100%;
+      }
+    }
+  }
+`;
+
+const StyledTile = styled(Tile)`
+  flex: 1;
+  min-width: 0;
+  border-radius: 0.625rem 0 0 0.625rem;
+
+  ${({ theme }) => theme.breakpoints.down('sm')} {
+    border-radius: 0.625rem;
+  }
+`;
+
+const MenuContainer = styled.div`
+  display: flex;
+  align-items: center;
+  background-color: ${({ theme }) => theme.palette.background.paper};
+  border-radius: 0 0.625rem 0.625rem 0;
 
   ${({ theme }) => theme.breakpoints.down('sm')} {
     display: none;
   }
 `;
+
+const StyledActionsMenu = styled(ActionsMenu)``;
 
 const StyledSurveyIcon = styled(SurveyIcon)`
   &.MuiSvgIcon-root {
@@ -28,20 +57,6 @@ const StyledSurveyIcon = styled(SurveyIcon)`
   }
 `;
 
-const StyledTile = styled(Tile)`
-  padding-right: 2.2rem;
-
-  ${({ theme }) => theme.breakpoints.down('sm')} {
-    padding-right: 1rem;
-    flex: 1;
-    span {
-      flex: 1;
-    }
-    a {
-      width: 100%;
-    }
-  }
-`;
 const TooltipText = styled.p`
   font-weight: normal;
   margin-block: 0;
@@ -98,14 +113,18 @@ export const DraftSurveyTile = ({
     </>
   );
   return (
-    <StyledTile
-      heading={surveyName ? `[draft] ${surveyName}` : 'Draft survey'}
-      leadingIcons={<StyledSurveyIcon />}
-      tooltip={tooltip}
-      to={`/survey/${countryCode}/${surveyCode}/${screenNumber}?draftId=${id}`}
-    >
-      <Typography>{entityText}</Typography>
-      <Menu draftId={id} />
-    </StyledTile>
+    <Wrapper>
+      <StyledTile
+        heading={surveyName ? `[draft] ${surveyName}` : 'Draft survey'}
+        leadingIcons={<StyledSurveyIcon />}
+        tooltip={tooltip}
+        to={`/survey/${countryCode}/${surveyCode}/${screenNumber}?draftId=${id}`}
+      >
+        <Typography>{entityText}</Typography>
+      </StyledTile>
+      <MenuContainer>
+        <Menu draftId={id} />
+      </MenuContainer>
+    </Wrapper>
   );
 };

--- a/packages/datatrak-web/src/views/LandingPage/DraftSurveysSection/DraftSurveyTile.tsx
+++ b/packages/datatrak-web/src/views/LandingPage/DraftSurveysSection/DraftSurveyTile.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import { ActionsMenu } from '@tupaia/ui-components';
 import { SurveyIcon } from '../../../components';
@@ -6,6 +6,7 @@ import { DatatrakWebSurveyResponseDraftsRequest } from '@tupaia/types';
 import { useDeleteSurveyResponseDraft } from '../../../api';
 import { Tile } from '../../../components';
 import { Typography } from '@material-ui/core';
+import { DeleteDraftModal } from './DeleteDraftModal';
 
 type DraftSurvey = DatatrakWebSurveyResponseDraftsRequest.DraftSurveyResponse;
 
@@ -50,25 +51,34 @@ const TooltipText = styled.p`
 
 const Menu = ({ draftId }: { draftId: string }) => {
   const { mutate: deleteDraft, isLoading } = useDeleteSurveyResponseDraft(draftId);
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   const actions = [
     {
       label: 'Delete',
-      action: () => {
-        if (isLoading) return;
-        deleteDraft();
-      },
+      action: () => setIsModalOpen(true),
       toolTipTitle: 'Delete draft',
     },
   ];
 
   return (
-    <StyledActionsMenu
-      anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
-      transformOrigin={{ vertical: 'top', horizontal: 'right' }}
-      options={actions}
-      includesIcons
-    />
+    <>
+      <StyledActionsMenu
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        options={actions}
+        includesIcons
+      />
+      <DeleteDraftModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        onDelete={() => {
+          deleteDraft();
+          setIsModalOpen(false);
+        }}
+        isLoading={isLoading}
+      />
+    </>
   );
 };
 

--- a/packages/datatrak-web/src/views/LandingPage/DraftSurveysSection/MobileDraftSurveys.tsx
+++ b/packages/datatrak-web/src/views/LandingPage/DraftSurveysSection/MobileDraftSurveys.tsx
@@ -9,6 +9,7 @@ import { useDeleteSurveyResponseDraft } from '../../../api';
 import { Button } from '../../../components';
 import { DraftSurveyTile } from './DraftSurveyTile';
 import { StickyMobileHeader } from '../../../layout';
+import { DeleteDraftModal } from './DeleteDraftModal';
 
 const Wrapper = styled.div`
   ${({ theme }) => theme.breakpoints.up('md')} {
@@ -76,6 +77,7 @@ const Transition = React.forwardRef(function Transition(
 
 const ListItem = ({ draft }) => {
   const { mutate: deleteDraft, isLoading } = useDeleteSurveyResponseDraft(draft.id);
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   return (
     <ListItemContainer>
@@ -84,13 +86,20 @@ const ListItem = ({ draft }) => {
         aria-label="Delete draft"
         onClick={e => {
           e.preventDefault();
-          if (!isLoading) {
-            deleteDraft();
-          }
+          setIsModalOpen(true);
         }}
       >
         <Trash2 />
       </DeleteButton>
+      <DeleteDraftModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        onDelete={() => {
+          deleteDraft();
+          setIsModalOpen(false);
+        }}
+        isLoading={isLoading}
+      />
     </ListItemContainer>
   );
 };


### PR DESCRIPTION
## Summary
- Adds a confirmation modal (`DeleteDraftModal`) before deleting a draft survey response, using the existing `SmallModal` component pattern
- Integrates the modal into both desktop (`DraftSurveyTile` via actions menu) and mobile (`MobileDraftSurveys` via trash icon) delete flows
- Modal shows "Delete draft" title, confirmation message, Cancel (outlined) and Delete draft (filled) buttons

**Review**

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->