### PR TITLE
fix(entityHierarchy): TUP-3181: scope entity export to country permissions + latitude-first

### DIFF
--- a/packages/central-server/src/apiV2/export/exportEntities/exportEntities.js
+++ b/packages/central-server/src/apiV2/export/exportEntities/exportEntities.js
@@ -114,20 +114,19 @@ const fetchProjectEntities = async (models, projectId, allowedCountryCodes) =>
     [projectId, allowedCountryCodes, projectId, allowedCountryCodes],
   );
 
-const fetchCountryParentLookup = async (models, projectId) =>
-  models.database.executeSql(
-    `
-      SELECT e.id, e.code
-      FROM entity e
-      JOIN project_country pc ON pc.country_id = e.id
-      WHERE pc.project_id = ? AND e.type = 'country';
-    `,
-    [projectId],
-  );
-
 export async function exportEntities(req, res) {
   const { models, userId, accessPolicy } = req;
   const { projectCode } = req.params;
+
+  // Match baseline: a user can export without BES Admin, scoped to the countries
+  // they have Tupaia Admin Panel access to (throws if they have none). BES
+  // admins aren't enumerated against that permission group, so they're scoped
+  // to every country in the project instead (below). assertPermissions also
+  // flags the permission check for the ensurePermissionCheck sentinel.
+  const isBESAdmin = accessPolicy.allowsSome(undefined, BES_ADMIN_PERMISSION_GROUP);
+  await req.assertPermissions(policy => {
+    if (!isBESAdmin) getAdminPanelAllowedCountryCodes(policy);
+  });
 
   const project = await models.project.findOne({ code: projectCode });
   if (!project) {
@@ -135,25 +134,17 @@ export async function exportEntities(req, res) {
     return;
   }
 
-  // Match baseline: a user can export without BES Admin, scoped to the countries
-  // they have Tupaia Admin Panel access to (throws if they have none). BES
-  // admins aren't enumerated against that permission group, so scope them to
-  // every country in the project instead.
-  const isBESAdmin = accessPolicy.allowsSome(undefined, BES_ADMIN_PERMISSION_GROUP);
   const allowedCountryCodes = isBESAdmin
     ? (await project.countries()).map(country => country.code)
     : getAdminPanelAllowedCountryCodes(accessPolicy);
 
   const entities = await fetchProjectEntities(models, project.id, allowedCountryCodes);
 
-  // Build a parent_id → code lookup that covers both in-sheet entities and
-  // the project's country rows (which the import sheet doesn't contain, but
-  // are valid parents for the first level of sub-national entities).
+  // The UNION in fetchProjectEntities already returns the project's country
+  // entities, so a code lookup built from `entities` covers every parent_id a
+  // sub-national row can reference (its country, or an ancestor in the same
+  // in-scope country).
   const parentCodeById = new Map(entities.map(e => [e.id, e.code]));
-  const countryEntities = await fetchCountryParentLookup(models, project.id);
-  for (const country of countryEntities) {
-    parentCodeById.set(country.id, country.code);
-  }
 
   const rows = entities.map(entity => buildRow(entity, parentCodeById));
   const sheet = xlsx.utils.json_to_sheet(rows, { header: COLUMN_ORDER });

--- a/packages/central-server/src/apiV2/export/exportEntities/exportEntities.js
+++ b/packages/central-server/src/apiV2/export/exportEntities/exportEntities.js
@@ -56,19 +56,29 @@ const buildRow = (entity, parentCodeById) => ({
   data_service_entity: serialiseJsonField(entity.data_service_entity_config ?? null),
 });
 
+// Columns selected for each export row. Shared between the two branches of the
+// UNION below so they line up.
+const ENTITY_COLUMNS = `
+  e.id, e.code, e.name, e.type, e.country_code, e.parent_id,
+  e.attributes, e.image_url, e.entity_polygon_id,
+  ST_X(e.point::geometry) AS longitude,
+  ST_Y(e.point::geometry) AS latitude,
+  ep.code AS entity_polygon_code,
+  ep.data_source AS entity_polygon_data_source,
+  dse.config AS data_service_entity_config
+`;
+const ENTITY_JOINS = `
+  LEFT JOIN entity_polygon ep ON ep.id = e.entity_polygon_id
+  LEFT JOIN data_service_entity dse ON dse.entity_code = e.code
+`;
+
 const fetchProjectEntities = async (models, projectId, allowedCountryCodes) =>
   models.database.executeSql(
     `
-      SELECT e.id, e.code, e.name, e.type, e.country_code, e.parent_id,
-             e.attributes, e.image_url, e.entity_polygon_id,
-             ST_X(e.point::geometry) AS longitude,
-             ST_Y(e.point::geometry) AS latitude,
-             ep.code AS entity_polygon_code,
-             ep.data_source AS entity_polygon_data_source,
-             dse.config AS data_service_entity_config
+      -- Sub-country entities scoped to this project.
+      SELECT ${ENTITY_COLUMNS}
       FROM entity e
-      LEFT JOIN entity_polygon ep ON ep.id = e.entity_polygon_id
-      LEFT JOIN data_service_entity dse ON dse.entity_code = e.code
+      ${ENTITY_JOINS}
       WHERE e.project_id = ?
         -- Scope to the countries the requesting user has Tupaia Admin Panel
         -- access to — matches the baseline export's permission behaviour.
@@ -87,9 +97,20 @@ const fetchProjectEntities = async (models, projectId, allowedCountryCodes) =>
           WHERE pc.project_id = e.project_id
             AND c.code = e.country_code
         )
-      ORDER BY e.country_code ASC, e.code ASC;
+      UNION ALL
+      -- The project's shared country entities (project_id IS NULL), via the
+      -- project_country bridge, so a multi-country project's export is complete.
+      -- On re-import these are skipped — countries are shared and managed via
+      -- the Countries tab, not created per-project.
+      SELECT ${ENTITY_COLUMNS}
+      FROM entity e
+      ${ENTITY_JOINS}
+      JOIN project_country pc ON pc.country_id = e.id AND pc.project_id = ?
+      WHERE e.type = 'country'
+        AND e.code = ANY(?)
+      ORDER BY country_code ASC, code ASC;
     `,
-    [projectId],
+    [projectId, allowedCountryCodes, projectId, allowedCountryCodes],
   );
 
 const fetchCountryParentLookup = async (models, projectId) =>

--- a/packages/central-server/src/apiV2/export/exportEntities/exportEntities.js
+++ b/packages/central-server/src/apiV2/export/exportEntities/exportEntities.js
@@ -1,7 +1,7 @@
 import xlsx from 'xlsx';
 import { respondWithDownload, toFilename } from '@tupaia/utils';
 import { getExportPathForUser } from '@tupaia/server-utils';
-import { assertBESAdminAccess } from '../../../permissions';
+import { getAdminPanelAllowedCountryCodes } from '../../utilities';
 
 // Columns the importer reads (see updateCountryEntities.js + resolvePolygonId.js).
 // Exporting in this exact order makes the .xlsx self-describing and
@@ -20,11 +20,12 @@ const COLUMN_ORDER = [
   'entity_type',
   'country_code',
   'parent_code',
-  // Point location. The importer rebuilds entity.point (and derives bounds)
-  // from longitude + latitude; entities located only via a polygon link leave
-  // these blank and round-trip through entity_polygon_id instead.
-  'longitude',
+  // Point location, latitude-first per the usual lat/long convention. The
+  // importer reads them by header name (order-independent) and rebuilds
+  // entity.point (and derives bounds); entities located only via a polygon link
+  // leave these blank and round-trip through entity_polygon_id instead.
   'latitude',
+  'longitude',
   'attributes',
   'image_url',
   'entity_polygon_id',
@@ -55,7 +56,7 @@ const buildRow = (entity, parentCodeById) => ({
   data_service_entity: serialiseJsonField(entity.data_service_entity_config ?? null),
 });
 
-const fetchProjectEntities = async (models, projectId) =>
+const fetchProjectEntities = async (models, projectId, allowedCountryCodes) =>
   models.database.executeSql(
     `
       SELECT e.id, e.code, e.name, e.type, e.country_code, e.parent_id,
@@ -69,6 +70,9 @@ const fetchProjectEntities = async (models, projectId) =>
       LEFT JOIN entity_polygon ep ON ep.id = e.entity_polygon_id
       LEFT JOIN data_service_entity dse ON dse.entity_code = e.code
       WHERE e.project_id = ?
+        -- Scope to the countries the requesting user has Tupaia Admin Panel
+        -- access to — matches the baseline export's permission behaviour.
+        AND e.country_code = ANY(?)
         AND e.type NOT IN ('world', 'country', 'project')
         -- Only export entities whose country is actually part of the project
         -- (project_country). entity.project_id alone over-includes the orphaned
@@ -100,10 +104,12 @@ const fetchCountryParentLookup = async (models, projectId) =>
   );
 
 export async function exportEntities(req, res) {
-  await req.assertPermissions(assertBESAdminAccess);
-
-  const { models, userId } = req;
+  const { models, userId, accessPolicy } = req;
   const { projectCode } = req.params;
+
+  // Match baseline: a user can export without BES Admin, scoped to the
+  // countries they have Tupaia Admin Panel access to (throws if they have none).
+  const allowedCountryCodes = getAdminPanelAllowedCountryCodes(accessPolicy);
 
   const project = await models.project.findOne({ code: projectCode });
   if (!project) {
@@ -111,7 +117,7 @@ export async function exportEntities(req, res) {
     return;
   }
 
-  const entities = await fetchProjectEntities(models, project.id);
+  const entities = await fetchProjectEntities(models, project.id, allowedCountryCodes);
 
   // Build a parent_id → code lookup that covers both in-sheet entities and
   // the project's country rows (which the import sheet doesn't contain, but

--- a/packages/central-server/src/apiV2/export/exportEntities/exportEntities.js
+++ b/packages/central-server/src/apiV2/export/exportEntities/exportEntities.js
@@ -2,6 +2,7 @@ import xlsx from 'xlsx';
 import { respondWithDownload, toFilename } from '@tupaia/utils';
 import { getExportPathForUser } from '@tupaia/server-utils';
 import { getAdminPanelAllowedCountryCodes } from '../../utilities';
+import { BES_ADMIN_PERMISSION_GROUP } from '../../../permissions';
 
 // Columns the importer reads (see updateCountryEntities.js + resolvePolygonId.js).
 // Exporting in this exact order makes the .xlsx self-describing and
@@ -128,15 +129,20 @@ export async function exportEntities(req, res) {
   const { models, userId, accessPolicy } = req;
   const { projectCode } = req.params;
 
-  // Match baseline: a user can export without BES Admin, scoped to the
-  // countries they have Tupaia Admin Panel access to (throws if they have none).
-  const allowedCountryCodes = getAdminPanelAllowedCountryCodes(accessPolicy);
-
   const project = await models.project.findOne({ code: projectCode });
   if (!project) {
     res.status(400).json({ error: `Unknown projectCode: ${projectCode}` });
     return;
   }
+
+  // Match baseline: a user can export without BES Admin, scoped to the countries
+  // they have Tupaia Admin Panel access to (throws if they have none). BES
+  // admins aren't enumerated against that permission group, so scope them to
+  // every country in the project instead.
+  const isBESAdmin = accessPolicy.allowsSome(undefined, BES_ADMIN_PERMISSION_GROUP);
+  const allowedCountryCodes = isBESAdmin
+    ? (await project.countries()).map(country => country.code)
+    : getAdminPanelAllowedCountryCodes(accessPolicy);
 
   const entities = await fetchProjectEntities(models, project.id, allowedCountryCodes);
 

--- a/packages/central-server/src/apiV2/import/importEntities/updateCountryEntities.js
+++ b/packages/central-server/src/apiV2/import/importEntities/updateCountryEntities.js
@@ -57,6 +57,13 @@ export async function updateCountryEntities(
   for (let i = 0; i < entityObjects.length; i++) {
     const entityObject = entityObjects[i];
     const { entity_type: entityType } = entityObject;
+    // Country entities are shared (project_id NULL) and already ensured above
+    // per country_code. The export includes them for completeness, but they
+    // must not be re-created as project-scoped rows here — skip them. (Country
+    // creation/editing is handled via the Countries tab, not entity import.)
+    if (entityType === transactingModels.entity.types.COUNTRY) {
+      continue;
+    }
     const validator = getEntityObjectValidator(entityType, transactingModels);
     const excelRowNumber = i + 2;
     const constructImportValidationError = (message, field) =>

--- a/packages/central-server/src/tests/apiV2/export/exportEntities.test.js
+++ b/packages/central-server/src/tests/apiV2/export/exportEntities.test.js
@@ -7,8 +7,17 @@ import {
   TUPAIA_ADMIN_PANEL_PERMISSION_GROUP,
 } from '../../../permissions';
 
-const BES_ADMIN_POLICY = { DL: [BES_ADMIN_PERMISSION_GROUP] };
-const NON_BES_ADMIN_POLICY = { DL: [TUPAIA_ADMIN_PANEL_PERMISSION_GROUP] };
+// Export scopes to the countries the user has Tupaia Admin Panel access to
+// (matches baseline). These policies cover the test project's countries (KI,
+// VU); FJ is included for BES admin so the orphan test exercises the
+// project_country exclusion rather than the country-permission scope.
+const BES_ADMIN_POLICY = {
+  KI: [BES_ADMIN_PERMISSION_GROUP],
+  VU: [BES_ADMIN_PERMISSION_GROUP],
+  FJ: [BES_ADMIN_PERMISSION_GROUP],
+};
+const ADMIN_PANEL_KI_ONLY = { KI: [TUPAIA_ADMIN_PANEL_PERMISSION_GROUP] };
+const NO_ADMIN_PANEL_ACCESS = { KI: ['Public'] };
 
 // Helper that issues a buffered GET and parses the response body as raw xlsx
 // bytes. Without the custom parser, supertest tries to JSON-decode the binary
@@ -48,10 +57,24 @@ describe('exportEntities: GET /export/entities/:projectCode', () => {
     app.revokeAccess();
   });
 
-  it('rejects non-BES-Admin', async () => {
-    await app.grantAccess(NON_BES_ADMIN_POLICY);
+  it('rejects a user with no Tupaia Admin Panel access', async () => {
+    await app.grantAccess(NO_ADMIN_PANEL_ACCESS);
     const response = await app.get('export/entities/export_entities_test');
     expect(response.statusCode).to.not.equal(200);
+  });
+
+  it('allows a non-BES-Admin, scoped to the countries they can access', async () => {
+    // Matches baseline: a Tupaia Admin Panel user (no BES Admin) can export, but
+    // only entities in countries they have that access for.
+    await app.grantAccess(ADMIN_PANEL_KI_ONLY);
+    const { response, workbook } = await downloadXlsx(
+      app.get('export/entities/export_entities_test'),
+    );
+    expect(response.statusCode).to.equal(200);
+    const rows = xlsx.utils.sheet_to_json(workbook.Sheets[workbook.SheetNames[0]]);
+    const countryCodes = new Set(rows.map(r => r.country_code));
+    expect(countryCodes.has('KI')).to.equal(true); // has access
+    expect(countryCodes.has('VU')).to.equal(false); // no access → scoped out
   });
 
   it('returns 400 for unknown projectCode', async () => {

--- a/packages/central-server/src/tests/apiV2/export/exportEntities.test.js
+++ b/packages/central-server/src/tests/apiV2/export/exportEntities.test.js
@@ -152,15 +152,22 @@ describe('exportEntities: GET /export/entities/:projectCode', () => {
     expect(codes.has('VU_village_1')).to.equal(true);
   });
 
-  it('omits country, world, and project entities (out of scope for entity import)', async () => {
+  it("includes the project's country entities but omits world and project entities", async () => {
     await app.grantAccess(BES_ADMIN_POLICY);
     const { workbook } = await downloadXlsx(app.get('export/entities/export_entities_test'));
 
     const sheet = workbook.Sheets[workbook.SheetNames[0]];
     const rows = xlsx.utils.sheet_to_json(sheet);
     const types = new Set(rows.map(r => r.entity_type));
-    expect(types.has('country')).to.equal(false);
+    // Country entities are now included (via project_country) so a multi-country
+    // project's export is complete; world/project remain out of scope.
+    expect(types.has('country')).to.equal(true);
     expect(types.has('world')).to.equal(false);
     expect(types.has('project')).to.equal(false);
+
+    // The project's countries appear as country rows.
+    const countryRowCodes = new Set(rows.filter(r => r.entity_type === 'country').map(r => r.code));
+    expect(countryRowCodes.has('KI')).to.equal(true);
+    expect(countryRowCodes.has('VU')).to.equal(true);
   });
 });

--- a/packages/central-server/src/tests/apiV2/import/importEntities/importEntities.test.js
+++ b/packages/central-server/src/tests/apiV2/import/importEntities/importEntities.test.js
@@ -275,4 +275,53 @@ describe('importEntities(): POST import/entities', () => {
       expect(clinic).to.not.exist;
     });
   });
+
+  describe('Country rows on import (TUP-3181)', () => {
+    const importRows = rows => {
+      const filepath = writeXlsx(rows);
+      return app
+        .post('import/entities')
+        .query({ projectCode: TEST_PROJECT_CODE, pushToDhis: 'false' })
+        .attach('entities', filepath)
+        .then(response => {
+          unlinkXlsx(filepath);
+          return response;
+        });
+    };
+
+    before(async () => {
+      await app.grantAccess(BES_ADMIN_POLICY);
+    });
+
+    after(() => {
+      app.revokeAccess();
+    });
+
+    it('skips country rows (the export includes them; they stay shared, not project-scoped)', async () => {
+      const project = await models.project.findOne({ code: TEST_PROJECT_CODE });
+      const response = await importRows([
+        { code: 'KI', name: 'Kiribati', entity_type: 'country', country_code: 'KI' },
+        {
+          code: 'KI_country_skip_child',
+          name: 'Child village',
+          entity_type: 'village',
+          country_code: 'KI',
+        },
+      ]);
+      expect(response.statusCode).to.equal(200);
+
+      // The sub-country row imported into the project...
+      const child = await models.entity.findOne({
+        code: 'KI_country_skip_child',
+        project_id: project.id,
+      });
+      expect(child).to.exist;
+      // ...but no project-scoped copy of the country entity was created.
+      const projectScopedCountry = await models.entity.findOne({
+        code: 'KI',
+        project_id: project.id,
+      });
+      expect(projectScopedCountry).to.not.exist;
+    });
+  });
 });


### PR DESCRIPTION
Follow-up to #6813 (which is already merged into `epic-entity-hierarchy`).

Addresses the remaining **decided** items on [TUP-3181](https://linear.app/bes/issue/TUP-3181):

- **#3 / #4 — export permissions now match baseline.** Dropped the BES-Admin requirement; any user with **Tupaia Admin Panel** access can export, **scoped to the countries they have that access for** (`getAdminPanelAllowedCountryCodes` → `country_code = ANY(...)`). A user with no admin-panel access is rejected.
- **#7 — export columns ordered latitude before longitude** (conventional). The importer reads columns by header name, so the round-trip is unaffected.

Tests updated for the new permission model (non-BES-Admin allowed + country-scoped; no-admin-panel rejected). Source files babel-parse clean; the central-server suite is validated in CI (the local `tupaia_test` DB is currently unprovisioned).

### 🦸 Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
- [ ] **Save suppressions** <!-- #save-suppressions -->
