### PR TITLE
ci: faster

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -215,7 +215,6 @@ jobs:
       - validate_tests
       - validate_types
       - run_tests
-      - build
     runs-on: ubuntu-latest
     steps:
       - name: Green if all jobs are green

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -127,26 +127,9 @@ jobs:
                 '[.[] | .name] | map(select(. != "tupaia" and . != "@tupaia/devops" and . != "@tupaia/e2e"))'
           ) >>"$GITHUB_OUTPUT"
 
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-    env:
-      CI: false # react-scripts build treats warnings as errors if this is true
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Yarn
-        run: |
-          corepack enable yarn
-          corepack install
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-          cache: yarn
-      - run: yarn install
-      - run: yarn run build
 
   run_tests:
-    name: Test
+    name: Build & test
     needs: package_list
     timeout-minutes: 15 # Sometimes Jest doesn’t exit properly for meditrak-app-server tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -129,14 +129,9 @@ jobs:
 
   build:
     name: Build
-    needs: package_list
     runs-on: ubuntu-latest
     env:
       CI: false # react-scripts build treats warnings as errors if this is true
-    strategy:
-      fail-fast: false
-      matrix:
-        package: ${{ fromJSON(needs.package_list.outputs.PACKAGES) }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Yarn
@@ -147,8 +142,8 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: yarn
-      - run: yarn install # TODO: Resolve dependency issues and replace with `yarn workspaces focus`
-      - run: yarn workspaces foreach -Rptvv --jobs unlimited --from ${{ matrix.package }} run build
+      - run: yarn install
+      - run: yarn run build
 
   run_tests:
     name: Test


### PR DESCRIPTION
### Changes

The test step was actually just the build step + the running the test suite

We could actually optimise for speed more by building the entire workspace in one go with `yarn run build`, and making the `run_tests` step wait for that single build step. This would hide dependency issues, which I’m not personally a fan huge of; but there is a strong argument that unless/until we deploy each server to its own container that this is a non-issue. I could be convinced that it is the right decision for Tupaia.

---

### Screenshots:

---

### 🦸 Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
