### PR TITLE
fix(database): TUP-3157: advance global sync tick in change-handler transaction

### DIFF
--- a/packages/database/src/server/changeHandlers/ChangeHandler.js
+++ b/packages/database/src/server/changeHandlers/ChangeHandler.js
@@ -150,10 +150,7 @@ export class ChangeHandler {
           // — `updateLookupTable` then tags them with `pushed_by_device_id = <pushing device>`
           // and the `avoidRepull` filter in `snapshotOutgoingChanges` hides them from the
           // originating device's next pull.
-          await transactingModels.database.executeSql(
-            `UPDATE local_system_fact SET value = value::INTEGER + 1 WHERE key = ?`,
-            [SyncFact.CURRENT_SYNC_TICK],
-          );
+          await transactingModels.localSystemFact.incrementValue(SyncFact.CURRENT_SYNC_TICK);
 
           winston.info(
             `Running ${this.lockKey} change handler (${currentQueue.length} ${

--- a/packages/database/src/server/changeHandlers/ChangeHandler.js
+++ b/packages/database/src/server/changeHandlers/ChangeHandler.js
@@ -1,5 +1,7 @@
 import winston from 'winston';
 
+import { SyncFact } from '@tupaia/constants';
+
 const MAX_RETRY_ATTEMPTS = 3;
 
 /**
@@ -140,6 +142,18 @@ export class ChangeHandler {
           profiler.done({
             message: `Acquired advisory lock for ${this.lockKey} change handler`,
           });
+
+          // Advance the global sync tick so records created/updated by this handler land at a
+          // tick that no `sync_device_tick` row owns. Without this bump, side-effect records
+          // (e.g. a task created by TaskCreationHandler from a just-pushed survey response)
+          // inherit the pushing device's sync tick via the `set_updated_at_sync_tick` trigger
+          // — `updateLookupTable` then tags them with `pushed_by_device_id = <pushing device>`
+          // and the `avoidRepull` filter in `snapshotOutgoingChanges` hides them from the
+          // originating device's next pull.
+          await transactingModels.database.executeSql(
+            `UPDATE local_system_fact SET value = value::INTEGER + 1 WHERE key = ?`,
+            [SyncFact.CURRENT_SYNC_TICK],
+          );
 
           winston.info(
             `Running ${this.lockKey} change handler (${currentQueue.length} ${


### PR DESCRIPTION
## Summary
Fixes a regression on the release branch where tasks created by `TaskCreationHandler` from a just-pushed survey response are never synced back to the originating device.

The sync system records `sync_device_tick` and the `avoidRepull` filter in `snapshotOutgoingChanges` excludes records whose `pushed_by_device_id` matches the pulling device. `avoidRepull` was off by default until recently flipped it to `true` on and that flip is what made this latent bug manifest.

The problem: `ChangeHandler` runs `handleChanges` in a new transaction ~1s after the push commits. At that point `local_system_fact.currentSyncTick` has not moved, so the `set_updated_at_sync_tick` trigger stamps any record the handler inserts with the same tick as the push that triggered it. `updateLookupTable.ts:51-54` then joins on that tick and tags the side-effect record with the originating device's id, and the device never sees it.

## Changes
The propsed fix is to advance `currentSyncTick` by 1 inside the change-handler transaction, right after acquiring the advisory lock and before running `handleChanges`. New records inherit the bumped tick, which has no `sync_device_tick` row, so `pushed_by_device_id` stays NULL and the records flow to all devices including the originator.

### 🦸 Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
- [ ] **Save suppressions** <!-- #save-suppressions -->


