### PR TITLE
refactor(admin-panel): tidy react-router imports and drop react-query-devtools

### DIFF
--- a/packages/admin-panel/package.json
+++ b/packages/admin-panel/package.json
@@ -36,7 +36,6 @@
     "@mui/icons-material": "^7.1.1",
     "@mui/material": "^7.1.1",
     "@tanstack/react-query": "4.36.1",
-    "@tanstack/react-query-devtools": "4.36.1",
     "@tupaia/types": "workspace:*",
     "@tupaia/ui-chart-components": "workspace:*",
     "@tupaia/ui-components": "workspace:*",

--- a/packages/admin-panel/src/layout/AuthLayout.jsx
+++ b/packages/admin-panel/src/layout/AuthLayout.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Outlet } from 'react-router';
+import { Outlet } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { SimplePageLayout } from './SimplePageLayout';

--- a/packages/admin-panel/src/layout/navigation/UserProfileInfo.jsx
+++ b/packages/admin-panel/src/layout/navigation/UserProfileInfo.jsx
@@ -11,7 +11,6 @@ import { useLogout } from '../../api/mutations';
 import { logout as logoutAction } from '../../authentication';
 
 const Wrapper = styled.div`
-  padding-inline: 1.25rem;
   display: flex;
   flex-direction: column;
 `;
@@ -22,9 +21,10 @@ const UserName = styled(Typography)`
 `;
 
 const UserEmail = styled(Typography)`
+  color: ${props => props.theme.palette.text.hint};
   font-size: 0.6875rem;
   margin-block-start: 0.25rem;
-  margin-block-end: 0.9rem;
+  margin-block-end: 0.4rem;
 `;
 
 const UserProfileInfoComponent = ({ profileLink, isFullWidth, onLogout }) => {
@@ -57,7 +57,6 @@ const UserProfileInfoComponent = ({ profileLink, isFullWidth, onLogout }) => {
     <Wrapper>
       {name && <UserName>{name}</UserName>}
       <UserEmail>{user.email}</UserEmail>
-      <Divider />
       {profileLink && (
         <UserButton key={profileLink.to} to={profileLink.to} component={Link}>
           {profileLink.label}

--- a/packages/admin-panel/src/pages/resources/editSurvey/EditSurveyPage.jsx
+++ b/packages/admin-panel/src/pages/resources/editSurvey/EditSurveyPage.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { keyBy } from 'es-toolkit/compat';
 import { connect } from 'react-redux';
-import { useNavigate, useParams } from 'react-router';
+import { useNavigate, useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import { Button, SpinningLoader, Modal } from '@tupaia/ui-components';
 import { Breadcrumbs } from '../../../layout';

--- a/packages/admin-panel/src/utilities/persistSearch.js
+++ b/packages/admin-panel/src/utilities/persistSearch.js
@@ -1,4 +1,4 @@
-import { useLocation } from 'react-router';
+import { useLocation } from 'react-router-dom';
 
 export const useLinkWithSearchState = url => {
   const location = useLocation();

--- a/yarn.lock
+++ b/yarn.lock
@@ -12298,7 +12298,6 @@ __metadata:
     "@mui/icons-material": "npm:^7.1.1"
     "@mui/material": "npm:^7.1.1"
     "@tanstack/react-query": "npm:4.36.1"
-    "@tanstack/react-query-devtools": "npm:4.36.1"
     "@tupaia/types": "workspace:*"
     "@tupaia/ui-chart-components": "workspace:*"
     "@tupaia/ui-components": "workspace:*"


### PR DESCRIPTION
## Summary
- Use `react-router-dom` imports consistently — three files were pulling `useLocation`/`Outlet`/`useNavigate` from `react-router` directly
- Drop the unused `@tanstack/react-query-devtools` dependency (and its yarn.lock entry)
- Small UserProfileInfo styling tweaks (hint color on email, spacing trim, drop divider)

Stage 1 of a 3-PR stack splitting #6737 — generic cleanup with no behaviour change.

## Test plan
- [ ] `yarn install` succeeds (no missing dep)
- [ ] Admin-panel still builds and runs (`yarn workspace @tupaia/admin-panel build`)
- [ ] Auth/login pages, profile pages, breadcrumb back nav still work