### PR TITLE
deps: require 7-day minimum release age

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -5,3 +5,5 @@ logFilters:
     level: discard
 
 nodeLinker: node-modules
+
+npmMinimalAgeGate: 7d


### PR DESCRIPTION
Docs: https://yarnpkg.com/configuration/yarnrc#npmMinimalAgeGate

Why 7 days? https://daniakash.com/posts/simplest-supply-chain-defense

Tested:

```sh
yarn
➤ YN0000: · Yarn 4.13.0
➤ YN0000: ┌ Resolution step
➤ YN0016: │ axios@npm:^1.15.0: All versions satisfying "^1.15.0" are quarantined
➤ YN0000: └ Completed in 0s 307ms
➤ YN0000: · Failed with errors in 0s 312ms
```

### 🦸 Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
