### PR TITLE
deps: bump axios to 1.15

### DIFF
--- a/packages/admin-panel/package.json
+++ b/packages/admin-panel/package.json
@@ -42,7 +42,7 @@
     "@tupaia/ui-components": "workspace:*",
     "@tupaia/utils": "workspace:*",
     "ace-builds": "^1.10.1",
-    "axios": "^1.12.2",
+    "axios": "^1.15.0",
     "content-disposition-header": "^0.6.0",
     "date-fns": "^2.30.0",
     "file-saver": "^1.3.3",

--- a/packages/datatrak-web/package.json
+++ b/packages/datatrak-web/package.json
@@ -28,7 +28,7 @@
     "@tupaia/ui-components": "workspace:*",
     "@tupaia/ui-map-components": "workspace:*",
     "@tupaia/utils": "workspace:*",
-    "axios": "^1.12.2",
+    "axios": "^1.15.0",
     "bson-objectid": "^1.2.2",
     "case": "^1.6.3",
     "csstype": "^3.1.3",

--- a/packages/lesmis/package.json
+++ b/packages/lesmis/package.json
@@ -35,7 +35,7 @@
     "@tupaia/ui-components": "workspace:*",
     "@tupaia/ui-map-components": "workspace:*",
     "@tupaia/utils": "workspace:*",
-    "axios": "^1.12.2",
+    "axios": "^1.15.0",
     "camelcase": "^6.2.0",
     "dom-to-image": "^2.6.0",
     "downloadjs": "^1.4.7",

--- a/packages/psss/package.json
+++ b/packages/psss/package.json
@@ -32,7 +32,7 @@
     "@tanstack/react-query-devtools": "4.36.1",
     "@tupaia/ui-components": "workspace:*",
     "@tupaia/utils": "workspace:*",
-    "axios": "^1.12.2",
+    "axios": "^1.15.0",
     "date-fns": "^2.30.0",
     "faker": "^4.1.0",
     "history": "^5.0.0",

--- a/packages/tupaia-web/package.json
+++ b/packages/tupaia-web/package.json
@@ -31,7 +31,7 @@
     "@tupaia/ui-components": "workspace:*",
     "@tupaia/ui-map-components": "workspace:*",
     "@tupaia/utils": "workspace:*",
-    "axios": "^1.12.2",
+    "axios": "^1.15.0",
     "csstype": "^3.1.3",
     "dom-to-image": "2.6.0",
     "downloadjs": "1.4.7",

--- a/packages/viz-test-tool/package.json
+++ b/packages/viz-test-tool/package.json
@@ -24,7 +24,7 @@
     "health-check": "ts-node src/index.ts health-check"
   },
   "dependencies": {
-    "@slack/web-api": "^7.0.3",
+    "@slack/web-api": "^7.15.1",
     "@tupaia/api-client": "workspace:*",
     "@tupaia/server-utils": "workspace:*",
     "@tupaia/types": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11540,39 +11540,39 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@slack/logger@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@slack/logger@npm:4.0.0"
+"@slack/logger@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@slack/logger@npm:4.0.1"
   dependencies:
-    "@types/node": "npm:>=18.0.0"
-  checksum: 10c0/32c4b1f3b4a832a506b7661855d1da88eae307334563916b7513748171545a120abaaca5146a8beed1130b44c9e92f37511010b1205710baa778f5626cc2f7fa
+    "@types/node": "npm:>=18"
+  checksum: 10c0/10d73b5ef326622da3713a9175a3f9e6ef8c1f166b4e1da4a7596c9b380e59a5fcc6eb37428e8a0454c4733e636e14bb45ac3e433b96d2fb662ad44ddb7a9855
   languageName: node
   linkType: hard
 
-"@slack/types@npm:^2.9.0":
-  version: 2.11.0
-  resolution: "@slack/types@npm:2.11.0"
-  checksum: 10c0/b93b36b17b40d737f0c1c7da504dd5bab8ef84ff1b59378a72bcfc0d58ccf1f0f82ea22a3c3850cbbe1d8572e0724aa96282a390b794834d7a65d763ae13e5e1
+"@slack/types@npm:^2.20.1":
+  version: 2.20.1
+  resolution: "@slack/types@npm:2.20.1"
+  checksum: 10c0/62f1ff4d387cf511316f45c18ce9beaa1d0989a063ede5b40458fa776d460417f49faafb6cf7312fe2a9a5c8dfeb5c39ab685b911332f117a8222708da6468d7
   languageName: node
   linkType: hard
 
-"@slack/web-api@npm:^7.0.3":
-  version: 7.0.3
-  resolution: "@slack/web-api@npm:7.0.3"
+"@slack/web-api@npm:^7.15.1":
+  version: 7.15.1
+  resolution: "@slack/web-api@npm:7.15.1"
   dependencies:
-    "@slack/logger": "npm:^4.0.0"
-    "@slack/types": "npm:^2.9.0"
-    "@types/node": "npm:>=18.0.0"
+    "@slack/logger": "npm:^4.0.1"
+    "@slack/types": "npm:^2.20.1"
+    "@types/node": "npm:>=18"
     "@types/retry": "npm:0.12.0"
-    axios: "npm:^1.6.5"
+    axios: "npm:^1.15.0"
     eventemitter3: "npm:^5.0.1"
-    form-data: "npm:^4.0.0"
+    form-data: "npm:^4.0.4"
     is-electron: "npm:2.2.2"
     is-stream: "npm:^2"
     p-queue: "npm:^6"
     p-retry: "npm:^4"
     retry: "npm:^0.13.1"
-  checksum: 10c0/98dbf4bf8d3faa5453df11494c08432d6d157cb7cb79f1043985ed6836c094bb5d77972a00f93473b4b83e55b0a2dd663bc960cc9d0c746ac00b380fc5cd4a38
+  checksum: 10c0/69abd28f60805a90fa57851b20f856a4f2bc929b2863f1e434d9cec8a844a4dc0574720c8d5543aa860cd627013d5ccac969391580dbc4f05c95a21d77c2116f
   languageName: node
   linkType: hard
 
@@ -12305,7 +12305,7 @@ __metadata:
     "@tupaia/utils": "workspace:*"
     "@types/jest": "npm:^29.5.14"
     ace-builds: "npm:^1.10.1"
-    axios: "npm:^1.12.2"
+    axios: "npm:^1.15.0"
     content-disposition-header: "npm:^0.6.0"
     date-fns: "npm:^2.30.0"
     file-saver: "npm:^1.3.3"
@@ -12675,7 +12675,7 @@ __metadata:
     "@types/lodash.omitby": "npm:^4.6.9"
     "@types/react": "npm:16.8.6"
     "@types/react-table": "npm:^7.7.14"
-    axios: "npm:^1.12.2"
+    axios: "npm:^1.15.0"
     bson-objectid: "npm:^1.2.2"
     case: "npm:^1.6.3"
     csstype: "npm:^3.1.3"
@@ -12881,7 +12881,7 @@ __metadata:
     "@tupaia/ui-components": "workspace:*"
     "@tupaia/ui-map-components": "workspace:*"
     "@tupaia/utils": "workspace:*"
-    axios: "npm:^1.12.2"
+    axios: "npm:^1.15.0"
     camelcase: "npm:^6.2.0"
     dom-to-image: "npm:^2.6.0"
     downloadjs: "npm:^1.4.7"
@@ -13043,7 +13043,7 @@ __metadata:
     "@testing-library/react": "npm:12.1.2"
     "@tupaia/ui-components": "workspace:*"
     "@tupaia/utils": "workspace:*"
-    axios: "npm:^1.12.2"
+    axios: "npm:^1.15.0"
     date-fns: "npm:^2.30.0"
     faker: "npm:^4.1.0"
     history: "npm:^5.0.0"
@@ -13317,7 +13317,7 @@ __metadata:
     "@types/leaflet": "npm:^1.7.1"
     "@types/mapbox__polyline": "npm:^1.0.2"
     "@types/react": "npm:16.8.6"
-    axios: "npm:^1.12.2"
+    axios: "npm:^1.15.0"
     csstype: "npm:^3.1.3"
     dom-to-image: "npm:2.6.0"
     downloadjs: "npm:1.4.7"
@@ -13507,7 +13507,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@tupaia/viz-test-tool@workspace:packages/viz-test-tool"
   dependencies:
-    "@slack/web-api": "npm:^7.0.3"
+    "@slack/web-api": "npm:^7.15.1"
     "@tupaia/api-client": "workspace:*"
     "@tupaia/server-utils": "workspace:*"
     "@tupaia/types": "workspace:*"
@@ -14354,12 +14354,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:>=18.0.0":
-  version: 20.12.7
-  resolution: "@types/node@npm:20.12.7"
+"@types/node@npm:>=18":
+  version: 25.6.0
+  resolution: "@types/node@npm:25.6.0"
   dependencies:
-    undici-types: "npm:~5.26.4"
-  checksum: 10c0/dce80d63a3b91892b321af823d624995c61e39c6a223cc0ac481a44d337640cc46931d33efb3beeed75f5c85c3bda1d97cef4c5cd4ec333caf5dee59cff6eca0
+    undici-types: "npm:~7.19.0"
+  checksum: 10c0/d2d2015630ff098a201407f55f5077a20270ae4f465c739b40865cd9933b91b9c5d2b85568eadaf3db0801b91e267333ca7eb39f007428b173d1cdab4b339ac5
   languageName: node
   linkType: hard
 
@@ -16284,25 +16284,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.12.2":
-  version: 1.12.2
-  resolution: "axios@npm:1.12.2"
+"axios@npm:^1.15.0":
+  version: 1.15.0
+  resolution: "axios@npm:1.15.0"
   dependencies:
-    follow-redirects: "npm:^1.15.6"
-    form-data: "npm:^4.0.4"
-    proxy-from-env: "npm:^1.1.0"
-  checksum: 10c0/80b063e318cf05cd33a4d991cea0162f3573481946f9129efb7766f38fde4c061c34f41a93a9f9521f02b7c9565ccbc197c099b0186543ac84a24580017adfed
-  languageName: node
-  linkType: hard
-
-"axios@npm:^1.6.5":
-  version: 1.6.8
-  resolution: "axios@npm:1.6.8"
-  dependencies:
-    follow-redirects: "npm:^1.15.6"
-    form-data: "npm:^4.0.0"
-    proxy-from-env: "npm:^1.1.0"
-  checksum: 10c0/0f22da6f490335479a89878bc7d5a1419484fbb437b564a80c34888fc36759ae4f56ea28d55a191695e5ed327f0bad56e7ff60fb6770c14d1be6501505d47ab9
+    follow-redirects: "npm:^1.15.11"
+    form-data: "npm:^4.0.5"
+    proxy-from-env: "npm:^2.1.0"
+  checksum: 10c0/47e0f860e98d4d7aa145e89ce0cae00e1fb0f1d2485f065c21fce955ddb1dba4103a46bd0e47acd18a27208a7f62c96249e620db575521b92a968619ab133409
   languageName: node
   linkType: hard
 
@@ -23269,13 +23258,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.15.6":
-  version: 1.15.6
-  resolution: "follow-redirects@npm:1.15.6"
+"follow-redirects@npm:^1.15.11":
+  version: 1.16.0
+  resolution: "follow-redirects@npm:1.16.0"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: 10c0/9ff767f0d7be6aa6870c82ac79cf0368cd73e01bbc00e9eb1c2a16fbb198ec105e3c9b6628bb98e9f3ac66fe29a957b9645bcb9a490bb7aa0d35f908b6b85071
+  checksum: 10c0/a1e2900163e6f1b4d1ed5c221b607f41decbab65534c63fe7e287e40a5d552a6496e7d9d7d976fa4ba77b4c51c11e5e9f683f10b43011ea11e442ff128d0e181
   languageName: node
   linkType: hard
 
@@ -23375,16 +23364,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:^4.0.4":
-  version: 4.0.4
-  resolution: "form-data@npm:4.0.4"
+"form-data@npm:^4.0.4, form-data@npm:^4.0.5":
+  version: 4.0.5
+  resolution: "form-data@npm:4.0.5"
   dependencies:
     asynckit: "npm:^0.4.0"
     combined-stream: "npm:^1.0.8"
     es-set-tostringtag: "npm:^2.1.0"
     hasown: "npm:^2.0.2"
     mime-types: "npm:^2.1.12"
-  checksum: 10c0/373525a9a034b9d57073e55eab79e501a714ffac02e7a9b01be1c820780652b16e4101819785e1e18f8d98f0aee866cc654d660a435c378e16a72f2e7cac9695
+  checksum: 10c0/dd6b767ee0bbd6d84039db12a0fa5a2028160ffbfaba1800695713b46ae974a5f6e08b3356c3195137f8530dcd9dfcb5d5ae1eeff53d0db1e5aad863b619ce3b
   languageName: node
   linkType: hard
 
@@ -33555,6 +33544,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"proxy-from-env@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "proxy-from-env@npm:2.1.0"
+  checksum: 10c0/ed01729fd4d094eab619cd7e17ce3698b3413b31eb102c4904f9875e677cd207392795d5b4adee9cec359dfd31c44d5ad7595a3a3ad51c40250e141512281c58
+  languageName: node
+  linkType: hard
+
 "proxyquire@npm:^2.1.3":
   version: 2.1.3
   resolution: "proxyquire@npm:2.1.3"
@@ -39732,6 +39728,13 @@ __metadata:
   version: 6.21.0
   resolution: "undici-types@npm:6.21.0"
   checksum: 10c0/c01ed51829b10aa72fc3ce64b747f8e74ae9b60eafa19a7b46ef624403508a54c526ffab06a14a26b3120d055e1104d7abe7c9017e83ced038ea5cf52f8d5e04
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~7.19.0":
+  version: 7.19.2
+  resolution: "undici-types@npm:7.19.2"
+  checksum: 10c0/7159f10546f9f6c47d36776bb1bbf8671e87c1e587a6fee84ae1f111ae8de4f914efa8ca0dfcd224f4f4a9dfc3f6028f627ccb5ddaccf82d7fd54671b89fac3e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
1.15.1 and .2 are still quarantined

### 🦸 Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
