### PR TITLE
fix(datatrak): RN-1843: sync failure because of duplicated options (HOTFIX)

### DIFF
--- a/packages/database/src/__tests__/modelClasses/SurveyResponse/upsertEntitiesAndOptions.test.js
+++ b/packages/database/src/__tests__/modelClasses/SurveyResponse/upsertEntitiesAndOptions.test.js
@@ -1,0 +1,139 @@
+import { upsertEntitiesAndOptions } from '../../../core/modelClasses/SurveyResponse/upsertEntitiesAndOptions';
+import { getTestModels, upsertDummyRecord } from '../../../server/testUtilities';
+import { generateId } from '../../../core/utilities';
+
+describe('upsertEntitiesAndOptions', () => {
+  const models = getTestModels();
+  let optionSet;
+
+  beforeAll(async () => {
+    optionSet = await upsertDummyRecord(models.optionSet, { name: 'Test Option Set' });
+  });
+
+  afterAll(async () => {
+    await models.option.delete({ option_set_id: optionSet.id });
+    await models.optionSet.delete({ id: optionSet.id });
+  });
+
+  describe('createOptions', () => {
+    afterEach(async () => {
+      await models.option.delete({ option_set_id: optionSet.id });
+    });
+
+    it('should create a new option when none exists', async () => {
+      await upsertEntitiesAndOptions(models, [
+        {
+          options_created: [
+            {
+              id: generateId(),
+              value: 'New Option',
+              option_set_id: optionSet.id,
+            },
+          ],
+        },
+      ]);
+
+      const options = await models.option.find({ option_set_id: optionSet.id });
+      expect(options).toHaveLength(1);
+      expect(options[0].value).toBe('New Option');
+    });
+
+    it('should not change the existing option id when the same option_set_id+value is pushed again', async () => {
+      const firstDeviceId = generateId();
+      await upsertEntitiesAndOptions(models, [
+        {
+          options_created: [
+            {
+              id: firstDeviceId,
+              value: 'PM-900',
+              option_set_id: optionSet.id,
+            },
+          ],
+        },
+      ]);
+
+      const [firstOption] = await models.option.find({ option_set_id: optionSet.id, value: 'PM-900' });
+      const originalId = firstOption.id;
+
+      const secondDeviceId = generateId();
+      await upsertEntitiesAndOptions(models, [
+        {
+          options_created: [
+            {
+              id: secondDeviceId,
+              value: 'PM-900',
+              option_set_id: optionSet.id,
+            },
+          ],
+        },
+      ]);
+
+      const options = await models.option.find({ option_set_id: optionSet.id, value: 'PM-900' });
+      expect(options).toHaveLength(1);
+      expect(options[0].id).toBe(originalId);
+      expect(options[0].id).not.toBe(secondDeviceId);
+    });
+
+    it('should work when options_created has no id field (DatatrakWeb path)', async () => {
+      await upsertEntitiesAndOptions(models, [
+        {
+          options_created: [
+            {
+              value: 'DatatrakOption',
+              option_set_id: optionSet.id,
+              label: 'DatatrakOption',
+            },
+          ],
+        },
+      ]);
+
+      const options = await models.option.find({ option_set_id: optionSet.id, value: 'DatatrakOption' });
+      expect(options).toHaveLength(1);
+      expect(options[0].value).toBe('DatatrakOption');
+      expect(options[0].id).toBeDefined();
+    });
+
+    it('should increment sort_order for each new option', async () => {
+      await upsertEntitiesAndOptions(models, [
+        {
+          options_created: [
+            { id: generateId(), value: 'Option A', option_set_id: optionSet.id },
+            { id: generateId(), value: 'Option B', option_set_id: optionSet.id },
+            { id: generateId(), value: 'Option C', option_set_id: optionSet.id },
+          ],
+        },
+      ]);
+
+      const options = await models.option.find(
+        { option_set_id: optionSet.id },
+        { sort: ['sort_order ASC'] },
+      );
+      expect(options).toHaveLength(3);
+      expect(options[0].sort_order).toBe(1);
+      expect(options[1].sort_order).toBe(2);
+      expect(options[2].sort_order).toBe(3);
+    });
+
+    it('should only have one option record after multiple pushes of the same value', async () => {
+      for (let i = 0; i < 3; i++) {
+        await upsertEntitiesAndOptions(models, [
+          {
+            options_created: [
+              {
+                id: generateId(),
+                value: 'Duplicate Test',
+                option_set_id: optionSet.id,
+              },
+            ],
+          },
+        ]);
+      }
+
+      const options = await models.option.find({
+        option_set_id: optionSet.id,
+        value: 'Duplicate Test',
+      });
+      expect(options).toHaveLength(1);
+    });
+  });
+});

--- a/packages/database/src/core/modelClasses/SurveyResponse/upsertEntitiesAndOptions.js
+++ b/packages/database/src/core/modelClasses/SurveyResponse/upsertEntitiesAndOptions.js
@@ -35,16 +35,22 @@ const createOptions = async (models, optionsCreated) => {
   /** @type {OptionRecord[]} */
   const options = [];
   for (const optionObject of optionsCreated) {
-    const { value, option_set_id: optionSetId } = optionObject;
+    const { value, option_set_id: optionSetId, id: _id, ...restOptionFields } = optionObject;
 
     /** @type {number} */
     const maxSortOrder = (await models.option.getLargestSortOrder(optionSetId)) ?? 0;
 
+    // Exclude `id` from the fields passed to updateOrCreate. The conflict target is
+    // (option_set_id, value), so when a matching option already exists the ON CONFLICT
+    // DO UPDATE fires. Including `id` in the update data would change the existing
+    // option's primary key via UPDATE (not DELETE+INSERT), which means the BEFORE DELETE
+    // trigger on the option table never fires and the old sync_lookup entry is orphaned
+    // with is_deleted = FALSE, causing duplicates.
     /** @type {OptionRecord} */
     const optionRecord = await models.option.updateOrCreate(
       { option_set_id: optionSetId, value },
       {
-        ...optionObject,
+        ...restOptionFields,
         sort_order: maxSortOrder + 1,
         attributes: {},
       },

--- a/packages/database/src/core/modelClasses/SurveyResponse/upsertEntitiesAndOptions.js
+++ b/packages/database/src/core/modelClasses/SurveyResponse/upsertEntitiesAndOptions.js
@@ -35,22 +35,23 @@ const createOptions = async (models, optionsCreated) => {
   /** @type {OptionRecord[]} */
   const options = [];
   for (const optionObject of optionsCreated) {
-    const { value, option_set_id: optionSetId, id: _id, ...restOptionFields } = optionObject;
-
-    /** @type {number} */
-    const maxSortOrder = (await models.option.getLargestSortOrder(optionSetId)) ?? 0;
-
+    const { value, option_set_id: optionSetId } = optionObject;
     // Exclude `id` from the fields passed to updateOrCreate. The conflict target is
     // (option_set_id, value), so when a matching option already exists the ON CONFLICT
     // DO UPDATE fires. Including `id` in the update data would change the existing
     // option's primary key via UPDATE (not DELETE+INSERT), which means the BEFORE DELETE
     // trigger on the option table never fires and the old sync_lookup entry is orphaned
     // with is_deleted = FALSE, causing duplicates.
+    const { id: _id, ...fieldsWithoutId } = optionObject;
+
+    /** @type {number} */
+    const maxSortOrder = (await models.option.getLargestSortOrder(optionSetId)) ?? 0;
+
     /** @type {OptionRecord} */
     const optionRecord = await models.option.updateOrCreate(
       { option_set_id: optionSetId, value },
       {
-        ...restOptionFields,
+        ...fieldsWithoutId,
         sort_order: maxSortOrder + 1,
         attributes: {},
       },


### PR DESCRIPTION
### Changes:
- Fix sync failure because of duplicated options
- Situation:

1. Device A submits a survey with a new autocomplete option “PM-900”. The device generates a unique ID (e.g. aaa) for this option and sends it to the central server.
2. Central server receives the survey response. Since no option “PM-900" exists for this option set yet, it creates the option in the database with ID aaa. The sync system records this option in the sync_lookup table (keyed by ID aaa) so it can be synced to other devices.
3. Device B independently submits a survey with the same autocomplete value “PM-900”. Device B generates its own unique ID (e.g. bbb) and sends it to the central server.
4. Central server receives Device B’s survey. It finds that an option “PM-900" already exists for this option set, so instead of creating a new one, it updates the existing option (using models.option.updateOrCreate - see file upsertEntitiesAndOptions.js ). However, the update overwrites all fields — including the ID. The option’s ID silently changes from aaa to bbb.

The problem: The sync system tracks deletions using a database trigger that fires when a record is deleted. But no deletion happened here — the option’s ID was changed via an update. So the old sync_lookup entry (for ID aaa) is never marked as deleted. It remains as a stale record that says “option aaa exists and is not deleted,” even though no option with that ID exists anymore. Causing duplicated option entries in the sync_lookup even tho there’s only 1 of them in the actual option table

TLDR: Because meditrak also updates the option.id , sync_lookup thought it’s a completely new option record and it inserts a new record instead of updating the existing one, causing duplicated entries

### 🦸 Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
