### PR TITLE
feat(entityHierarchy): TUP-3184: phase out project entities (type=project)

### DIFF
--- a/packages/central-server/src/apiV2/dashboardRelations/assertDashboardRelationsPermissions.js
+++ b/packages/central-server/src/apiV2/dashboardRelations/assertDashboardRelationsPermissions.js
@@ -2,6 +2,7 @@ import {
   hasAccessToEntityForVisualisation,
   hasVizBuilderAccessToEntity,
   hasVizBuilderAccessToEntityCode,
+  resolveEntityOrProjectRoot,
 } from '../utilities';
 
 export const hasDashboardRelationGetPermissions = async (
@@ -10,7 +11,8 @@ export const hasDashboardRelationGetPermissions = async (
   permissionGroups,
   entityCode,
 ) => {
-  const entity = await models.entity.findOneByCodeInProject(entityCode, null);
+  const entity = await resolveEntityOrProjectRoot(models, entityCode);
+  if (!entity) return false;
   const permissionGroupAccessResults = await Promise.all(
     permissionGroups.map(async pg =>
       hasAccessToEntityForVisualisation(accessPolicy, models, entity, pg),
@@ -25,7 +27,8 @@ export const hasDashboardRelationEditPermissions = async (
   permissionGroups,
   entityCode,
 ) => {
-  const entity = await models.entity.findOneByCodeInProject(entityCode, null);
+  const entity = await resolveEntityOrProjectRoot(models, entityCode);
+  if (!entity) return false;
 
   // users should all the permission group access (that's why using every() below)
   const permissionGroupAccessResults = await Promise.all(
@@ -110,9 +113,9 @@ export const assertDashboardRelationCreatePermissions = async (
     throw new Error(`Cannot find dashboard with id ${dashboardId}`);
   }
 
-  const entity = await models.entity.findOneByCodeInProject(dashboard.root_entity_code, null);
+  const entity = await resolveEntityOrProjectRoot(models, dashboard.root_entity_code);
 
-  if (!(await hasVizBuilderAccessToEntity(accessPolicy, models, entity))) {
+  if (!entity || !(await hasVizBuilderAccessToEntity(accessPolicy, models, entity))) {
     throw new Error(
       `Requires Viz Builder access to the dashboard root entity code '${dashboard.root_entity_code}'`,
     );

--- a/packages/central-server/src/apiV2/dashboards/assertDashboardsPermissions.js
+++ b/packages/central-server/src/apiV2/dashboards/assertDashboardsPermissions.js
@@ -2,7 +2,11 @@ import {
   hasDashboardRelationGetPermissions,
   hasDashboardRelationEditPermissions,
 } from '../dashboardRelations';
-import { hasVizBuilderAccessToEntity, hasVizBuilderAccessToEntityCode } from '../utilities';
+import {
+  hasVizBuilderAccessToEntity,
+  hasVizBuilderAccessToEntityCode,
+  resolveEntityOrProjectRoot,
+} from '../utilities';
 
 export const assertDashboardGetPermissions = async (accessPolicy, models, dashboardId) => {
   const dashboard = await models.dashboard.findById(dashboardId);
@@ -31,9 +35,9 @@ export const assertDashboardCreatePermissions = async (
   models,
   { root_entity_code: rootEntityCode },
 ) => {
-  const entity = await models.entity.findOneByCodeInProject(rootEntityCode, null);
+  const entity = await resolveEntityOrProjectRoot(models, rootEntityCode);
 
-  if (!(await hasVizBuilderAccessToEntity(accessPolicy, models, entity))) {
+  if (!entity || !(await hasVizBuilderAccessToEntity(accessPolicy, models, entity))) {
     throw new Error(`Requires Viz Builder access to the entity code: '${rootEntityCode}'`);
   }
 

--- a/packages/central-server/src/apiV2/projects/CreateProject.js
+++ b/packages/central-server/src/apiV2/projects/CreateProject.js
@@ -1,4 +1,3 @@
-import { EntityTypeEnum } from '@tupaia/types';
 import { snake } from 'case';
 import { BESAdminCreateHandler } from '../CreateHandler';
 import { uploadImage } from '../utilities';
@@ -26,12 +25,6 @@ export class CreateProject extends BESAdminCreateHandler {
 
     const projectCode = snake(rawProjectCode);
     await this.models.wrapInTransaction(async transactingModels => {
-      const { id: projectEntityId } = await this.createProjectEntity(
-        transactingModels,
-        projectCode,
-        name,
-      );
-
       const { name: projectDashboardGroupName } = await this.createProjectDashboard(
         transactingModels,
         dashboardGroupName,
@@ -46,6 +39,7 @@ export class CreateProject extends BESAdminCreateHandler {
       // Add the project, and then upload the images afterward, so that if an error is caught when creating the record, the images aren't uploaded unnecessarily
       const newProject = await transactingModels.project.create({
         code: projectCode,
+        name,
         description,
         sort_order: sortOrder === '' ? null : sortOrder,
         image_url: '',
@@ -53,7 +47,6 @@ export class CreateProject extends BESAdminCreateHandler {
         permission_groups: [projectPermissionGroup.name, ...permissionGroups],
         default_measure: defaultMeasure,
         dashboard_group_name: projectDashboardGroupName,
-        entity_id: projectEntityId,
       });
 
       await this.createProjectCountries(transactingModels, newProject.id, countries);
@@ -79,18 +72,6 @@ export class CreateProject extends BESAdminCreateHandler {
     };
     // The record has already been updated, so update the existing record with the new fields
     return models.project.updateById(projectId, updates);
-  }
-
-  async createProjectEntity(models, projectCode, name) {
-    const worldCode = 'World';
-    const { id: worldId } = await models.entity.findOneByCodeInProject(worldCode, null);
-
-    return models.entity.create({
-      name,
-      code: projectCode,
-      parent_id: worldId,
-      type: EntityTypeEnum.project,
-    });
   }
 
   async createProjectCountries(models, projectId, countries) {

--- a/packages/central-server/src/apiV2/projects/GETProjects.js
+++ b/packages/central-server/src/apiV2/projects/GETProjects.js
@@ -10,13 +10,13 @@ export const assertProjectPermissions = async (accessPolicy, models, projectId) 
   if (!project) {
     throw new Error(`No project exists with id ${projectId}`);
   }
-  const entity = await models.entity.findById(project.entity_id);
+  const rootEntity = await project.getRootEntity();
   for (let i = 0; i < project.permission_groups.length; ++i) {
     if (
       await hasAccessToEntityForVisualisation(
         accessPolicy,
         models,
-        entity,
+        rootEntity,
         project.permission_groups[i],
       )
     ) {
@@ -28,13 +28,6 @@ export const assertProjectPermissions = async (accessPolicy, models, projectId) 
 
 export class GETProjects extends GETHandler {
   permissionsFilteredInternally = /** @type {const} */ (true);
-
-  customJoinConditions = {
-    entity: {
-      nearTableKey: 'project.entity_id',
-      farTableKey: 'entity.id',
-    },
-  };
 
   // `countries` and `countryCodes` are virtual columns attached post-query by
   // attachCountries, not real project columns — strip them from the SQL select

--- a/packages/central-server/src/apiV2/utilities/hasAccessToEntityForVisualisation.js
+++ b/packages/central-server/src/apiV2/utilities/hasAccessToEntityForVisualisation.js
@@ -7,6 +7,16 @@ const getProjectCountryCodes = async (models, projectEntityCode) => {
   return countries.map(country => country.code);
 };
 
+// A project code no longer resolves to a stored entity. Fall back to the project's
+// synthesized root so visualisation/dashboard permission checks keyed on a code
+// (e.g. a dashboard's root_entity_code) keep working for project-level roots.
+export const resolveEntityOrProjectRoot = async (models, code) => {
+  const entity = await models.entity.findOneByCodeInProject(code, null);
+  if (entity) return entity;
+  const project = await models.project.findOne({ code });
+  return project ? project.getRootEntity() : undefined;
+};
+
 export const hasAccessToEntityForVisualisation = async (
   accessPolicy,
   models,
@@ -35,6 +45,7 @@ export const hasVizBuilderAccessToEntity = async (accessPolicy, models, entity) 
 };
 
 export const hasVizBuilderAccessToEntityCode = async (accessPolicy, models, entityCode) => {
-  const entity = await models.entity.findOneByCodeInProject(entityCode, null);
+  const entity = await resolveEntityOrProjectRoot(models, entityCode);
+  if (!entity) return false;
   return hasVizBuilderAccessToEntity(accessPolicy, models, entity);
 };

--- a/packages/central-server/src/apiV2/utilities/index.js
+++ b/packages/central-server/src/apiV2/utilities/index.js
@@ -11,6 +11,7 @@ export {
   hasAccessToEntityForVisualisation,
   hasVizBuilderAccessToEntity,
   hasVizBuilderAccessToEntityCode,
+  resolveEntityOrProjectRoot,
 } from './hasAccessToEntityForVisualisation';
 export { hasTupaiaAdminAccessToEntityForVisualisation } from './hasTupaiaAdminAccessToEntityForVisualisation';
 export { mergeFilter } from './mergeFilter';

--- a/packages/central-server/src/tests/apiV2/projects/CreateProject.test.js
+++ b/packages/central-server/src/tests/apiV2/projects/CreateProject.test.js
@@ -13,10 +13,6 @@ const rollbackRecords = async (models, projectCode, projectName) => {
   }
   await models.project.delete({ code: projectCode });
   await models.dashboard.delete({ root_entity_code: projectCode });
-  const projectEntity = await models.entity.findOne({ code: projectCode, type: 'project' });
-  if (projectEntity !== null) {
-    await models.entity.delete({ id: projectEntity.id });
-  }
   if (permissionGroup) {
     await models.permissionGroup.delete({ name: `${projectName} Admin` });
     await models.userEntityPermission.delete({ permission_group_id: permissionGroup.id });
@@ -160,7 +156,7 @@ describe('Creating a project', async () => {
         expect(result[0].description).to.equal(TEST_PROJECT_INPUT.description);
       });
 
-      it('creates a valid entity record', async () => {
+      it('stores the name on the project record and creates no project entity', async () => {
         await app.grantAccess(BES_ADMIN_POLICY);
 
         await app.post('projects', {
@@ -169,9 +165,14 @@ describe('Creating a project', async () => {
           },
         });
 
-        const result = await models.entity.find({ name: TEST_PROJECT_INPUT.name, type: 'project' });
-        expect(result.length).to.equal(1);
-        expect(result[0].code).to.equal(TEST_PROJECT_INPUT.code);
+        const project = await models.project.findOne({ code: TEST_PROJECT_INPUT.code });
+        expect(project.name).to.equal(TEST_PROJECT_INPUT.name);
+
+        const projectEntity = await models.entity.findOne({
+          code: TEST_PROJECT_INPUT.code,
+          type: 'project',
+        });
+        expect(projectEntity).to.be.null;
       });
 
       it('creates a new admin permission group for the project', async () => {

--- a/packages/central-server/src/tests/apiV2/projects/GETProjects.test.js
+++ b/packages/central-server/src/tests/apiV2/projects/GETProjects.test.js
@@ -14,26 +14,18 @@ const removeTestData = async (models, projectCode) => {
     await models.projectCountry.delete({ project_id: project.id });
   }
   await models.project.delete({ code: projectCode });
-  const projectEntity = await models.entity.findOne({ code: projectCode, type: 'project' });
-  if (projectEntity !== null) {
-    await models.entity.delete({ id: projectEntity.id });
-  }
 };
 
 // generate the test data for the provided project code
 const createTestData = async (models, projectCode, permissionGroup, countryEntityId) => {
-  const { id: projectEntityId } = await findOrCreateDummyRecord(models.entity, {
-    code: projectCode,
-    type: 'project',
-  });
   const project = await findOrCreateDummyRecord(
     models.project,
     {
       id: generateId(),
       code: projectCode,
-      entity_id: projectEntityId,
     },
     {
+      name: projectCode,
       permission_groups: [permissionGroup],
     },
   );

--- a/packages/central-server/src/tests/apiV2/surveys/CreateAndEditSurveys.test.js
+++ b/packages/central-server/src/tests/apiV2/surveys/CreateAndEditSurveys.test.js
@@ -90,13 +90,8 @@ describe('Create and Edit Surveys', () => {
       name: 'Tonga',
     }));
 
-    const projectEntity = await findOrCreateDummyRecord(models.entity, {
-      code: 'project1',
-    });
-
     project1 = await findOrCreateDummyRecord(models.project, {
       code: 'project1',
-      entity_id: projectEntity.id,
     });
 
     project2 = await findOrCreateDummyRecord(models.project, {

--- a/packages/database/src/core/migrations/20260612000001-addProjectName-modifies-schema.js
+++ b/packages/database/src/core/migrations/20260612000001-addProjectName-modifies-schema.js
@@ -1,0 +1,41 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * First step of phasing out `type = 'project'` entities. The project's display
+ * name lived on its entity; move it onto the project table so a project is
+ * represented purely by the project record + its project_country links.
+ *
+ * Also drops the `ancestor_descendant_relation.ancestor_id` → entity foreign key:
+ * the closure cache now stores the project id (not a project entity id) as the
+ * ancestor of a project's countries, which is not an entity. The FK was also
+ * ON DELETE CASCADE, so it has to go before the project entities are removed.
+ */
+
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = async function (db) {
+  await db.runSql(`ALTER TABLE project ADD COLUMN IF NOT EXISTS name TEXT;`);
+  await db.runSql(`
+    ALTER TABLE ancestor_descendant_relation
+      DROP CONSTRAINT IF EXISTS ancestor_descendant_relation_ancestor_id_entity_id_fk;
+  `);
+};
+
+exports.down = async function (db) {
+  await db.runSql(`ALTER TABLE project DROP COLUMN IF EXISTS name;`);
+  // The ancestor_id FK is not re-added: once the project root is keyed by project
+  // id the column is intentionally polymorphic, so the constraint can't hold.
+};
+
+exports._meta = {
+  version: 1,
+  targets: ['server'],
+};

--- a/packages/database/src/core/migrations/20260612000002-phaseOutProjectEntities-modifies-data.js
+++ b/packages/database/src/core/migrations/20260612000002-phaseOutProjectEntities-modifies-data.js
@@ -1,0 +1,67 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * Removes the `type = 'project'` entities. Post-epic a project's countries come
+ * from `project_country` and its hierarchy root is the project record itself, so
+ * the project entity is a redundant hierarchy-era anomaly.
+ *
+ * Steps:
+ *   1. Backfill project.name from the project entity (fall back to code).
+ *   2. Re-point the closure cache: rows whose ancestor was the project entity now
+ *      point at the project id (matching the new project_country hierarchy edge).
+ *   3. Detach children (countries) that still point at a project entity via
+ *      parent_id — countries reach their project via project_country, not parent_id.
+ *   4. Delete the project entities.
+ */
+
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+const log = msg => {
+  // eslint-disable-next-line no-console
+  console.log(`[Phase out project entities] ${msg}`);
+};
+
+exports.up = async function (db) {
+  await db.runSql(`
+    UPDATE project p
+      SET name = e.name
+      FROM entity e
+      WHERE e.id = p.entity_id AND p.name IS NULL;
+  `);
+  await db.runSql(`UPDATE project SET name = code WHERE name IS NULL;`);
+
+  const rePointed = await db.runSql(`
+    UPDATE ancestor_descendant_relation adr
+      SET ancestor_id = p.id
+      FROM project p
+      WHERE adr.ancestor_id = p.entity_id;
+  `);
+  log(`Re-pointed ${rePointed.rowCount ?? '?'} closure rows onto the project id`);
+
+  const detached = await db.runSql(`
+    UPDATE entity
+      SET parent_id = NULL
+      WHERE parent_id IN (SELECT id FROM entity WHERE type = 'project');
+  `);
+  log(`Detached ${detached.rowCount ?? '?'} children from project entities`);
+
+  const dropped = await db.runSql(`DELETE FROM entity WHERE type = 'project';`);
+  log(`Deleted ${dropped.rowCount ?? '?'} project entities`);
+};
+
+exports.down = async function () {
+  log('down() is a no-op — deleted project entities are not resurrected');
+};
+
+exports._meta = {
+  version: 1,
+  targets: ['server'],
+};

--- a/packages/database/src/core/migrations/20260612000003-dropProjectEntityId-modifies-schema.js
+++ b/packages/database/src/core/migrations/20260612000003-dropProjectEntityId-modifies-schema.js
@@ -1,0 +1,32 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * Final step of phasing out project entities: `project.name` is now populated, so
+ * make it NOT NULL, and drop the now-dangling `project.entity_id` column (its FK
+ * is dropped with the column).
+ */
+
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = async function (db) {
+  await db.runSql(`ALTER TABLE project ALTER COLUMN name SET NOT NULL;`);
+  await db.runSql(`ALTER TABLE project DROP COLUMN IF EXISTS entity_id;`);
+};
+
+exports.down = async function (db) {
+  await db.runSql(`ALTER TABLE project ADD COLUMN IF NOT EXISTS entity_id TEXT REFERENCES entity(id);`);
+  await db.runSql(`ALTER TABLE project ALTER COLUMN name DROP NOT NULL;`);
+};
+
+exports._meta = {
+  version: 1,
+  targets: ['server'],
+};

--- a/packages/database/src/core/modelClasses/Entity.js
+++ b/packages/database/src/core/modelClasses/Entity.js
@@ -954,9 +954,9 @@ export class EntityModel extends MaterializedViewLogDatabaseModel {
 
   async buildSyncLookupQueryDetails() {
     //Sub-country entities carry a direct project_id; structural entities
-    // (world/country/project) are synced unconditionally because every project
-    // needs them for hierarchy walks. Country-level rows reach their owning projects
-    // via project_country.
+    // (world/country) are synced unconditionally because every project needs them
+    // for hierarchy walks. Country-level rows reach their owning projects via
+    // project_country.
     //
     // TODO (MAUI-5722): Remove survey response / task entity unions once mobile no
     // longer pulls those entities through entity sync.
@@ -964,11 +964,6 @@ export class EntityModel extends MaterializedViewLogDatabaseModel {
       ctes: [
         `
           entities_to_sync AS (
-            -- root project entities → owning project
-            SELECT entity.id AS entity_id, project.id AS project_id
-            FROM entity JOIN project ON entity.id = project.entity_id
-            UNION
-
             -- country entities → projects that include them via project_country
             SELECT pc.country_id AS entity_id, pc.project_id
             FROM project_country pc

--- a/packages/database/src/core/modelClasses/Project.js
+++ b/packages/database/src/core/modelClasses/Project.js
@@ -15,6 +15,7 @@ import { DatabaseModel } from '../DatabaseModel';
 import { DatabaseRecord } from '../DatabaseRecord';
 import { SqlQuery } from '../SqlQuery';
 import { RECORDS } from '../records';
+import { buildProjectRootEntityFields } from './projectRootEntity';
 
 const TUPAIA_ADMIN_PANEL_PERMISSION_GROUP = 'Tupaia Admin Panel';
 const BES_ADMIN_PERMISSION_GROUP = 'BES Admin';
@@ -44,8 +45,15 @@ export class ProjectRecord extends DatabaseRecord {
     return this.otherModels.permissionGroup.find({ name: this.permission_groups });
   }
 
-  async entity() {
-    return this.otherModels.entity.findById(this.entity_id);
+  /**
+   * The project's hierarchy root. There is no longer a stored `type = 'project'`
+   * entity, so this is synthesized from the project record. Its id is the project
+   * id, matching the ancestor the hierarchy edges/closure use for the project's
+   * countries.
+   * @returns {Promise<EntityRecord>}
+   */
+  async getRootEntity() {
+    return this.otherModels.entity.generateInstance(buildProjectRootEntityFields(this));
   }
 
   async hasAccess(accessPolicy) {
@@ -112,12 +120,11 @@ export class ProjectModel extends DatabaseModel {
           p.id,
           p.code,
           to_json(sub.country_id) AS entity_ids,
-          e."name",
-          e."code" AS entity_code,
+          p."name",
+          p."code" AS entity_code,
           p.description,
           p.sort_order,
           p.permission_groups,
-          p.entity_id,
           p.image_url,
           p.logo_url,
           p.dashboard_group_name,
@@ -125,7 +132,6 @@ export class ProjectModel extends DatabaseModel {
           p.config
         FROM
           project p
-          LEFT JOIN entity e ON p.entity_id = e.id
           LEFT JOIN (
             -- TUP-3065: project's entities are now its countries (via project_country),
             -- not all hierarchy descendants. Sub-country entities live under
@@ -180,10 +186,6 @@ export class ProjectModel extends DatabaseModel {
           )`,
           parameters: [JSON.stringify(countryCodesByPermissionGroup)],
         },
-      },
-      {
-        joinWith: RECORDS.ENTITY,
-        joinCondition: ['entity.id', 'project.entity_id'],
       },
     );
   }

--- a/packages/database/src/core/modelClasses/projectHierarchyEdges.js
+++ b/packages/database/src/core/modelClasses/projectHierarchyEdges.js
@@ -9,9 +9,8 @@ export const PROJECT_HIERARCHY_EDGES_SUBQUERY = `
     AND e.type NOT IN ('project', 'country')
     AND (e.project_id IS NULL OR e.project_id = ?)
   UNION ALL
-  SELECT p.entity_id AS ancestor_id, pc.country_id AS descendant_id
+  SELECT pc.project_id AS ancestor_id, pc.country_id AS descendant_id
   FROM project_country pc
-  INNER JOIN project p ON p.id = pc.project_id
   WHERE pc.project_id = ?
 `;
 

--- a/packages/database/src/core/modelClasses/projectRootEntity.js
+++ b/packages/database/src/core/modelClasses/projectRootEntity.js
@@ -1,0 +1,23 @@
+/**
+ * @typedef {import('@tupaia/types').Project} Project
+ */
+
+import { EntityTypeEnum } from '@tupaia/types';
+
+/**
+ * A project's root node is no longer a stored `type = 'project'` entity. It is
+ * synthesized from the project record: its `id` IS the project id, which the
+ * hierarchy edges (`project_country`) and the closure cache use as the ancestor
+ * of the project's countries.
+ *
+ * @param {Pick<Project, 'id' | 'code' | 'name' | 'image_url'>} project
+ */
+export const buildProjectRootEntityFields = project => ({
+  id: project.id,
+  code: project.code,
+  name: project.name,
+  type: EntityTypeEnum.project,
+  parent_id: null,
+  country_code: null,
+  image_url: project.image_url ?? null,
+});

--- a/packages/database/src/server/changeHandlers/entityHierarchyCacher/EntityHierarchyCacher.js
+++ b/packages/database/src/server/changeHandlers/entityHierarchyCacher/EntityHierarchyCacher.js
@@ -57,9 +57,8 @@ export class EntityHierarchyCacher extends ChangeHandler {
       return [...new Set(subCountryProjectIds)];
     }
 
-    // Structural entities (project, country, world) have project_id NULL. Derive
-    // owning project(s) by walking outward: a project entity's project record, or a
-    // country's project_country rows.
+    // Structural entities (country, world) have project_id NULL. Derive owning
+    // project(s) by walking outward from a country via its project_country rows.
     const candidateEntityIds = [
       oldRecord?.id,
       newRecord?.id,
@@ -71,9 +70,6 @@ export class EntityHierarchyCacher extends ChangeHandler {
     }
 
     const projectIds = new Set();
-    const projectsByEntity = await this.models.project.find({ entity_id: candidateEntityIds });
-    projectsByEntity.forEach(p => projectIds.add(p.id));
-
     const projectCountryRows = await this.models.projectCountry.find({
       country_id: candidateEntityIds,
     });

--- a/packages/database/src/server/testUtilities/buildAndInsertProjectsAndHierarchies.js
+++ b/packages/database/src/server/testUtilities/buildAndInsertProjectsAndHierarchies.js
@@ -10,29 +10,20 @@ const inferType = (entityProps, isDirectChildOfProject) => {
 const STRUCTURAL_TYPES = new Set(['world', 'project', 'country']);
 
 export const buildAndInsertProjectsAndHierarchies = async (models, projects) => {
-  // Pass 1 — projects + project entities + entity hierarchies. These are 1:1 with the
-  // input list and don't depend on each other.
+  // Pass 1 — projects + entity hierarchies. These are 1:1 with the input list and
+  // don't depend on each other. There is no longer a `type = 'project'` entity; a
+  // project's root is the project record itself (its countries come from project_country).
   const createdProjects = projects.map(() => ({}));
   for (let i = 0; i < projects.length; i++) {
     const { code, ...projectProps } = projects[i];
 
-    const projectEntity = await findOrCreateDummyRecord(
-      models.entity,
-      { code },
-      {
-        type: 'project',
-        name: projectProps.projectEntityName,
-        attributes: projectProps.projectEntityAttributes || {},
-      },
-    );
-
     const project = await findOrCreateDummyRecord(
       models.project,
       { code },
-      { entity_id: projectEntity.id, ...projectProps },
+      { name: projectProps.projectEntityName ?? code, ...projectProps },
     );
 
-    createdProjects[i] = { project, projectEntity };
+    createdProjects[i] = { project };
   }
 
   // Pass 2 — entities. Tabulate which projects use each entity code so we can decide
@@ -110,9 +101,12 @@ export const buildAndInsertProjectsAndHierarchies = async (models, projects) => 
   // through this project's entityByCode map so duplicates land in the right project.
   for (let i = 0; i < projects.length; i++) {
     const { entities: entitiesProps = [], relations: relationProps } = projects[i];
-    const { project, projectEntity } = createdProjects[i];
+    const { project } = createdProjects[i];
     const byCode = entityByProjectAndCode[i];
-    byCode[projectEntity.code] = projectEntity;
+    // The project root is the project record, keyed by its code so relations that
+    // name the project as a parent resolve to a project_country link below.
+    const projectRoot = { id: project.id, code: project.code, type: 'project' };
+    byCode[project.code] = projectRoot;
 
     const projectScopedEntities = entitiesProps
       .map(({ code }) => byCode[code])
@@ -120,7 +114,7 @@ export const buildAndInsertProjectsAndHierarchies = async (models, projects) => 
 
     const relations =
       relationProps ||
-      projectScopedEntities.map(entity => ({ parent: projectEntity.code, child: entity.code }));
+      projectScopedEntities.map(entity => ({ parent: project.code, child: entity.code }));
 
     for (const { parent, child } of relations) {
       const parentEntity = byCode[parent];

--- a/packages/datatrak-web-server/src/routes/ProjectUsersRoute.ts
+++ b/packages/datatrak-web-server/src/routes/ProjectUsersRoute.ts
@@ -20,14 +20,10 @@ const getFilterUsersForProject = async (
     WITH
     country_list AS (
       SELECT DISTINCT country_entity.code::TEXT
-      FROM entity country_entity
-      JOIN entity_relation ON entity_relation.child_id = country_entity.id
-      WHERE entity_relation.parent_id IN (
-        SELECT e.id
-        FROM entity e
-        JOIN project p ON p.entity_id = e.id
-        WHERE p.code = ?
-      )
+      FROM project_country pc
+      JOIN project p ON p.id = pc.project_id
+      JOIN entity country_entity ON country_entity.id = pc.country_id
+      WHERE p.code = ?
     )
     SELECT u.id
     FROM user_account u

--- a/packages/datatrak-web/src/database/entity/getEntityDescendants.ts
+++ b/packages/datatrak-web/src/database/entity/getEntityDescendants.ts
@@ -78,7 +78,12 @@ const getAllowedCountries = async (
   isPublic: boolean,
   accessPolicy: AccessPolicy,
 ): Promise<Entity['code'][]> => {
-  const rootEntity = await models.entity.findByIdOrThrow(rootEntityId);
+  // The project root has no entity row (its id is the project id), so synthesize it
+  // from the project record; other roots resolve to a real entity.
+  const rootEntity =
+    rootEntityId === project.id
+      ? await project.getRootEntity()
+      : await models.entity.findByIdOrThrow(rootEntityId);
 
   const countryEntities = await rootEntity.getChildrenFromParentChildRelation(project.id);
   const childCodes = countryEntities.map(child => child.country_code).filter(isNotNullish);
@@ -150,7 +155,7 @@ export const getEntityDescendants = async ({
   const formattedEntities = await models.wrapInReadOnlyTransaction(async transactingModels => {
     const project = await transactingModels.project.findOneOrThrow({ code: projectCode });
 
-    const rootEntityId = parentId || grandparentId || project.entity_id;
+    const rootEntityId = parentId || grandparentId || project.id;
     if (!rootEntityId) throw new Error('No valid rootEntity found');
 
     const allowedCountries = await getAllowedCountries(

--- a/packages/datatrak-web/src/database/user/getUser.ts
+++ b/packages/datatrak-web/src/database/user/getUser.ts
@@ -23,10 +23,7 @@ export const getUser = async ({ models }: GetUserLocalContext) => {
       ? await transactingModels.database.findOne(
           RECORDS.PROJECT,
           { [`${RECORDS.PROJECT}.id`]: projectId },
-          {
-            joinWith: RECORDS.ENTITY,
-            joinCondition: ['entity.id', 'project.entity_id'],
-          },
+          {},
         )
       : null;
     const project = projectRecord ? camelcaseKeys(projectRecord, { deep: true }) : null;

--- a/packages/entity-server/src/routes/hierarchy/middleware/attachEntityContext.ts
+++ b/packages/entity-server/src/routes/hierarchy/middleware/attachEntityContext.ts
@@ -2,12 +2,27 @@ import { NextFunction, Request, Response } from 'express';
 
 import { EntityFilter, EntityRecord, extractEntityFilterFromQuery } from '@tupaia/tsmodels';
 import { ajvValidate, isNotNullish } from '@tupaia/tsutils';
-import { Entity, EntityTypeEnum } from '@tupaia/types';
+import { Entity } from '@tupaia/types';
 import { PermissionsError } from '@tupaia/utils';
+import { EntityServerModelRegistry } from '../../../types';
 import { MultiEntityRequestBody, MultiEntityRequestBodySchema } from '../types';
 
 const throwNoAccessError = (entityCodes: string[]) => {
   throw new PermissionsError(`No access to requested entities: ${entityCodes}`);
+};
+
+// A project's hierarchy root is no longer a stored `type = 'project'` entity — it is
+// synthesized from the project record. Its id is the project id, which the hierarchy
+// edges/closure use as the ancestor of the project's countries.
+const getProjectRootEntity = async (
+  models: EntityServerModelRegistry,
+  hierarchyName: string,
+): Promise<EntityRecord> => {
+  const project = await models.project.findOne({ code: hierarchyName });
+  if (!project) {
+    throw new PermissionsError(`Cannot find root entity for hierarchy: ${hierarchyName}`);
+  }
+  return project.getRootEntity();
 };
 
 const userCanAccessEntity = (
@@ -29,15 +44,7 @@ const validateEntitiesAndBuildContext = async (
 
   const { projectId } = req.ctx;
   const { hierarchyName } = req.params;
-  // Root type shouldn't be locked into being a project entity, see: https://github.com/beyondessential/tupaia-backlog/issues/2570
-  const rootEntity = await req.models.entity.findOneOrThrow(
-    {
-      type: EntityTypeEnum.project,
-      code: hierarchyName,
-    },
-    undefined,
-    `Cannot find root entity for hierarchy: ${req.params.hierarchyName}`,
-  );
+  const rootEntity = await getProjectRootEntity(req.models, hierarchyName);
 
   const entities = await rootEntity.getDescendants(projectId, {
     code: entityCodes,
@@ -155,10 +162,7 @@ export const attachEntityFilterContext = async (
   _res: Response,
   next: NextFunction,
 ) => {
-  const rootEntity = await req.models.entity.findOneOrThrow({
-    type: EntityTypeEnum.project,
-    code: req.params.hierarchyName,
-  });
+  const rootEntity = await getProjectRootEntity(req.models, req.params.hierarchyName);
 
   const context = await getFilterInfo(req, rootEntity);
 

--- a/packages/tsmodels/src/models/Project.ts
+++ b/packages/tsmodels/src/models/Project.ts
@@ -4,9 +4,12 @@ import {
   ProjectModel as BaseProjectModel,
   ProjectRecord as BaseProjectRecord,
 } from '@tupaia/database';
+import { EntityRecord } from './Entity';
 import { Model } from './types';
 
-export interface ProjectRecord extends Project, BaseProjectRecord {}
+export interface ProjectRecord extends Project, BaseProjectRecord {
+  getRootEntity: () => Promise<EntityRecord>;
+}
 
 export interface ProjectModel extends Model<BaseProjectModel, Project, ProjectRecord> {
   getAccessibleProjects: (accessPolicy: AccessPolicy) => Promise<ProjectRecord[]>;

--- a/packages/types/src/types/models.ts
+++ b/packages/types/src/types/models.ts
@@ -1231,10 +1231,10 @@ export interface Project {
   'dashboard_group_name'?: string | null;
   'default_measure'?: string | null;
   'description'?: string | null;
-  'entity_id'?: string | null;
   'id': string;
   'image_url'?: string | null;
   'logo_url'?: string | null;
+  'name': string;
   'permission_groups': string[];
   'sort_order'?: number | null;
   'updated_at_sync_tick': string;
@@ -1245,9 +1245,9 @@ export interface ProjectCreate {
   'dashboard_group_name'?: string | null;
   'default_measure'?: string | null;
   'description'?: string | null;
-  'entity_id'?: string | null;
   'image_url'?: string | null;
   'logo_url'?: string | null;
+  'name': string;
   'permission_groups'?: string[];
   'sort_order'?: number | null;
 }
@@ -1257,10 +1257,10 @@ export interface ProjectUpdate {
   'dashboard_group_name'?: string | null;
   'default_measure'?: string | null;
   'description'?: string | null;
-  'entity_id'?: string | null;
   'id'?: string;
   'image_url'?: string | null;
   'logo_url'?: string | null;
+  'name'?: string;
   'permission_groups'?: string[];
   'sort_order'?: number | null;
 }


### PR DESCRIPTION
## Summary

Phases out the redundant hierarchy-era `type = 'project'` entity. Post-epic a project's countries come from `project_country` and its hierarchy root is the project record itself, so the project entity (`project.entity_id` → `entity`) is an anomaly. This removes it end-to-end.

Linear: [TUP-3184](https://linear.app/bes/issue/TUP-3184/phase-out-project-entities-typeproject)

## Core mechanic

Both hierarchy traversal systems — the `ancestor_descendant_relation` closure cache and the recursive-CTE walk — build from one edge definition, `PROJECT_HIERARCHY_EDGES_SUBQUERY`. Its project→country edge is re-anchored from `p.entity_id` onto `pc.project_id`, making **`project.id` the hierarchy id of the project root**. A virtual root (`id=project.id, code, name, type='project'`) is synthesized from the project record wherever the project is explicitly requested, so the project landing page, dashboards keyed on `root_entity_code = projectCode`, and descendant/permission scoping keep working with no project entity row.

The project's **name** lived on the entity, so a `project.name` column is added and backfilled.

## Changes

**Schema/data migrations (run in order):**
1. `addProjectName` — add `project.name`; drop the cascading `ancestor_descendant_relation.ancestor_id → entity` FK.
2. `phaseOutProjectEntities` — backfill `project.name` from the entity; re-point closure rows from project-entity-id to `project.id`; detach children whose `parent_id` was the project entity; delete `type='project'` entities.
3. `dropProjectEntityId` — `project.name` NOT NULL; drop `project.entity_id`.

**Code:**
- `database`: edge re-anchor; `Project.getRootEntity()` (replaces `.entity()`); `getAllProjectDetails`/`getAccessibleProjects` source `name`/`entity_code` from the project; sync CTE + closure-cacher no longer reference `project.entity_id`; new `projectRootEntity.js`.
- `entity-server`: `attachEntityContext` synthesizes the root from the project.
- `central-server`: `CreateProject` writes `name` to the project and creates no project entity; `GETProjects` checks permissions via the synthesized root; dashboard/viz-builder permission paths gain `resolveEntityOrProjectRoot` (project-code → synthesized root fallback).
- `datatrak-web` / `datatrak-web-server`: root resolution via `project.id` + `project_country`.
- `types` regenerated (drop `entity_id`, add `name`).

## Design note

The project root is **not** injected into closure reads — a country's ancestors stay `[]`, matching the existing entity-server integration-test contract. It materializes only on explicit resolution (`getRootEntity`, `attachEntityContext`, `resolveEntityOrProjectRoot`, datatrak `getAllowedCountries`).

## Testing

- ✅ All changed server/lib packages compile (types, tsmodels, server-boilerplate, database, entity-server, central-server, datatrak-web + -server).
- Updated central-server project tests; entity-server integration fixtures verified consistent (the synthesized root matches `getHierarchyWithFields`; `getEntityWithFields('redblue')` etc.).
- ⚠️ **DB-backed suites not yet run** — they need the test DB with the new migrations applied. Please run:
  ```sh
  yarn workspace @tupaia/central-server setup-test && yarn workspace @tupaia/central-server test
  yarn workspace @tupaia/entity-server setup-test && yarn workspace @tupaia/entity-server test
  yarn workspace @tupaia/database setup-test && yarn workspace @tupaia/database test
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)