### PR TITLE
deps: TAM-6854: patch lodash code-injection & prototype-pollution (high)

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "@babel/types": "7.25.6",
     "@joshwooding/vite-plugin-react-docgen-typescript": "0.3.0",
     "@types/react@*": "16.9.17",
-    "on-headers": "1.1.0"
+    "on-headers": "1.1.0",
+    "react-smooth/lodash": "^4.18.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.25.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -21333,17 +21333,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:4, lodash@npm:^4.15.0, lodash@npm:^4.17.11, lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.17.4, lodash@npm:^4.17.5, lodash@npm:^4.2.1":
+"lodash@npm:4, lodash@npm:^4.15.0, lodash@npm:^4.17.11, lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.17.4, lodash@npm:^4.17.5, lodash@npm:^4.18.0, lodash@npm:^4.2.1":
   version: 4.18.1
   resolution: "lodash@npm:4.18.1"
   checksum: 10c0/757228fc68805c59789e82185135cf85f05d0b2d3d54631d680ca79ec21944ec8314d4533639a14b8bcfbd97a517e78960933041a5af17ecb693ec6eecb99a27
-  languageName: node
-  linkType: hard
-
-"lodash@npm:~4.17.4":
-  version: 4.17.23
-  resolution: "lodash@npm:4.17.23"
-  checksum: 10c0/1264a90469f5bb95d4739c43eb6277d15b6d9e186df4ac68c3620443160fc669e2f14c11e7d8b2ccf078b81d06147c01a8ccced9aab9f9f63d50dcf8cace6bf6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes the two open lodash advisories: **GHSA-r5fr-rjxr-66jc** (high — code injection via `_.template`) and **GHSA-f23m-r3pf-42rh** (medium — prototype pollution in `_.unset`/`_.omit`). Dependabot #543 / #542.
