### PR TITLE
feat(datatrak-web): RN-1810: add save & exit confirmation modal

### DIFF
--- a/packages/datatrak-web/src/features/Survey/Components/MobileSurveyMenu.tsx
+++ b/packages/datatrak-web/src/features/Survey/Components/MobileSurveyMenu.tsx
@@ -1,5 +1,5 @@
 import { IconButton } from '@material-ui/core';
-import React, { HTMLAttributes } from 'react';
+import React, { HTMLAttributes, useState } from 'react';
 import styled from 'styled-components';
 import { FormatListBulleted, KeyboardArrowRight } from '@material-ui/icons';
 
@@ -8,6 +8,7 @@ import { BOTTOM_NAVIGATION_HEIGHT_DYNAMIC } from '../../../constants';
 import { useSurveyForm } from '../SurveyContext';
 import { useShare } from '../utils/useShare';
 import { useSaveAsDraft } from '../hooks/useSaveAsDraft';
+import { SaveAndExitModal } from './SaveAndExitModal';
 
 const Container = styled.nav`
   align-items: stretch;
@@ -61,6 +62,7 @@ export const MobileSurveyMenu = (props: HTMLAttributes<HTMLDivElement>) => {
   const { toggleSideMenu, isLast, isResubmit, isReviewScreen } = useSurveyForm();
   const share = useShare();
   const { saveAsDraft, isLoading: isSavingDraft } = useSaveAsDraft();
+  const [isSaveModalOpen, setIsSaveModalOpen] = useState(false);
 
   const getNextButtonText = () => {
     if (isReviewScreen) return isResubmit ? 'Resubmit' : 'Submit';
@@ -70,7 +72,7 @@ export const MobileSurveyMenu = (props: HTMLAttributes<HTMLDivElement>) => {
 
   return (
     <Container {...props}>
-      <SaveButton onClick={saveAsDraft} disabled={isSavingDraft}>
+      <SaveButton onClick={() => setIsSaveModalOpen(true)} disabled={isSavingDraft}>
         Save & exit
       </SaveButton>
       <IconButton onClick={toggleSideMenu}>
@@ -82,6 +84,12 @@ export const MobileSurveyMenu = (props: HTMLAttributes<HTMLDivElement>) => {
       <SubmitButton type="submit" endIcon={<KeyboardArrowRight />}>
         {getNextButtonText()}
       </SubmitButton>
+      <SaveAndExitModal
+        isOpen={isSaveModalOpen}
+        onClose={() => setIsSaveModalOpen(false)}
+        onSave={saveAsDraft}
+        isLoading={isSavingDraft}
+      />
     </Container>
   );
 };

--- a/packages/datatrak-web/src/features/Survey/Components/SaveAndExitModal.tsx
+++ b/packages/datatrak-web/src/features/Survey/Components/SaveAndExitModal.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Typography } from '@material-ui/core';
+import { SmallModal } from '../../../components';
+
+interface SaveAndExitModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: () => void;
+  isLoading: boolean;
+}
+
+export const SaveAndExitModal = ({
+  isOpen,
+  onClose,
+  onSave,
+  isLoading,
+}: SaveAndExitModalProps) => {
+  return (
+    <SmallModal
+      open={isOpen}
+      onClose={onClose}
+      title="Save & exit"
+      primaryButton={{
+        label: 'Save and exit',
+        onClick: onSave,
+      }}
+      secondaryButton={{
+        label: 'Cancel',
+        onClick: onClose,
+      }}
+      isLoading={isLoading}
+    >
+      <Typography align="center">
+        You can continue completing this survey at anytime by accessing it on the dashboard
+      </Typography>
+    </SmallModal>
+  );
+};

--- a/packages/datatrak-web/src/features/Survey/Components/SurveyPaginator.tsx
+++ b/packages/datatrak-web/src/features/Survey/Components/SurveyPaginator.tsx
@@ -1,11 +1,12 @@
 import ArrowBackIosIcon from '@material-ui/icons/ArrowBackIos';
-import React from 'react';
+import React, { useState } from 'react';
 import { useOutletContext } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { Button } from '../../../components';
 import { useSurveyForm } from '../SurveyContext';
 import { useSaveAsDraft } from '../hooks/useSaveAsDraft';
+import { SaveAndExitModal } from './SaveAndExitModal';
 
 const FormActions = styled.div`
   display: flex;
@@ -50,6 +51,7 @@ export const SurveyPaginator = () => {
   const { isLast, isResubmit, isReviewScreen, openCancelConfirmation } = useSurveyForm();
   const { isLoading, onStepPrevious, hasBackButton } = useOutletContext<SurveyLayoutContextT>();
   const { saveAsDraft, isLoading: isSavingDraft } = useSaveAsDraft();
+  const [isSaveModalOpen, setIsSaveModalOpen] = useState(false);
 
   const getNextButtonText = () => {
     if (isReviewScreen) return isResubmit ? 'Resubmit' : 'Submit';
@@ -67,7 +69,7 @@ export const SurveyPaginator = () => {
             Back
           </BackButton>
         )}
-        <Button onClick={saveAsDraft} variant="outlined" disabled={isDisabled}>
+        <Button onClick={() => setIsSaveModalOpen(true)} variant="outlined" disabled={isDisabled}>
           Save &amp; exit
         </Button>
       </ButtonGroup>
@@ -79,6 +81,12 @@ export const SurveyPaginator = () => {
           {getNextButtonText()}
         </Button>
       </ButtonGroup>
+      <SaveAndExitModal
+        isOpen={isSaveModalOpen}
+        onClose={() => setIsSaveModalOpen(false)}
+        onSave={saveAsDraft}
+        isLoading={isSavingDraft}
+      />
     </FormActions>
   );
 };


### PR DESCRIPTION
## Summary
- Adds a `SaveAndExitModal` confirmation dialog shown when clicking "Save & exit" during a survey
- Uses the `SmallModal` component with "Cancel" and "Save and exit" buttons
- Applied consistently on both desktop (`SurveyPaginator`) and mobile (`MobileSurveyMenu`) layouts
- Cancel closes the modal and returns the user to the survey; Save and exit triggers the existing `saveAsDraft` logic

## Test plan
- [ ] Desktop: Click "Save & exit" in a survey → modal appears with title, description, and two buttons
- [ ] Desktop: Click "Cancel" in modal → modal closes, user stays on survey
- [ ] Desktop: Click "Save and exit" in modal → draft is saved and user is navigated home
- [ ] Mobile: Same three checks on mobile layout
- [ ] Modal X button closes the modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)