### PR TITLE
feat(datatrak): RN-1810: Sync draft deletions from client to central-server

### DIFF
--- a/packages/database/src/core/migrations/20260326000001-addIsDeletedToSurveyResponseDraft-modifies-schema.js
+++ b/packages/database/src/core/migrations/20260326000001-addIsDeletedToSurveyResponseDraft-modifies-schema.js
@@ -1,0 +1,32 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = async function (db) {
+  await db.runSql(`
+    ALTER TABLE survey_response_draft ADD COLUMN is_deleted BOOLEAN NOT NULL DEFAULT false;
+  `);
+};
+
+exports.down = async function (db) {
+  await db.runSql(`
+    ALTER TABLE survey_response_draft DROP COLUMN IF EXISTS is_deleted;
+  `);
+};
+
+exports._meta = {
+  version: 1,
+  targets: ['browser', 'server'],
+};

--- a/packages/datatrak-web-server/src/routes/SurveyResponseDraft/GetSurveyResponseDraftsRoute.ts
+++ b/packages/datatrak-web-server/src/routes/SurveyResponseDraft/GetSurveyResponseDraftsRoute.ts
@@ -21,7 +21,7 @@ export class GetSurveyResponseDraftsRoute extends Route<GetSurveyResponseDraftsR
 
     const { id: userId } = await ctx.services.central.getUser();
 
-    const findConditions: Record<string, any> = { user_id: userId };
+    const findConditions: Record<string, any> = { user_id: userId, is_deleted: false };
 
     // Filter by project if specified: join through survey table
     if (projectId) {

--- a/packages/datatrak-web/src/api/queries/useSurveyResponseDrafts.ts
+++ b/packages/datatrak-web/src/api/queries/useSurveyResponseDrafts.ts
@@ -20,7 +20,7 @@ const localQueryFunction = async ({
   projectId,
 }: DraftsQueryContext): Promise<PageResponse> => {
   const drafts = await models.surveyResponseDraft.find(
-    { user_id: ensure(userId) },
+    { user_id: ensure(userId), is_deleted: false },
     { sort: ['updated_at DESC'] },
   );
 

--- a/packages/datatrak-web/src/database/surveyResponseDraft/deleteSurveyResponseDraft.ts
+++ b/packages/datatrak-web/src/database/surveyResponseDraft/deleteSurveyResponseDraft.ts
@@ -9,5 +9,6 @@ export const deleteSurveyResponseDraft = async ({
   draftId?: string;
 }) => {
   assertIsNotNullish(draftId, 'deleteSurveyResponseDraft called with undefined draftId');
-  return models.surveyResponseDraft.deleteById(draftId);
+  // Soft-delete so the record is picked up by the next sync push with isDeleted: true
+  return models.surveyResponseDraft.updateById(draftId, { is_deleted: true });
 };

--- a/packages/datatrak-web/src/sync/ClientSyncManager.ts
+++ b/packages/datatrak-web/src/sync/ClientSyncManager.ts
@@ -443,6 +443,12 @@ export class ClientSyncManager {
       currentSyncClockTime.toString(),
     );
     log.debug('ClientSyncManager.updatedLastSuccessfulPush', { currentSyncClockTime });
+
+    // Clean up soft-deleted records that have been successfully pushed
+    await this.models.surveyResponseDraft.delete({
+      is_deleted: true,
+      updated_at_sync_tick: { comparator: '<=', comparisonValue: currentSyncClockTime },
+    });
   }
 
   async pullChanges(sessionId: string, projectIds: Project['id'][]): Promise<number> {

--- a/packages/datatrak-web/src/sync/snapshotOutgoingChanges.ts
+++ b/packages/datatrak-web/src/sync/snapshotOutgoingChanges.ts
@@ -16,6 +16,7 @@ const snapshotChangesForModel = async (model: DatabaseModel, since: number) => {
     direction: SYNC_SESSION_DIRECTION.OUTGOING,
     recordType: model.databaseRecord,
     recordId: r.id,
+    isDeleted: Boolean(r.is_deleted),
     data: sanitizeRecord(r),
   })) as SyncSnapshotAttributes[];
 };

--- a/packages/types/src/schemas/schemas.ts
+++ b/packages/types/src/schemas/schemas.ts
@@ -98944,6 +98944,9 @@ export const SurveyResponseDraftSchema = {
 		"id": {
 			"type": "string"
 		},
+		"is_deleted": {
+			"type": "boolean"
+		},
 		"screen_number": {
 			"type": "number"
 		},
@@ -98969,6 +98972,7 @@ export const SurveyResponseDraftSchema = {
 	"required": [
 		"form_data",
 		"id",
+		"is_deleted",
 		"screen_number",
 		"start_time",
 		"survey_id",
@@ -98989,6 +98993,9 @@ export const SurveyResponseDraftCreateSchema = {
 		"form_data": {
 			"type": "object",
 			"properties": {}
+		},
+		"is_deleted": {
+			"type": "boolean"
 		},
 		"screen_number": {
 			"type": "number"
@@ -99030,6 +99037,9 @@ export const SurveyResponseDraftUpdateSchema = {
 		},
 		"id": {
 			"type": "string"
+		},
+		"is_deleted": {
+			"type": "boolean"
 		},
 		"screen_number": {
 			"type": "number"

--- a/packages/types/src/types/models.ts
+++ b/packages/types/src/types/models.ts
@@ -1533,6 +1533,7 @@ export interface SurveyResponseDraft {
   'entity_id'?: string | null;
   'form_data': {};
   'id': string;
+  'is_deleted': boolean;
   'screen_number': number;
   'start_time': Date;
   'survey_id': string;
@@ -1544,6 +1545,7 @@ export interface SurveyResponseDraftCreate {
   'country_code'?: string | null;
   'entity_id'?: string | null;
   'form_data'?: {};
+  'is_deleted'?: boolean;
   'screen_number'?: number;
   'start_time': Date;
   'survey_id': string;
@@ -1555,6 +1557,7 @@ export interface SurveyResponseDraftUpdate {
   'entity_id'?: string | null;
   'form_data'?: {};
   'id'?: string;
+  'is_deleted'?: boolean;
   'screen_number'?: number;
   'start_time'?: Date;
   'survey_id'?: string;


### PR DESCRIPTION
## Summary
- Fixes Issue 17: draft deletions/completions in the web app (offline-first mode) were not syncing to central-server
- Changes hard-delete of `survey_response_draft` to soft-delete (`is_deleted = true`), allowing the sync push to detect and propagate the deletion
- Adds `is_deleted` column via migration, filters soft-deleted records from UI queries, and cleans up after successful push

## Changes
- **Migration**: Adds `is_deleted BOOLEAN NOT NULL DEFAULT false` to `survey_response_draft` (browser + server)
- **Soft-delete**: `deleteSurveyResponseDraft` now calls `updateById(id, { is_deleted: true })` instead of `deleteById`
- **Snapshot**: `snapshotOutgoingChanges` sets `isDeleted: true` on soft-deleted records — server already handles this
- **Query filters**: Both client (`useSurveyResponseDrafts`) and server (`GetSurveyResponseDraftsRoute`) filter out `is_deleted: true`
- **Cleanup**: `ClientSyncManager.pushChanges()` hard-deletes soft-deleted records after successful push
- **Types**: Updated generated types and schemas for new column

## Test plan
- [ ] Create a draft in a browser
- [ ] Install the DataTrak web app, log in, complete initial sync
- [ ] Delete or complete the draft in the web app
- [ ] Wait for sync cycle (~30s)
- [ ] Verify the draft is gone in the browser and server DB
- [ ] Verify creating/updating/resuming drafts still works as before


**Review**

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->