### PR TITLE
fix(datatrakWeb): TUP-3157: initial request tile missing on installed PWA

### DIFF
--- a/packages/datatrak-web/src/api/queries/useSurveyResponse.ts
+++ b/packages/datatrak-web/src/api/queries/useSurveyResponse.ts
@@ -62,8 +62,12 @@ const getLocal = async ({
       { survey_response_id: surveyResponseId },
       { columns: ['text', 'question_id', 'type'] },
     );
-    if (answerList.length === 0) return null;
 
+    // answerList may be empty as the AnswerModel is PUSH_TO_CENTRAL only, so the
+    // offline DB has no answer rows for responses submitted on other devices. Consumers that
+    // need the answers should treat an empty `answers` map as "submission unavailable on this
+    // device"; consumers that only need response metadata (e.g. the initial-request tile on
+    // the task details page) can render normally.
     const answers = await SurveyResponseModel.formatAnswersForClient(transactingModels, answerList);
 
     return camelcaseKeys({

--- a/packages/datatrak-web/src/features/SurveyResponseModal.tsx
+++ b/packages/datatrak-web/src/features/SurveyResponseModal.tsx
@@ -174,7 +174,10 @@ export const SurveyResponseModal = () => {
   if (!surveyResponseId) return null;
 
   const responseUnavailable =
-    isOfflineFirst && !isLoadingSurveyResponse && !surveyResponse && !error;
+    isOfflineFirst &&
+    !isLoadingSurveyResponse &&
+    !error &&
+    (!surveyResponse || Object.keys(surveyResponse.answers ?? {}).length === 0);
 
   if (responseUnavailable) {
     return <UnavailableResponseModal isOpen onClose={onClose} />;

--- a/packages/datatrak-web/src/views/Tasks/TaskDetailsPage.tsx
+++ b/packages/datatrak-web/src/views/Tasks/TaskDetailsPage.tsx
@@ -69,7 +69,9 @@ const ButtonComponent = ({ task }: { task?: SingleTaskResponse }) => {
   const surveyLink = `${surveyUrl}?${PRIMARY_ENTITY_CODE_PARAM}=${entity?.code}`;
 
   if (taskStatus === TaskStatus.completed) {
-    const responseUnavailable = isOfflineFirst ? !surveyResponse : !surveyResponseId;
+    const responseUnavailable = isOfflineFirst
+      ? !surveyResponse || Object.keys(surveyResponse.answers ?? {}).length === 0
+      : !surveyResponseId;
     if (responseUnavailable)
       return (
         <>


### PR DESCRIPTION
## Summary

Restores the initial-request tile on the task details page in the installed PWA. The tile silently disappeared after #6732 (RN-1870) made `AnswerModel` push-only and added a defensive null-return in `useSurveyResponse.getLocal` whenever no local answers were found

### 🦸 Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
- [ ] **Save suppressions** <!-- #save-suppressions -->
