### PR TITLE
fix(adminPanel): RN-1849: data groups page crash

### DIFF
--- a/packages/admin-panel/src/theme/theme.js
+++ b/packages/admin-panel/src/theme/theme.js
@@ -198,9 +198,6 @@ const overrides = {
       '*': {
         textDecorationThickness: 'from-font',
       },
-      html: {
-        textWrap: 'pretty',
-      },
       'button, figcaption, h1, h2, h3, h4, h5, h6, input, label': {
         textWrap: 'balance',
       },


### PR DESCRIPTION
## RN-1849

Partially reverts #6700

Setting `text-wrap: pretty` on `html` causes fatal crash in Chromium browsers.


### 🦸 Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
