### PR TITLE
fix: TUP-3165: smoke test fixing

### DIFF
--- a/llm/specs/entity-hierarchy-improvements.md
+++ b/llm/specs/entity-hierarchy-improvements.md
@@ -282,13 +282,8 @@ SELECT COUNT(*) FROM entity
  WHERE (metadata->>'orphaned')::boolean = true;
 -- expect: ~26,532 (matches pre-migration validation in this spec)
 
--- 1g. Anomalous repointed responses tagged
-SELECT COUNT(*) FROM survey_response
- WHERE (metadata->>'migrated_from_orphan_response')::boolean = true;
--- expect: ~44
-
--- 1h. entity_geolocations split (TUP-3053)
-SELECT COUNT(*) FROM entity_geolocations;
+-- 1h. entity_polygon split (TUP-3053)
+SELECT COUNT(*) FROM entity_polygon;
 -- expect: matches old entity.region count (no orphans)
 ```
 

--- a/packages/central-server/src/index.js
+++ b/packages/central-server/src/index.js
@@ -121,7 +121,7 @@ configureEnv();
       await dbMigrator.up();
       winston.info('Database migrations complete');
 
-      await buildEntityParentChildRelationIfEmpty(models);
+      await buildAncestorDescendantRelationIfEmpty(models);
 
       if (isFeatureEnabled('MEDITRAK_SYNC_QUEUE')) {
         winston.info('Creating permissions based meditrak sync queue');
@@ -129,7 +129,7 @@ configureEnv();
         createPermissionsBasedMeditrakSyncQueue(database);
       }
     } else {
-      await buildEntityParentChildRelationIfEmpty(models);
+      await buildAncestorDescendantRelationIfEmpty(models);
     }
   } catch (error) {
     winston.error(error.message);

--- a/packages/database/src/core/modelClasses/Entity.js
+++ b/packages/database/src/core/modelClasses/Entity.js
@@ -830,11 +830,11 @@ export class EntityModel extends MaterializedViewLogDatabaseModel {
   }
 
   /**
-   * @param {EntityHierarchy['id']} hierarchyId
+   * @param {Project['id']} projectId
    * @param {Entity['id'][]} childIds
    * @returns {Promise<Record<Entity['id'], { parent_name?: Entity['name'], parent_code?: Entity['code'] }>>}
    */
-  async getParentFieldsByChildIdFromParentChildRelation(hierarchyId, childIds) {
+  async getParentFieldsByChildIdFromParentChildRelation(projectId, childIds) {
     if (!childIds || childIds.length === 0) {
       return {};
     }
@@ -842,15 +842,16 @@ export class EntityModel extends MaterializedViewLogDatabaseModel {
     const rows = await this.database.executeSql(
       `
         SELECT
-          relation.child_id,
+          adr.descendant_id AS child_id,
           parent.name AS parent_name,
           parent.code AS parent_code
-        FROM entity_parent_child_relation relation
-        JOIN entity parent ON parent.id = relation.parent_id
-        WHERE relation.entity_hierarchy_id = ?
-        AND relation.child_id IN ${SqlQuery.record(childIds)}
+        FROM ancestor_descendant_relation adr
+        JOIN entity parent ON parent.id = adr.ancestor_id
+        WHERE adr.project_id = ?
+        AND adr.generational_distance = 1
+        AND adr.descendant_id IN ${SqlQuery.record(childIds)}
       `,
-      [hierarchyId, ...childIds],
+      [projectId, ...childIds],
     );
 
     return Object.fromEntries(

--- a/packages/tsmodels/src/models/Entity.ts
+++ b/packages/tsmodels/src/models/Entity.ts
@@ -58,7 +58,7 @@ export interface EntityModel extends Model<BaseEntityModel, Entity, EntityRecord
     criteria?: EntityFilter,
   ) => Promise<EntityRecord[]>;
   getParentFieldsByChildIdFromParentChildRelation: (
-    hierarchyId: string,
+    projectId: string,
     childIds: string[],
   ) => Promise<ParentFieldsByChildId>;
 }


### PR DESCRIPTION
The method's SQL still queried entity_parent_child_relation — dropped by TUP-3066b (PR #6787). Surfaced as a latent runtime bug during smoke testing prep: the build passed after the FormatContext hierarchyId → projectId rename, but the underlying SQL would throw against the missing table when datatrak-web's formatEntity batched parent_name / parent_code lookups.

Rewrite uses ancestor_descendant_relation (the closure cache, project-scoped via project_id, with generational_distance = 1 for immediate parents). Matches the pattern entity-server's format.ts uses via ancestorDescendantRelation.getChildCodeToParentCode(projectId).

Param renamed hierarchyId → projectId in the JS impl and tsmodels declaration (the underlying TUP-3066a rename was missed on this signature).

### Issue #:

### Changes:

- Example

---

### Screenshots:

---

### 🦸 Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
- [ ] **Save suppressions** <!-- #save-suppressions -->
