### PR TITLE
Add Save suppressions checkbox to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,3 +15,4 @@
 - [ ] **Run Review Hero** <!-- #ai-review -->
 - [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
 - [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
+- [ ] **Save suppressions** <!-- #save-suppressions -->


### PR DESCRIPTION
### Issue #:

### Changes:

- Adds the new `Save suppressions` checkbox to the Review Hero section, matching [review-hero#40](https://github.com/beyondessential/review-hero/pull/40). Tick it on a PR with 👎 reactions on Review Hero comments to capture them as suppression rules in `.github/review-hero/suppressions.yml`. The same step also runs automatically at the end of every auto-fix run; the checkbox is only needed when there's nothing to auto-fix.

---

### Screenshots:

n/a — template-only change.

---

### 🦸 Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
- [ ] **Save suppressions** <!-- #save-suppressions -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)