### PR TITLE
fix(entityHierarchy): TUP-3167: match entity upserts by (code, project_id)

### DIFF
--- a/packages/central-server/src/apiV2/dashboardRelations/assertDashboardRelationsPermissions.js
+++ b/packages/central-server/src/apiV2/dashboardRelations/assertDashboardRelationsPermissions.js
@@ -10,7 +10,7 @@ export const hasDashboardRelationGetPermissions = async (
   permissionGroups,
   entityCode,
 ) => {
-  const entity = await models.entity.findOne({ code: entityCode });
+  const entity = await models.entity.findOneByCodeInProject(entityCode, null);
   const permissionGroupAccessResults = await Promise.all(
     permissionGroups.map(async pg =>
       hasAccessToEntityForVisualisation(accessPolicy, models, entity, pg),
@@ -25,7 +25,7 @@ export const hasDashboardRelationEditPermissions = async (
   permissionGroups,
   entityCode,
 ) => {
-  const entity = await models.entity.findOne({ code: entityCode });
+  const entity = await models.entity.findOneByCodeInProject(entityCode, null);
 
   // users should all the permission group access (that's why using every() below)
   const permissionGroupAccessResults = await Promise.all(
@@ -110,7 +110,7 @@ export const assertDashboardRelationCreatePermissions = async (
     throw new Error(`Cannot find dashboard with id ${dashboardId}`);
   }
 
-  const entity = await models.entity.findOne({ code: dashboard.root_entity_code });
+  const entity = await models.entity.findOneByCodeInProject(dashboard.root_entity_code, null);
 
   if (!(await hasVizBuilderAccessToEntity(accessPolicy, models, entity))) {
     throw new Error(

--- a/packages/central-server/src/apiV2/dashboards/assertDashboardsPermissions.js
+++ b/packages/central-server/src/apiV2/dashboards/assertDashboardsPermissions.js
@@ -31,7 +31,7 @@ export const assertDashboardCreatePermissions = async (
   models,
   { root_entity_code: rootEntityCode },
 ) => {
-  const entity = await models.entity.findOne({ code: rootEntityCode });
+  const entity = await models.entity.findOneByCodeInProject(rootEntityCode, null);
 
   if (!(await hasVizBuilderAccessToEntity(accessPolicy, models, entity))) {
     throw new Error(`Requires Viz Builder access to the entity code: '${rootEntityCode}'`);

--- a/packages/central-server/src/apiV2/entityPolygons/GETEntityPolygons.js
+++ b/packages/central-server/src/apiV2/entityPolygons/GETEntityPolygons.js
@@ -3,14 +3,18 @@ import { BESAdminGETHandler } from '../GETHandler';
 const attachLinkedEntityCodes = async (database, rows) => {
   if (!rows?.length) return rows;
   const ids = rows.map(r => r.id);
+  // Use an `IN (...)` clause with one placeholder per id — executeSql's `?`
+  // binding doesn't coerce a JS array to a PG array for `ANY(?)`, but binds
+  // each placeholder positionally for `IN (?, ?, ...)` cleanly.
+  const placeholders = ids.map(() => '?').join(', ');
   const linked = await database.executeSql(
     `
       SELECT entity_polygon_id AS id, STRING_AGG(code, ', ' ORDER BY code) AS linked_entity_codes
       FROM entity
-      WHERE entity_polygon_id = ANY(?)
+      WHERE entity_polygon_id IN (${placeholders})
       GROUP BY entity_polygon_id;
     `,
-    [ids],
+    ids,
   );
   const lookup = new Map(linked.map(({ id, linked_entity_codes }) => [id, linked_entity_codes]));
   return rows.map(row => ({ ...row, linked_entity_codes: lookup.get(row.id) ?? null }));

--- a/packages/central-server/src/apiV2/entityPolygons/GETEntityPolygons.js
+++ b/packages/central-server/src/apiV2/entityPolygons/GETEntityPolygons.js
@@ -1,8 +1,7 @@
 import { BESAdminGETHandler } from '../GETHandler';
 
-const attachLinkedEntityCodes = async (database, rows) => {
-  if (!rows?.length) return rows;
-  const ids = rows.map(r => r.id);
+const fetchLinkedCodesByPolygonId = async (database, ids) => {
+  if (!ids.length) return new Map();
   // Use an `IN (...)` clause with one placeholder per id — executeSql's `?`
   // binding doesn't coerce a JS array to a PG array for `ANY(?)`, but binds
   // each placeholder positionally for `IN (?, ?, ...)` cleanly.
@@ -16,11 +15,11 @@ const attachLinkedEntityCodes = async (database, rows) => {
     `,
     ids,
   );
-  const lookup = new Map(linked.map(({ id, linked_entity_codes }) => [id, linked_entity_codes]));
-  return rows.map(row => ({ ...row, linked_entity_codes: lookup.get(row.id) ?? null }));
+  return new Map(linked.map(({ id, linked_entity_codes }) => [id, linked_entity_codes]));
 };
 
 const LINKED_CODES_KEY = 'linked_entity_codes';
+const ID_KEY = 'id';
 
 export class GETEntityPolygons extends BESAdminGETHandler {
   // linked_entity_codes can't be a customColumnSelector — the framework only
@@ -28,21 +27,41 @@ export class GETEntityPolygons extends BESAdminGETHandler {
   // quoted as an identifier and the query fails. Instead we strip
   // linked_entity_codes from the SQL column list, let the stock GET pipeline
   // fetch the row(s), then attach the aggregate in a single follow-up batch
-  // query keyed on the page of ids we already have.
+  // query keyed on the polygon ids we already have.
   async getProcessedColumns() {
     const columns = await super.getProcessedColumns();
-    return columns.filter(spec => !(LINKED_CODES_KEY in spec));
+    // Track whether the caller actually requested `id`. We force it into the
+    // SQL select so we can key the linked-codes lookup, then strip it back
+    // out below if it wasn't requested.
+    this.idColumnRequested = columns.some(spec => ID_KEY in spec);
+    const filtered = columns.filter(spec => !(LINKED_CODES_KEY in spec));
+    if (this.idColumnRequested) return filtered;
+    return [...filtered, { [ID_KEY]: `${this.recordType}.${ID_KEY}` }];
   }
 
   async findRecords(criteria, options) {
     const rows = await super.findRecords(criteria, options);
-    return attachLinkedEntityCodes(this.database, rows);
+    if (!rows?.length) return rows;
+    const lookup = await fetchLinkedCodesByPolygonId(this.database, rows.map(r => r.id));
+    return rows.map(row => {
+      const linkedCode = lookup.get(row.id) ?? null;
+      if (this.idColumnRequested) {
+        return { ...row, linked_entity_codes: linkedCode };
+      }
+      const { id, ...rest } = row;
+      return { ...rest, linked_entity_codes: linkedCode };
+    });
   }
 
   async findSingleRecord(recordId, options) {
     const row = await super.findSingleRecord(recordId, options);
     if (!row) return row;
-    const [withLinked] = await attachLinkedEntityCodes(this.database, [row]);
-    return withLinked;
+    const lookup = await fetchLinkedCodesByPolygonId(this.database, [recordId]);
+    const linkedCode = lookup.get(recordId) ?? null;
+    if (this.idColumnRequested) {
+      return { ...row, linked_entity_codes: linkedCode };
+    }
+    const { id, ...rest } = row;
+    return { ...rest, linked_entity_codes: linkedCode };
   }
 }

--- a/packages/central-server/src/apiV2/entityPolygons/GETEntityPolygons.js
+++ b/packages/central-server/src/apiV2/entityPolygons/GETEntityPolygons.js
@@ -2,10 +2,6 @@ import { BESAdminGETHandler } from '../GETHandler';
 
 const fetchLinkedCodesByPolygonId = async (database, ids) => {
   if (!ids.length) return new Map();
-  // Use an `IN (...)` clause with one placeholder per id — executeSql's `?`
-  // binding doesn't coerce a JS array to a PG array for `ANY(?)`, but binds
-  // each placeholder positionally for `IN (?, ?, ...)` cleanly.
-  const placeholders = ids.map(() => '?').join(', ');
   const linked = await database.executeSql(
     `
       SELECT entity_polygon_id AS id, STRING_AGG(code, ', ' ORDER BY code) AS linked_entity_codes
@@ -42,7 +38,10 @@ export class GETEntityPolygons extends BESAdminGETHandler {
   async findRecords(criteria, options) {
     const rows = await super.findRecords(criteria, options);
     if (!rows?.length) return rows;
-    const lookup = await fetchLinkedCodesByPolygonId(this.database, rows.map(r => r.id));
+    const lookup = await fetchLinkedCodesByPolygonId(
+      this.database,
+      rows.map(r => r.id),
+    );
     return rows.map(row => {
       const linkedCode = lookup.get(row.id) ?? null;
       if (this.idColumnRequested) {

--- a/packages/central-server/src/apiV2/import/importEntities/getOrCreateParentEntity.js
+++ b/packages/central-server/src/apiV2/import/importEntities/getOrCreateParentEntity.js
@@ -71,8 +71,11 @@ export async function getOrCreateParentEntity(
       projectId,
     );
     districtEntity = await transactingModels.entity.updateOrCreate(
+      // Match by (code, project_id) — districts are project-scoped post-epic.
+      // See TUP-3167.
       {
         code,
+        project_id: projectId,
       },
       {
         name: districtName,
@@ -80,6 +83,7 @@ export async function getOrCreateParentEntity(
         parent_id: countryEntity.id,
         country_code: country.code,
         metadata: districtEntityMetadata,
+        project_id: projectId,
       },
     );
   }
@@ -109,6 +113,7 @@ export async function getOrCreateParentEntity(
       parent_id: countryEntity.id,
       country_code: country.code,
       metadata: subDistrictEntityMetadata,
+      project_id: projectId,
     };
     // If a district is also being added, use as the parent of the sub_district
     if (district.id) {
@@ -117,8 +122,11 @@ export async function getOrCreateParentEntity(
     }
     subDistrict = await transactingModels.geographicalArea.findOrCreate(subDistrictObject);
     subDistrictEntity = await transactingModels.entity.updateOrCreate(
+      // Match by (code, project_id) — sub-districts are project-scoped post-epic.
+      // See TUP-3167.
       {
         code,
+        project_id: projectId,
       },
       subDistrictEntityObject,
     );

--- a/packages/central-server/src/apiV2/import/importEntities/getOrCreateParentEntity.js
+++ b/packages/central-server/src/apiV2/import/importEntities/getOrCreateParentEntity.js
@@ -71,8 +71,6 @@ export async function getOrCreateParentEntity(
       projectId,
     );
     districtEntity = await transactingModels.entity.updateOrCreate(
-      // Match by (code, project_id) — districts are project-scoped post-epic.
-      // See TUP-3167.
       {
         code,
         project_id: projectId,
@@ -122,8 +120,6 @@ export async function getOrCreateParentEntity(
     }
     subDistrict = await transactingModels.geographicalArea.findOrCreate(subDistrictObject);
     subDistrictEntity = await transactingModels.entity.updateOrCreate(
-      // Match by (code, project_id) — sub-districts are project-scoped post-epic.
-      // See TUP-3167.
       {
         code,
         project_id: projectId,

--- a/packages/central-server/src/apiV2/import/importEntities/updateCountryEntities.js
+++ b/packages/central-server/src/apiV2/import/importEntities/updateCountryEntities.js
@@ -199,8 +199,12 @@ export async function updateCountryEntities(
       pushToDhis,
       projectId,
     );
+    // Match by (code, project_id) so importing into project A doesn't
+    // mutate a row that belongs to project B. Post-epic the natural key is
+    // (code, project_id) — single code matching would silently steal another
+    // project's row. See TUP-3167.
     await transactingModels.entity.updateOrCreate(
-      { code },
+      { code, project_id: projectId },
       {
         name,
         parent_id: parentEntity ? parentEntity.id : null,

--- a/packages/central-server/src/apiV2/import/importEntities/updateCountryEntities.js
+++ b/packages/central-server/src/apiV2/import/importEntities/updateCountryEntities.js
@@ -199,10 +199,7 @@ export async function updateCountryEntities(
       pushToDhis,
       projectId,
     );
-    // Match by (code, project_id) so importing into project A doesn't
-    // mutate a row that belongs to project B. Post-epic the natural key is
-    // (code, project_id) — single code matching would silently steal another
-    // project's row. See TUP-3167.
+
     await transactingModels.entity.updateOrCreate(
       { code, project_id: projectId },
       {

--- a/packages/central-server/src/apiV2/import/importStriveLabResults/importStriveLabResults.js
+++ b/packages/central-server/src/apiV2/import/importStriveLabResults/importStriveLabResults.js
@@ -25,7 +25,7 @@ const createImporter = models => {
     const entityCode = input[ENTITY_CODE_KEY];
     const getEntityId = async () => {
       try {
-        const { id } = await models.entity.findOne({ code: entityCode });
+        const { id } = await models.entity.findOneByCodeInProject(entityCode, null);
         return id;
       } catch {
         throw new UploadError({ message: `No entity found with code '${entityCode}'` });

--- a/packages/central-server/src/apiV2/projects/CreateProject.js
+++ b/packages/central-server/src/apiV2/projects/CreateProject.js
@@ -99,7 +99,7 @@ export class CreateProject extends BESAdminCreateHandler {
 
   async createProjectEntity(models, projectCode, name) {
     const worldCode = 'World';
-    const { id: worldId } = await models.entity.findOne({ code: worldCode });
+    const { id: worldId } = await models.entity.findOneByCodeInProject(worldCode, null);
 
     return models.entity.create({
       name,

--- a/packages/central-server/src/apiV2/utilities/constructNewRecordValidationRules.js
+++ b/packages/central-server/src/apiV2/utilities/constructNewRecordValidationRules.js
@@ -448,6 +448,14 @@ export const constructForSingle = (models, recordType) => {
         due_date: [hasContent],
         status: [hasContent],
       };
+    case RECORDS.ENTITY_POLYGON:
+      // CreateEntityPolygon enforces the deeper checks (geometry coercion,
+      // required fields). Keep these minimal so the model-level validator
+      // doesn't reject the GeoJSON object before the handler can coerce it.
+      return {
+        name: [hasContent],
+        data_source: [hasContent],
+      };
 
     default:
       throw new ValidationError(`${recordType} is not a valid POST endpoint`);

--- a/packages/central-server/src/apiV2/utilities/getAdminPanelAllowedCountries.js
+++ b/packages/central-server/src/apiV2/utilities/getAdminPanelAllowedCountries.js
@@ -46,7 +46,7 @@ export const getAdminPanelAllowedPermissionGroupIdsByCountryIds = async (accessP
   return Object.fromEntries(
     await Promise.all(
       allowedCountryCodes.map(async countryCode => [
-        (await models.entity.findOne({ code: countryCode })).id,
+        (await models.entity.findOneByCodeInProject(countryCode, null)).id,
         (
           await models.permissionGroup.find({
             name: accessPolicy.getPermissionGroups([countryCode]),

--- a/packages/central-server/src/apiV2/utilities/hasAccessToEntityForVisualisation.js
+++ b/packages/central-server/src/apiV2/utilities/hasAccessToEntityForVisualisation.js
@@ -35,6 +35,6 @@ export const hasVizBuilderAccessToEntity = async (accessPolicy, models, entity) 
 };
 
 export const hasVizBuilderAccessToEntityCode = async (accessPolicy, models, entityCode) => {
-  const entity = await models.entity.findOne({ code: entityCode });
+  const entity = await models.entity.findOneByCodeInProject(entityCode, null);
   return hasVizBuilderAccessToEntity(accessPolicy, models, entity);
 };

--- a/packages/central-server/src/hooks/entityCreate.js
+++ b/packages/central-server/src/hooks/entityCreate.js
@@ -18,9 +18,6 @@ async function getEntityInfoFromSurveyResponse(surveyResponse) {
 async function createNewEntity(answerValues, parent, models) {
   const { id, code, name, type, image_url, location } = answerValues;
 
-  // create the entity, inheriting project_id from the parent so the new row
-  // lands in the same project context as where the survey was submitted.
-  // See TUP-3167.
   const entity = await models.entity.create({
     id,
     code,
@@ -50,9 +47,6 @@ export async function entityCreate({ surveyResponse, models }) {
   const answerValues = await getEntityInfoFromSurveyResponse(surveyResponse);
   const parentEntity = await surveyResponse.entity();
 
-  // Look up the existing entity in the parent's project — pre-TUP-3167 this
-  // was a code-only match which silently resolved to another project's row
-  // when duplicates existed.
   const { code } = answerValues;
   const existingEntity = await models.entity.findOneByCodeInProject(
     code,

--- a/packages/central-server/src/hooks/entityCreate.js
+++ b/packages/central-server/src/hooks/entityCreate.js
@@ -18,7 +18,9 @@ async function getEntityInfoFromSurveyResponse(surveyResponse) {
 async function createNewEntity(answerValues, parent, models) {
   const { id, code, name, type, image_url, location } = answerValues;
 
-  // create the entity
+  // create the entity, inheriting project_id from the parent so the new row
+  // lands in the same project context as where the survey was submitted.
+  // See TUP-3167.
   const entity = await models.entity.create({
     id,
     code,
@@ -27,6 +29,7 @@ async function createNewEntity(answerValues, parent, models) {
     image_url,
     parent_id: parent.id,
     country_code: parent.country_code,
+    project_id: parent.project_id,
   });
 
   // update location/bounds in a separate pass
@@ -47,9 +50,14 @@ export async function entityCreate({ surveyResponse, models }) {
   const answerValues = await getEntityInfoFromSurveyResponse(surveyResponse);
   const parentEntity = await surveyResponse.entity();
 
-  // check if we're creating or updating
+  // Look up the existing entity in the parent's project — pre-TUP-3167 this
+  // was a code-only match which silently resolved to another project's row
+  // when duplicates existed.
   const { code } = answerValues;
-  const existingEntity = await models.entity.findOne({ code });
+  const existingEntity = await models.entity.findOneByCodeInProject(
+    code,
+    parentEntity?.project_id ?? null,
+  );
 
   if (existingEntity) {
     // individual hooks will trigger entityUpdate
@@ -64,7 +72,11 @@ function entityUpdater(func) {
   return async ({ answer, surveyResponse, models }) => {
     const answerValues = await getEntityInfoFromSurveyResponse(surveyResponse);
     const { code } = answerValues;
-    const existingEntity = await models.entity.findOne({ code });
+    const parentEntity = await surveyResponse.entity();
+    const existingEntity = await models.entity.findOneByCodeInProject(
+      code,
+      parentEntity?.project_id ?? null,
+    );
 
     // no entity exists - it will be created when the `code` survey answer
     // is processed (and this answer will be processed along with it)

--- a/packages/central-server/src/tests/apiV2/export/exportEntities.test.js
+++ b/packages/central-server/src/tests/apiV2/export/exportEntities.test.js
@@ -1,4 +1,3 @@
-import fs from 'node:fs';
 import xlsx from 'xlsx';
 import { expect } from 'chai';
 import { buildAndInsertProjectsAndHierarchies } from '@tupaia/database';
@@ -11,12 +10,18 @@ import {
 const BES_ADMIN_POLICY = { DL: [BES_ADMIN_PERMISSION_GROUP] };
 const NON_BES_ADMIN_POLICY = { DL: [TUPAIA_ADMIN_PANEL_PERMISSION_GROUP] };
 
-const downloadXlsx = response => {
-  const tmp = `/tmp/exportEntities-test-${Date.now()}.xlsx`;
-  fs.writeFileSync(tmp, response.body);
-  const workbook = xlsx.readFile(tmp);
-  fs.unlinkSync(tmp);
-  return workbook;
+// Helper that issues a buffered GET and parses the response body as raw xlsx
+// bytes. Without the custom parser, supertest tries to JSON-decode the binary
+// body and `response.body` ends up as `{}` — writing that to disk fails.
+const downloadXlsx = async getRequest => {
+  const response = await getRequest
+    .buffer(true)
+    .parse((res, callback) => {
+      const chunks = [];
+      res.on('data', chunk => chunks.push(chunk));
+      res.on('end', () => callback(null, Buffer.concat(chunks)));
+    });
+  return { response, workbook: xlsx.read(response.body, { type: 'buffer' }) };
 };
 
 describe('exportEntities: GET /export/entities/:projectCode', () => {
@@ -57,10 +62,11 @@ describe('exportEntities: GET /export/entities/:projectCode', () => {
 
   it('emits a single sheet containing all project entities', async () => {
     await app.grantAccess(BES_ADMIN_POLICY);
-    const response = await app.get('export/entities/export_entities_test').buffer();
+    const { response, workbook } = await downloadXlsx(
+      app.get('export/entities/export_entities_test'),
+    );
     expect(response.statusCode).to.equal(200);
 
-    const workbook = downloadXlsx(response);
     expect(workbook.SheetNames).to.have.lengthOf(1);
     const sheet = workbook.Sheets[workbook.SheetNames[0]];
     const rows = xlsx.utils.sheet_to_json(sheet);
@@ -72,8 +78,7 @@ describe('exportEntities: GET /export/entities/:projectCode', () => {
 
   it('emits the round-trip column set including all three polygon-ref columns', async () => {
     await app.grantAccess(BES_ADMIN_POLICY);
-    const response = await app.get('export/entities/export_entities_test').buffer();
-    const workbook = downloadXlsx(response);
+    const { workbook } = await downloadXlsx(app.get('export/entities/export_entities_test'));
 
     const sheet = workbook.Sheets[workbook.SheetNames[0]];
     const rows = xlsx.utils.sheet_to_json(sheet, { defval: '' });
@@ -97,8 +102,7 @@ describe('exportEntities: GET /export/entities/:projectCode', () => {
 
   it('omits country, world, and project entities (out of scope for entity import)', async () => {
     await app.grantAccess(BES_ADMIN_POLICY);
-    const response = await app.get('export/entities/export_entities_test').buffer();
-    const workbook = downloadXlsx(response);
+    const { workbook } = await downloadXlsx(app.get('export/entities/export_entities_test'));
 
     const sheet = workbook.Sheets[workbook.SheetNames[0]];
     const rows = xlsx.utils.sheet_to_json(sheet);

--- a/packages/central-server/src/tests/apiV2/import/importEntities/assertCanImportEntities.test.js
+++ b/packages/central-server/src/tests/apiV2/import/importEntities/assertCanImportEntities.test.js
@@ -11,26 +11,29 @@ const DEFAULT_POLICY = {
   LA: ['Admin'],
 };
 
+// Post-TUP-3061, assertCanImportEntities takes country codes directly (the
+// importer pulls them from each row's country_code column rather than
+// deriving them from sheet names). Tests pass codes accordingly.
 describe('assertCanImportEntities(): Permissions checker for Importing Entities', async () => {
   const accessPolicy = new AccessPolicy(DEFAULT_POLICY);
 
   it('Sufficient permissions: Should allow importing entities within 1 country if users have access to the country that the entities are within', async () => {
-    const countryNames = ['Kiribati'];
+    const countryCodes = ['KI'];
 
-    const result = await assertCanImportEntities(accessPolicy, countryNames);
+    const result = await assertCanImportEntities(accessPolicy, countryCodes);
     expect(result).to.true;
   });
 
   it('Sufficient permissions: Should allow importing entities within multiple country if users have access to all the countries that the entities are within', async () => {
-    const countryNames = ['Kiribati', 'Solomon Islands'];
+    const countryCodes = ['KI', 'SB'];
 
-    const result = await assertCanImportEntities(accessPolicy, countryNames);
+    const result = await assertCanImportEntities(accessPolicy, countryCodes);
     expect(result).to.true;
   });
 
   it('Insufficient permissions: Should not allow import entities within 1 country if users do not have access to the country that the entities are within', async () => {
-    const countryNames = ['Laos', 'Vanuatu'];
+    const countryCodes = ['LA', 'VU'];
 
-    expect(() => assertCanImportEntities(accessPolicy, countryNames)).to.throw;
+    expect(() => assertCanImportEntities(accessPolicy, countryCodes)).to.throw;
   });
 });

--- a/packages/central-server/src/tests/apiV2/import/importEntities/assertCanImportEntities.test.js
+++ b/packages/central-server/src/tests/apiV2/import/importEntities/assertCanImportEntities.test.js
@@ -11,9 +11,6 @@ const DEFAULT_POLICY = {
   LA: ['Admin'],
 };
 
-// Post-TUP-3061, assertCanImportEntities takes country codes directly (the
-// importer pulls them from each row's country_code column rather than
-// deriving them from sheet names). Tests pass codes accordingly.
 describe('assertCanImportEntities(): Permissions checker for Importing Entities', async () => {
   const accessPolicy = new AccessPolicy(DEFAULT_POLICY);
 

--- a/packages/database/src/__tests__/modelClasses/Entity.test.js
+++ b/packages/database/src/__tests__/modelClasses/Entity.test.js
@@ -155,4 +155,81 @@ describe('EntityModel', () => {
       assertHaveEqualIds(grandparentInExploreHierarchy, result);
     });
   });
+
+  describe('findOneByCodeInProject(code, projectId)', () => {
+    // Each scenario uses a fresh unique code so parallel test runs don't
+    // collide on the (code, project_id) unique constraint.
+    const uniqueCode = () => `findOneByCodeInProject_test_${Math.random().toString(36).slice(2)}`;
+
+    const createProject = async () =>
+      findOrCreateDummyRecord(models.project, { code: uniqueCode() });
+
+    describe('null projectId (deterministic fallback)', () => {
+      it('returns the shared row when only a project_id IS NULL row exists', async () => {
+        const code = uniqueCode();
+        const shared = await upsertEntity({ code, project_id: null });
+
+        const result = await models.entity.findOneByCodeInProject(code, null);
+        assertHaveEqualIds(shared, result);
+      });
+
+      it('returns the project-specific row when no shared row exists', async () => {
+        const code = uniqueCode();
+        const project = await createProject();
+        const projectRow = await upsertEntity({ code, project_id: project.id });
+
+        const result = await models.entity.findOneByCodeInProject(code, null);
+        assertHaveEqualIds(projectRow, result);
+      });
+
+      it('prefers the shared row over any project-specific row', async () => {
+        const code = uniqueCode();
+        const projectA = await createProject();
+        const projectB = await createProject();
+        const shared = await upsertEntity({ code, project_id: null });
+        await upsertEntity({ code, project_id: projectA.id });
+        await upsertEntity({ code, project_id: projectB.id });
+
+        const result = await models.entity.findOneByCodeInProject(code, null);
+        assertHaveEqualIds(shared, result);
+      });
+
+      it('returns the lowest-id project row when only project-specific rows exist', async () => {
+        const code = uniqueCode();
+        const projectA = await createProject();
+        const projectB = await createProject();
+        const firstInserted = await upsertEntity({ code, project_id: projectA.id });
+        const secondInserted = await upsertEntity({ code, project_id: projectB.id });
+
+        // Sanity check: `id` is timestamp-prefixed, so the earlier insert has
+        // the lower id and is therefore the canonical row.
+        expect(firstInserted.id < secondInserted.id).toBe(true);
+
+        const result = await models.entity.findOneByCodeInProject(code, null);
+        assertHaveEqualIds(firstInserted, result);
+      });
+    });
+
+    describe('explicit projectId', () => {
+      it("returns the project's own row when one exists alongside another project's row", async () => {
+        const code = uniqueCode();
+        const projectA = await createProject();
+        const projectB = await createProject();
+        await upsertEntity({ code, project_id: projectA.id });
+        const inProjectB = await upsertEntity({ code, project_id: projectB.id });
+
+        const result = await models.entity.findOneByCodeInProject(code, projectB.id);
+        assertHaveEqualIds(inProjectB, result);
+      });
+
+      it('falls back to the shared row when no project-specific row exists', async () => {
+        const code = uniqueCode();
+        const project = await createProject();
+        const shared = await upsertEntity({ code, project_id: null });
+
+        const result = await models.entity.findOneByCodeInProject(code, project.id);
+        assertHaveEqualIds(shared, result);
+      });
+    });
+  });
 });

--- a/packages/database/src/core/modelClasses/Entity.js
+++ b/packages/database/src/core/modelClasses/Entity.js
@@ -448,13 +448,9 @@ export class EntityModel extends MaterializedViewLogDatabaseModel {
     // clause. `rawSort` is forwarded straight to knex's `orderByRaw`.
     if (!projectId) {
       // Deterministic resolution when no project context is available
-      // (read-only permission lookups, structural entity lookups, etc.):
       //   1. Prefer the shared/structural row (`project_id IS NULL`).
       //   2. Otherwise return the lowest-id project-specific row — the same
       //      "canonical row" tiebreaker MediTrak compatibility uses
-      //      (see TUP-3067).
-      // Without this sort, Postgres' planner picks an arbitrary row when
-      // duplicates exist and the result becomes non-deterministic.
       return this.findOne(
         { code, ...otherCriteria },
         { ...options, rawSort: 'project_id ASC NULLS FIRST, id ASC' },

--- a/packages/database/src/core/modelClasses/Entity.js
+++ b/packages/database/src/core/modelClasses/Entity.js
@@ -442,6 +442,10 @@ export class EntityModel extends MaterializedViewLogDatabaseModel {
    * @returns {Promise<EntityRecord | null>}
    */
   async findOneByCodeInProject(code, projectId = null, otherCriteria = {}, options = {}) {
+    // Use `rawSort` rather than `sort` for the NULLS FIRST/LAST modifiers —
+    // BaseDatabase's `sort` parser does `sortKey.split(' ')` and only keeps
+    // the first two tokens (column + direction), silently dropping the NULLS
+    // clause. `rawSort` is forwarded straight to knex's `orderByRaw`.
     if (!projectId) {
       // Deterministic resolution when no project context is available
       // (read-only permission lookups, structural entity lookups, etc.):
@@ -453,10 +457,10 @@ export class EntityModel extends MaterializedViewLogDatabaseModel {
       // duplicates exist and the result becomes non-deterministic.
       return this.findOne(
         { code, ...otherCriteria },
-        { ...options, sort: ['project_id ASC NULLS FIRST', 'id ASC'] },
+        { ...options, rawSort: 'project_id ASC NULLS FIRST, id ASC' },
       );
     }
-    // Sort `NULLS LAST` so a project-specific match (project_id = projectId) always
+    // `NULLS LAST` so a project-specific match (project_id = projectId) always
     // wins over the structural fallback (project_id IS NULL). Without this, when the
     // same code exists as both a shared structural row and a per-project copy, Postgres
     // returns them in planner-dependent order and the result is non-deterministic.
@@ -469,7 +473,7 @@ export class EntityModel extends MaterializedViewLogDatabaseModel {
           parameters: [projectId],
         },
       },
-      { ...options, sort: ['project_id ASC NULLS LAST'] },
+      { ...options, rawSort: 'project_id ASC NULLS LAST' },
     );
   }
 

--- a/packages/database/src/core/modelClasses/Entity.js
+++ b/packages/database/src/core/modelClasses/Entity.js
@@ -443,7 +443,18 @@ export class EntityModel extends MaterializedViewLogDatabaseModel {
    */
   async findOneByCodeInProject(code, projectId = null, otherCriteria = {}, options = {}) {
     if (!projectId) {
-      return this.findOne({ code, ...otherCriteria }, options);
+      // Deterministic resolution when no project context is available
+      // (read-only permission lookups, structural entity lookups, etc.):
+      //   1. Prefer the shared/structural row (`project_id IS NULL`).
+      //   2. Otherwise return the lowest-id project-specific row — the same
+      //      "canonical row" tiebreaker MediTrak compatibility uses
+      //      (see TUP-3067).
+      // Without this sort, Postgres' planner picks an arbitrary row when
+      // duplicates exist and the result becomes non-deterministic.
+      return this.findOne(
+        { code, ...otherCriteria },
+        { ...options, sort: ['project_id ASC NULLS FIRST', 'id ASC'] },
+      );
     }
     // Sort `NULLS LAST` so a project-specific match (project_id = projectId) always
     // wins over the structural fallback (project_id IS NULL). Without this, when the


### PR DESCRIPTION
## Summary

Post-epic, entity rows are project-scoped — multiple rows can share a `code` as long as `project_id` differs. The natural key is now `(code, project_id)`, with `project_id IS NULL` reserved for structural rows (World, country).

A pile of central-server code still resolves entities by `code` alone. The most damaging case is the entity importer's `updateOrCreate({ code }, …)` — importing code `'X'` into project A when `'X'` already exists in project B silently mutates B's row instead of creating a new row in A.

This PR converts every code-alone entity lookup in central-server (except DHIS2 push, which TUP-3156 owns) to a project-aware lookup via the shared `Entity.findOneByCodeInProject` helper. Write paths route to the active project's row (or create a new one); read-only paths get a deterministic shared-first → lowest-id-first fallback.

## Changes

- **`Entity.findOneByCodeInProject(code, null)`** now sorts `project_id ASC NULLS FIRST, id ASC` — returns the shared row when present, else the lowest-id project row (same canonical tiebreaker MediTrak compatibility uses, see TUP-3067).
- **Entity importer** (`updateCountryEntities.js`, `getOrCreateParentEntity.js`) matches by `(code, project_id)`. Country `findOrCreate` calls stay code-only (countries are shared).
- **`hooks/entityCreate.js`** uses project-aware duplicate check; created entities inherit `project_id` from parent.
- **Read-only lookups** (`dashboardRelations`, `dashboards`, `utilities`, `CreateProject`, `importStriveLabResults`) use `findOneByCodeInProject(code, null)` for deterministic resolution when no project context is available.
- **6 new unit tests** covering the helper's behaviour across the null/explicit projectId × shared/project-specific row matrix.

---

### 🦸 Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
- [ ] **Save suppressions** <!-- #save-suppressions -->