### PR TITLE
feat(datatrak-web): RN-1830: warn user when starting survey with existing draft

### DIFF
--- a/packages/datatrak-web/src/components/SmallModal.tsx
+++ b/packages/datatrak-web/src/components/SmallModal.tsx
@@ -4,8 +4,8 @@ import { To } from 'react-router';
 import { Typography } from '@material-ui/core';
 import { Button, Modal } from '.';
 
-const Wrapper = styled.div`
-  width: 25rem;
+const Wrapper = styled.div<{ $width: string }>`
+  width: ${({ $width }) => $width};
   max-width: 100%;
 
   .MuiTypography-root.MuiTypography-body1 {
@@ -58,6 +58,7 @@ interface ModalProps {
   secondaryButton?: ButtonProps | null;
   children?: ReactNode;
   isLoading?: boolean;
+  width?: string;
 }
 
 export const SmallModal = ({
@@ -68,10 +69,11 @@ export const SmallModal = ({
   secondaryButton,
   children,
   isLoading = false,
+  width = '24rem',
 }: ModalProps) => {
   return (
     <Modal open={open} onClose={onClose}>
-      <Wrapper>
+      <Wrapper $width={width}>
         {title && <Heading>{title}</Heading>}
         {children}
         <ButtonWrapper>

--- a/packages/datatrak-web/src/features/Survey/Components/SaveAndExitModal.tsx
+++ b/packages/datatrak-web/src/features/Survey/Components/SaveAndExitModal.tsx
@@ -20,6 +20,7 @@ export const SaveAndExitModal = ({
       open={isOpen}
       onClose={onClose}
       title="Save & exit"
+      width="28rem"
       primaryButton={{
         label: 'Save and exit',
         onClick: onSave,

--- a/packages/datatrak-web/src/features/Survey/SurveyContext/SurveyContext.tsx
+++ b/packages/datatrak-web/src/features/Survey/SurveyContext/SurveyContext.tsx
@@ -245,8 +245,8 @@ export const useSurveyForm = () => {
     return surveyFormContext.formData[questionId];
   };
 
-  const openCancelConfirmation = ({ confirmPath }: { confirmPath?: To | number }) => {
-    dispatch({ type: ACTION_TYPES.OPEN_CANCEL_CONFIRMATION, payload: confirmPath });
+  const openCancelConfirmation = (options?: { confirmPath?: To | number }) => {
+    dispatch({ type: ACTION_TYPES.OPEN_CANCEL_CONFIRMATION, payload: options?.confirmPath ?? '/' });
   };
 
   const closeCancelConfirmation = () => {

--- a/packages/datatrak-web/src/views/SurveySelectPage/DraftExistsModal.tsx
+++ b/packages/datatrak-web/src/views/SurveySelectPage/DraftExistsModal.tsx
@@ -7,7 +7,6 @@ interface DraftExistsModalProps {
   isOpen: boolean;
   onClose: () => void;
   onStartNew: () => void;
-  draftCount: number;
   resumePath: string;
 }
 
@@ -15,31 +14,28 @@ export const DraftExistsModal = ({
   isOpen,
   onClose,
   onStartNew,
-  draftCount,
   resumePath,
 }: DraftExistsModalProps) => {
   const navigate = useNavigate();
-
-  const message =
-    draftCount > 1
-      ? `You have ${draftCount} saved drafts for this survey. Would you like to continue where you left off?`
-      : 'You have a saved draft for this survey. Would you like to continue where you left off?';
 
   return (
     <SmallModal
       open={isOpen}
       onClose={onClose}
-      title="Draft in progress"
+      title="This survey is existing in a draft"
       primaryButton={{
-        label: 'Continue draft',
-        onClick: () => navigate(resumePath),
-      }}
-      secondaryButton={{
         label: 'Start new survey',
         onClick: onStartNew,
       }}
+      secondaryButton={{
+        label: 'Continue existing draft',
+        onClick: () => navigate(resumePath),
+      }}
     >
-      <Typography align="center">{message}</Typography>
+      <Typography align="center">
+        This survey has a saved draft version. Would you like to start a new survey or continue the
+        existing draft?
+      </Typography>
     </SmallModal>
   );
 };

--- a/packages/datatrak-web/src/views/SurveySelectPage/DraftExistsModal.tsx
+++ b/packages/datatrak-web/src/views/SurveySelectPage/DraftExistsModal.tsx
@@ -20,6 +20,7 @@ export const DraftExistsModal = ({
       open={isOpen}
       onClose={onClose}
       title="This survey is existing in a draft"
+      width="32rem"
       primaryButton={{
         label: 'Start new survey',
         onClick: onStartNew,

--- a/packages/datatrak-web/src/views/SurveySelectPage/DraftExistsModal.tsx
+++ b/packages/datatrak-web/src/views/SurveySelectPage/DraftExistsModal.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Typography } from '@material-ui/core';
+import { useNavigate } from 'react-router';
+import { SmallModal } from '../../components';
+
+interface DraftExistsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onStartNew: () => void;
+  draftCount: number;
+  resumePath: string;
+}
+
+export const DraftExistsModal = ({
+  isOpen,
+  onClose,
+  onStartNew,
+  draftCount,
+  resumePath,
+}: DraftExistsModalProps) => {
+  const navigate = useNavigate();
+
+  const message =
+    draftCount > 1
+      ? `You have ${draftCount} saved drafts for this survey. Would you like to continue where you left off?`
+      : 'You have a saved draft for this survey. Would you like to continue where you left off?';
+
+  return (
+    <SmallModal
+      open={isOpen}
+      onClose={onClose}
+      title="Draft in progress"
+      primaryButton={{
+        label: 'Continue draft',
+        onClick: () => navigate(resumePath),
+      }}
+      secondaryButton={{
+        label: 'Start new survey',
+        onClick: onStartNew,
+      }}
+    >
+      <Typography align="center">{message}</Typography>
+    </SmallModal>
+  );
+};

--- a/packages/datatrak-web/src/views/SurveySelectPage/DraftExistsModal.tsx
+++ b/packages/datatrak-web/src/views/SurveySelectPage/DraftExistsModal.tsx
@@ -1,23 +1,20 @@
 import React from 'react';
 import { Typography } from '@material-ui/core';
-import { useNavigate } from 'react-router';
 import { SmallModal } from '../../components';
 
 interface DraftExistsModalProps {
   isOpen: boolean;
   onClose: () => void;
   onStartNew: () => void;
-  resumePath: string;
+  onResume: () => void;
 }
 
 export const DraftExistsModal = ({
   isOpen,
   onClose,
   onStartNew,
-  resumePath,
+  onResume,
 }: DraftExistsModalProps) => {
-  const navigate = useNavigate();
-
   return (
     <SmallModal
       open={isOpen}
@@ -29,7 +26,7 @@ export const DraftExistsModal = ({
       }}
       secondaryButton={{
         label: 'Continue existing draft',
-        onClick: () => navigate(resumePath),
+        onClick: onResume,
       }}
     >
       <Typography align="center">

--- a/packages/datatrak-web/src/views/SurveySelectPage/SurveySelectPage.tsx
+++ b/packages/datatrak-web/src/views/SurveySelectPage/SurveySelectPage.tsx
@@ -52,7 +52,7 @@ export const SurveySelectPage = () => {
   } = useUserCountries();
   const navigateToSurvey = useNavigateToSurvey();
   const { isUpdatingUser, isSyncingProject } = useSyncProjectFromUrl();
-  const { draftModalProps, handleSelectSurvey } = useSurveySelectionWithDrafts(
+  const { draftModalProps, handleSelectSurvey, isDraftsLoading } = useSurveySelectionWithDrafts(
     selectedCountry,
     selectedSurvey,
     setSelectedSurvey,
@@ -69,7 +69,7 @@ export const SurveySelectPage = () => {
     setSelectedSurvey(null);
   }
 
-  const showLoader = isFetchingSurveys || isFetchingCountries || isUpdatingUser || isSyncingProject;
+  const showLoader = isFetchingSurveys || isFetchingCountries || isUpdatingUser || isSyncingProject || isDraftsLoading;
 
   const sharedProps = {
     selectedCountry,
@@ -102,7 +102,7 @@ export const SurveySelectPage = () => {
           submitButton={
             <Button
               onClick={() => handleSelectSurvey(selectedCountry, selectedSurvey)}
-              disabled={!selectedSurvey || isUpdatingUser}
+              disabled={!selectedSurvey || isUpdatingUser || isDraftsLoading}
               tooltip={selectedSurvey ? '' : 'Select survey to proceed'}
             >
               Next

--- a/packages/datatrak-web/src/views/SurveySelectPage/SurveySelectPage.tsx
+++ b/packages/datatrak-web/src/views/SurveySelectPage/SurveySelectPage.tsx
@@ -1,11 +1,8 @@
-import React, { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router';
-import { useSearchParams } from 'react-router-dom';
-
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Country, KeysToCamelCase } from '@tupaia/types';
 import { useCurrentUserContext } from '../../api';
 import { useEditUser } from '../../api/mutations';
-import { useSurveyResponseDrafts } from '../../api/queries/useSurveyResponseDrafts';
 import { useSurveysQuery } from '../../api/queries/useSurveysQuery';
 import { Button } from '../../components';
 import { CountrySelector } from '../../features';
@@ -15,6 +12,8 @@ import { useIsMobile } from '../../utils';
 import { DesktopTemplate } from './DesktopTemplate';
 import { DraftExistsModal } from './DraftExistsModal';
 import { MobileTemplate } from './MobileTemplate';
+import { useSurveySelectionWithDrafts } from './useSurveySelectionWithDrafts';
+import { useSyncProjectFromUrl } from './useSyncProjectFromUrl';
 
 const useNavigateToSurvey = () => {
   const navigate = useNavigate();
@@ -45,17 +44,20 @@ export type NavigateToSurveyType = ReturnType<typeof useNavigateToSurvey>;
 
 export const SurveySelectPage = () => {
   const [selectedSurvey, setSelectedSurvey] = useState<Survey['code'] | null>(null);
-  const [showDraftModal, setShowDraftModal] = useState(false);
-  const [urlSearchParams] = useSearchParams();
-  const urlProjectId = urlSearchParams.get('projectId');
+  const isMobile = useIsMobile();
+  const user = useCurrentUserContext();
   const {
     queryResult: { data: countries, isFetching: isFetchingCountries },
     state: [selectedCountry, updateSelectedCountry],
   } = useUserCountries();
   const navigateToSurvey = useNavigateToSurvey();
-  const { mutate: updateUser, isLoading: isUpdatingUser } = useEditUser();
-  const user = useCurrentUserContext();
-  const { data: allDrafts } = useSurveyResponseDrafts();
+  const { isUpdatingUser, isSyncingProject } = useSyncProjectFromUrl();
+  const { draftModalProps, handleSelectSurvey } = useSurveySelectionWithDrafts(
+    selectedCountry,
+    selectedSurvey,
+    setSelectedSurvey,
+    navigateToSurvey,
+  );
 
   const { isFetching: isFetchingSurveys, data: surveys } = useSurveysQuery({
     countryCode: selectedCountry?.code,
@@ -67,88 +69,47 @@ export const SurveySelectPage = () => {
     setSelectedSurvey(null);
   }
 
-  useEffect(() => {
-    const updateUserProject = async () => {
-      if (urlProjectId && user.projectId !== urlProjectId) {
-        updateUser({ projectId: urlProjectId });
-      }
-    };
-    updateUserProject();
-  }, [urlProjectId]);
+  const showLoader = isFetchingSurveys || isFetchingCountries || isUpdatingUser || isSyncingProject;
 
-  const showLoader =
-    isFetchingSurveys ||
-    isFetchingCountries ||
-    isUpdatingUser ||
-    (urlProjectId !== null && urlProjectId !== user?.projectId); // in this case the user will be updating and all surveys etc will be reloaded, so showing a loader when this is the case means a more seamless experience
-
-  const matchingDrafts = allDrafts.filter(
-    draft => draft.surveyCode === selectedSurvey && draft.countryCode === selectedCountry?.code,
-  );
-
-  const firstDraft = matchingDrafts[0];
-  const resumePath = firstDraft
-    ? `/survey/${firstDraft.countryCode}/${firstDraft.surveyCode}/${firstDraft.screenNumber ?? 0}?draftId=${firstDraft.id}`
-    : '';
-
-  const handleSelectSurvey: NavigateToSurveyType = (country, surveyCode) => {
-    const draftsForSurvey = allDrafts.filter(
-      draft => draft.surveyCode === surveyCode && draft.countryCode === country?.code,
-    );
-
-    if (draftsForSurvey.length > 0) {
-      setSelectedSurvey(surveyCode);
-      setShowDraftModal(true);
-      return;
-    }
-
-    navigateToSurvey(country, surveyCode);
+  const sharedProps = {
+    selectedCountry,
+    selectedSurvey,
+    setSelectedSurvey,
+    showLoader,
   };
 
-  const countrySelector = (
-    <CountrySelector
-      countries={countries}
-      key={user.projectId} // Force fresh instance when project changes
-      onChange={e => updateSelectedCountry(e.target.value)}
-      selectedCountry={selectedCountry}
-    />
-  );
-
-  const draftExistsModal = (
-    <DraftExistsModal
-      isOpen={showDraftModal}
-      onClose={() => setShowDraftModal(false)}
-      onStartNew={() => {
-        setShowDraftModal(false);
-        navigateToSurvey(selectedCountry, selectedSurvey);
-      }}
-      resumePath={resumePath}
-    />
-  );
-
-  if (useIsMobile()) {
+  if (isMobile) {
     return (
       <>
         <MobileTemplate
-          countrySelector={countrySelector}
-          selectedCountry={selectedCountry}
-          selectedSurvey={selectedSurvey}
-          setSelectedSurvey={setSelectedSurvey}
+          {...sharedProps}
+          countrySelector={
+            <CountrySelector
+              countries={countries}
+              key={user.projectId}
+              onChange={e => updateSelectedCountry(e.target.value)}
+              selectedCountry={selectedCountry}
+            />
+          }
           handleSelectSurvey={handleSelectSurvey}
-          showLoader={showLoader}
         />
-        {draftExistsModal}
+        <DraftExistsModal {...draftModalProps} />
       </>
     );
   }
+
   return (
     <>
       <DesktopTemplate
-        selectedCountry={selectedCountry}
-        countrySelector={countrySelector}
-        selectedSurvey={selectedSurvey}
-        setSelectedSurvey={setSelectedSurvey}
-        showLoader={showLoader}
+        {...sharedProps}
+        countrySelector={
+          <CountrySelector
+            countries={countries}
+            key={user.projectId}
+            onChange={e => updateSelectedCountry(e.target.value)}
+            selectedCountry={selectedCountry}
+          />
+        }
         submitButton={
           <Button
             onClick={() => handleSelectSurvey(selectedCountry, selectedSurvey)}
@@ -159,7 +120,7 @@ export const SurveySelectPage = () => {
           </Button>
         }
       />
-      {draftExistsModal}
+      <DraftExistsModal {...draftModalProps} />
     </>
   );
 };

--- a/packages/datatrak-web/src/views/SurveySelectPage/SurveySelectPage.tsx
+++ b/packages/datatrak-web/src/views/SurveySelectPage/SurveySelectPage.tsx
@@ -78,19 +78,21 @@ export const SurveySelectPage = () => {
     showLoader,
   };
 
+  const countrySelector = (
+    <CountrySelector
+      countries={countries}
+      key={user.projectId}
+      onChange={e => updateSelectedCountry(e.target.value)}
+      selectedCountry={selectedCountry}
+    />
+  );
+
   if (isMobile) {
     return (
       <>
         <MobileTemplate
           {...sharedProps}
-          countrySelector={
-            <CountrySelector
-              countries={countries}
-              key={user.projectId}
-              onChange={e => updateSelectedCountry(e.target.value)}
-              selectedCountry={selectedCountry}
-            />
-          }
+          countrySelector={countrySelector}
           handleSelectSurvey={handleSelectSurvey}
         />
         <DraftExistsModal {...draftModalProps} />
@@ -102,14 +104,7 @@ export const SurveySelectPage = () => {
     <>
       <DesktopTemplate
         {...sharedProps}
-        countrySelector={
-          <CountrySelector
-            countries={countries}
-            key={user.projectId}
-            onChange={e => updateSelectedCountry(e.target.value)}
-            selectedCountry={selectedCountry}
-          />
-        }
+        countrySelector={countrySelector}
         submitButton={
           <Button
             onClick={() => handleSelectSurvey(selectedCountry, selectedSurvey)}

--- a/packages/datatrak-web/src/views/SurveySelectPage/SurveySelectPage.tsx
+++ b/packages/datatrak-web/src/views/SurveySelectPage/SurveySelectPage.tsx
@@ -122,7 +122,6 @@ export const SurveySelectPage = () => {
         setShowDraftModal(false);
         navigateToSurvey(selectedCountry, selectedSurvey);
       }}
-      draftCount={matchingDrafts.length}
       resumePath={resumePath}
     />
   );

--- a/packages/datatrak-web/src/views/SurveySelectPage/SurveySelectPage.tsx
+++ b/packages/datatrak-web/src/views/SurveySelectPage/SurveySelectPage.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from 'react-router-dom';
 import { Country, KeysToCamelCase } from '@tupaia/types';
 import { useCurrentUserContext } from '../../api';
 import { useEditUser } from '../../api/mutations';
+import { useSurveyResponseDrafts } from '../../api/queries/useSurveyResponseDrafts';
 import { useSurveysQuery } from '../../api/queries/useSurveysQuery';
 import { Button } from '../../components';
 import { CountrySelector } from '../../features';
@@ -12,6 +13,7 @@ import { useUserCountries } from '../../features/CountrySelector/useUserCountrie
 import { Survey } from '../../types';
 import { useIsMobile } from '../../utils';
 import { DesktopTemplate } from './DesktopTemplate';
+import { DraftExistsModal } from './DraftExistsModal';
 import { MobileTemplate } from './MobileTemplate';
 
 const useNavigateToSurvey = () => {
@@ -43,15 +45,17 @@ export type NavigateToSurveyType = ReturnType<typeof useNavigateToSurvey>;
 
 export const SurveySelectPage = () => {
   const [selectedSurvey, setSelectedSurvey] = useState<Survey['code'] | null>(null);
+  const [showDraftModal, setShowDraftModal] = useState(false);
   const [urlSearchParams] = useSearchParams();
   const urlProjectId = urlSearchParams.get('projectId');
   const {
     queryResult: { data: countries, isFetching: isFetchingCountries },
     state: [selectedCountry, updateSelectedCountry],
   } = useUserCountries();
-  const handleSelectSurvey = useNavigateToSurvey();
+  const navigateToSurvey = useNavigateToSurvey();
   const { mutate: updateUser, isLoading: isUpdatingUser } = useEditUser();
   const user = useCurrentUserContext();
+  const { data: allDrafts } = useSurveyResponseDrafts();
 
   const { isFetching: isFetchingSurveys, data: surveys } = useSurveysQuery({
     countryCode: selectedCountry?.code,
@@ -78,6 +82,29 @@ export const SurveySelectPage = () => {
     isUpdatingUser ||
     (urlProjectId !== null && urlProjectId !== user?.projectId); // in this case the user will be updating and all surveys etc will be reloaded, so showing a loader when this is the case means a more seamless experience
 
+  const matchingDrafts = allDrafts.filter(
+    draft => draft.surveyCode === selectedSurvey && draft.countryCode === selectedCountry?.code,
+  );
+
+  const firstDraft = matchingDrafts[0];
+  const resumePath = firstDraft
+    ? `/survey/${firstDraft.countryCode}/${firstDraft.surveyCode}/${firstDraft.screenNumber ?? 0}?draftId=${firstDraft.id}`
+    : '';
+
+  const handleSelectSurvey: NavigateToSurveyType = (country, surveyCode) => {
+    const draftsForSurvey = allDrafts.filter(
+      draft => draft.surveyCode === surveyCode && draft.countryCode === country?.code,
+    );
+
+    if (draftsForSurvey.length > 0) {
+      setSelectedSurvey(surveyCode);
+      setShowDraftModal(true);
+      return;
+    }
+
+    navigateToSurvey(country, surveyCode);
+  };
+
   const countrySelector = (
     <CountrySelector
       countries={countries}
@@ -87,34 +114,53 @@ export const SurveySelectPage = () => {
     />
   );
 
+  const draftExistsModal = (
+    <DraftExistsModal
+      isOpen={showDraftModal}
+      onClose={() => setShowDraftModal(false)}
+      onStartNew={() => {
+        setShowDraftModal(false);
+        navigateToSurvey(selectedCountry, selectedSurvey);
+      }}
+      draftCount={matchingDrafts.length}
+      resumePath={resumePath}
+    />
+  );
+
   if (useIsMobile()) {
     return (
-      <MobileTemplate
-        countrySelector={countrySelector}
-        selectedCountry={selectedCountry}
-        selectedSurvey={selectedSurvey}
-        setSelectedSurvey={setSelectedSurvey}
-        handleSelectSurvey={handleSelectSurvey}
-        showLoader={showLoader}
-      />
+      <>
+        <MobileTemplate
+          countrySelector={countrySelector}
+          selectedCountry={selectedCountry}
+          selectedSurvey={selectedSurvey}
+          setSelectedSurvey={setSelectedSurvey}
+          handleSelectSurvey={handleSelectSurvey}
+          showLoader={showLoader}
+        />
+        {draftExistsModal}
+      </>
     );
   }
   return (
-    <DesktopTemplate
-      selectedCountry={selectedCountry}
-      countrySelector={countrySelector}
-      selectedSurvey={selectedSurvey}
-      setSelectedSurvey={setSelectedSurvey}
-      showLoader={showLoader}
-      submitButton={
-        <Button
-          onClick={() => handleSelectSurvey(selectedCountry, selectedSurvey)}
-          disabled={!selectedSurvey || isUpdatingUser}
-          tooltip={selectedSurvey ? '' : 'Select survey to proceed'}
-        >
-          Next
-        </Button>
-      }
-    />
+    <>
+      <DesktopTemplate
+        selectedCountry={selectedCountry}
+        countrySelector={countrySelector}
+        selectedSurvey={selectedSurvey}
+        setSelectedSurvey={setSelectedSurvey}
+        showLoader={showLoader}
+        submitButton={
+          <Button
+            onClick={() => handleSelectSurvey(selectedCountry, selectedSurvey)}
+            disabled={!selectedSurvey || isUpdatingUser}
+            tooltip={selectedSurvey ? '' : 'Select survey to proceed'}
+          >
+            Next
+          </Button>
+        }
+      />
+      {draftExistsModal}
+    </>
   );
 };

--- a/packages/datatrak-web/src/views/SurveySelectPage/SurveySelectPage.tsx
+++ b/packages/datatrak-web/src/views/SurveySelectPage/SurveySelectPage.tsx
@@ -87,34 +87,29 @@ export const SurveySelectPage = () => {
     />
   );
 
-  if (isMobile) {
-    return (
-      <>
+  return (
+    <>
+      {isMobile ? (
         <MobileTemplate
           {...sharedProps}
           countrySelector={countrySelector}
           handleSelectSurvey={handleSelectSurvey}
         />
-        <DraftExistsModal {...draftModalProps} />
-      </>
-    );
-  }
-
-  return (
-    <>
-      <DesktopTemplate
-        {...sharedProps}
-        countrySelector={countrySelector}
-        submitButton={
-          <Button
-            onClick={() => handleSelectSurvey(selectedCountry, selectedSurvey)}
-            disabled={!selectedSurvey || isUpdatingUser}
-            tooltip={selectedSurvey ? '' : 'Select survey to proceed'}
-          >
-            Next
-          </Button>
-        }
-      />
+      ) : (
+        <DesktopTemplate
+          {...sharedProps}
+          countrySelector={countrySelector}
+          submitButton={
+            <Button
+              onClick={() => handleSelectSurvey(selectedCountry, selectedSurvey)}
+              disabled={!selectedSurvey || isUpdatingUser}
+              tooltip={selectedSurvey ? '' : 'Select survey to proceed'}
+            >
+              Next
+            </Button>
+          }
+        />
+      )}
       <DraftExistsModal {...draftModalProps} />
     </>
   );

--- a/packages/datatrak-web/src/views/SurveySelectPage/useSurveySelectionWithDrafts.ts
+++ b/packages/datatrak-web/src/views/SurveySelectPage/useSurveySelectionWithDrafts.ts
@@ -26,7 +26,7 @@ export const useSurveySelectionWithDrafts = (
 ) => {
   const [isOpen, setIsOpen] = useState(false);
   const navigate = useNavigate();
-  const { data: allDrafts = [] } = useSurveyResponseDrafts();
+  const { data: allDrafts = [], isLoading: isDraftsLoading } = useSurveyResponseDrafts();
 
   const matchingDrafts = getDraftsForSurvey(allDrafts, selectedCountry?.code, selectedSurvey);
   const firstDraft = matchingDrafts[0];
@@ -35,6 +35,10 @@ export const useSurveySelectionWithDrafts = (
     : '';
 
   const handleSelectSurvey: NavigateToSurveyType = (country, surveyCode) => {
+    // Don't navigate until drafts have loaded — otherwise we'd skip the
+    // draft-exists modal because allDrafts defaults to [].
+    if (isDraftsLoading) return;
+
     const draftsForSurvey = getDraftsForSurvey(allDrafts, country?.code, surveyCode);
 
     if (draftsForSurvey.length > 0) {
@@ -59,5 +63,5 @@ export const useSurveySelectionWithDrafts = (
     },
   };
 
-  return { draftModalProps, handleSelectSurvey };
+  return { draftModalProps, handleSelectSurvey, isDraftsLoading };
 };

--- a/packages/datatrak-web/src/views/SurveySelectPage/useSurveySelectionWithDrafts.ts
+++ b/packages/datatrak-web/src/views/SurveySelectPage/useSurveySelectionWithDrafts.ts
@@ -1,0 +1,63 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Country, KeysToCamelCase } from '@tupaia/types';
+import { useSurveyResponseDrafts } from '../../api/queries/useSurveyResponseDrafts';
+import { Survey } from '../../types';
+import { NavigateToSurveyType } from './SurveySelectPage';
+
+const getDraftsForSurvey = (
+  allDrafts: ReturnType<typeof useSurveyResponseDrafts>['data'],
+  countryCode?: string,
+  surveyCode?: string | null,
+) => (allDrafts ?? []).filter(
+  draft => draft.surveyCode === surveyCode && draft.countryCode === countryCode,
+);
+
+/**
+ * Manages draft-detection when selecting a survey.
+ * Returns modal props and a wrapped `handleSelectSurvey` that shows the modal
+ * when a matching draft exists, or navigates directly otherwise.
+ */
+export const useSurveySelectionWithDrafts = (
+  selectedCountry: KeysToCamelCase<Country> | null | undefined,
+  selectedSurvey: Survey['code'] | null,
+  setSelectedSurvey: (code: Survey['code'] | null) => void,
+  navigateToSurvey: NavigateToSurveyType,
+) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const navigate = useNavigate();
+  const { data: allDrafts = [] } = useSurveyResponseDrafts();
+
+  const matchingDrafts = getDraftsForSurvey(allDrafts, selectedCountry?.code, selectedSurvey);
+  const firstDraft = matchingDrafts[0];
+  const resumePath = firstDraft
+    ? `/survey/${firstDraft.countryCode}/${firstDraft.surveyCode}/${firstDraft.screenNumber ?? 0}?draftId=${firstDraft.id}`
+    : '';
+
+  const handleSelectSurvey: NavigateToSurveyType = (country, surveyCode) => {
+    const draftsForSurvey = getDraftsForSurvey(allDrafts, country?.code, surveyCode);
+
+    if (draftsForSurvey.length > 0) {
+      setSelectedSurvey(surveyCode);
+      setIsOpen(true);
+      return;
+    }
+
+    navigateToSurvey(country, surveyCode);
+  };
+
+  const draftModalProps = {
+    isOpen,
+    onClose: () => setIsOpen(false),
+    onStartNew: () => {
+      setIsOpen(false);
+      navigateToSurvey(selectedCountry, selectedSurvey);
+    },
+    onResume: () => {
+      setIsOpen(false);
+      navigate(resumePath);
+    },
+  };
+
+  return { draftModalProps, handleSelectSurvey };
+};

--- a/packages/datatrak-web/src/views/SurveySelectPage/useSurveySelectionWithDrafts.ts
+++ b/packages/datatrak-web/src/views/SurveySelectPage/useSurveySelectionWithDrafts.ts
@@ -58,8 +58,12 @@ export const useSurveySelectionWithDrafts = (
       navigateToSurvey(selectedCountry, selectedSurvey);
     },
     onResume: () => {
-      setIsOpen(false);
-      navigate(resumePath);
+      if (resumePath) {
+        setIsOpen(false);
+        navigate(resumePath);
+      } else {
+        setIsOpen(false);
+      }
     },
   };
 

--- a/packages/datatrak-web/src/views/SurveySelectPage/useSyncProjectFromUrl.ts
+++ b/packages/datatrak-web/src/views/SurveySelectPage/useSyncProjectFromUrl.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { useCurrentUserContext } from '../../api';
+import { useEditUser } from '../../api/mutations';
+
+/**
+ * Syncs the project from a `projectId` URL search param to the user's profile.
+ * Returns loading state so the page can show a loader while the update is in flight.
+ */
+export const useSyncProjectFromUrl = () => {
+  const [urlSearchParams] = useSearchParams();
+  const urlProjectId = urlSearchParams.get('projectId');
+  const user = useCurrentUserContext();
+  const { mutate: updateUser, isLoading: isUpdatingUser } = useEditUser();
+
+  useEffect(() => {
+    if (urlProjectId && user.projectId !== urlProjectId) {
+      updateUser({ projectId: urlProjectId });
+    }
+  }, [urlProjectId]);
+
+  const isSyncingProject = urlProjectId !== null && urlProjectId !== user?.projectId;
+
+  return { isUpdatingUser, isSyncingProject };
+};


### PR DESCRIPTION
## Summary
- Add a "Draft in progress" modal that appears when a user selects a survey+country combination for which they already have a saved draft
- Modal offers "Continue draft" (navigates to saved draft) or "Start new survey" (proceeds with fresh survey)
- Uses existing `useSurveyResponseDrafts` cache — no backend changes needed

**Review**

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->