### PR TITLE
deps: TAM-6854: upgrade node-fetch v1->v2 and nodemailer v6->v8

### DIFF
--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -27,7 +27,7 @@
     "@tupaia/utils": "workspace:*",
     "es-toolkit": "^1.46.0",
     "express": "^4.21.2",
-    "node-fetch": "^1.7.3",
+    "node-fetch": "^2.6.7",
     "qs": "^6.12.0"
   },
   "devDependencies": {

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -35,7 +35,7 @@
     "eslint-plugin-cypress": "^2.11.1",
     "js-beautify": "^1.13.0",
     "moment": "^2.24.0",
-    "node-fetch": "^1.7.3",
+    "node-fetch": "^2.6.7",
     "react": "^16.14.0"
   }
 }

--- a/packages/server-utils/package.json
+++ b/packages/server-utils/package.json
@@ -34,7 +34,7 @@
     "fs-extra": "^11.3.0",
     "handlebars": "^4.7.9",
     "node-schedule": "^2.1.1",
-    "nodemailer": "^6.9.12",
+    "nodemailer": "^8.0.5",
     "puppeteer": "^24.3.1",
     "sha256": "^0.2.0",
     "sharp": "~0.34.4"

--- a/packages/superset-api/package.json
+++ b/packages/superset-api/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@tupaia/utils": "workspace:*",
     "https-proxy-agent": "^5.0.1",
-    "node-fetch": "^1.7.3",
+    "node-fetch": "^2.6.7",
     "winston": "^3.17.0"
   },
   "devDependencies": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -33,7 +33,7 @@
     "jsonwebtoken": "^9.0.0",
     "moment": "^2.24.0",
     "moment-timezone": "^0.5.45",
-    "node-fetch": "^1.7.3",
+    "node-fetch": "^2.6.7",
     "numeral": "^2.0.6",
     "omit-deep": "^0.3.0",
     "prop-types": "^15.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7364,7 +7364,7 @@ __metadata:
     es-toolkit: "npm:^1.46.0"
     express: "npm:^4.21.2"
     jest: "npm:^29.7.0"
-    node-fetch: "npm:^1.7.3"
+    node-fetch: "npm:^2.6.7"
     qs: "npm:^6.12.0"
     rimraf: "npm:^6.0.1"
   languageName: unknown
@@ -7740,7 +7740,7 @@ __metadata:
     eslint-plugin-cypress: "npm:^2.11.1"
     js-beautify: "npm:^1.13.0"
     moment: "npm:^2.24.0"
-    node-fetch: "npm:^1.7.3"
+    node-fetch: "npm:^2.6.7"
     react: "npm:^16.14.0"
   languageName: unknown
   linkType: soft
@@ -8126,7 +8126,7 @@ __metadata:
     jest: "npm:^29.7.0"
     knex: "npm:^3.1.0"
     node-schedule: "npm:^2.1.1"
-    nodemailer: "npm:^6.9.12"
+    nodemailer: "npm:^8.0.5"
     puppeteer: "npm:^24.3.1"
     rimraf: "npm:^6.0.1"
     sha256: "npm:^0.2.0"
@@ -8142,7 +8142,7 @@ __metadata:
     "@types/jest": "npm:^29.5.14"
     https-proxy-agent: "npm:^5.0.1"
     jest: "npm:^29.7.0"
-    node-fetch: "npm:^1.7.3"
+    node-fetch: "npm:^2.6.7"
     rimraf: "npm:^6.0.1"
     winston: "npm:^3.17.0"
   languageName: unknown
@@ -8431,7 +8431,7 @@ __metadata:
     mockdate: "npm:^3.0.5"
     moment: "npm:^2.24.0"
     moment-timezone: "npm:^0.5.45"
-    node-fetch: "npm:^1.7.3"
+    node-fetch: "npm:^2.6.7"
     npm-run-all: "npm:^4.1.5"
     numeral: "npm:^2.0.6"
     omit-deep: "npm:^0.3.0"
@@ -14647,7 +14647,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"encoding@npm:^0.1.11, encoding@npm:^0.1.13":
+"encoding@npm:^0.1.13":
   version: 0.1.13
   resolution: "encoding@npm:0.1.13"
   dependencies:
@@ -18710,7 +18710,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-stream@npm:^1.0.1, is-stream@npm:^1.1.0":
+"is-stream@npm:^1.1.0":
   version: 1.1.0
   resolution: "is-stream@npm:1.1.0"
   checksum: 10c0/b8ae7971e78d2e8488d15f804229c6eed7ed36a28f8807a1815938771f4adff0e705218b7dab968270433f67103e4fef98062a0beea55d64835f705ee72c7002
@@ -23001,16 +23001,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^1.7.3":
-  version: 1.7.3
-  resolution: "node-fetch@npm:1.7.3"
-  dependencies:
-    encoding: "npm:^0.1.11"
-    is-stream: "npm:^1.0.1"
-  checksum: 10c0/5a6b56b3edf909ccd20414355867d24f15f1885da3b26be90840241c46e63754ebf4697050f897daab676e3952d969611ffe1d4bc4506cf50f70837e20ad5328
-  languageName: node
-  linkType: hard
-
 "node-fetch@npm:^2.2.0, node-fetch@npm:^2.6.0, node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.12, node-fetch@npm:^2.6.7, node-fetch@npm:^2.6.9":
   version: 2.7.0
   resolution: "node-fetch@npm:2.7.0"
@@ -23173,10 +23163,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nodemailer@npm:^6.9.12":
-  version: 6.9.12
-  resolution: "nodemailer@npm:6.9.12"
-  checksum: 10c0/2c5ff1f064a264e008ca27f66db0dbf25c44bc38178e5ddb9a05bd7b5517bfa3c0e018845b87256df56b554ed6c3720380f3735e9029cf9f7c830e9fdab4189a
+"nodemailer@npm:^8.0.5":
+  version: 8.0.10
+  resolution: "nodemailer@npm:8.0.10"
+  checksum: 10c0/b96fd2ea7146de58141219061e094509fd0f19aac5ac86ac35d9ce9c479dbf6c12b143fa7e7050a1be539a3542eb59520c33aabf5a119c8d28fc7d151bde329f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Final part of the TAM-6854 dependency work (replaces #6817, which auto-closed when its stacked base branch was merged). Now based directly on `dev`.

The major-version upgrades carrying the highest regression risk, isolated so they can be reviewed/merged separately from the low-risk dependency work:

- **node-fetch** `^1.7.3` → `^2.6.7` (api-client, e2e, server-utils, superset-api, utils)
- **nodemailer** `^6.9.12` → `^8.0.5` (server-utils)

## Risk
Highest of the TAM-6854 set — major bumps with API/behaviour changes (node-fetch v2 stream/ESM differences; nodemailer v7/v8). Warrants the most review and QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)