### PR TITLE
fix(adminPanel): RN-1855: populate sidebar on All Data routes via preferences fallback

### DIFF
--- a/packages/admin-panel/src/api/mutations/index.js
+++ b/packages/admin-panel/src/api/mutations/index.js
@@ -4,3 +4,4 @@ export { useUpdateProfile } from './useUpdateProfile';
 export { useResetPassword } from './useResetPassword';
 export { useRequestResetPassword } from './useRequestResetPassword';
 export { useOneTimeLogin } from './useOneTimeLogin';
+export { useSaveSelectedProject } from './useSaveSelectedProject';

--- a/packages/admin-panel/src/api/mutations/useSaveSelectedProject.js
+++ b/packages/admin-panel/src/api/mutations/useSaveSelectedProject.js
@@ -1,23 +1,11 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { put } from '../../VizBuilderApp/api';
 
-/**
- * Persists the user's selected project to user_account.preferences.project_id.
- * This lets the sidebar Single-Project nav stay populated on All Data routes
- * across sessions/reloads.
- *
- * EditUserForMe expects `project_id` as a top-level field, not nested under
- * `preferences` (see EditUserAccounts.js — it explicitly rejects a
- * `preferences` payload).
- */
 export const useSaveSelectedProject = () => {
   const queryClient = useQueryClient();
-  return useMutation(
-    projectId => put('me', { data: { project_id: projectId } }),
-    {
-      onSuccess: () => {
-        queryClient.invalidateQueries(['user']);
-      },
+  return useMutation(projectId => put('me', { data: { project_id: projectId } }), {
+    onSuccess: () => {
+      queryClient.invalidateQueries(['user']);
     },
-  );
+  });
 };

--- a/packages/admin-panel/src/api/mutations/useSaveSelectedProject.js
+++ b/packages/admin-panel/src/api/mutations/useSaveSelectedProject.js
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { put } from '../../VizBuilderApp/api';
+
+/**
+ * Persists the user's selected project to user_account.preferences.project_id.
+ * This lets the sidebar Single-Project nav stay populated on All Data routes
+ * across sessions/reloads.
+ *
+ * EditUserForMe expects `project_id` as a top-level field, not nested under
+ * `preferences` (see EditUserAccounts.js — it explicitly rejects a
+ * `preferences` payload).
+ */
+export const useSaveSelectedProject = () => {
+  const queryClient = useQueryClient();
+  return useMutation(
+    projectId => put('me', { data: { project_id: projectId } }),
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(['user']);
+      },
+    },
+  );
+};

--- a/packages/admin-panel/src/layout/AppPageLayout.jsx
+++ b/packages/admin-panel/src/layout/AppPageLayout.jsx
@@ -76,9 +76,6 @@ export const AppPageLayout = ({
   homeLink,
   profileLink,
 }) => {
-  // Sidebar-only project code: falls back to user preferences when the URL has
-  // no project segment (e.g. All Data routes), so Single-Project nav stays
-  // populated. Request scoping still uses the URL-only readSelectedProjectCode.
   const selectedProjectCode = useSidebarProjectCode();
   const [navOpen, setNavOpen] = useState(true);
   const toggleOpen = () => {
@@ -96,9 +93,7 @@ export const AppPageLayout = ({
             buildItem(route, singleProjectBasePath, singleProjectSection.id),
           )
         : [],
-      allData: allDataRoutes.map(route =>
-        buildItem(route, ALL_DATA_BASE_PATH, allDataSection.id),
-      ),
+      allData: allDataRoutes.map(route => buildItem(route, ALL_DATA_BASE_PATH, allDataSection.id)),
     };
   }, [allDataRoutes, singleProjectRoutes, selectedProjectCode]);
 

--- a/packages/admin-panel/src/layout/AppPageLayout.jsx
+++ b/packages/admin-panel/src/layout/AppPageLayout.jsx
@@ -7,7 +7,7 @@ import { labelToId } from '../utilities';
 import { NavPanel } from './navigation';
 import { CaretLeftIcon } from '../icons';
 import { NAV_PANEL_CLOSED_WIDTH, NAV_PANEL_OPEN_WIDTH } from './navigation/NavPanel';
-import { ProjectSelector, useSelectedProjectCode } from '../projects';
+import { ProjectSelector, useSidebarProjectCode } from '../projects';
 import { ALL_DATA_BASE_PATH, SECTIONS, buildSingleProjectBasePath } from '../routes/scopes';
 
 const PageWrapper = styled.div`
@@ -76,7 +76,10 @@ export const AppPageLayout = ({
   homeLink,
   profileLink,
 }) => {
-  const selectedProjectCode = useSelectedProjectCode();
+  // Sidebar-only project code: falls back to user preferences when the URL has
+  // no project segment (e.g. All Data routes), so Single-Project nav stays
+  // populated. Request scoping still uses the URL-only readSelectedProjectCode.
+  const selectedProjectCode = useSidebarProjectCode();
   const [navOpen, setNavOpen] = useState(true);
   const toggleOpen = () => {
     setNavOpen(!navOpen);

--- a/packages/admin-panel/src/projects/DefaultRedirect.jsx
+++ b/packages/admin-panel/src/projects/DefaultRedirect.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Navigate } from 'react-router-dom';
 import { useProjects, useUser } from '../api/queries';
+import { useSidebarProjectCode } from './useSelectedProject';
 import { buildSingleProjectBasePath } from '../routes/scopes';
 
 const buildAllDataTarget = allDataRoutes => {
@@ -18,21 +19,17 @@ const buildSingleProjectTarget = (singleProjectRoutes, projectCode) => {
 };
 
 /**
- * Picks where to land the user when they hit `/`. Prefer the user's saved
- * project (user_account.preferences.project_id) if it's still in the
- * accessible project list; otherwise fall back to the first project (useProjects
- * sorts alphabetically by name). Final fallbacks are the all-data section,
- * then the login page.
+ * Picks where to land the user when they hit `/`. Reuses useSidebarProjectCode
+ * so the preferred → first-alphabetical fallback chain stays in one place
+ * (the URL check inside it is a no-op on `/`). Final fallbacks if no projects
+ * are available are the all-data section, then the login page.
  */
 export const DefaultRedirect = ({ allDataRoutes, singleProjectRoutes }) => {
-  const { data: projects, isLoading: projectsLoading } = useProjects();
-  const { data: user, isLoading: userLoading } = useUser();
+  const { isLoading: projectsLoading } = useProjects();
+  const { isLoading: userLoading } = useUser();
+  const projectCode = useSidebarProjectCode();
 
   if (projectsLoading || userLoading) return null;
-
-  const preferredProjectId = user?.preferences?.project_id ?? null;
-  const preferred = preferredProjectId ? projects?.find(p => p.id === preferredProjectId) : null;
-  const projectCode = preferred?.code ?? projects?.[0]?.code ?? null;
 
   const singleProjectTarget = buildSingleProjectTarget(singleProjectRoutes, projectCode);
   if (singleProjectTarget) return <Navigate to={singleProjectTarget} replace />;

--- a/packages/admin-panel/src/projects/ProjectSelector.jsx
+++ b/packages/admin-panel/src/projects/ProjectSelector.jsx
@@ -104,8 +104,7 @@ export const ProjectSelector = ({ collapsed }) => {
 
     const project = projects?.find(p => p.code === code);
     if (project?.id) {
-      // Fire-and-forget — the new project is reflected immediately via the
-      // controlled select; the persisted preference catches up async.
+      // the new project is reflected immediately via the controlled select
       saveSelectedProject(project.id);
     }
 

--- a/packages/admin-panel/src/projects/ProjectSelector.jsx
+++ b/packages/admin-panel/src/projects/ProjectSelector.jsx
@@ -5,7 +5,8 @@ import { MenuItem, Select, FormControl, CircularProgress } from '@material-ui/co
 import ExpandMore from '@material-ui/icons/ExpandMore';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useProjects } from '../api/queries';
-import { useSelectedProjectCode } from './useSelectedProject';
+import { useSaveSelectedProject } from '../api/mutations';
+import { useSelectedProjectCode, useSidebarProjectCode } from './useSelectedProject';
 import { SINGLE_PROJECT_PATH_PARAM } from '../routes/scopes';
 import { BLUE, LIGHT_BLACK, WHITE } from '../theme/colors';
 
@@ -79,30 +80,45 @@ const Loading = styled.div`
   padding-block: 0.5rem;
 `;
 
-// Swap the project-code segment when already on a project URL; otherwise enter
-// the new project's section by navigating to /:code.
-const buildTargetUrl = (pathname, search, hash, fromCode, toCode) => {
+// Swap the project-code segment when already on a single-project URL.
+// Returns null when the user isn't on a project URL — caller stays put.
+const buildSingleProjectTargetUrl = (pathname, search, hash, fromUrlCode, toCode) => {
+  if (!fromUrlCode) return null;
   const segments = pathname.split('/');
-  if (fromCode && segments[1] === fromCode) {
-    segments[1] = toCode;
-    return `${segments.join('/')}${search}${hash}`;
-  }
-  return `/${toCode}`;
+  if (segments[1] !== fromUrlCode) return null;
+  segments[1] = toCode;
+  return `${segments.join('/')}${search}${hash}`;
 };
 
 export const ProjectSelector = ({ collapsed }) => {
   const { data: projects, isLoading } = useProjects();
   const navigate = useNavigate();
   const location = useLocation();
-  const selectedProjectCode = useSelectedProjectCode();
+  const urlProjectCode = useSelectedProjectCode();
+  const sidebarProjectCode = useSidebarProjectCode();
+  const { mutate: saveSelectedProject } = useSaveSelectedProject();
 
   const handleChange = event => {
     const code = event.target.value;
-    if (!code || code === selectedProjectCode) return;
-    navigate(
-      buildTargetUrl(location.pathname, location.search, location.hash, selectedProjectCode, code),
-      { replace: true },
+    if (!code || code === sidebarProjectCode) return;
+
+    const project = projects?.find(p => p.code === code);
+    if (project?.id) {
+      // Fire-and-forget — the new project is reflected immediately via the
+      // controlled select; the persisted preference catches up async.
+      saveSelectedProject(project.id);
+    }
+
+    // Single-project URL → swap the code segment.
+    // All Data URL → stay put; sidebar updates from the saved preference.
+    const target = buildSingleProjectTargetUrl(
+      location.pathname,
+      location.search,
+      location.hash,
+      urlProjectCode,
+      code,
     );
+    if (target) navigate(target, { replace: true });
   };
 
   if (collapsed) {
@@ -130,7 +146,7 @@ export const ProjectSelector = ({ collapsed }) => {
       <Label>Project</Label>
       <FormControl fullWidth>
         <StyledSelect
-          value={selectedProjectCode ?? ''}
+          value={sidebarProjectCode ?? ''}
           onChange={handleChange}
           MenuProps={menuProps}
           IconComponent={ExpandMore}

--- a/packages/admin-panel/src/projects/index.js
+++ b/packages/admin-panel/src/projects/index.js
@@ -1,6 +1,7 @@
 export {
   useSelectedProject,
   useSelectedProjectCode,
+  useSidebarProjectCode,
   readSelectedProjectCode,
   PROJECT_CODE_PARAM,
 } from './useSelectedProject';

--- a/packages/admin-panel/src/projects/useSelectedProject.js
+++ b/packages/admin-panel/src/projects/useSelectedProject.js
@@ -48,9 +48,6 @@ export const useSelectedProject = () => {
  *   1. URL segment (matches request-scoping behaviour)
  *   2. user.preferences.project_id (last project the user explicitly picked)
  *   3. First project alphabetically (useProjects sorts by name)
- * This keeps the Single-Project nav populated on All Data routes where the URL
- * has no project segment, without changing request scoping (the axios
- * interceptor still parses the URL only — All Data routes stay unscoped).
  */
 export const useSidebarProjectCode = () => {
   const urlCode = useSelectedProjectCode();

--- a/packages/admin-panel/src/projects/useSelectedProject.js
+++ b/packages/admin-panel/src/projects/useSelectedProject.js
@@ -1,5 +1,5 @@
 import { useLocation } from 'react-router-dom';
-import { useProjects } from '../api/queries';
+import { useProjects, useUser } from '../api/queries';
 
 export const PROJECT_CODE_PARAM = 'projectCode';
 
@@ -40,4 +40,27 @@ export const useSelectedProject = () => {
   const { data: projects } = useProjects();
   if (!code || !projects) return null;
   return projects.find(p => p.code === code) ?? null;
+};
+
+/**
+ * Resolves the project code the sidebar should treat as "active". Differs from
+ * useSelectedProjectCode() in that it falls back beyond the URL:
+ *   1. URL segment (matches request-scoping behaviour)
+ *   2. user.preferences.project_id (last project the user explicitly picked)
+ *   3. First project alphabetically (useProjects sorts by name)
+ * This keeps the Single-Project nav populated on All Data routes where the URL
+ * has no project segment, without changing request scoping (the axios
+ * interceptor still parses the URL only — All Data routes stay unscoped).
+ */
+export const useSidebarProjectCode = () => {
+  const urlCode = useSelectedProjectCode();
+  const { data: user } = useUser();
+  const { data: projects } = useProjects();
+
+  if (urlCode) return urlCode;
+  if (!projects || projects.length === 0) return null;
+
+  const preferredId = user?.preferences?.project_id ?? null;
+  const preferred = preferredId ? projects.find(p => p.id === preferredId) : null;
+  return preferred?.code ?? projects[0]?.code ?? null;
 };


### PR DESCRIPTION
## Summary

- Sidebar's Single-Project nav was empty on All Data routes (no project in URL → `useSelectedProjectCode()` returned null → `navItems.single` = `[]`).
- New `useSidebarProjectCode()` falls back to `user_account.preferences.project_id`, then first project alphabetically. URL still wins when present.
- `ProjectSelector` saves the chosen project to preferences (`PUT /me { project_id }`). On single-project URLs it still swaps the URL segment; on All Data URLs it stays put and the sidebar updates from the new preference.
- Request scoping is **unchanged** — the axios interceptor still reads the URL only, so All Data routes remain unscoped. The fallback is sidebar-only.


### 🦸 Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
- [ ] **Save suppressions** <!-- #save-suppressions -->