### PR TITLE
refactor(adminPanel): deduplicate QueryClientProvider in StoreProvider

### DIFF
--- a/packages/admin-panel/src/utilities/StoreProvider.jsx
+++ b/packages/admin-panel/src/utilities/StoreProvider.jsx
@@ -2,8 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { createStore, applyMiddleware, compose } from 'redux';
 import { Provider } from 'react-redux';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import thunk from 'redux-thunk';
 import { rootReducer } from '../rootReducer';
 
@@ -22,18 +20,9 @@ export const StoreProvider = React.memo(({ children, api }) => {
   const composedEnhancers = compose(applyMiddleware(...middleware), ...enhancers);
   const store = createStore(rootReducer, initialState, composedEnhancers);
 
-  const queryClient = new QueryClient();
-
   api.injectReduxStore(store);
 
-  return (
-    <Provider store={store}>
-      <QueryClientProvider client={queryClient}>
-        <ReactQueryDevtools />
-        {children}
-      </QueryClientProvider>
-    </Provider>
-  );
+  return <Provider store={store}>{children}</Provider>;
 });
 
 StoreProvider.propTypes = {


### PR DESCRIPTION
## Summary
Follow-up to #6800. main.jsx already wraps the app in `QueryClientProvider`; `StoreProvider` was creating a **second** `QueryClient` and provider underneath, which meant queries were caching in the inner client rather than the outer one. Drop the inner wrapper and the unused `ReactQueryDevtools` import (the devtools package itself was already removed in #6800).

Should have been part of #6800 — splitting it out so it lands before #6802 (the project-filter PR) and doesn't muddy that diff with unrelated provider plumbing.

### 🦸 Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
- [ ] **Save suppressions** <!-- #save-suppressions -->