### PR TITLE
fix(deployment): make delete_old_servers tolerant of orphan deployments

### DIFF
--- a/packages/devops/scripts/lambda/actions/delete_old_servers.py
+++ b/packages/devops/scripts/lambda/actions/delete_old_servers.py
@@ -1,7 +1,14 @@
 from datetime import datetime
 
+from botocore.exceptions import ClientError
+
 from helpers.teardown import teardown_instance
 from helpers.utilities import find_instances, get_tag
+
+# IAM/auth failures we want to surface (via Lambda error metric) rather than
+# silently log and skip — otherwise a missing permission means the cron does
+# nothing forever with no alarm.
+AUTH_ERROR_CODES = {"AccessDenied", "UnauthorizedOperation"}
 
 
 def delete_old_servers(event):
@@ -25,8 +32,10 @@ def delete_old_servers(event):
         if current_datetime > delete_instance_after:
             try:
                 teardown_instance(instance)
+            except ClientError as e:
+                if e.response.get("Error", {}).get("Code") in AUTH_ERROR_CODES:
+                    raise
+                print(f"Failed to tear down {get_tag(instance, 'Name')}: {e}")
             except Exception as e:
                 # Don't let one failed teardown block the rest of the cron run
-                print(
-                    f"Failed to tear down {get_tag(instance, 'Name')}: {e}"
-                )
+                print(f"Failed to tear down {get_tag(instance, 'Name')}: {e}")

--- a/packages/devops/scripts/lambda/actions/delete_old_servers.py
+++ b/packages/devops/scripts/lambda/actions/delete_old_servers.py
@@ -6,9 +6,19 @@ from helpers.teardown import teardown_instance
 from helpers.utilities import find_instances, get_tag
 
 # IAM/auth failures we want to surface (via Lambda error metric) rather than
-# silently log and skip — otherwise a missing permission means the cron does
-# nothing forever with no alarm.
-AUTH_ERROR_CODES = {"AccessDenied", "UnauthorizedOperation"}
+# silently log and skip — covers both IAM policy denials and credential-level
+# failures (revoked keys, expired STS tokens). Without this, a missing
+# permission or an expired token means the cron does nothing forever with no
+# alarm.
+AUTH_ERROR_CODES = {
+    "AccessDenied",
+    "UnauthorizedOperation",
+    "AuthFailure",
+    "InvalidClientTokenId",
+    "ExpiredToken",
+    "ExpiredTokenException",
+    "SignatureDoesNotMatch",
+}
 
 
 def delete_old_servers(event):

--- a/packages/devops/scripts/lambda/actions/delete_old_servers.py
+++ b/packages/devops/scripts/lambda/actions/delete_old_servers.py
@@ -23,4 +23,10 @@ def delete_old_servers(event):
             get_tag(instance, "DeleteAfter"), "%Y-%m-%d %H:%M"
         )
         if current_datetime > delete_instance_after:
-            teardown_instance(instance)
+            try:
+                teardown_instance(instance)
+            except Exception as e:
+                # Don't let one failed teardown block the rest of the cron run
+                print(
+                    f"Failed to tear down {get_tag(instance, 'Name')}: {e}"
+                )

--- a/packages/devops/scripts/lambda/helpers/networking.py
+++ b/packages/devops/scripts/lambda/helpers/networking.py
@@ -24,6 +24,10 @@ def get_cert(type_tag):
 elbv2 = boto3.client("elbv2")
 
 
+class GatewayNotFoundError(Exception):
+    """Raised when no gateway ELB or target group matches the given deployment tags."""
+
+
 def get_gateway_name(deployment_type, deployment_name):
     name = deployment_type + "-" + deployment_name
     name = name[0:32]  # max 32 chars in an ELB or gateway name
@@ -52,7 +56,7 @@ def get_gateway_elb(deployment_type, deployment_name):
             )
         if len(matching_arns) == 1:
             return elb
-    raise Exception(
+    raise GatewayNotFoundError(
         "No "
         + deployment_type
         + " gateway elb found tagged with deployment name: "
@@ -83,7 +87,7 @@ def get_gateway_target_group(deployment_type, deployment_name):
         if len(matching_arns) == 1:
             return target_group
 
-    raise Exception(
+    raise GatewayNotFoundError(
         "No "
         + deployment_type
         + " gateway target group found tagged with deployment name: "

--- a/packages/devops/scripts/lambda/helpers/teardown.py
+++ b/packages/devops/scripts/lambda/helpers/teardown.py
@@ -84,20 +84,31 @@ def teardown_instance(instance):
 
     # Delete gateway subdomains
     subdomains_via_gateway = get_tag(instance, "SubdomainsViaGateway")
+    gateway_elb = None
     if subdomains_via_gateway != "":
-        gateway_elb = get_gateway_elb(deployment_type, deployment_name)
-        record_set_deletions = record_set_deletions + [
-            build_record_set_deletion(
-                "tupaia.org", subdomain, deployment_name, gateway=gateway_elb
+        try:
+            gateway_elb = get_gateway_elb(deployment_type, deployment_name)
+            record_set_deletions = record_set_deletions + [
+                build_record_set_deletion(
+                    "tupaia.org", subdomain, deployment_name, gateway=gateway_elb
+                )
+                for subdomain in subdomains_via_gateway.split(",")
+            ]
+        except Exception as e:
+            # Gateway may have failed to spin up (e.g. invalid ELB name) or already been
+            # cleaned up. Skip gateway-related cleanup so we still terminate the EC2.
+            print(
+                f"Skipping gateway record-set cleanup for {deployment_name}: {e}"
             )
-            for subdomain in subdomains_via_gateway.split(",")
-        ]
 
     delete_route53_record_sets(deployment_name, record_set_deletions)
 
     # Delete gateway
-    if subdomains_via_gateway != "":
-        delete_gateway(deployment_type, deployment_name)
+    if gateway_elb is not None:
+        try:
+            delete_gateway(deployment_type, deployment_name)
+        except Exception as e:
+            print(f"Skipping gateway deletion for {deployment_name}: {e}")
 
     terminate_instance(instance)
 

--- a/packages/devops/scripts/lambda/helpers/teardown.py
+++ b/packages/devops/scripts/lambda/helpers/teardown.py
@@ -1,5 +1,6 @@
 import boto3
 from helpers.networking import (
+    GatewayNotFoundError,
     build_record_set_deletion,
     delete_gateway,
     get_gateway_elb,
@@ -84,7 +85,6 @@ def teardown_instance(instance):
 
     # Delete gateway subdomains
     subdomains_via_gateway = get_tag(instance, "SubdomainsViaGateway")
-    gateway_elb = None
     if subdomains_via_gateway != "":
         try:
             gateway_elb = get_gateway_elb(deployment_type, deployment_name)
@@ -94,21 +94,20 @@ def teardown_instance(instance):
                 )
                 for subdomain in subdomains_via_gateway.split(",")
             ]
-        except Exception as e:
-            # Gateway may have failed to spin up (e.g. invalid ELB name) or already been
-            # cleaned up. Skip gateway-related cleanup so we still terminate the EC2.
-            print(
-                f"Skipping gateway record-set cleanup for {deployment_name}: {e}"
-            )
+        except GatewayNotFoundError as e:
+            # Deployment never finished spinning up its gateway (e.g. branch name
+            # rejected by AWS as an ELB name). Skip gateway-related cleanup so we
+            # still terminate the EC2; let other errors bubble.
+            print(f"No gateway to clean up for {deployment_name}: {e}")
 
     delete_route53_record_sets(deployment_name, record_set_deletions)
 
     # Delete gateway
-    if gateway_elb is not None:
+    if subdomains_via_gateway != "":
         try:
             delete_gateway(deployment_type, deployment_name)
-        except Exception as e:
-            print(f"Skipping gateway deletion for {deployment_name}: {e}")
+        except GatewayNotFoundError as e:
+            print(f"No gateway to delete for {deployment_name}: {e}")
 
     terminate_instance(instance)
 

--- a/packages/devops/scripts/lambda/helpers/teardown.py
+++ b/packages/devops/scripts/lambda/helpers/teardown.py
@@ -83,31 +83,31 @@ def teardown_instance(instance):
             for subdomain in subdomains_via_dns.split(",")
         ]
 
-    # Delete gateway subdomains
+    # Delete gateway subdomains. Looking up the gateway ELB up-front doubles as
+    # the existence check: if it's missing the deployment never finished spinning
+    # up (e.g. branch name rejected by AWS as an ELB name) and there's nothing to
+    # clean up. Any failure inside delete_gateway after this point — including a
+    # missing target group, which would indicate partial state — must surface.
     subdomains_via_gateway = get_tag(instance, "SubdomainsViaGateway")
+    gateway_elb = None
     if subdomains_via_gateway != "":
         try:
             gateway_elb = get_gateway_elb(deployment_type, deployment_name)
-            record_set_deletions = record_set_deletions + [
-                build_record_set_deletion(
-                    "tupaia.org", subdomain, deployment_name, gateway=gateway_elb
-                )
-                for subdomain in subdomains_via_gateway.split(",")
-            ]
         except GatewayNotFoundError as e:
-            # Deployment never finished spinning up its gateway (e.g. branch name
-            # rejected by AWS as an ELB name). Skip gateway-related cleanup so we
-            # still terminate the EC2; let other errors bubble.
             print(f"No gateway to clean up for {deployment_name}: {e}")
+
+    if gateway_elb is not None:
+        record_set_deletions = record_set_deletions + [
+            build_record_set_deletion(
+                "tupaia.org", subdomain, deployment_name, gateway=gateway_elb
+            )
+            for subdomain in subdomains_via_gateway.split(",")
+        ]
 
     delete_route53_record_sets(deployment_name, record_set_deletions)
 
-    # Delete gateway
-    if subdomains_via_gateway != "":
-        try:
-            delete_gateway(deployment_type, deployment_name)
-        except GatewayNotFoundError as e:
-            print(f"No gateway to delete for {deployment_name}: {e}")
+    if gateway_elb is not None:
+        delete_gateway(deployment_type, deployment_name)
 
     terminate_instance(instance)
 


### PR DESCRIPTION
## Summary

- Wrap `teardown_instance` in a per-iteration `try/except` inside `delete_old_servers`, so one bad instance no longer aborts the rest of the cron run.
- Inside `teardown_instance`, treat a missing/orphaned gateway as skippable: log it and continue to `terminate_instance` instead of bubbling the exception out of the whole loop.

## Background

CloudWatch traceback from a recent failed run:

```
[ERROR] Exception: No tupaia gateway elb found tagged with deployment name: fix/rn-1867-dynamic-codegen-draft-regeneration
  File "/var/task/actions/delete_old_servers.py", line 26, in delete_old_servers
    teardown_instance(instance)
  File "/var/task/helpers/teardown.py", line 88, in teardown_instance
    gateway_elb = get_gateway_elb(deployment_type, deployment_name)
```

The branch name contains a `/`, which AWS rejects in ELB names — so that deployment's gateway never actually got created, but the EC2 still has the `SubdomainsViaGateway` tag. Every cron run since has crashed on that one orphan, and because the loop has no error handling, every other expired EC2 was left running too. Meanwhile `delete_old_databases` kept working (its teardown path has no gateway dependency), which is why the symptom was "RDS cleans up but EC2 doesn't".

This PR doesn't try to prevent the orphan-deployment case at spin-up time; it just makes cleanup tolerant of it. The orphan EC2 still needs a one-off manual terminate.


### 🦸 Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
