### PR TITLE
feat(entityHierarchy): TUP-3181: manage a project's countries from the edit modal

### DIFF
--- a/packages/admin-panel/src/routes/projects/projects.js
+++ b/packages/admin-panel/src/routes/projects/projects.js
@@ -98,6 +98,22 @@ const EDIT_FIELDS = [
   },
   ...DEFAULT_FIELDS,
   {
+    // List shows the country codes; the modal edits the project_country links.
+    // Pre-fills and submits `countries` (country ids) like the Add project modal.
+    Header: 'Countries',
+    source: 'countryCodes',
+    Filter: ArrayFilter,
+    Cell: ({ value }) => prettyArray(value),
+    editConfig: {
+      type: 'checkboxList',
+      optionsEndpoint: 'countries',
+      optionLabelKey: 'country.name',
+      optionValueKey: 'country.id',
+      sourceKey: 'countries',
+      pageSize: 'ALL',
+    },
+  },
+  {
     Header: 'Config',
     source: 'config',
     type: 'jsonTooltip',

--- a/packages/admin-panel/src/routes/projects/projects.js
+++ b/packages/admin-panel/src/routes/projects/projects.js
@@ -100,10 +100,13 @@ const EDIT_FIELDS = [
   {
     // List shows the country codes; the modal edits the project_country links.
     // Pre-fills and submits `countries` (country ids) like the Add project modal.
+    // countryCodes is a virtual (post-query) column, so it can't be sorted or
+    // filtered at the SQL level.
     Header: 'Countries',
     source: 'countryCodes',
-    Filter: ArrayFilter,
     Cell: ({ value }) => prettyArray(value),
+    filterable: false,
+    disableSortBy: true,
     editConfig: {
       type: 'checkboxList',
       optionsEndpoint: 'countries',

--- a/packages/admin-panel/src/routes/projects/projects.js
+++ b/packages/admin-panel/src/routes/projects/projects.js
@@ -98,13 +98,14 @@ const EDIT_FIELDS = [
   },
   ...DEFAULT_FIELDS,
   {
-    // List shows the country codes; the modal edits the project_country links.
-    // Pre-fills and submits `countries` (country ids) like the Add project modal.
-    // countryCodes is a virtual (post-query) column, so it can't be sorted or
-    // filtered at the SQL level.
+    // The modal edits the project_country links. `source` is the `countries`
+    // (country id) array so it survives the editor's record processing and
+    // pre-fills/submits like the Add project modal; the list cell shows the
+    // human-readable codes from the same record. Both are virtual (post-query)
+    // columns, so the list column can't be sorted or filtered at the SQL level.
     Header: 'Countries',
-    source: 'countryCodes',
-    Cell: ({ value }) => prettyArray(value),
+    source: 'countries',
+    Cell: ({ row }) => prettyArray(row?.original?.countryCodes ?? []),
     filterable: false,
     disableSortBy: true,
     editConfig: {

--- a/packages/central-server/src/apiV2/projects/CreateProject.js
+++ b/packages/central-server/src/apiV2/projects/CreateProject.js
@@ -2,27 +2,11 @@ import { EntityTypeEnum } from '@tupaia/types';
 import { snake } from 'case';
 import { BESAdminCreateHandler } from '../CreateHandler';
 import { uploadImage } from '../utilities';
+import { getCountryEntityId } from './getCountryEntityId';
 /**
  * Handles POST endpoints:
  * - /projects
  */
-
-const getCountryEntityId = async (models, countryId) => {
-  const country = await models.country.findOne({
-    id: countryId,
-  });
-
-  if (!country) throw new Error(`Country with id ${countryId} not found`);
-
-  const entity = await models.entity.findOne({
-    code: country.code,
-    type: 'country',
-  });
-
-  if (!entity) throw new Error(`Entity with code ${country.code} not found`);
-
-  return entity.id;
-};
 
 export class CreateProject extends BESAdminCreateHandler {
   async createRecord() {

--- a/packages/central-server/src/apiV2/projects/EditProject.js
+++ b/packages/central-server/src/apiV2/projects/EditProject.js
@@ -7,6 +7,7 @@ import {
 } from '../../permissions';
 import { EditHandler } from '../EditHandler';
 import { uploadImage } from '../utilities';
+import { getCountryEntityId } from './getCountryEntityId';
 
 const assertCanEditProject = async (accessPolicy, models, recordId) => {
   assertAdminPanelAccess(accessPolicy);
@@ -49,7 +50,9 @@ export class EditProject extends EditHandler {
       code: updatedCode,
       sort_order: updatedSortOrder,
     } = this.updatedFields;
-    const updatedFields = { ...this.updatedFields };
+    // `countries` is a relation (project_country), not a project column, so keep
+    // it out of the record update and reconcile it separately.
+    const { countries, ...updatedFields } = this.updatedFields;
 
     const {
       image_url: existingBackgroundImage,
@@ -81,6 +84,34 @@ export class EditProject extends EditHandler {
     if (updatedSortOrder === '') {
       updatedFields.sort_order = null;
     }
-    await this.models.project.updateById(this.recordId, updatedFields);
+
+    await this.models.wrapInTransaction(async transactingModels => {
+      await transactingModels.project.updateById(this.recordId, updatedFields);
+      if (countries !== undefined) {
+        await this.reconcileProjectCountries(transactingModels, countries);
+      }
+    });
+  }
+
+  // Bring project_country into line with the selected `country` table ids:
+  // add links for newly-selected countries, remove deselected ones.
+  async reconcileProjectCountries(models, countryIds) {
+    const desiredEntityIds = [];
+    for (const countryId of countryIds) {
+      desiredEntityIds.push(await getCountryEntityId(models, countryId));
+    }
+
+    const existingLinks = await models.projectCountry.find({ project_id: this.recordId });
+    const existingEntityIds = existingLinks.map(link => link.country_id);
+
+    const toAdd = desiredEntityIds.filter(id => !existingEntityIds.includes(id));
+    const toRemove = existingEntityIds.filter(id => !desiredEntityIds.includes(id));
+
+    for (const countryId of toAdd) {
+      await models.projectCountry.create({ project_id: this.recordId, country_id: countryId });
+    }
+    if (toRemove.length > 0) {
+      await models.projectCountry.delete({ project_id: this.recordId, country_id: toRemove });
+    }
   }
 }

--- a/packages/central-server/src/apiV2/projects/GETProjects.js
+++ b/packages/central-server/src/apiV2/projects/GETProjects.js
@@ -36,6 +36,14 @@ export class GETProjects extends GETHandler {
     },
   };
 
+  // `countries` and `countryCodes` are virtual columns attached post-query by
+  // attachCountries, not real project columns — strip them from the SQL select
+  // so a request for them doesn't try to select project.countryCodes.
+  async getProcessedColumns() {
+    const columns = await super.getProcessedColumns();
+    return columns.filter(spec => !('countries' in spec) && !('countryCodes' in spec));
+  }
+
   async findSingleRecord(projectId, options) {
     const projectPermissionChecker = accessPolicy =>
       assertProjectPermissions(accessPolicy, this.models, projectId);

--- a/packages/central-server/src/apiV2/projects/GETProjects.js
+++ b/packages/central-server/src/apiV2/projects/GETProjects.js
@@ -52,23 +52,33 @@ export class GETProjects extends GETHandler {
     );
 
     const record = await super.findSingleRecord(projectId, options);
-    const [withCountries] = await this.attachCountries([record]);
-    return withCountries;
+    if (!record) return record;
+    // Key off the known projectId, not record.id — the single-record fetch
+    // doesn't request the id column, so record.id is usually absent.
+    const byProject = await this.fetchCountriesByProject([projectId]);
+    const { countries = [], countryCodes = [] } = byProject.get(projectId) ?? {};
+    return { ...record, countries, countryCodes };
   }
 
   async findRecords(criteria, options) {
     const records = await super.findRecords(criteria, options);
-    return this.attachCountries(records);
+    const projectIds = records.map(record => record?.id).filter(Boolean);
+    const byProject = await this.fetchCountriesByProject(projectIds);
+    return records.map(record => {
+      if (!record) return record;
+      const { countries = [], countryCodes = [] } = byProject.get(record.id) ?? {};
+      return { ...record, countries, countryCodes };
+    });
   }
 
-  // Attach each project's countries. `countries` is the array of `country` table
-  // ids the edit form's checkbox list pre-fills and submits (matching the create
-  // field's optionValueKey); `countryCodes` is the human-readable list display.
-  // project_country stores country *entity* ids, so map back to the country table
-  // via the shared entity code.
-  async attachCountries(records) {
-    const projectIds = records.map(record => record?.id).filter(Boolean);
-    if (projectIds.length === 0) return records;
+  // Map each project id to its countries: `countries` is the array of `country`
+  // table ids the edit form's checkbox list pre-fills and submits (matching the
+  // create field's optionValueKey); `countryCodes` is the human-readable list
+  // display. project_country stores country *entity* ids, so map back to the
+  // country table via the shared entity code.
+  async fetchCountriesByProject(projectIds) {
+    const byProject = new Map();
+    if (projectIds.length === 0) return byProject;
 
     const rows = await this.database.executeSql(
       `
@@ -82,18 +92,13 @@ export class GETProjects extends GETHandler {
       projectIds,
     );
 
-    const byProject = new Map();
     for (const { project_id: projectId, country_id: countryId, country_code: code } of rows) {
       if (!byProject.has(projectId)) byProject.set(projectId, { countries: [], countryCodes: [] });
       byProject.get(projectId).countries.push(countryId);
       byProject.get(projectId).countryCodes.push(code);
     }
 
-    return records.map(record => {
-      if (!record) return record;
-      const { countries = [], countryCodes = [] } = byProject.get(record.id) ?? {};
-      return { ...record, countries, countryCodes };
-    });
+    return byProject;
   }
 
   async getPermissionsFilter(criteria, options) {

--- a/packages/central-server/src/apiV2/projects/GETProjects.js
+++ b/packages/central-server/src/apiV2/projects/GETProjects.js
@@ -43,7 +43,49 @@ export class GETProjects extends GETHandler {
       assertAnyPermissions([assertBESAdminAccess, projectPermissionChecker]),
     );
 
-    return super.findSingleRecord(projectId, options);
+    const record = await super.findSingleRecord(projectId, options);
+    const [withCountries] = await this.attachCountries([record]);
+    return withCountries;
+  }
+
+  async findRecords(criteria, options) {
+    const records = await super.findRecords(criteria, options);
+    return this.attachCountries(records);
+  }
+
+  // Attach each project's countries. `countries` is the array of `country` table
+  // ids the edit form's checkbox list pre-fills and submits (matching the create
+  // field's optionValueKey); `countryCodes` is the human-readable list display.
+  // project_country stores country *entity* ids, so map back to the country table
+  // via the shared entity code.
+  async attachCountries(records) {
+    const projectIds = records.map(record => record?.id).filter(Boolean);
+    if (projectIds.length === 0) return records;
+
+    const rows = await this.database.executeSql(
+      `
+        SELECT pc.project_id, c.id AS country_id, c.code AS country_code
+        FROM project_country pc
+        JOIN entity e ON e.id = pc.country_id
+        JOIN country c ON c.code = e.code
+        WHERE pc.project_id IN (${projectIds.map(() => '?').join(', ')})
+        ORDER BY c.code ASC;
+      `,
+      projectIds,
+    );
+
+    const byProject = new Map();
+    for (const { project_id: projectId, country_id: countryId, country_code: code } of rows) {
+      if (!byProject.has(projectId)) byProject.set(projectId, { countries: [], countryCodes: [] });
+      byProject.get(projectId).countries.push(countryId);
+      byProject.get(projectId).countryCodes.push(code);
+    }
+
+    return records.map(record => {
+      if (!record) return record;
+      const { countries = [], countryCodes = [] } = byProject.get(record.id) ?? {};
+      return { ...record, countries, countryCodes };
+    });
   }
 
   async getPermissionsFilter(criteria, options) {

--- a/packages/central-server/src/apiV2/projects/getCountryEntityId.js
+++ b/packages/central-server/src/apiV2/projects/getCountryEntityId.js
@@ -1,0 +1,14 @@
+/**
+ * Resolve a `country` table id to its shared country entity's id. project_country
+ * links projects to country *entities* (entity.id), but the admin-panel works in
+ * terms of `country` table ids, so both create and edit translate via this.
+ */
+export const getCountryEntityId = async (models, countryId) => {
+  const country = await models.country.findOne({ id: countryId });
+  if (!country) throw new Error(`Country with id ${countryId} not found`);
+
+  const entity = await models.entity.findOne({ code: country.code, type: 'country' });
+  if (!entity) throw new Error(`Entity with code ${country.code} not found`);
+
+  return entity.id;
+};

--- a/packages/central-server/src/tests/apiV2/projects/EditProject.test.js
+++ b/packages/central-server/src/tests/apiV2/projects/EditProject.test.js
@@ -148,4 +148,48 @@ describe('Editing a project', async () => {
       expect(result[0].logo_url).to.equal(TEST_PROJECT_INPUT.logo_url);
     });
   });
+
+  describe('PUT /projects — country reconciliation (TUP-3181)', () => {
+    let kiCountryId;
+    let vuCountryId;
+
+    const countryEntityId = async code =>
+      (await models.entity.findOne({ code, type: 'country' })).id;
+
+    before(async () => {
+      const ki = await findOrCreateDummyRecord(models.country, { code: 'KI', name: 'Kiribati' });
+      const vu = await findOrCreateDummyRecord(models.country, { code: 'VU', name: 'Vanuatu' });
+      kiCountryId = ki.id;
+      vuCountryId = vu.id;
+      await findOrCreateDummyRecord(models.entity, { code: 'KI', type: 'country', country_code: 'KI' });
+      await findOrCreateDummyRecord(models.entity, { code: 'VU', type: 'country', country_code: 'VU' });
+    });
+
+    it('adds project_country links for newly selected countries', async () => {
+      await app.grantAccess(BES_ADMIN_POLICY);
+      await app.put(`projects/${TEST_PROJECT_INPUT.id}`, {
+        body: { description: 'with countries', countries: [kiCountryId, vuCountryId] },
+      });
+
+      const links = await models.projectCountry.find({ project_id: TEST_PROJECT_INPUT.id });
+      const linkedEntityIds = links.map(link => link.country_id);
+      expect(linkedEntityIds).to.include(await countryEntityId('KI'));
+      expect(linkedEntityIds).to.include(await countryEntityId('VU'));
+    });
+
+    it('removes deselected countries', async () => {
+      await app.grantAccess(BES_ADMIN_POLICY);
+      await app.put(`projects/${TEST_PROJECT_INPUT.id}`, {
+        body: { description: 'both', countries: [kiCountryId, vuCountryId] },
+      });
+      await app.put(`projects/${TEST_PROJECT_INPUT.id}`, {
+        body: { description: 'just KI', countries: [kiCountryId] },
+      });
+
+      const links = await models.projectCountry.find({ project_id: TEST_PROJECT_INPUT.id });
+      const linkedEntityIds = links.map(link => link.country_id);
+      expect(linkedEntityIds).to.include(await countryEntityId('KI'));
+      expect(linkedEntityIds).to.not.include(await countryEntityId('VU'));
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Closes the gap surfaced in TUP-3181 Issue 6: in the new model `project_country` is the source of truth for a project's countries, but it was only written at project **creation** — there was no way to add a country to an *existing* project. This adds country management to the project **edit** modal.

- **`GETProjects`** attaches each project's countries: `countries` (array of `country` table ids — what the checkbox list pre-fills/submits, matching the Add project modal's `optionValueKey`) and `countryCodes` (for the list-column display). `project_country` stores country *entity* ids, so it maps back to the country table via the shared entity code.
- **`EditProject`** reconciles `project_country` against the submitted selection — adds links for newly-selected countries (table id → entity id), removes deselected ones — in a transaction with the record update. `countries` is stripped from the column update (it's a relation, not a project column).
- Extracts the shared `getCountryEntityId` helper used by both create and edit.
- **admin-panel** `projects.js`: adds the Countries checkbox list to the project edit fields (mirrors the create field).

## Test plan
- `EditProject.test.js`: new "country reconciliation" cases — adding links for selected countries, removing deselected ones.
- Central-server `babel`-parses clean; tests run on CI.

> ⚠️ Local `tupaia_test` is currently unavailable, so the backend tests run on **CI**. The **frontend field needs manual verification** once deployed: confirm the edit modal pre-checks the project's current countries and that saving adds/removes them. The field config mirrors the working Add project modal, but the checkbox pre-fill (`recordData.countries`) couldn't be exercised without running the admin panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)