### PR TITLE
fix(imports): RN-1283: Clear nullable question fields when reimporting survey with empty cells

### DIFF
--- a/packages/central-server/src/apiV2/import/importSurveys/importSurveyQuestions.js
+++ b/packages/central-server/src/apiV2/import/importSurveys/importSurveyQuestions.js
@@ -300,15 +300,15 @@ export async function importSurveysQuestions({ models, file, survey, dataGroup, 
       const {
         code,
         type,
-        name,
+        name = null,
         text,
-        detail,
+        detail = null,
         options,
         optionLabels,
         optionColors,
         newScreen,
         optionSet,
-        hook,
+        hook = null,
       } = questionObject;
 
       let dataElement;


### PR DESCRIPTION
## Summary
- When reimporting a survey, empty spreadsheet cells for `detail`, `hook`, and `name` were silently dropped (treated as `undefined`), preventing these fields from being cleared in the database
- Defaults these nullable fields to `null` during destructuring so they are explicitly written to the DB, matching the existing pattern used for `detailLabel`, `visibilityCriteria`, and `validationCriteria` on survey screen components

**Review**

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->

## Test plan
- [ ] Export an existing survey that has questions with details (e.g. "Tupaia User Survey (Feedback)")
- [ ] Delete a detail from the exported file and save
- [ ] Reimport the updated file via the Edit button on the survey
- [ ] Export the survey again and confirm the detail is now cleared
- [ ] Verify that importing a survey with detail values still works correctly

