### PR TITLE
fix(uiComponents): disable spellcheck in login email field

### DIFF
--- a/packages/ui-components/src/features/Auth/LoginForm.tsx
+++ b/packages/ui-components/src/features/Auth/LoginForm.tsx
@@ -95,6 +95,7 @@ export const LoginForm = ({
           Input={AuthFormTextField}
           label={email}
           disabled={isLoading}
+          spellCheck={false}
         />
         <FormInput
           autoComplete="current-password"

--- a/packages/ui-components/src/features/Auth/LoginForm.tsx
+++ b/packages/ui-components/src/features/Auth/LoginForm.tsx
@@ -81,13 +81,18 @@ export const LoginForm = ({
   } = labels || {};
   return (
     <Wrapper title={title} subtitle={subtitle} className={className}>
-      {error && <Typography color="error" align="center">{error.message}</Typography>}
+      {error && (
+        <Typography color="error" align="center">
+          {error.message}
+        </Typography>
+      )}
       {message && <EmailVerificationDisplay message={message} />}
       <StyledForm onSubmit={onSubmit} formContext={formContext}>
         <FormInput
           autoComplete="email"
           autoFocus
           id="email"
+          inputProps={{ enterKeyHint: 'next', spellCheck: false }}
           name="email"
           type="email"
           options={FORM_FIELD_VALIDATION.EMAIL}
@@ -95,11 +100,11 @@ export const LoginForm = ({
           Input={AuthFormTextField}
           label={email}
           disabled={isLoading}
-          spellCheck={false}
         />
         <FormInput
           autoComplete="current-password"
           id="password"
+          inputProps={{ enterKeyHint: 'go' }}
           name="password"
           type="password"
           required


### PR DESCRIPTION
Safari in particular is quite aggressive about autocapitalising in an `<input type="field">`.

---

### 🦸 Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
