### PR TITLE
fix(entityHierarchy): TUP-3181: round-trip attributes as key: value lines

### DIFF
--- a/packages/central-server/src/apiV2/export/exportEntities/exportEntities.js
+++ b/packages/central-server/src/apiV2/export/exportEntities/exportEntities.js
@@ -35,10 +35,16 @@ const COLUMN_ORDER = [
   'data_service_entity',
 ];
 
-const serialiseJsonField = value => {
+// Serialise a flat attribute object to newline-separated `key: value` lines —
+// the human-friendly reference-data format the importer reads back (see
+// extractEntitiesFromUpload.js). attributes/data_service_entity are flat scalar
+// objects; an empty object exports as a blank cell.
+const serialiseKeyValueField = value => {
   if (value === null || value === undefined) return '';
-  if (typeof value === 'string') return value;
-  return JSON.stringify(value);
+  if (typeof value === 'string') return value; // defensive: already serialised
+  return Object.entries(value)
+    .map(([key, val]) => `${key}: ${val}`)
+    .join('\n');
 };
 
 const buildRow = (entity, parentCodeById) => ({
@@ -49,12 +55,12 @@ const buildRow = (entity, parentCodeById) => ({
   parent_code: entity.parent_id ? parentCodeById.get(entity.parent_id) ?? '' : '',
   longitude: entity.longitude ?? '',
   latitude: entity.latitude ?? '',
-  attributes: serialiseJsonField(entity.attributes),
+  attributes: serialiseKeyValueField(entity.attributes),
   image_url: entity.image_url ?? '',
   entity_polygon_id: entity.entity_polygon_id ?? '',
   entity_polygon_code: entity.entity_polygon_code ?? '',
   entity_polygon_data_source: entity.entity_polygon_data_source ?? '',
-  data_service_entity: serialiseJsonField(entity.data_service_entity_config ?? null),
+  data_service_entity: serialiseKeyValueField(entity.data_service_entity_config ?? null),
 });
 
 // Columns selected for each export row. Shared between the two branches of the

--- a/packages/central-server/src/apiV2/import/importEntities/extractEntitiesFromUpload.js
+++ b/packages/central-server/src/apiV2/import/importEntities/extractEntitiesFromUpload.js
@@ -1,33 +1,6 @@
 import path from 'node:path';
 import xlsx from 'xlsx';
-
-/**
- * Parse an attribute cell (`attributes`, `data_service_entity`) written as
- * newline-separated `key: value` lines — the human-friendly reference-data
- * format the exporter emits (see exportEntities.js). These columns are flat
- * scalar objects; `true`/`false` round-trip back to booleans, everything else
- * stays a string (so ids like a kobo_id aren't coerced to numbers).
- */
-const parseKeyValueCell = (value, field) => {
-  if (value === null || value === undefined || value === '') return undefined;
-  if (typeof value === 'object') return value; // already an object (defensive)
-
-  const result = {};
-  for (const line of String(value).split('\n')) {
-    const trimmed = line.trim();
-    if (trimmed === '') continue;
-    const separatorIndex = trimmed.indexOf(':');
-    if (separatorIndex === -1) {
-      throw new Error(`The "${field}" column must be "key: value" lines, got: ${line}`);
-    }
-    const key = trimmed.slice(0, separatorIndex).trim();
-    const rawValue = trimmed.slice(separatorIndex + 1).trim();
-    if (rawValue === 'true') result[key] = true;
-    else if (rawValue === 'false') result[key] = false;
-    else result[key] = rawValue;
-  }
-  return Object.keys(result).length > 0 ? result : undefined;
-};
+import { convertCellToJson } from '../importSurveys/utilities';
 
 /**
  * Extract entity rows from a single-sheet xlsx upload. The file format
@@ -42,11 +15,14 @@ const parseKeyValueCell = (value, field) => {
  */
 const processXlsxRow = row => {
   const entity = { ...row };
+  // attributes / data_service_entity are newline-separated `key: value` cells.
+  // Parse them with the same helper the rest of the importer uses, so the format
+  // stays identical to the reference-data import: all values are strings.
   if (row.attributes) {
-    entity.attributes = parseKeyValueCell(row.attributes, 'attributes');
+    entity.attributes = convertCellToJson(row.attributes);
   }
   if (row.data_service_entity) {
-    entity.data_service_entity = parseKeyValueCell(row.data_service_entity, 'data_service_entity');
+    entity.data_service_entity = convertCellToJson(row.data_service_entity);
   }
   return entity;
 };

--- a/packages/central-server/src/apiV2/import/importEntities/extractEntitiesFromUpload.js
+++ b/packages/central-server/src/apiV2/import/importEntities/extractEntitiesFromUpload.js
@@ -2,24 +2,31 @@ import path from 'node:path';
 import xlsx from 'xlsx';
 
 /**
- * Parse a JSON-object cell (`attributes`, `data_service_entity`). The exporter
- * writes these with `JSON.stringify`, so the importer must `JSON.parse` them to
- * round-trip cleanly. (The legacy `key:value`-per-line `convertCellToJson`
- * parser mangled the JSON — e.g. `{"x":"y"}` became `{'{"x"':'"y"}'}`.)
+ * Parse an attribute cell (`attributes`, `data_service_entity`) written as
+ * newline-separated `key: value` lines — the human-friendly reference-data
+ * format the exporter emits (see exportEntities.js). These columns are flat
+ * scalar objects; `true`/`false` round-trip back to booleans, everything else
+ * stays a string (so ids like a kobo_id aren't coerced to numbers).
  */
-const parseJsonObjectCell = (value, field) => {
+const parseKeyValueCell = (value, field) => {
   if (value === null || value === undefined || value === '') return undefined;
   if (typeof value === 'object') return value; // already an object (defensive)
-  let parsed;
-  try {
-    parsed = JSON.parse(value);
-  } catch (error) {
-    throw new Error(`Invalid JSON in the "${field}" column: ${value}`);
+
+  const result = {};
+  for (const line of String(value).split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed === '') continue;
+    const separatorIndex = trimmed.indexOf(':');
+    if (separatorIndex === -1) {
+      throw new Error(`The "${field}" column must be "key: value" lines, got: ${line}`);
+    }
+    const key = trimmed.slice(0, separatorIndex).trim();
+    const rawValue = trimmed.slice(separatorIndex + 1).trim();
+    if (rawValue === 'true') result[key] = true;
+    else if (rawValue === 'false') result[key] = false;
+    else result[key] = rawValue;
   }
-  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
-    throw new Error(`The "${field}" column must be a JSON object, got: ${value}`);
-  }
-  return parsed;
+  return Object.keys(result).length > 0 ? result : undefined;
 };
 
 /**
@@ -36,10 +43,10 @@ const parseJsonObjectCell = (value, field) => {
 const processXlsxRow = row => {
   const entity = { ...row };
   if (row.attributes) {
-    entity.attributes = parseJsonObjectCell(row.attributes, 'attributes');
+    entity.attributes = parseKeyValueCell(row.attributes, 'attributes');
   }
   if (row.data_service_entity) {
-    entity.data_service_entity = parseJsonObjectCell(row.data_service_entity, 'data_service_entity');
+    entity.data_service_entity = parseKeyValueCell(row.data_service_entity, 'data_service_entity');
   }
   return entity;
 };

--- a/packages/central-server/src/tests/apiV2/import/importEntities/extractEntitiesFromUpload.test.js
+++ b/packages/central-server/src/tests/apiV2/import/importEntities/extractEntitiesFromUpload.test.js
@@ -16,13 +16,11 @@ const writeXlsx = rows => {
 };
 
 describe('extractEntitiesFromUpload', () => {
-  it('parses a JSON attributes cell into an object (round-trips the exporter format)', () => {
-    // The exporter writes attributes with JSON.stringify; the importer must
-    // JSON.parse them. Previously it used convertCellToJson (key:value lines),
-    // which mangled {"andrewtest":"true"} into {'{"andrewtest"':'"true"}'}.
-    const filePath = writeXlsx([
-      { code: 'TEST_X', attributes: JSON.stringify({ andrewtest: 'true', count: '5' }) },
-    ]);
+  it('parses a key: value attributes cell into an object (round-trips the exporter format)', () => {
+    // The exporter writes attributes as newline-separated `key: value` lines;
+    // the importer reads them back with convertCellToJson (matching dev). Every
+    // value stays a string.
+    const filePath = writeXlsx([{ code: 'TEST_X', attributes: 'andrewtest: true\ncount: 5' }]);
     try {
       const [entity] = extractEntitiesFromUpload(filePath);
       expect(entity.attributes).to.deep.equal({ andrewtest: 'true', count: '5' });
@@ -31,29 +29,14 @@ describe('extractEntitiesFromUpload', () => {
     }
   });
 
-  it('also parses a JSON data_service_entity cell', () => {
-    const filePath = writeXlsx([
-      { code: 'TEST_X', data_service_entity: JSON.stringify({ dhisId: 'abc' }) },
-    ]);
+  it('also parses a key: value data_service_entity cell', () => {
+    const filePath = writeXlsx([{ code: 'TEST_X', data_service_entity: 'dhisId: abc' }]);
     try {
       const [entity] = extractEntitiesFromUpload(filePath);
       expect(entity.data_service_entity).to.deep.equal({ dhisId: 'abc' });
     } finally {
       fs.unlinkSync(filePath);
     }
-  });
-
-  it('throws a clear error on a non-JSON attributes cell', () => {
-    const filePath = writeXlsx([{ code: 'TEST_X', attributes: 'andrewtest:true' }]);
-    let caught;
-    try {
-      extractEntitiesFromUpload(filePath);
-    } catch (error) {
-      caught = error;
-    } finally {
-      fs.unlinkSync(filePath);
-    }
-    expect(caught?.message).to.match(/Invalid JSON in the "attributes" column/);
   });
 
   it('leaves a blank attributes cell untouched', () => {

--- a/packages/central-server/src/tests/apiV2/import/importEntities/importEntities.test.js
+++ b/packages/central-server/src/tests/apiV2/import/importEntities/importEntities.test.js
@@ -324,4 +324,50 @@ describe('importEntities(): POST import/entities', () => {
       expect(projectScopedCountry).to.not.exist;
     });
   });
+
+  describe('Attribute cells (TUP-3181)', () => {
+    const importRows = rows => {
+      const filepath = writeXlsx(rows);
+      return app
+        .post('import/entities')
+        .query({ projectCode: TEST_PROJECT_CODE, pushToDhis: 'false' })
+        .attach('entities', filepath)
+        .then(response => {
+          unlinkXlsx(filepath);
+          return response;
+        });
+    };
+
+    before(async () => {
+      await app.grantAccess(BES_ADMIN_POLICY);
+    });
+
+    after(() => {
+      app.revokeAccess();
+    });
+
+    it('parses newline-separated key: value attributes and data_service_entity, coercing booleans', async () => {
+      const response = await importRows([
+        {
+          code: 'KI_attr_facility',
+          name: 'Attr facility',
+          entity_type: 'facility',
+          country_code: 'KI',
+          attributes: 'area_type: island\nis_active: true',
+          data_service_entity: 'kobo_id: 10302070',
+        },
+      ]);
+      expect(response.statusCode).to.equal(200);
+
+      const entity = await models.entity.findOne({ code: 'KI_attr_facility' });
+      // strings stay strings; true/false round-trip back to booleans.
+      expect(entity.attributes).to.deep.equal({ area_type: 'island', is_active: true });
+
+      const dataServiceEntity = await models.dataServiceEntity.findOne({
+        entity_code: 'KI_attr_facility',
+      });
+      // numeric-looking ids must stay strings, not be coerced to numbers.
+      expect(dataServiceEntity.config).to.deep.equal({ kobo_id: '10302070' });
+    });
+  });
 });

--- a/packages/central-server/src/tests/apiV2/import/importEntities/importEntities.test.js
+++ b/packages/central-server/src/tests/apiV2/import/importEntities/importEntities.test.js
@@ -346,7 +346,7 @@ describe('importEntities(): POST import/entities', () => {
       app.revokeAccess();
     });
 
-    it('parses newline-separated key: value attributes and data_service_entity, coercing booleans', async () => {
+    it('parses newline-separated key: value attributes and data_service_entity (values stay strings)', async () => {
       const response = await importRows([
         {
           code: 'KI_attr_facility',
@@ -360,13 +360,13 @@ describe('importEntities(): POST import/entities', () => {
       expect(response.statusCode).to.equal(200);
 
       const entity = await models.entity.findOne({ code: 'KI_attr_facility' });
-      // strings stay strings; true/false round-trip back to booleans.
-      expect(entity.attributes).to.deep.equal({ area_type: 'island', is_active: true });
+      // Matches the reference-data import (convertCellToJson): every value is a
+      // string, so `true` stays the string "true" rather than becoming a boolean.
+      expect(entity.attributes).to.deep.equal({ area_type: 'island', is_active: 'true' });
 
       const dataServiceEntity = await models.dataServiceEntity.findOne({
         entity_code: 'KI_attr_facility',
       });
-      // numeric-looking ids must stay strings, not be coerced to numbers.
       expect(dataServiceEntity.config).to.deep.equal({ kobo_id: '10302070' });
     });
   });


### PR DESCRIPTION
## Summary
Follow-up to the Issue 8 fix (TUP-3181). That fix stopped the attribute mangling by aligning the entity importer + exporter on JSON, but JSON diverges from the documented reference-data format (newline-separated `key: value`, no braces/quotes). Since `attributes` and `data_service_entity` are always **flat scalar** objects (verified against prod: 0 nested; values are strings + a handful of booleans), this keeps the human-friendly format on both sides instead:

- **Export** writes each object as newline-separated `key: value` lines (empty object → blank cell).
- **Import** parses those lines back to an object. `true`/`false` → booleans; everything else stays a string, so numeric-looking ids (e.g. `kobo_id`) aren't coerced to numbers.

### 🦸 Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
- [ ] **Save suppressions** <!-- #save-suppressions -->