### PR TITLE
fix(uiComponents): generate ARIA IDs without crypto.randomUUID

### DIFF
--- a/packages/tupaia-web/src/features/Dashboard/DashboardMenu/DashboardMenu.tsx
+++ b/packages/tupaia-web/src/features/Dashboard/DashboardMenu/DashboardMenu.tsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react';
 import { Link, useLocation, useParams } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { useId } from '@tupaia/ui-components';
+import { useAriaId } from '@tupaia/ui-components';
 import { useDashboards } from '../../../api/queries';
 import { TOP_BAR_HEIGHT } from '../../../constants';
 import { Dashboard } from '../../../types';
@@ -91,7 +91,7 @@ export const DashboardMenu = () => {
 
   const hasMultipleDashboards = dashboards.length > 1;
 
-  const menuId = useId();
+  const menuId = useAriaId();
 
   return (
     <>

--- a/packages/tupaia-web/src/layout/UserMenu/UserMenu.tsx
+++ b/packages/tupaia-web/src/layout/UserMenu/UserMenu.tsx
@@ -3,7 +3,7 @@ import MuiMenuIcon from '@material-ui/icons/Menu';
 import React, { useRef, useState } from 'react';
 import styled from 'styled-components';
 
-import { ErrorBoundary, VisuallyHidden, useId } from '@tupaia/ui-components';
+import { ErrorBoundary, VisuallyHidden, useAriaId } from '@tupaia/ui-components';
 import { useLogout } from '../../api/mutations';
 import { useLandingPage, useUser } from '../../api/queries';
 import { MODAL_ROUTES } from '../../constants';
@@ -116,9 +116,9 @@ export const UserMenu = () => {
   const menuPrimaryColor = primaryHexcode || theme.palette.background.default;
   const menuSecondaryColor = secondaryHexcode || theme.palette.text.primary;
 
-  const buttonId = useId();
+  const buttonId = useAriaId();
   const buttonRef = useRef<HTMLButtonElement>(null);
-  const menuId = useId();
+  const menuId = useAriaId();
 
   return (
     <ErrorBoundary>

--- a/packages/ui-components/src/components/ActionsMenu.tsx
+++ b/packages/ui-components/src/components/ActionsMenu.tsx
@@ -10,7 +10,7 @@ import {
 import { EllipsisVertical } from 'lucide-react';
 import React from 'react';
 import styled from 'styled-components';
-import { useId } from '../hooks';
+import { useAriaId } from '../hooks';
 import { ActionsMenuOptionType } from '../types';
 import { VisuallyHidden } from './VisuallyHidden';
 
@@ -63,7 +63,7 @@ export const ActionsMenu = ({
   IconButton = MuiIconButton,
   className,
 }: ActionMenuProps) => {
-  const id = useId();
+  const id = useAriaId();
   const [anchorEl, setAnchorEl] = React.useState<(EventTarget & HTMLButtonElement) | null>(null);
   const isExpanded = anchorEl !== null;
 

--- a/packages/ui-components/src/hooks/index.js
+++ b/packages/ui-components/src/hooks/index.js
@@ -1,5 +1,5 @@
 export { GEOLOCATION_UNSUPPORTED_ERROR, useCurrentPosition } from './useCurrentPosition';
 export * from './useDebounce';
 export * from './useFetch';
-export { useId } from './useId';
+export { useAriaId } from './useAriaId';
 export * from './useTableSorting';

--- a/packages/ui-components/src/hooks/useAriaId.ts
+++ b/packages/ui-components/src/hooks/useAriaId.ts
@@ -1,0 +1,19 @@
+import { useState } from 'react';
+
+let nextId = 0;
+
+/**
+ * Generates a stable, page-unique string suitable for wiring up ARIA attributes (`id`,
+ * `aria-controls`, `aria-labelledby`, etc.). Uses a module-level counter rather than
+ * `crypto.randomUUID()` because the latter is only available in secure contexts (HTTPS or
+ * localhost) and throws on plain HTTP.
+ *
+ * @privateRemarks Retire in favour of `React.useId` after upgrading to React 18+
+ */
+export function useAriaId(): string {
+  const [id] = useState(() => {
+    nextId += 1;
+    return `aria-id-${nextId}`;
+  });
+  return id;
+}

--- a/packages/ui-components/src/hooks/useId.ts
+++ b/packages/ui-components/src/hooks/useId.ts
@@ -1,7 +1,0 @@
-import { useState } from 'react';
-
-/** @privateRemarks Retire in favour of `React.useId` after upgrading to React 18+ */
-export function useId(): string {
-  const [id] = useState(() => crypto.randomUUID());
-  return id;
-}


### PR DESCRIPTION
## Summary

- `useId` (added in #6753) calls `crypto.randomUUID()`, which is only defined in **secure contexts** (HTTPS or `localhost`). On plain HTTP the call throws `TypeError: crypto.randomUUID is not a function`, breaking any page that mounts `UserMenu` — including `/verify-email`.
- Replaced the call with a module-level counter; the generated strings are only used for ARIA wiring (`aria-controls`, `aria-labelledby`, etc.), so there's no need for cryptographic randomness.
- Renamed the hook to `useAriaId` so its purpose is explicit and it isn't confused with a UUID generator. Updated the three callsites (`UserMenu`, `DashboardMenu`, `ActionsMenu`).

### 🦸 Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
- [ ] **Save suppressions** <!-- #save-suppressions -->