### PR TITLE
fix(datatrak): RN-1807: address dynamic CodeGenerator prefix testing issues

### DIFF
--- a/packages/central-server/src/apiV2/import/importSurveys/Validator/ConfigValidator/CodeGeneratorConfigValidator.js
+++ b/packages/central-server/src/apiV2/import/importSurveys/Validator/ConfigValidator/CodeGeneratorConfigValidator.js
@@ -5,13 +5,18 @@ import { CODE_GENERATORS } from '../../codeGenerators';
 export class CodeGeneratorConfigValidator extends JsonFieldValidator {
   static fieldName = 'config';
 
-  getFieldValidators = () => ({
-    type: [constructIsNotPresentOr(constructIsOneOf(Object.values(CODE_GENERATORS)))],
-    alphabet: [() => true],
-    length: [constructIsNotPresentOr(isNumber)],
-    chunkLength: [constructIsNotPresentOr(isNumber)],
-    prefix: [() => true],
-    dynamicPrefix: [() => true],
-    'dynamicPrefix.entityAttribute': [() => true],
-  });
+  getFieldValidators(rowIndex) {
+    const pointsToAnotherQuestion = this.constructPointsToAnotherQuestion(rowIndex);
+
+    return {
+      type: [constructIsNotPresentOr(constructIsOneOf(Object.values(CODE_GENERATORS)))],
+      alphabet: [() => true],
+      length: [constructIsNotPresentOr(isNumber)],
+      chunkLength: [constructIsNotPresentOr(isNumber)],
+      prefix: [() => true],
+      dynamicPrefix: [constructIsNotPresentOr(pointsToAnotherQuestion)],
+      'dynamicPrefix.entityField': [() => true],
+      'dynamicPrefix.entityAttribute': [() => true],
+    };
+  }
 }

--- a/packages/datatrak-web/src/api/queries/useEntity.ts
+++ b/packages/datatrak-web/src/api/queries/useEntity.ts
@@ -25,8 +25,9 @@ const entityByCodeQueryFunctions = {
     );
     const entityRecord = await models.entity.findOne({ code: entityCode });
     if (isNullish(entityRecord)) return null;
-    const entity = await entityRecord.getData();
-    return camelcaseKeys(entity, { deep: true });
+    const entity = (await entityRecord.getData()) as Record<string, any>;
+    const { attributes, ...rest } = entity;
+    return { ...camelcaseKeys(rest), attributes };
   },
 };
 
@@ -67,8 +68,9 @@ const entityByIdQueryFunctions = {
   local: async ({ entityId, models }: EntityByIdQueryFunctionContext) => {
     assertIsNotNullish(entityId, `useEntityById query function called with ${entityId} entityId`);
     const entityRecord = await models.entity.findByIdOrThrow(entityId);
-    const entity = await entityRecord.getData();
-    return camelcaseKeys(entity, { deep: true });
+    const entity = (await entityRecord.getData()) as Record<string, any>;
+    const { attributes, ...rest } = entity;
+    return { ...camelcaseKeys(rest), attributes };
   },
 };
 

--- a/packages/datatrak-web/src/features/Survey/SurveyContext/DynamicCodeGeneratorWatcher.tsx
+++ b/packages/datatrak-web/src/features/Survey/SurveyContext/DynamicCodeGeneratorWatcher.tsx
@@ -1,56 +1,91 @@
 import { useEffect, useRef } from 'react';
-import { CodeGeneratorQuestionConfig } from '@tupaia/types';
+import { CodeGeneratorQuestionConfig, QuestionType } from '@tupaia/types';
 import { useEntityById } from '../../../api/queries/useEntity';
 import { generateShortId } from './generateId';
 import { SurveyScreenComponent } from '../../../types';
 import { ACTION_TYPES, SurveyFormAction } from './actions';
 
-const TOP_LEVEL_ENTITY_FIELDS = new Set(['code', 'name', 'type']);
+const ENTITY_QUESTION_TYPES = new Set<string>([QuestionType.Entity, QuestionType.PrimaryEntity]);
 
-const resolveEntityAttribute = (
+const resolvePrefix = (
   entity: Record<string, any>,
-  entityAttribute: string,
+  dynamicPrefix: NonNullable<CodeGeneratorQuestionConfig['dynamicPrefix']>,
 ): string | undefined => {
-  if (TOP_LEVEL_ENTITY_FIELDS.has(entityAttribute)) {
-    return entity[entityAttribute];
+  const { entityField, entityAttribute } = dynamicPrefix;
+  if (entityField) return entity[entityField];
+  if (entityAttribute) return entity.attributes?.[entityAttribute];
+  return entity.name;
+};
+
+/**
+ * Extract the trailing code (the random part after the prefix) from a generated code string.
+ * e.g. "EBN-HM8-Z1N-CJV0" → "HM8-Z1N-CJV0"
+ */
+const extractTrailingCode = (code: string, prefix: string): string => {
+  if (code.startsWith(`${prefix}-`)) {
+    return code.slice(prefix.length + 1);
   }
-  return entity.attributes?.[entityAttribute];
+  return code;
 };
 
 interface DynamicCodeGeneratorWatcherProps {
   question: SurveyScreenComponent;
+  allComponents: SurveyScreenComponent[];
   formData: Record<string, any>;
   dispatch: React.Dispatch<SurveyFormAction>;
+  isResponseScreen: boolean;
 }
 
 export const DynamicCodeGeneratorWatcher = ({
   question,
+  allComponents,
   formData,
   dispatch,
+  isResponseScreen,
 }: DynamicCodeGeneratorWatcherProps) => {
   const { questionId, config } = question;
   const codeGenerator = config!.codeGenerator as CodeGeneratorQuestionConfig;
   const { dynamicPrefix } = codeGenerator;
   const sourceAnswer = formData[dynamicPrefix!.questionId];
 
-  const shouldFetchEntity = Boolean(dynamicPrefix!.entityAttribute && sourceAnswer);
+  const sourceQuestion = allComponents.find(q => q.questionId === dynamicPrefix!.questionId);
+  const isEntitySource = sourceQuestion ? ENTITY_QUESTION_TYPES.has(sourceQuestion.type) : false;
+
+  // Fetch entity if the source question is an entity question and has an answer
+  const shouldFetchEntity = Boolean(isEntitySource && sourceAnswer);
   const { data: entity } = useEntityById(shouldFetchEntity ? sourceAnswer : undefined);
 
   const prevPrefixRef = useRef<string | undefined>(undefined);
+  const trailingCodeRef = useRef<string | undefined>(undefined);
 
   let resolvedPrefix: string | undefined;
-  if (dynamicPrefix!.entityAttribute) {
+  if (isEntitySource) {
     if (entity) {
-      resolvedPrefix = resolveEntityAttribute(entity, dynamicPrefix!.entityAttribute);
+      resolvedPrefix = resolvePrefix(entity, dynamicPrefix!);
     }
   } else {
     resolvedPrefix = sourceAnswer;
   }
 
   useEffect(() => {
-    if (resolvedPrefix === undefined || resolvedPrefix === prevPrefixRef.current) return;
+    // Don't overwrite saved answers when viewing a submitted response
+    if (isResponseScreen) return;
 
-    prevPrefixRef.current = resolvedPrefix;
+    if (resolvedPrefix === undefined) {
+      // If a code was previously generated and the prefix is now undefined (e.g. entity
+      // changed to one without the required attribute), clear the code
+      if (prevPrefixRef.current !== undefined) {
+        prevPrefixRef.current = undefined;
+        trailingCodeRef.current = undefined;
+        dispatch({
+          type: ACTION_TYPES.SET_FORM_DATA,
+          payload: { [questionId]: undefined },
+        });
+      }
+      return;
+    }
+
+    if (resolvedPrefix === prevPrefixRef.current) return;
 
     if (codeGenerator.type !== 'shortid') {
       throw new Error(
@@ -58,13 +93,23 @@ export const DynamicCodeGeneratorWatcher = ({
       );
     }
 
-    const newCode = generateShortId({ ...codeGenerator, prefix: resolvedPrefix });
+    prevPrefixRef.current = resolvedPrefix;
+
+    let newCode: string;
+    if (trailingCodeRef.current) {
+      // Prefix changed but trailing code already exists — just swap the prefix
+      newCode = `${resolvedPrefix}-${trailingCodeRef.current}`;
+    } else {
+      // First generation — create a full new code
+      newCode = generateShortId({ ...codeGenerator, prefix: resolvedPrefix });
+      trailingCodeRef.current = extractTrailingCode(newCode, resolvedPrefix);
+    }
 
     dispatch({
       type: ACTION_TYPES.SET_FORM_DATA,
       payload: { [questionId]: newCode },
     });
-  }, [resolvedPrefix, codeGenerator, dispatch, questionId]);
+  }, [resolvedPrefix, codeGenerator, dispatch, questionId, isResponseScreen]);
 
   return null;
 };

--- a/packages/datatrak-web/src/features/Survey/SurveyContext/DynamicCodeGeneratorWatcher.tsx
+++ b/packages/datatrak-web/src/features/Survey/SurveyContext/DynamicCodeGeneratorWatcher.tsx
@@ -1,11 +1,9 @@
 import { useEffect, useRef } from 'react';
-import { CodeGeneratorQuestionConfig, QuestionType } from '@tupaia/types';
+import { CodeGeneratorQuestionConfig } from '@tupaia/types';
 import { useEntityById } from '../../../api/queries/useEntity';
 import { generateShortId } from './generateId';
 import { SurveyScreenComponent } from '../../../types';
 import { ACTION_TYPES, SurveyFormAction } from './actions';
-
-const ENTITY_QUESTION_TYPES = new Set<string>([QuestionType.Entity, QuestionType.PrimaryEntity]);
 
 const resolvePrefix = (
   entity: Record<string, any>,
@@ -30,7 +28,7 @@ const extractTrailingCode = (code: string, prefix: string): string => {
 
 interface DynamicCodeGeneratorWatcherProps {
   question: SurveyScreenComponent;
-  allComponents: SurveyScreenComponent[];
+  isEntitySource: boolean;
   formData: Record<string, any>;
   dispatch: React.Dispatch<SurveyFormAction>;
   isResponseScreen: boolean;
@@ -38,7 +36,7 @@ interface DynamicCodeGeneratorWatcherProps {
 
 export const DynamicCodeGeneratorWatcher = ({
   question,
-  allComponents,
+  isEntitySource,
   formData,
   dispatch,
   isResponseScreen,
@@ -47,9 +45,6 @@ export const DynamicCodeGeneratorWatcher = ({
   const codeGenerator = config!.codeGenerator as CodeGeneratorQuestionConfig;
   const { dynamicPrefix } = codeGenerator;
   const sourceAnswer = formData[dynamicPrefix!.questionId];
-
-  const sourceQuestion = allComponents.find(q => q.questionId === dynamicPrefix!.questionId);
-  const isEntitySource = sourceQuestion ? ENTITY_QUESTION_TYPES.has(sourceQuestion.type) : false;
 
   // Fetch entity if the source question is an entity question and has an answer
   const shouldFetchEntity = Boolean(isEntitySource && sourceAnswer);

--- a/packages/datatrak-web/src/features/Survey/SurveyContext/DynamicCodeGeneratorWatcher.tsx
+++ b/packages/datatrak-web/src/features/Survey/SurveyContext/DynamicCodeGeneratorWatcher.tsx
@@ -20,10 +20,13 @@ const resolvePrefix = (
  * e.g. "EBN-HM8-Z1N-CJV0" → "HM8-Z1N-CJV0"
  */
 const extractTrailingCode = (code: string, prefix: string): string => {
-  if (code.startsWith(`${prefix}-`)) {
-    return code.slice(prefix.length + 1);
+  const expectedPrefix = `${prefix}-`;
+  if (!code.startsWith(expectedPrefix)) {
+    throw new Error(
+      `Generated code "${code}" does not start with expected prefix "${expectedPrefix}"`,
+    );
   }
-  return code;
+  return code.slice(expectedPrefix.length);
 };
 
 interface DynamicCodeGeneratorWatcherProps {

--- a/packages/datatrak-web/src/features/Survey/SurveyContext/SurveyContext.tsx
+++ b/packages/datatrak-web/src/features/Survey/SurveyContext/SurveyContext.tsx
@@ -191,8 +191,10 @@ export const SurveyContext = ({
           <DynamicCodeGeneratorWatcher
             key={q.questionId}
             question={q}
+            allComponents={flattenedScreenComponents}
             formData={formData}
             dispatch={dispatch}
+            isResponseScreen={isResponseScreen}
           />
         ))}
         {children}

--- a/packages/datatrak-web/src/features/Survey/SurveyContext/SurveyContext.tsx
+++ b/packages/datatrak-web/src/features/Survey/SurveyContext/SurveyContext.tsx
@@ -187,16 +187,28 @@ export const SurveyContext = ({
       }}
     >
       <SurveyFormDispatchContext.Provider value={dispatch}>
-        {dynamicCodeGenQuestions.map(q => (
-          <DynamicCodeGeneratorWatcher
-            key={q.questionId}
-            question={q}
-            allComponents={flattenedScreenComponents}
-            formData={formData}
-            dispatch={dispatch}
-            isResponseScreen={isResponseScreen}
-          />
-        ))}
+        {dynamicCodeGenQuestions.map(q => {
+          const sourceQuestionId = (
+            q.config!.codeGenerator as CodeGeneratorQuestionConfig
+          ).dynamicPrefix!.questionId;
+          const sourceQuestion = flattenedScreenComponents.find(
+            c => c.questionId === sourceQuestionId,
+          );
+          const isEntitySource =
+            sourceQuestion?.type === QuestionType.Entity ||
+            sourceQuestion?.type === QuestionType.PrimaryEntity;
+
+          return (
+            <DynamicCodeGeneratorWatcher
+              key={q.questionId}
+              question={q}
+              isEntitySource={isEntitySource}
+              formData={formData}
+              dispatch={dispatch}
+              isResponseScreen={isResponseScreen}
+            />
+          );
+        })}
         {children}
       </SurveyFormDispatchContext.Provider>
     </SurveyFormContext.Provider>

--- a/packages/types/src/schemas/schemas.ts
+++ b/packages/types/src/schemas/schemas.ts
@@ -45445,6 +45445,14 @@ export const CodeGeneratorQuestionConfigSchema = {
 				"questionId": {
 					"type": "string"
 				},
+				"entityField": {
+					"enum": [
+						"code",
+						"name",
+						"type"
+					],
+					"type": "string"
+				},
 				"entityAttribute": {
 					"type": "string"
 				}
@@ -46690,6 +46698,14 @@ export const SurveyScreenComponentConfigSchema = {
 					"type": "object",
 					"properties": {
 						"questionId": {
+							"type": "string"
+						},
+						"entityField": {
+							"enum": [
+								"code",
+								"name",
+								"type"
+							],
 							"type": "string"
 						},
 						"entityAttribute": {

--- a/packages/types/src/types/models-extra/survey/surveyScreenComponent.ts
+++ b/packages/types/src/types/models-extra/survey/surveyScreenComponent.ts
@@ -6,6 +6,7 @@ export type CodeGeneratorQuestionConfig = {
   prefix?: string;
   dynamicPrefix?: {
     questionId: Question['id'];
+    entityField?: 'name' | 'code' | 'type';
     entityAttribute?: string;
   };
   length?: number;


### PR DESCRIPTION
## Summary

Fixes 6 issues found during testing of dynamic CodeGenerator prefixes (PR #6686):

- **Issue 1:** Submission history no longer regenerates codes — `DynamicCodeGeneratorWatcher` now skips code generation when `isResponseScreen` is true
- **Issue 2:** Entity questions without explicit config now default to entity `name` instead of `id` — also detects entity source questions automatically
- **Issue 3:** Changing the source question answer now only swaps the prefix while keeping the trailing random code the same
- **Issue 4:** When an entity lacks the specified attribute, the code is cleared (shows blank) rather than showing a stale code
- **Issue 5:** Survey import now validates that `dynamicPrefix` references a question that exists in the same survey (using existing `constructPointsToAnotherQuestion` pattern)
- **Issue 6:** Entity attribute prefixes now work in the PWA — local entity fetch no longer deep-camelCases the `attributes` JSON, preserving original keys

Also resolves the `entityAttribute` ambiguity flagged by Edwin by introducing separate config keys:
- `entityField` — for top-level entity columns (`name`, `code`, `type`)
- `entityAttribute` — exclusively for keys in the entity `attributes` JSON column

### Config examples

**Dynamic prefix from a text/dropdown question answer:**
```
type: shortid
dynamicPrefix: SOURCE_QUESTION_CODE
```

**Dynamic prefix from entity name (default when source is an entity question):**
```
type: shortid
dynamicPrefix: ENTITY_QUESTION_CODE
```

**Dynamic prefix from entity code:**
```
type: shortid
dynamicPrefix: ENTITY_QUESTION_CODE
dynamicPrefix.entityField: code
```

**Dynamic prefix from a custom entity attribute:**
```
type: shortid
dynamicPrefix: ENTITY_QUESTION_CODE
dynamicPrefix.entityAttribute: code_prefix
```


### 🦸 Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->