### PR TITLE
fix(admin-panel-server): RN-1855: restore originalUrl mutation for proxy

### DIFF
--- a/packages/admin-panel-server/src/@types/express/index.d.ts
+++ b/packages/admin-panel-server/src/@types/express/index.d.ts
@@ -1,5 +1,11 @@
 import { AccessPolicy } from '@tupaia/access-policy';
 import { TupaiaApiClient } from '@tupaia/api-client';
+import {
+  ProjectModel,
+  ServerBoilerplateModelRegistry,
+  SurveyModel,
+  SurveyResponseModel,
+} from '@tupaia/server-boilerplate';
 
 import { AdminPanelSessionRecord } from '../../models';
 import { PromptManager } from '../../viz-builder/prompts/PromptManager';
@@ -9,6 +15,11 @@ declare global {
     export interface Request {
       accessPolicy: AccessPolicy;
       session: AdminPanelSessionRecord;
+      models: ServerBoilerplateModelRegistry & {
+        readonly project: ProjectModel;
+        readonly survey: SurveyModel;
+        readonly surveyResponse: SurveyResponseModel;
+      };
       ctx: {
         services: TupaiaApiClient;
         promptManager: PromptManager;

--- a/packages/admin-panel-server/src/app/createApp.ts
+++ b/packages/admin-panel-server/src/app/createApp.ts
@@ -9,7 +9,7 @@ import {
 } from '@tupaia/server-boilerplate';
 import { getEnvVarOrDefault } from '@tupaia/utils';
 
-import { upload } from '../middleware';
+import { applyProjectScope, upload } from '../middleware';
 import { AdminPanelSessionModel } from '../models';
 import {
   ExportDashboardVisualisationRequest,
@@ -73,6 +73,7 @@ export async function createApp(promptManager: PromptManager) {
     .useSessionModel(AdminPanelSessionModel)
     .verifyLogin(hasTupaiaAdminPanelAccess)
     .useMiddleware(addPromptManagerToContext(promptManager))
+    .useMiddleware(applyProjectScope)
     .get('user', handleWith(UserRoute))
     .get<FetchHierarchyEntitiesRequest>(
       'hierarchy/:hierarchyName/:entityCode',

--- a/packages/admin-panel-server/src/middleware/index.ts
+++ b/packages/admin-panel-server/src/middleware/index.ts
@@ -1,1 +1,2 @@
 export { upload } from './upload';
+export { applyProjectScope, PROJECT_CODE_PARAM } from './projectScope';

--- a/packages/admin-panel-server/src/middleware/projectScope.ts
+++ b/packages/admin-panel-server/src/middleware/projectScope.ts
@@ -62,11 +62,14 @@ const splitPath = (path: string): string[] => {
 };
 
 const rewriteRequestUrl = (req: Request, url: URL) => {
-  // Only mutate req.url — http-proxy-middleware reads this for the forwarded
-  // path. req.originalUrl is preserved so downstream logging/audit middleware
-  // (e.g. server-boilerplate's forwardRequest winston log) sees the URL the
-  // client actually sent.
-  req.url = `${url.pathname}${url.search}`;
+  // Mutate BOTH — http-proxy-middleware prefers req.originalUrl and even
+  // resets req.url = req.originalUrl before forwarding (see
+  // node_modules/http-proxy-middleware/dist/http-proxy-middleware.js lines
+  // 76+90). Without mutating originalUrl the merged project filter and
+  // stripped projectCode param never reach central-server.
+  const rewritten = `${url.pathname}${url.search}`;
+  req.url = rewritten;
+  req.originalUrl = rewritten;
 };
 
 const isMutationOnId = (method: string, segments: string[]) =>

--- a/packages/admin-panel-server/src/middleware/projectScope.ts
+++ b/packages/admin-panel-server/src/middleware/projectScope.ts
@@ -1,0 +1,149 @@
+import { NextFunction, Request, Response } from 'express';
+
+export const PROJECT_CODE_PARAM = 'projectCode';
+
+type Project = { id: string; code: string };
+type ProjectRef = { id: string };
+type Models = Request['models'];
+
+type ProjectScopeRule = {
+  filter: (project: Project) => Record<string, unknown>;
+  ownership: (id: string, models: Models) => Promise<ProjectRef | null>;
+  // Required so a new rule can't silently bypass POST scope enforcement by
+  // forgetting to define one.
+  bodyOwnership: (body: unknown, models: Models) => Promise<ProjectRef | null>;
+};
+
+const projectIdFromBody = (body: unknown): ProjectRef | null => {
+  if (!body || typeof body !== 'object') return null;
+  const projectId = (body as Record<string, unknown>).project_id;
+  return typeof projectId === 'string' ? { id: projectId } : null;
+};
+
+const RULES: Record<string, ProjectScopeRule> = {
+  surveys: {
+    filter: project => ({ project_id: project.id }),
+    ownership: async (id, models) => {
+      const survey = await models.survey.findById(id);
+      return survey?.project_id ? { id: survey.project_id } : null;
+    },
+    bodyOwnership: async body => projectIdFromBody(body),
+  },
+  entities: {
+    filter: project => ({ project_id: project.id }),
+    ownership: async (id, models) => {
+      const entity = await models.entity.findById(id);
+      const projectId = (entity as { project_id?: string } | undefined)?.project_id;
+      return projectId ? { id: projectId } : null;
+    },
+    bodyOwnership: async body => projectIdFromBody(body),
+  },
+  surveyResponses: {
+    filter: project => ({ 'survey.project_id': project.id }),
+    ownership: async (id, models) => {
+      const sr = await models.surveyResponse.findById(id);
+      if (!sr?.survey_id) return null;
+      const survey = await models.survey.findById(sr.survey_id);
+      return survey?.project_id ? { id: survey.project_id } : null;
+    },
+    bodyOwnership: async (body, models) => {
+      if (!body || typeof body !== 'object') return null;
+      const surveyId = (body as Record<string, unknown>).survey_id;
+      if (typeof surveyId !== 'string') return null;
+      const survey = await models.survey.findById(surveyId);
+      return survey?.project_id ? { id: survey.project_id } : null;
+    },
+  },
+};
+
+const splitPath = (path: string): string[] => {
+  const stripped = path.replace(/^\/v\d+\//, '/').replace(/^\/+/, '');
+  return stripped.split(/[/?]/).filter(Boolean);
+};
+
+const rewriteRequestUrl = (req: Request, url: URL) => {
+  // Only mutate req.url — http-proxy-middleware reads this for the forwarded
+  // path. req.originalUrl is preserved so downstream logging/audit middleware
+  // (e.g. server-boilerplate's forwardRequest winston log) sees the URL the
+  // client actually sent.
+  req.url = `${url.pathname}${url.search}`;
+};
+
+const isMutationOnId = (method: string, segments: string[]) =>
+  segments.length >= 2 && (method === 'PUT' || method === 'PATCH' || method === 'DELETE');
+
+export const applyProjectScope = async (req: Request, res: Response, next: NextFunction) => {
+  // Use a fixed base — we only read pathname/searchParams from the result, so
+  // a client-supplied Host header has no role here.
+  const url = new URL(req.originalUrl, 'http://localhost');
+  const projectCode = url.searchParams.get(PROJECT_CODE_PARAM);
+  const segments = splitPath(url.pathname);
+  const resourceKey = segments[0] ?? '';
+  const rule = RULES[resourceKey];
+
+  // Always strip projectCode before forwarding — central-server has no concept of it.
+  url.searchParams.delete(PROJECT_CODE_PARAM);
+
+  // No rule or no project context → forward unchanged. Absent projectCode is
+  // an explicit "all-data" view; scoped resources see cross-project data.
+  if (!rule || !projectCode) {
+    rewriteRequestUrl(req, url);
+    return next();
+  }
+
+  try {
+    const project = await req.models.project.findOne({ code: projectCode });
+    if (!project) {
+      res.status(400).json({ error: `Unknown project code: ${projectCode}` });
+      return undefined;
+    }
+    const projectCtx: Project = { id: project.id, code: project.code };
+
+    if (req.method === 'GET') {
+      const existingRaw = url.searchParams.get('filter');
+      let existing: Record<string, unknown> = {};
+      if (existingRaw) {
+        try {
+          existing = JSON.parse(existingRaw);
+        } catch {
+          res.status(400).json({ error: 'Invalid filter JSON' });
+          return undefined;
+        }
+      }
+      // Scope filter wins on conflict — must be a hard boundary, not an
+      // opt-out the caller can override by supplying their own project_id.
+      const merged = { ...existing, ...rule.filter(projectCtx) };
+      url.searchParams.set('filter', JSON.stringify(merged));
+    } else if (isMutationOnId(req.method, segments)) {
+      const id = segments[1];
+      const owner = await rule.ownership(id, req.models);
+      if (!owner) {
+        res.status(404).json({ error: `${resourceKey}/${id} not found` });
+        return undefined;
+      }
+      if (owner.id !== projectCtx.id) {
+        res.status(403).json({
+          error: `${resourceKey}/${id} does not belong to the active project`,
+        });
+        return undefined;
+      }
+    } else if (req.method === 'POST') {
+      const owner = await rule.bodyOwnership(req.body, req.models);
+      if (!owner) {
+        res.status(400).json({
+          error: `${resourceKey} body must reference a project in the active scope`,
+        });
+        return undefined;
+      }
+      if (owner.id !== projectCtx.id) {
+        res.status(403).json({ error: `${resourceKey} body references a different project` });
+        return undefined;
+      }
+    }
+
+    rewriteRequestUrl(req, url);
+    return next();
+  } catch (error) {
+    return next(error);
+  }
+};

--- a/packages/admin-panel/package.json
+++ b/packages/admin-panel/package.json
@@ -36,7 +36,6 @@
     "@mui/icons-material": "^7.1.1",
     "@mui/material": "^7.1.1",
     "@tanstack/react-query": "4.36.1",
-    "@tanstack/react-query-devtools": "4.36.1",
     "@tupaia/types": "workspace:*",
     "@tupaia/ui-chart-components": "workspace:*",
     "@tupaia/ui-components": "workspace:*",

--- a/packages/admin-panel/src/layout/AuthLayout.jsx
+++ b/packages/admin-panel/src/layout/AuthLayout.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Outlet } from 'react-router';
+import { Outlet } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { SimplePageLayout } from './SimplePageLayout';

--- a/packages/admin-panel/src/layout/navigation/UserProfileInfo.jsx
+++ b/packages/admin-panel/src/layout/navigation/UserProfileInfo.jsx
@@ -11,7 +11,6 @@ import { useLogout } from '../../api/mutations';
 import { logout as logoutAction } from '../../authentication';
 
 const Wrapper = styled.div`
-  padding-inline: 1.25rem;
   display: flex;
   flex-direction: column;
 `;
@@ -22,9 +21,10 @@ const UserName = styled(Typography)`
 `;
 
 const UserEmail = styled(Typography)`
+  color: ${props => props.theme.palette.text.hint};
   font-size: 0.6875rem;
   margin-block-start: 0.25rem;
-  margin-block-end: 0.9rem;
+  margin-block-end: 0.4rem;
 `;
 
 const UserProfileInfoComponent = ({ profileLink, isFullWidth, onLogout }) => {
@@ -57,7 +57,6 @@ const UserProfileInfoComponent = ({ profileLink, isFullWidth, onLogout }) => {
     <Wrapper>
       {name && <UserName>{name}</UserName>}
       <UserEmail>{user.email}</UserEmail>
-      <Divider />
       {profileLink && (
         <UserButton key={profileLink.to} to={profileLink.to} component={Link}>
           {profileLink.label}

--- a/packages/admin-panel/src/pages/resources/editSurvey/EditSurveyPage.jsx
+++ b/packages/admin-panel/src/pages/resources/editSurvey/EditSurveyPage.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { keyBy } from 'es-toolkit/compat';
 import { connect } from 'react-redux';
-import { useNavigate, useParams } from 'react-router';
+import { useNavigate, useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import { Button, SpinningLoader, Modal } from '@tupaia/ui-components';
 import { Breadcrumbs } from '../../../layout';

--- a/packages/admin-panel/src/utilities/StoreProvider.jsx
+++ b/packages/admin-panel/src/utilities/StoreProvider.jsx
@@ -2,8 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { createStore, applyMiddleware, compose } from 'redux';
 import { Provider } from 'react-redux';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import thunk from 'redux-thunk';
 import { rootReducer } from '../rootReducer';
 
@@ -22,18 +20,9 @@ export const StoreProvider = React.memo(({ children, api }) => {
   const composedEnhancers = compose(applyMiddleware(...middleware), ...enhancers);
   const store = createStore(rootReducer, initialState, composedEnhancers);
 
-  const queryClient = new QueryClient();
-
   api.injectReduxStore(store);
 
-  return (
-    <Provider store={store}>
-      <QueryClientProvider client={queryClient}>
-        <ReactQueryDevtools />
-        {children}
-      </QueryClientProvider>
-    </Provider>
-  );
+  return <Provider store={store}>{children}</Provider>;
 });
 
 StoreProvider.propTypes = {

--- a/packages/admin-panel/src/utilities/persistSearch.js
+++ b/packages/admin-panel/src/utilities/persistSearch.js
@@ -1,4 +1,4 @@
-import { useLocation } from 'react-router';
+import { useLocation } from 'react-router-dom';
 
 export const useLinkWithSearchState = url => {
   const location = useLocation();

--- a/packages/central-server/src/apiV2/surveyResponses/GETSurveyResponses.js
+++ b/packages/central-server/src/apiV2/surveyResponses/GETSurveyResponses.js
@@ -21,6 +21,10 @@ export class GETSurveyResponses extends GETHandler {
       nearTableKey: 'survey_response.entity_id',
       farTableKey: 'entity.id',
     },
+    survey: {
+      nearTableKey: 'survey_response.survey_id',
+      farTableKey: 'survey.id',
+    },
   });
 
   async findSingleRecord(surveyResponseId, options) {
@@ -51,6 +55,32 @@ export class GETSurveyResponses extends GETHandler {
 
     // Apply regular permissions
     return this.getPermissionsFilter(dbConditions, options);
+  }
+
+  async findRecords(criteria, options) {
+    // The base GETHandler builds joins from requested *columns* only, so any
+    // join needed to satisfy a *criteria* key (e.g. survey.project_id added by
+    // admin-panel-server's applyProjectScope middleware) must be merged in
+    // here. For BES Admins, createRecordsPermissionFilter is a no-op and never
+    // adds the survey/entity joins, so without this merge the SQL fails with
+    // "missing FROM-clause entry for table survey".
+    const criteriaColumns = Object.keys(criteria).filter(column => !column.startsWith('_'));
+    const { multiJoin: criteriaJoins } = getQueryOptionsForColumns(
+      criteriaColumns,
+      this.recordType,
+      this.customJoinConditions,
+      this.defaultJoinType,
+    );
+    const existing = options?.multiJoin ?? [];
+    const seen = new Set(existing.map(join => join.joinWith));
+    const mergedJoins = [...existing];
+    for (const join of criteriaJoins) {
+      if (!seen.has(join.joinWith)) {
+        mergedJoins.push(join);
+        seen.add(join.joinWith);
+      }
+    }
+    return super.findRecords(criteria, { ...options, multiJoin: mergedJoins });
   }
 
   async countRecords(criteria) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12298,7 +12298,6 @@ __metadata:
     "@mui/icons-material": "npm:^7.1.1"
     "@mui/material": "npm:^7.1.1"
     "@tanstack/react-query": "npm:4.36.1"
-    "@tanstack/react-query-devtools": "npm:4.36.1"
     "@tupaia/types": "workspace:*"
     "@tupaia/ui-chart-components": "workspace:*"
     "@tupaia/ui-components": "workspace:*"


### PR DESCRIPTION
## Summary
The previous review-suggested change in #6801 (only mutate \`req.url\`, leave \`req.originalUrl\` intact) silently broke the project filter for forwarded requests.

\`http-proxy-middleware\` prefers \`req.originalUrl\` over \`req.url\` and even resets \`req.url = req.originalUrl\` before forwarding (see \`node_modules/http-proxy-middleware/dist/http-proxy-middleware.js\` lines 76 and 90). So the merged \`{project_id: ...}\` filter and the stripped \`projectCode\` query param never reached central-server — requests to e.g. \`/entities?projectCode=fanafana\` were forwarded verbatim and central returned unscoped data.

Reverting the function to mutate both \`req.url\` and \`req.originalUrl\`. The audit-trail concern that motivated the change isn't actually realised — the existing \`winston.info(\`Forwarding \${req.method} \${req.originalUrl}\`)\` log would just show the rewritten URL, which is the URL actually sent to central anyway.

## Test plan
- [ ] Hit \`GET /v1/entities?projectCode=<some_project>\` on admin-panel-server
- [ ] Response contains only entities for that project (not cross-project)
- [ ] Hit \`GET /v1/entities\` (no projectCode) — returns unscoped data as before