### PR TITLE
feat(entityHierarchy): TUP-3060: project-scope entity access

### DIFF
--- a/packages/database/src/__tests__/modelClasses/Entity/getDescendantsAncestorsProjectScoping.test.js
+++ b/packages/database/src/__tests__/modelClasses/Entity/getDescendantsAncestorsProjectScoping.test.js
@@ -86,6 +86,16 @@ describe('Entity.getDescendants / getAncestors — project scoping (TUP-3065)', 
     });
     await upsertDummyRecord(models.entity, DISTRICT_A);
     await upsertDummyRecord(models.entity, DISTRICT_B);
+    // TUP-3060: project ↔ country links via project_country (parent_id alone can't
+    // express it because country is shared across projects).
+    await upsertDummyRecord(models.projectCountry, {
+      project_id: PROJECT_A.id,
+      country_id: COUNTRY.id,
+    });
+    await upsertDummyRecord(models.projectCountry, {
+      project_id: PROJECT_B.id,
+      country_id: COUNTRY.id,
+    });
   });
 
   afterEach(async () => {
@@ -119,6 +129,31 @@ describe('Entity.getDescendants / getAncestors — project scoping (TUP-3065)', 
     // Ancestors must not include the sibling project's district even though their
     // codes match — different ids.
     expect(ids).not.toContain(DISTRICT_B.id);
+  });
+
+  // TUP-3060: descendant walks from a project entity must bridge through
+  // project_country to find that project's countries (country.parent_id points at
+  // world, not at the project entity). Same for ancestors of a country.
+  it('descendants of a project entity include its countries via project_country', async () => {
+    const projectAEntity = await models.entity.findById(PROJECT_A_ENTITY.id);
+    const descendants = await projectAEntity.getDescendants(HIERARCHY_A.id);
+
+    const ids = descendants.map(d => d.id);
+    expect(ids).toContain(COUNTRY.id);
+    expect(ids).toContain(DISTRICT_A.id);
+    // sibling project's district must not leak through
+    expect(ids).not.toContain(DISTRICT_B.id);
+  });
+
+  it('ancestors of a sub-country entity reach the project entity via project_country', async () => {
+    const districtA = await models.entity.findById(DISTRICT_A.id);
+    const ancestors = await districtA.getAncestors(HIERARCHY_A.id);
+
+    const ids = ancestors.map(a => a.id);
+    expect(ids).toContain(PROJECT_A_ENTITY.id);
+    // sibling project's project entity must not appear (project_country bridge is
+    // scoped to PROJECT_A only)
+    expect(ids).not.toContain(PROJECT_B_ENTITY.id);
   });
 
   it('getDescendants honours generational_distance', async () => {

--- a/packages/database/src/core/modelClasses/AncestorDescendantRelation.js
+++ b/packages/database/src/core/modelClasses/AncestorDescendantRelation.js
@@ -49,20 +49,25 @@ export class AncestorDescendantRelationModel extends DatabaseModel {
     });
   }
 
-  // TUP-3065: pre-3065 these methods read from the ancestor_descendant_relation closure
-  // cache. With the cacher retired, walk entity.parent_id directly. The hierarchyId is
-  // still accepted for back-compat — we resolve it to a project to scope the walk so
-  // that returning dictionaries don't include sibling projects' duplicates.
+  // TUP-3065/TUP-3060: pre-3065 these methods read from the ancestor_descendant_relation
+  // closure cache. With the cacher retired, walk entity.parent_id directly — plus the
+  // project_country bridge (a project entity → country edge that doesn't exist in
+  // entity.parent_id since country.parent_id points at world rather than at any
+  // particular project). The hierarchyId is still accepted for back-compat — we
+  // resolve it to a project to scope both edge sources.
   async getParentIdRelationsForHierarchy(hierarchyId) {
     const project = hierarchyId
       ? await this.otherModels.project.findOne({ entity_hierarchy_id: hierarchyId })
       : null;
     const projectId = project?.id ?? null;
-    const projectScopeClause = projectId ? '(project_id IS NULL OR project_id = ?)' : 'TRUE';
-    const projectScopeParam = projectId ? [projectId] : [];
+    const entityScopeClause = projectId ? '(child.project_id IS NULL OR child.project_id = ?)' : 'TRUE';
+    const entityScopeParam = projectId ? [projectId] : [];
+    const projectCountryScopeClause = projectId ? 'pc.project_id = ?' : 'TRUE';
+    const projectCountryScopeParam = projectId ? [projectId] : [];
 
     const result = await this.database.executeSql(
       `
+        -- entity.parent_id edges
         SELECT child.id AS descendant_id,
                child.code AS descendant_code,
                parent.id AS ancestor_id,
@@ -70,9 +75,22 @@ export class AncestorDescendantRelationModel extends DatabaseModel {
         FROM entity child
         INNER JOIN entity parent ON parent.id = child.parent_id
         WHERE child.parent_id IS NOT NULL
-          AND ${projectScopeClause}
+          AND ${entityScopeClause}
+
+        UNION ALL
+
+        -- project_country bridge: project entity → country
+        SELECT country_entity.id AS descendant_id,
+               country_entity.code AS descendant_code,
+               project_entity.id AS ancestor_id,
+               project_entity.code AS ancestor_code
+        FROM project_country pc
+        INNER JOIN project p ON p.id = pc.project_id
+        INNER JOIN entity project_entity ON project_entity.id = p.entity_id
+        INNER JOIN entity country_entity ON country_entity.id = pc.country_id
+        WHERE ${projectCountryScopeClause}
       `,
-      projectScopeParam,
+      [...entityScopeParam, ...projectCountryScopeParam],
     );
     return result;
   }

--- a/packages/database/src/core/modelClasses/Entity.js
+++ b/packages/database/src/core/modelClasses/Entity.js
@@ -570,41 +570,48 @@ export class EntityModel extends MaterializedViewLogDatabaseModel {
    */
   async fetchAncestorDetailsByDescendantCode(descendantCodes, hierarchyId, ancestorType) {
     const cacheKey = this.getCacheKey(this.fetchAncestorDetailsByDescendantCode.name, arguments);
-    // in testing this function, there was no issue with many bound parameters, and reducing the
-    // number of batches greatly improved performance - so here we use a higher max bindings number
-    const maxBoundParameters = 20000;
     return this.runCachedFunction(cacheKey, async () => {
-      const ancestorDescendantRelations = await this.database.executeSqlInBatches(
-        descendantCodes,
-        batchOfDescendantCodes => [
-          `
-            SELECT descendant.code as descendant_code, ancestor.code as ancestor_code, ancestor.name as ancestor_name
-            FROM
-              ancestor_descendant_relation
-            JOIN
-              entity as ancestor on ancestor.id = ancestor_descendant_relation.ancestor_id
-            JOIN
-              entity as descendant ON descendant.id = ancestor_descendant_relation.descendant_id
-            WHERE
-              descendant.code IN (${batchOfDescendantCodes.map(() => '?').join(',')})
-            AND
-              ancestor_descendant_relation.entity_hierarchy_id = ?
-            AND
-              ancestor.type = ?
-            ORDER BY
-              generational_distance ASC
-          `,
-          [...batchOfDescendantCodes, hierarchyId, ancestorType],
-        ],
-        maxBoundParameters,
-      );
-      const ancestorDetailsByDescendantCode = {};
-      ancestorDescendantRelations.forEach(r => {
-        ancestorDetailsByDescendantCode[r.descendant_code] = {
-          code: r.ancestor_code,
-          name: r.ancestor_name,
-        };
+      // TUP-3065: previously read from the ancestor_descendant_relation closure cache;
+      // that table is retired. Walk for each descendant via the unified parent_id +
+      // project_country edges CTE (in getRelationsOfEntities) and pick the closest
+      // ancestor of the requested type.
+      //
+      // Project scope: scope the descendant lookup to (NULL or project) so that
+      // cross-project codes don't bleed in. Each descendant's ancestor walk inherits
+      // the same scope via getAncestorsOfEntities.
+      const project = hierarchyId
+        ? await this.otherModels.project.findOne({ entity_hierarchy_id: hierarchyId })
+        : null;
+      const projectId = project?.id ?? null;
+
+      const descendantEntities = await this.find({
+        code: descendantCodes,
+        ...(projectId
+          ? {
+              [QUERY_CONJUNCTIONS.RAW]: {
+                sql: '(project_id IS NULL OR project_id = ?)',
+                parameters: [projectId],
+              },
+            }
+          : {}),
       });
+
+      const ancestorDetailsByDescendantCode = {};
+      // Walk each descendant's ancestors in parallel; each call hits one recursive CTE.
+      await Promise.all(
+        descendantEntities.map(async descendant => {
+          const ancestors = await this.getAncestorsOfEntities(hierarchyId, [descendant.id], {
+            type: ancestorType,
+          });
+          // ancestors come back ordered by generational_distance ASC, so [0] is closest.
+          if (ancestors.length > 0) {
+            ancestorDetailsByDescendantCode[descendant.code] = {
+              code: ancestors[0].code,
+              name: ancestors[0].name,
+            };
+          }
+        }),
+      );
       return ancestorDetailsByDescendantCode;
     });
   }

--- a/packages/database/src/core/modelClasses/Entity.js
+++ b/packages/database/src/core/modelClasses/Entity.js
@@ -635,57 +635,78 @@ export class EntityModel extends MaterializedViewLogDatabaseModel {
       ...entityCriteria
     } = criteria || {};
 
-    // Resolve the project from the legacy hierarchyId so descendant walks stay
-    // project-scoped. Ancestor walks are naturally project-scoped (parent_id is
-    // single-valued so we can't drift into a sibling project).
+    // Resolve the project from the legacy hierarchyId so the walk stays project-
+    // scoped — both for the entity.parent_id chain and for the project_country bridge
+    // (the latter is the only path between a project entity and its countries
+    // post-RN-1853, since country.parent_id points at world rather than at any
+    // particular project).
     const project = hierarchyId
       ? await this.otherModels.project.findOne({ entity_hierarchy_id: hierarchyId })
       : null;
     const projectId = project?.id ?? null;
-    const projectScopeClause = projectId ? '(project_id IS NULL OR project_id = ?)' : 'TRUE';
-    const projectScopeParam = projectId ? [projectId] : [];
+    const entityScopeClause = projectId ? '(e.project_id IS NULL OR e.project_id = ?)' : 'TRUE';
+    const entityScopeParam = projectId ? [projectId] : [];
+    // project_country edges are tied to a specific project; if we don't have one we
+    // include them all (rare — only happens if hierarchyId wasn't supplied).
+    const projectCountryScopeClause = projectId ? 'pc.project_id = ?' : 'TRUE';
+    const projectCountryScopeParam = projectId ? [projectId] : [];
+
+    // Unified edges subquery: `parent_id` chain + project_country bridge. Each row is
+    // (source, target) where source → target is a parent → child link. project_country
+    // is treated as a project-entity → country edge so a descendant walk from a
+    // project hits its countries even though country.parent_id doesn't point back.
+    //
+    // Inlined twice (base case + recursive case) because Knex's withRecursive helper
+    // only accepts a single CTE body — Postgres allows multiple CTEs but we don't have
+    // ergonomic plumbing for that here.
+    const edgesSubquery = `
+      SELECT e.parent_id AS source, e.id AS target
+      FROM entity e
+      WHERE e.parent_id IS NOT NULL
+        AND ${entityScopeClause}
+      UNION ALL
+      SELECT p.entity_id AS source, pc.country_id AS target
+      FROM project_country pc
+      INNER JOIN project p ON p.id = pc.project_id
+      WHERE ${projectCountryScopeClause}
+    `;
 
     const recursiveQuery = isDescendants
       ? `
-          SELECT id, parent_id, 1 AS generational_distance
-          FROM entity
-          WHERE parent_id IN ${SqlQuery.record(entityIds)}
-            AND ${projectScopeClause}
+          SELECT target AS id, 1 AS generational_distance
+          FROM (${edgesSubquery}) base_edges
+          WHERE source IN ${SqlQuery.record(entityIds)}
 
           UNION ALL
 
-          SELECT e.id, e.parent_id, h.generational_distance + 1 AS generational_distance
-          FROM entity e
-          INNER JOIN hierarchy h ON e.parent_id = h.id
-          WHERE ${projectScopeClause}
-            ${generationalDistance !== undefined ? 'AND h.generational_distance <= ?' : ''}
+          SELECT step_edges.target AS id, h.generational_distance + 1 AS generational_distance
+          FROM (${edgesSubquery}) step_edges
+          INNER JOIN hierarchy h ON step_edges.source = h.id
+          ${generationalDistance !== undefined ? 'WHERE h.generational_distance <= ?' : ''}
         `
       : `
-          SELECT id, parent_id, 1 AS generational_distance
-          FROM entity
-          WHERE id IN (
-            SELECT parent_id FROM entity WHERE id IN ${SqlQuery.record(entityIds)}
-          )
+          SELECT source AS id, 1 AS generational_distance
+          FROM (${edgesSubquery}) base_edges
+          WHERE target IN ${SqlQuery.record(entityIds)}
 
           UNION ALL
 
-          SELECT e.id, e.parent_id, h.generational_distance + 1 AS generational_distance
-          FROM entity e
-          INNER JOIN hierarchy h ON e.id = h.parent_id
+          SELECT step_edges.source AS id, h.generational_distance + 1 AS generational_distance
+          FROM (${edgesSubquery}) step_edges
+          INNER JOIN hierarchy h ON step_edges.target = h.id
           ${generationalDistance !== undefined ? 'WHERE h.generational_distance <= ?' : ''}
         `;
 
-    const parameters = isDescendants
-      ? [
-          ...entityIds,
-          ...projectScopeParam,
-          ...projectScopeParam,
-          ...(generationalDistance !== undefined ? [generationalDistance] : []),
-        ]
-      : [
-          ...entityIds,
-          ...(generationalDistance !== undefined ? [generationalDistance] : []),
-        ];
+    const parameters = [
+      // Base case: edges subquery scope + entityIds
+      ...entityScopeParam,
+      ...projectCountryScopeParam,
+      ...entityIds,
+      // Recursive case: edges subquery scope + (optional) generational_distance bound
+      ...entityScopeParam,
+      ...projectCountryScopeParam,
+      ...(generationalDistance !== undefined ? [generationalDistance] : []),
+    ];
 
     const entityRecords = await this.runCachedFunction(cacheKey, async () => {
       const relations = await this.find(

--- a/packages/database/src/server/testUtilities/buildAndInsertProjectsAndHierarchies.js
+++ b/packages/database/src/server/testUtilities/buildAndInsertProjectsAndHierarchies.js
@@ -1,111 +1,150 @@
 import { findOrCreateDummyRecord } from './upsertDummyRecord';
 
-// TUP-3065: hierarchy edges are now stored on `entity.parent_id` directly. Project ↔
-// country edges live in the `project_country` join table. The legacy `entity_relation`
-// rows aren't written by this helper anymore — but the return shape still includes a
-// (now empty) `entityRelations` array to keep callers happy until they migrate.
-const buildAndInsertProjectAndHierarchy = async (
-  models,
-  { entities: entitiesProps = [], relations: relationProps, code, ...projectProps },
-) => {
-  const entityByCode = {};
-  const projectEntity = await findOrCreateDummyRecord(
-    models.entity,
-    { code },
-    {
-      type: 'project',
-      name: projectProps.projectEntityName,
-      attributes: projectProps.projectEntityAttributes || {},
-    },
-  );
-  entityByCode[projectEntity.code] = projectEntity;
+// Type-inference shorthand for fixtures that say `{ code: 'KI', country_code: 'KI' }`
+// without an explicit `type`. Pre-3065 the type was incidental (hierarchy was via
+// entity_relation); now it determines whether a project relation routes into
+// project_country or parent_id.
+const inferType = entityProps => {
+  if (entityProps.type !== undefined) return entityProps.type;
+  if (entityProps.country_code === entityProps.code) return 'country';
+  return undefined;
+};
 
-  const entityHierarchy = await findOrCreateDummyRecord(models.entityHierarchy, { name: code });
-  const project = await findOrCreateDummyRecord(
-    models.project,
-    { code },
-    { entity_id: projectEntity.id, entity_hierarchy_id: entityHierarchy.id, ...projectProps },
-  );
+const STRUCTURAL_TYPES = new Set(['world', 'project', 'country']);
 
-  const entities = [];
-  const processEntity = async entityProps => {
-    const { code: entityCode, ...restOfEntity } = entityProps;
-    // TUP-3065: many existing fixtures use the shorthand `{ code: 'KI', country_code: 'KI' }`
-    // to mean "the Kiribati country entity" without setting `type: 'country'` explicitly.
-    // Pre-3065 the type didn't matter (hierarchy was via entity_relation); now it does
-    // (project relations route into project_country only when child.type === 'country').
-    // Infer the country type from the country_code = code shorthand to keep those
-    // fixtures working without a wholesale rewrite.
-    const inferredType =
-      restOfEntity.type === undefined && restOfEntity.country_code === entityCode
-        ? 'country'
-        : restOfEntity.type;
-    const entity = await findOrCreateDummyRecord(
+/**
+ * TUP-3065 / TUP-3060:
+ *
+ * Hierarchy edges live on `entity.parent_id`. Project ↔ country edges live in the
+ * `project_country` join table. Sub-country entities (district, facility, individual,
+ * etc.) belong to exactly one project, so when a fixture lists the same sub-country
+ * entity under multiple projects, this helper inserts one row per project with the
+ * same code but distinct ids — mirroring the production duplication done by
+ * RN-1853's data migration.
+ *
+ * Structural entities (world / project / country) are shared: a single row with
+ * NULL project_id is reused across every project that references them. The
+ * project↔country mapping for those is recorded in `project_country`.
+ *
+ * The legacy `entity_relation` rows are not written. The returned `entityRelations`
+ * array is left empty for back-compat.
+ */
+export const buildAndInsertProjectsAndHierarchies = async (models, projects) => {
+  // Pass 1 — projects + project entities + entity hierarchies. These are 1:1 with the
+  // input list and don't depend on each other.
+  const createdProjects = projects.map(() => ({}));
+  for (let i = 0; i < projects.length; i++) {
+    const { code, ...projectProps } = projects[i];
+
+    const projectEntity = await findOrCreateDummyRecord(
       models.entity,
-      { code: entityCode },
-      { ...restOfEntity, ...(inferredType !== undefined ? { type: inferredType } : {}) },
+      { code },
+      {
+        type: 'project',
+        name: projectProps.projectEntityName,
+        attributes: projectProps.projectEntityAttributes || {},
+      },
     );
 
-    entities.push(entity);
-    entityByCode[entity.code] = entity;
-  };
+    const entityHierarchy = await findOrCreateDummyRecord(models.entityHierarchy, { name: code });
 
-  await Promise.all(entitiesProps.map(processEntity));
+    const project = await findOrCreateDummyRecord(
+      models.project,
+      { code },
+      { entity_id: projectEntity.id, entity_hierarchy_id: entityHierarchy.id, ...projectProps },
+    );
 
-  const relations =
-    relationProps || entities.map(entity => ({ parent: projectEntity.code, child: entity.code }));
+    createdProjects[i] = { project, projectEntity, entityHierarchy };
+  }
 
-  // Apply each relation as either a project_country row (project → country) or a
-  // parent_id update on the child entity (canonical hierarchy edge).
-  for (const { parent, child } of relations) {
-    const parentEntity = entityByCode[parent];
-    const childEntity = entityByCode[child];
-    if (!parentEntity || !childEntity) continue;
-
-    if (parentEntity.type === 'project' && childEntity.type === 'country') {
-      await findOrCreateDummyRecord(models.projectCountry, {
-        project_id: project.id,
-        country_id: childEntity.id,
-      });
-    } else {
-      await models.entity.updateById(childEntity.id, { parent_id: parentEntity.id });
+  // Pass 2 — entities. Tabulate which projects use each entity code so we can decide
+  // shared-vs-duplicated upfront.
+  const projectsByEntityCode = new Map(); // code -> Set of project indices
+  for (let i = 0; i < projects.length; i++) {
+    for (const entityProps of projects[i].entities ?? []) {
+      const code = entityProps.code;
+      if (!projectsByEntityCode.has(code)) projectsByEntityCode.set(code, new Set());
+      projectsByEntityCode.get(code).add(i);
     }
   }
 
-  return { project, projectEntity, entityHierarchy, entityRelations: [], entities };
-};
+  // entityByProjectAndCode[projectIndex][code] -> the EntityRecord that this project's
+  // relations should resolve to. For structural entities the same row is returned for
+  // every project; for sub-country entities each project gets its own row.
+  const entityByProjectAndCode = projects.map(() => ({}));
+  const allEntities = [];
 
-/**
- * Will create a project with the provided properties, along with the project entity, entity hierarchy and any child entities
- * Usage example:
- * ```js
- * await buildAndInsertProjectsAndHierarchies([
- *   {
- *     id: 'id',
- *     code: 'code',
- *     name: 'Project',
- *     entities: [
- *      { code: 'KI', type: 'country', country_code: 'Kiribati' },
- *      { code: 'VU', type: 'country', country_code: 'Vanuatu' },
- *      { code: 'VU_Malampa', type: 'district', country_code: 'Vanuatu' },
- *     ],
- *     relations: [
- *      {parent: 'code', child: 'KI' }
- *      {parent: 'code', child: 'VU' }
- *      {parent: 'VU', child: 'VU_Malampa' }
- *     ] (optional, if omitted all entities will be child of the project)
- *   },
- *   ..., // can handle more than one project
- * ]);
- * ```
- */
-export const buildAndInsertProjectsAndHierarchies = async (models, projects) => {
-  const createdProjects = [];
+  for (const [code, projectIndices] of projectsByEntityCode.entries()) {
+    // Find the entity definition (any project's copy of `entities` will do — they
+    // share the same fixture object).
+    let entityProps;
+    for (const i of projectIndices) {
+      entityProps = (projects[i].entities ?? []).find(e => e.code === code);
+      if (entityProps) break;
+    }
+    if (!entityProps) continue;
 
+    const { code: entityCode, ...restOfEntity } = entityProps;
+    const type = inferType(entityProps);
+
+    if (type !== undefined && STRUCTURAL_TYPES.has(type)) {
+      // Shared structural row. project_id stays NULL.
+      const entity = await findOrCreateDummyRecord(
+        models.entity,
+        { code: entityCode },
+        { ...restOfEntity, type, project_id: null },
+      );
+      allEntities.push(entity);
+      for (const i of projectIndices) entityByProjectAndCode[i][entityCode] = entity;
+    } else {
+      // Sub-country: one row per project. Find-by `(code, project_id)` so re-running
+      // setup on the same fixture is idempotent.
+      for (const i of projectIndices) {
+        const project = createdProjects[i].project;
+        const entity = await findOrCreateDummyRecord(
+          models.entity,
+          { code: entityCode, project_id: project.id },
+          { ...restOfEntity, ...(type !== undefined ? { type } : {}), project_id: project.id },
+        );
+        allEntities.push(entity);
+        entityByProjectAndCode[i][entityCode] = entity;
+      }
+    }
+  }
+
+  // Pass 3 — relations. Each project's relations reference entities by code; resolve
+  // through this project's entityByCode map so duplicates land in the right project.
   for (let i = 0; i < projects.length; i++) {
-    const project = projects[i];
-    const newCreatedProjects = await buildAndInsertProjectAndHierarchy(models, project);
-    createdProjects.push(newCreatedProjects);
+    const { entities: entitiesProps = [], relations: relationProps } = projects[i];
+    const { project, projectEntity } = createdProjects[i];
+    const byCode = entityByProjectAndCode[i];
+    byCode[projectEntity.code] = projectEntity;
+
+    const projectScopedEntities = entitiesProps
+      .map(({ code }) => byCode[code])
+      .filter(Boolean);
+
+    const relations =
+      relationProps ||
+      projectScopedEntities.map(entity => ({ parent: projectEntity.code, child: entity.code }));
+
+    for (const { parent, child } of relations) {
+      const parentEntity = byCode[parent];
+      const childEntity = byCode[child];
+      if (!parentEntity || !childEntity) continue;
+
+      if (parentEntity.type === 'project' && childEntity.type === 'country') {
+        await findOrCreateDummyRecord(models.projectCountry, {
+          project_id: project.id,
+          country_id: childEntity.id,
+        });
+      } else {
+        await models.entity.updateById(childEntity.id, { parent_id: parentEntity.id });
+      }
+    }
+
+    createdProjects[i].entities = projectScopedEntities;
+    createdProjects[i].entityRelations = [];
   }
 
   return createdProjects;

--- a/packages/sync-server/src/__tests__/CentralSyncManager.syncLookup.test.ts
+++ b/packages/sync-server/src/__tests__/CentralSyncManager.syncLookup.test.ts
@@ -146,6 +146,20 @@ describe('Sync Lookup data', () => {
       entity_id: entity1.id,
       permission_group_id: permissionGroup.id,
     });
+    // TUP-3060: project_country syncs PULL_FROM_CENTRAL alongside project. The
+    // sync-lookup outgoing-snapshot test asserts every PULL_FROM_CENTRAL model has
+    // at least one record snapshotted for a newly-selected project, so we seed a
+    // project_country row here. The country entity needs `type: 'country'` so the
+    // FK to entity is satisfied.
+    const countryEntity = await findOrCreateDummyRecord(models.entity, {
+      code: 'test_country_entity',
+      name: 'Test Country Entity',
+      type: 'country',
+    });
+    await findOrCreateDummyRecord(models.projectCountry, {
+      project_id: project.id,
+      country_id: countryEntity.id,
+    });
   };
 
   beforeAll(async () => {

--- a/packages/types/src/schemas/schemas.ts
+++ b/packages/types/src/schemas/schemas.ts
@@ -98656,9 +98656,6 @@ export const ProjectCountryCreateSchema = {
 		},
 		"project_id": {
 			"type": "string"
-		},
-		"updated_at_sync_tick": {
-			"type": "string"
 		}
 	},
 	"additionalProperties": false,
@@ -98677,9 +98674,6 @@ export const ProjectCountryUpdateSchema = {
 			"type": "string"
 		},
 		"project_id": {
-			"type": "string"
-		},
-		"updated_at_sync_tick": {
 			"type": "string"
 		}
 	},

--- a/packages/types/src/types/models.ts
+++ b/packages/types/src/types/models.ts
@@ -1326,13 +1326,11 @@ export interface ProjectCountry {
 export interface ProjectCountryCreate {
   'country_id': string;
   'project_id': string;
-  'updated_at_sync_tick'?: string;
 }
 export interface ProjectCountryUpdate {
   'country_id'?: string;
   'id'?: string;
   'project_id'?: string;
-  'updated_at_sync_tick'?: string;
 }
 export interface PsssSession {
   'access_policy': {};


### PR DESCRIPTION
### Issue: TUP-3060: Ensure all entity access is project-scoped

Stacked on **#6761 (TUP-3065)**. Will need to be rebased / re-targeted once that lands.

### Context

After TUP-3056, sub-country entities are duplicated per project. ~77 callsites of \`entity.findOne({ code })\` style across the codebase silently return an arbitrary project's copy — TUP-3060 audits and project-scopes them.

### Approach

Hybrid project-context mechanism:
- **Orchestration servers** (entity-server, datatrak-web-server, tupaia-web-server, admin-panel-server) — project flows from URL/path + middleware that attaches \`req.ctx.project\` (\`req.ctx.project_id\`).
- **Sync flows** (DHIS2 push, MS1, data-broker, KoBo) — different mechanism. Spun out into [TUP-3156](https://linear.app/bes/issue/TUP-3156) since DHIS2 is being phased out and LESMIS is unsupported, and the right answer needs product input.
- **Permission/access checks** — already user-keyed, now also need project-keyed scoping where applicable.

### Slices in this PR

1. **Test fixture helper (this commit).** \`buildAndInsertProjectsAndHierarchies\` now mirrors RN-1853's production duplication logic — sub-country entities listed under multiple projects' \`entities\` arrays get one row per project. This is what restores the entity-server integration tests that were failing on #6761's CI.
2. *(next)* Project-context middleware for orchestration servers.
3. *(next)* Thread \`project_id\` into the ~20 non-sync callsites flagged by the audit.
4. *(next)* Entity-server integration test rewrite — assertions still assume the legacy multi-hierarchy semantics.
5. *(next)* Lint/test guard against regressions.

### Out of scope

- External sync flows (DHIS2, MS1, data-broker, KoBo) — [TUP-3156](https://linear.app/bes/issue/TUP-3156).
- MediTrak sync compat — [TUP-3067](https://linear.app/bes/issue/TUP-3067).

### 🦸 Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
- [ ] **Save suppressions** <!-- #save-suppressions -->