### PR TITLE
fix(entityHierarchy): TUP-3181: drop the dead project-link branch from country creation

### DIFF
--- a/packages/admin-panel-server/src/middleware/projectScope.ts
+++ b/packages/admin-panel-server/src/middleware/projectScope.ts
@@ -44,9 +44,8 @@ const projectRefFromBody = async (
 };
 
 // Endpoints that consume projectCode themselves rather than having it stripped
-// before forwarding: the entity importer reads it for project-scoping, and
-// country creation reads it to link the new country to the active project.
-const PROJECT_CODE_PASSTHROUGH_PATHS = new Set(['import/entities', 'countries']);
+// before forwarding: the entity importer reads it for project-scoping.
+const PROJECT_CODE_PASSTHROUGH_PATHS = new Set(['import/entities']);
 
 const RULES: Record<string, ProjectScopeRule> = {
   surveys: {

--- a/packages/central-server/src/apiV2/CreateCountry.js
+++ b/packages/central-server/src/apiV2/CreateCountry.js
@@ -4,17 +4,15 @@ import { BESAdminCreateHandler } from './CreateHandler';
 /**
  * Handles POST /countries.
  *
- * Creating a country is no longer just a `country` table row: a country needs a
- * matching shared entity (type `country`, parented to World, `project_id` NULL)
- * for the hierarchy, and — when created from within a project scope — a
- * `project_country` row so the new country belongs to the active project. This
- * keeps the three in step so a freshly added country is immediately usable for
- * entity import/export and visualisation within that project.
+ * Creating a country is no longer just a `country` table row: a country also
+ * needs a matching shared entity (type `country`, parented to World,
+ * `project_id` NULL) for the hierarchy. The Countries tab is an all-projects
+ * view, so the country isn't tied to any project here — associating it with a
+ * project is a separate step (project_country).
  */
 export class CreateCountry extends BESAdminCreateHandler {
   async createRecord() {
     const { code, name } = this.newRecordData;
-    const { projectCode } = this.req.query;
 
     await this.models.wrapInTransaction(async transactingModels => {
       await transactingModels.country.create({ code, name });
@@ -27,7 +25,7 @@ export class CreateCountry extends BESAdminCreateHandler {
           'World entity not found — run entity hierarchy setup before creating countries',
         );
       }
-      const countryEntity = await transactingModels.entity.findOrCreate(
+      await transactingModels.entity.findOrCreate(
         { code, project_id: null },
         {
           name,
@@ -39,19 +37,6 @@ export class CreateCountry extends BESAdminCreateHandler {
           metadata: { dhis: { dhisInstanceCode: 'regional' } },
         },
       );
-
-      if (projectCode) {
-        const project = await transactingModels.project.findOne({ code: projectCode });
-        if (!project) {
-          // projectCode was explicitly supplied, so a missing project is a
-          // caller error, not a reason to silently create an unlinked country.
-          throw new Error(`Cannot link country to unknown project: ${projectCode}`);
-        }
-        await transactingModels.projectCountry.findOrCreate({
-          project_id: project.id,
-          country_id: countryEntity.id,
-        });
-      }
     });
   }
 }

--- a/packages/central-server/src/tests/apiV2/countries/CreateCountry.test.js
+++ b/packages/central-server/src/tests/apiV2/countries/CreateCountry.test.js
@@ -6,18 +6,16 @@ import { TestableApp } from '../../testUtilities';
 const BES_ADMIN_POLICY = { DL: [BES_ADMIN_PERMISSION_GROUP] };
 const NON_BES_ADMIN_POLICY = { DL: [TUPAIA_ADMIN_PANEL_PERMISSION_GROUP] };
 
-const TEST_PROJECT_CODE = 'create_country_test';
 const NEW_COUNTRY = { code: 'ZZ', name: 'Zedland' };
 
 describe('CreateCountry: POST /countries', () => {
   const app = new TestableApp();
   const { models } = app;
-  let project;
 
   const cleanup = async () => {
     const entity = await models.entity.findOne({ code: NEW_COUNTRY.code, type: 'country' });
     if (entity) {
-      if (project) await models.projectCountry.delete({ country_id: entity.id });
+      await models.projectCountry.delete({ country_id: entity.id });
       await models.entity.delete({ id: entity.id });
     }
     await models.country.delete({ code: NEW_COUNTRY.code });
@@ -25,7 +23,6 @@ describe('CreateCountry: POST /countries', () => {
 
   before(async () => {
     await findOrCreateDummyRecord(models.entity, { code: 'World', type: 'world' });
-    project = await findOrCreateDummyRecord(models.project, { code: TEST_PROJECT_CODE });
     await cleanup();
   });
 
@@ -57,39 +54,12 @@ describe('CreateCountry: POST /countries', () => {
     expect(entity.parent_id).to.equal(world.id);
   });
 
-  it('links the new country to the active project when projectCode is supplied', async () => {
-    await app.grantAccess(BES_ADMIN_POLICY);
-    const response = await app
-      .post('countries', { body: NEW_COUNTRY })
-      .query({ projectCode: TEST_PROJECT_CODE });
-    expect(response.statusCode).to.equal(200);
-
-    const entity = await models.entity.findOne({ code: NEW_COUNTRY.code, type: 'country' });
-    const link = await models.projectCountry.findOne({
-      project_id: project.id,
-      country_id: entity.id,
-    });
-    expect(link).to.exist;
-  });
-
-  it('creates no project_country link when no projectCode is supplied', async () => {
+  it('does not link the new country to any project (Countries tab is all-projects)', async () => {
     await app.grantAccess(BES_ADMIN_POLICY);
     await app.post('countries', { body: NEW_COUNTRY });
 
     const entity = await models.entity.findOne({ code: NEW_COUNTRY.code, type: 'country' });
     const link = await models.projectCountry.findOne({ country_id: entity.id });
     expect(link).to.not.exist;
-  });
-
-  it('rejects (and creates nothing) when an unknown projectCode is supplied', async () => {
-    await app.grantAccess(BES_ADMIN_POLICY);
-    const response = await app
-      .post('countries', { body: NEW_COUNTRY })
-      .query({ projectCode: 'does_not_exist_xyz' });
-    expect(response.statusCode).to.not.equal(200);
-
-    // The whole create is transactional, so nothing should persist.
-    const country = await models.country.findOne({ code: NEW_COUNTRY.code });
-    expect(country).to.not.exist;
   });
 });


### PR DESCRIPTION
## Summary
Follow-up to #6823. The `CreateCountry` handler tried to link a new country to the active project via `projectCode`, but the **Countries tab is an all-projects view** — `readSelectedProjectCode()` parses the project from the URL path, and `/countries` has none, so no `projectCode` ever reached the endpoint and the `project_country` auto-link never fired.

Removes that dead branch (and the `countries` entry in the project-scope `projectCode` passthrough). Creating a country now just creates the `country` row and its shared `country` entity (World parent, `project_id` NULL); associating a country with a project is a separate concern handled via `project_country`.

## Test plan
- `CreateCountry` test updated: asserts the country row + shared entity are created and that no `project_country` link is made.
- `admin-panel-server` typechecks clean.

> Note: local `tupaia_test` is unavailable, so the central-server test runs on CI. The change is a strict simplification of the merged #6823 behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)