### PR TITLE
feat(entityHierarchy): TUP-3181: speed up entity import (skip unchanged + email after timeout)

### DIFF
--- a/packages/admin-panel/src/routes/entities/entities.js
+++ b/packages/admin-panel/src/routes/entities/entities.js
@@ -97,9 +97,11 @@ const IMPORT_CONFIG = {
   actionConfig: {
     importEndpoint: ENTITIES_ENDPOINT,
     extraQueryParameters: {
-      // If a large import doesn't finish in 10s, respond and email the result
-      // rather than holding the request open until it times out.
-      respondWithEmailTimeout: 10 * 1000,
+      // If a large import doesn't finish in 30s, respond and email the result
+      // rather than holding the request open until it times out. 30s gives a
+      // big project's skip-unchanged pass (parse + snapshot) room to finish
+      // synchronously.
+      respondWithEmailTimeout: 30 * 1000,
     },
     accept: {
       'application/geo+json': ['.geojson'],

--- a/packages/admin-panel/src/routes/entities/entities.js
+++ b/packages/admin-panel/src/routes/entities/entities.js
@@ -96,6 +96,11 @@ const IMPORT_CONFIG = {
     'Please note that if this is the first time a country is being imported, you will need to restart central-server post-import for it to sync to DHIS2.', // hope to fix one day in https://github.com/beyondessential/central-server/issues/481
   actionConfig: {
     importEndpoint: ENTITIES_ENDPOINT,
+    extraQueryParameters: {
+      // If a large import doesn't finish in 10s, respond and email the result
+      // rather than holding the request open until it times out.
+      respondWithEmailTimeout: 10 * 1000,
+    },
     accept: {
       'application/geo+json': ['.geojson'],
       'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': ['.xlsx'],

--- a/packages/central-server/src/apiV2/import/importEntities/constructImportEmail.js
+++ b/packages/central-server/src/apiV2/import/importEntities/constructImportEmail.js
@@ -1,0 +1,17 @@
+/**
+ * Builds the email sent when an entity import runs past the emailAfterTimeout
+ * window (large imports). Mirrors the survey-response import email.
+ */
+export const constructEntityImportEmail = responseBody => {
+  const { error } = responseBody;
+  const templateContext = error
+    ? {
+        title: 'Import Failed',
+        message: `Unfortunately, your entity import failed.\n\n${error}`,
+      }
+    : {
+        title: 'Import Successful',
+        message: 'Your entities have been successfully imported.',
+      };
+  return { subject: 'Tupaia Entity Import', templateContext };
+};

--- a/packages/central-server/src/apiV2/import/importEntities/importEntities.js
+++ b/packages/central-server/src/apiV2/import/importEntities/importEntities.js
@@ -30,7 +30,8 @@ export const loadProjectCountryCodes = async (models, projectId) => {
 // skip rows that wouldn't change anything (see isEntityUnchanged). This makes
 // re-importing a whole exported sheet with only a few edits fast — the unchanged
 // rows cost no per-row queries. Read once, before the write transaction.
-export const loadExistingEntities = async (models, projectId) => {
+export const loadExistingEntities = async (models, projectId, countryCodes) => {
+  if (countryCodes.length === 0) return new Map();
   const rows = await models.database.executeSql(
     `
       SELECT e.code, e.name, e.type, e.country_code, e.image_url, e.attributes,
@@ -42,9 +43,12 @@ export const loadExistingEntities = async (models, projectId) => {
       FROM entity e
       LEFT JOIN entity parent ON parent.id = e.parent_id
       LEFT JOIN data_service_entity dse ON dse.entity_code = e.code
-      WHERE e.project_id = ?;
+      WHERE e.project_id = ?
+        -- Only the countries actually being imported, so a small single-country
+        -- import doesn't load the whole (potentially huge) project into memory.
+        AND e.country_code = ANY(?);
     `,
-    [projectId],
+    [projectId, countryCodes],
   );
   return new Map(rows.map(row => [row.code, row]));
 };
@@ -119,7 +123,11 @@ export async function importEntities(req, res) {
       assertAnyPermissions([assertBESAdminAccess, importEntitiesPermissionsChecker]),
     );
 
-    const existingEntitiesByCode = await loadExistingEntities(models, project.id);
+    const existingEntitiesByCode = await loadExistingEntities(
+      models,
+      project.id,
+      Object.keys(rowsByCountryCode),
+    );
 
     await models.wrapInTransaction(async transactingModels => {
       for (const [countryCode, countryRows] of Object.entries(rowsByCountryCode)) {

--- a/packages/central-server/src/apiV2/import/importEntities/importEntities.js
+++ b/packages/central-server/src/apiV2/import/importEntities/importEntities.js
@@ -26,6 +26,29 @@ export const loadProjectCountryCodes = async (models, projectId) => {
   return new Set(rows.map(r => r.code));
 };
 
+// Snapshot the project's existing entities (keyed by code) so the importer can
+// skip rows that wouldn't change anything (see isEntityUnchanged). This makes
+// re-importing a whole exported sheet with only a few edits fast — the unchanged
+// rows cost no per-row queries. Read once, before the write transaction.
+export const loadExistingEntities = async (models, projectId) => {
+  const rows = await models.database.executeSql(
+    `
+      SELECT e.code, e.name, e.type, e.country_code, e.image_url, e.attributes,
+             e.entity_polygon_id,
+             ST_X(e.point::geometry) AS longitude,
+             ST_Y(e.point::geometry) AS latitude,
+             parent.code AS parent_code,
+             dse.config AS data_service_config
+      FROM entity e
+      LEFT JOIN entity parent ON parent.id = e.parent_id
+      LEFT JOIN data_service_entity dse ON dse.entity_code = e.code
+      WHERE e.project_id = ?;
+    `,
+    [projectId],
+  );
+  return new Map(rows.map(row => [row.code, row]));
+};
+
 /**
  * Responds to POST requests to the /import/entities endpoint.
  *
@@ -96,6 +119,8 @@ export async function importEntities(req, res) {
       assertAnyPermissions([assertBESAdminAccess, importEntitiesPermissionsChecker]),
     );
 
+    const existingEntitiesByCode = await loadExistingEntities(models, project.id);
+
     await models.wrapInTransaction(async transactingModels => {
       for (const [countryCode, countryRows] of Object.entries(rowsByCountryCode)) {
         await updateCountryEntities(
@@ -104,6 +129,7 @@ export async function importEntities(req, res) {
           countryRows,
           pushToDhis,
           project.id,
+          existingEntitiesByCode,
         );
       }
     });

--- a/packages/central-server/src/apiV2/import/importEntities/index.js
+++ b/packages/central-server/src/apiV2/import/importEntities/index.js
@@ -1,1 +1,2 @@
 export { importEntities } from './importEntities';
+export { constructEntityImportEmail } from './constructImportEmail';

--- a/packages/central-server/src/apiV2/import/importEntities/isEntityUnchanged.js
+++ b/packages/central-server/src/apiV2/import/importEntities/isEntityUnchanged.js
@@ -1,5 +1,9 @@
 const normaliseString = value => (value === null || value === undefined ? '' : String(value));
 
+// xlsx parsing emits null for blank cells (defval: null), so treat null like a
+// missing value everywhere.
+const isBlank = value => value === undefined || value === null || value === '';
+
 // Canonical form of a flat attribute object for comparison: sorted keys, values
 // stringified. Stringifying means a stored boolean `true` and an imported string
 // `"true"` compare equal, so a round-trip doesn't churn those rows. An empty or
@@ -32,26 +36,26 @@ export const isEntityUnchanged = (row, existing) => {
   if (normaliseString(row.image_url) !== normaliseString(existing.image_url)) return false;
 
   // Point coordinates — only written when the row supplies both, so only diffed then.
-  const hasCoordinates =
-    row.longitude !== undefined &&
-    row.longitude !== '' &&
-    row.latitude !== undefined &&
-    row.latitude !== '';
-  if (hasCoordinates) {
+  if (!isBlank(row.longitude) && !isBlank(row.latitude)) {
     if (Number(row.longitude) !== existing.longitude || Number(row.latitude) !== existing.latitude) {
       return false;
     }
   }
 
-  // attributes / data_service_entity — only written (and so only diffed) when supplied.
+  // attributes — the importer writes whenever the column is present (a blank cell
+  // clears them to {}), so a blank here is a real change. Match that: compare
+  // unless the column is entirely absent (undefined). canonicalObject treats
+  // null/{}/empty alike, so a blank cell vs an empty stored value still matches.
   if (
     row.attributes !== undefined &&
     canonicalObject(row.attributes) !== canonicalObject(existing.attributes)
   ) {
     return false;
   }
+  // data_service_entity — the importer only writes when the cell is truthy, so a
+  // blank leaves it untouched: skip the comparison for blanks.
   if (
-    row.data_service_entity !== undefined &&
+    !isBlank(row.data_service_entity) &&
     canonicalObject(row.data_service_entity) !== canonicalObject(existing.data_service_config)
   ) {
     return false;

--- a/packages/central-server/src/apiV2/import/importEntities/isEntityUnchanged.js
+++ b/packages/central-server/src/apiV2/import/importEntities/isEntityUnchanged.js
@@ -35,9 +35,16 @@ export const isEntityUnchanged = (row, existing) => {
   if (normaliseString(row.parent_code) !== normaliseString(existing.parent_code)) return false;
   if (normaliseString(row.image_url) !== normaliseString(existing.image_url)) return false;
 
-  // Point coordinates — only written when the row supplies both, so only diffed then.
+  // Point coordinates — only written when the row supplies both, so only diffed
+  // then. Compare rounded to ~6 decimal places (~0.1m): the exporter writes full
+  // ST_X/ST_Y precision but xlsx reads cells back rounded (raw:false), so exact
+  // equality would flag every located entity as changed and defeat the skip.
   if (!isBlank(row.longitude) && !isBlank(row.latitude)) {
-    if (Number(row.longitude) !== existing.longitude || Number(row.latitude) !== existing.latitude) {
+    const round = value => Math.round(Number(value) * 1e6) / 1e6;
+    if (
+      round(row.longitude) !== round(existing.longitude) ||
+      round(row.latitude) !== round(existing.latitude)
+    ) {
       return false;
     }
   }

--- a/packages/central-server/src/apiV2/import/importEntities/isEntityUnchanged.js
+++ b/packages/central-server/src/apiV2/import/importEntities/isEntityUnchanged.js
@@ -1,0 +1,72 @@
+const normaliseString = value => (value === null || value === undefined ? '' : String(value));
+
+// Canonical form of a flat attribute object for comparison: sorted keys, values
+// stringified. Stringifying means a stored boolean `true` and an imported string
+// `"true"` compare equal, so a round-trip doesn't churn those rows. An empty or
+// missing object canonicalises to '' so `{}`, null and undefined all match.
+const canonicalObject = value => {
+  if (value === null || value === undefined) return '';
+  const entries = Object.entries(value);
+  if (entries.length === 0) return '';
+  return JSON.stringify(
+    entries
+      .map(([key, val]) => [key, val === null || val === undefined ? '' : String(val)])
+      .sort(([a], [b]) => a.localeCompare(b)),
+  );
+};
+
+/**
+ * True only when re-importing this row would change nothing, so the importer can
+ * skip all of its per-row work (the common "edit a few rows, re-import the whole
+ * sheet" case). `existing` is the pre-loaded current state (see
+ * loadExistingEntities). Conservative by design: anything that can't be cheaply
+ * compared here counts as changed, so a real update is never skipped.
+ */
+export const isEntityUnchanged = (row, existing) => {
+  if (!existing) return false; // new entity
+
+  if (normaliseString(row.name) !== normaliseString(existing.name)) return false;
+  if (normaliseString(row.entity_type) !== normaliseString(existing.type)) return false;
+  if (normaliseString(row.country_code) !== normaliseString(existing.country_code)) return false;
+  if (normaliseString(row.parent_code) !== normaliseString(existing.parent_code)) return false;
+  if (normaliseString(row.image_url) !== normaliseString(existing.image_url)) return false;
+
+  // Point coordinates — only written when the row supplies both, so only diffed then.
+  const hasCoordinates =
+    row.longitude !== undefined &&
+    row.longitude !== '' &&
+    row.latitude !== undefined &&
+    row.latitude !== '';
+  if (hasCoordinates) {
+    if (Number(row.longitude) !== existing.longitude || Number(row.latitude) !== existing.latitude) {
+      return false;
+    }
+  }
+
+  // attributes / data_service_entity — only written (and so only diffed) when supplied.
+  if (
+    row.attributes !== undefined &&
+    canonicalObject(row.attributes) !== canonicalObject(existing.attributes)
+  ) {
+    return false;
+  }
+  if (
+    row.data_service_entity !== undefined &&
+    canonicalObject(row.data_service_entity) !== canonicalObject(existing.data_service_config)
+  ) {
+    return false;
+  }
+
+  // Polygon link — compare only when referenced by id. A code/data_source ref or
+  // screen_bounds needs resolution we don't do here, so treat as changed.
+  if (row.entity_polygon_id) {
+    if (normaliseString(row.entity_polygon_id) !== normaliseString(existing.entity_polygon_id)) {
+      return false;
+    }
+  } else if (row.entity_polygon_code || row.entity_polygon_data_source) {
+    return false;
+  }
+  if (row.screen_bounds) return false;
+
+  return true;
+};

--- a/packages/central-server/src/apiV2/import/importEntities/updateCountryEntities.js
+++ b/packages/central-server/src/apiV2/import/importEntities/updateCountryEntities.js
@@ -66,6 +66,18 @@ export async function updateCountryEntities(
     if (entityType === transactingModels.entity.types.COUNTRY) {
       continue;
     }
+    const excelRowNumber = i + 2;
+    // Catch duplicate codes within the upload up front, so an accidental
+    // duplicate line still errors even when a row would otherwise be skipped.
+    if (codes.includes(entityObject.code)) {
+      throw new ImportValidationError(
+        `Entity code '${entityObject.code}' is not unique`,
+        excelRowNumber,
+        'code',
+        countryCode,
+      );
+    }
+    codes.push(entityObject.code);
     // Skip rows that would change nothing — the common case is re-importing a
     // whole exported sheet after editing only a few rows. Unchanged rows cost no
     // per-row queries (resolution + writes below are all skipped).
@@ -73,7 +85,6 @@ export async function updateCountryEntities(
       continue;
     }
     const validator = getEntityObjectValidator(entityType, transactingModels);
-    const excelRowNumber = i + 2;
     const constructImportValidationError = (message, field) =>
       new ImportValidationError(message, excelRowNumber, field, countryCode);
     await validator.validate(entityObject, constructImportValidationError);
@@ -102,15 +113,6 @@ export async function updateCountryEntities(
       countryCode,
     });
 
-    if (codes.includes(code)) {
-      throw new ImportValidationError(
-        `Entity code '${code}' is not unique`,
-        excelRowNumber,
-        'code',
-        countryCode,
-      );
-    }
-    codes.push(code);
     const { parentEntity } =
       (await getOrCreateParentEntity(
         transactingModels,

--- a/packages/central-server/src/apiV2/import/importEntities/updateCountryEntities.js
+++ b/packages/central-server/src/apiV2/import/importEntities/updateCountryEntities.js
@@ -54,7 +54,7 @@ export async function updateCountryEntities(
       metadata: countryEntityMetadata,
     },
   );
-  const codes = []; // An array to hold all facility codes, allowing duplicate checking
+  const codes = new Set(); // Track seen codes for O(1) duplicate checking
 
   for (let i = 0; i < entityObjects.length; i++) {
     const entityObject = entityObjects[i];
@@ -69,7 +69,7 @@ export async function updateCountryEntities(
     const excelRowNumber = i + 2;
     // Catch duplicate codes within the upload up front, so an accidental
     // duplicate line still errors even when a row would otherwise be skipped.
-    if (codes.includes(entityObject.code)) {
+    if (codes.has(entityObject.code)) {
       throw new ImportValidationError(
         `Entity code '${entityObject.code}' is not unique`,
         excelRowNumber,
@@ -77,7 +77,7 @@ export async function updateCountryEntities(
         countryCode,
       );
     }
-    codes.push(entityObject.code);
+    codes.add(entityObject.code);
     // Skip rows that would change nothing — the common case is re-importing a
     // whole exported sheet after editing only a few rows. Unchanged rows cost no
     // per-row queries (resolution + writes below are all skipped).

--- a/packages/central-server/src/apiV2/import/importEntities/updateCountryEntities.js
+++ b/packages/central-server/src/apiV2/import/importEntities/updateCountryEntities.js
@@ -3,6 +3,7 @@ import { getEntityObjectValidator } from './getEntityObjectValidator';
 import { getOrCreateParentEntity } from './getOrCreateParentEntity';
 import { getEntityMetadata } from './getEntityMetadata';
 import { resolvePolygonId } from './resolvePolygonId';
+import { isEntityUnchanged } from './isEntityUnchanged';
 
 /**
  * Apply a batch of entity rows that all share the same `country_code`.
@@ -17,6 +18,7 @@ export async function updateCountryEntities(
   entityObjects,
   pushToDhis = true,
   projectId = null,
+  existingEntitiesByCode = new Map(),
 ) {
   const country = await transactingModels.country.findOne({ code: countryCode });
   if (!country) {
@@ -62,6 +64,12 @@ export async function updateCountryEntities(
     // must not be re-created as project-scoped rows here — skip them. (Country
     // creation/editing is handled via the Countries tab, not entity import.)
     if (entityType === transactingModels.entity.types.COUNTRY) {
+      continue;
+    }
+    // Skip rows that would change nothing — the common case is re-importing a
+    // whole exported sheet after editing only a few rows. Unchanged rows cost no
+    // per-row queries (resolution + writes below are all skipped).
+    if (isEntityUnchanged(entityObject, existingEntitiesByCode.get(entityObject.code))) {
       continue;
     }
     const validator = getEntityObjectValidator(entityType, transactingModels);

--- a/packages/central-server/src/apiV2/import/index.js
+++ b/packages/central-server/src/apiV2/import/index.js
@@ -5,7 +5,7 @@ import { emailAfterTimeout } from '@tupaia/server-boilerplate';
 import { catchAsyncErrors } from '../middleware';
 
 import { importOptionSets } from './importOptionSets';
-import { importEntities } from './importEntities';
+import { importEntities, constructEntityImportEmail } from './importEntities';
 import { importEntityPolygons } from './importEntityPolygons';
 import { importStriveLabResults } from './importStriveLabResults';
 import { importUsers } from './importUsers';
@@ -26,7 +26,12 @@ const upload = multer({
 
 const importRoutes = express.Router();
 
-importRoutes.post('/entities', upload.single('entities'), catchAsyncErrors(importEntities));
+importRoutes.post(
+  '/entities',
+  emailAfterTimeout(constructEntityImportEmail),
+  upload.single('entities'),
+  catchAsyncErrors(importEntities),
+);
 importRoutes.post(
   '/entityPolygons',
   upload.single('entityPolygons'),

--- a/packages/central-server/src/tests/apiV2/import/importEntities/importEntities.test.js
+++ b/packages/central-server/src/tests/apiV2/import/importEntities/importEntities.test.js
@@ -391,4 +391,48 @@ describe('importEntities(): POST import/entities', () => {
       expect(dataServiceEntity.config).to.deep.equal({ kobo_id: '10302070' });
     });
   });
+
+  describe('Skip unchanged rows (TUP-3181)', () => {
+    const importRows = rows => {
+      const filepath = writeXlsx(rows);
+      return app
+        .post('import/entities')
+        .query({ projectCode: TEST_PROJECT_CODE, pushToDhis: 'false' })
+        .attach('entities', filepath)
+        .then(response => {
+          unlinkXlsx(filepath);
+          return response;
+        });
+    };
+
+    before(async () => {
+      await app.grantAccess(BES_ADMIN_POLICY);
+    });
+
+    after(() => {
+      app.revokeAccess();
+    });
+
+    it('re-importing unchanged rows is a no-op, and edits still apply', async () => {
+      const row = {
+        code: 'KI_skip_test',
+        name: 'Original',
+        entity_type: 'village',
+        country_code: 'KI',
+        parent_code: 'KI',
+      };
+
+      expect((await importRows([row])).statusCode).to.equal(200);
+      expect((await models.entity.findOne({ code: 'KI_skip_test' })).name).to.equal('Original');
+
+      // Identical re-import — skipped, leaves the entity as-is.
+      const reimport = await importRows([row]);
+      expect(reimport.statusCode).to.equal(200);
+      expect((await models.entity.findOne({ code: 'KI_skip_test' })).name).to.equal('Original');
+
+      // An actual edit still applies.
+      expect((await importRows([{ ...row, name: 'Renamed' }])).statusCode).to.equal(200);
+      expect((await models.entity.findOne({ code: 'KI_skip_test' })).name).to.equal('Renamed');
+    });
+  });
 });

--- a/packages/central-server/src/tests/apiV2/import/importEntities/importEntities.test.js
+++ b/packages/central-server/src/tests/apiV2/import/importEntities/importEntities.test.js
@@ -409,7 +409,9 @@ describe('importEntities(): POST import/entities', () => {
       await app.grantAccess(BES_ADMIN_POLICY);
     });
 
-    after(() => {
+    after(async () => {
+      // Clean up so the "create" assertion holds on repeat runs against the real DB.
+      await models.entity.delete({ code: 'KI_skip_test' });
       app.revokeAccess();
     });
 

--- a/packages/central-server/src/tests/apiV2/import/importEntities/isEntityUnchanged.test.js
+++ b/packages/central-server/src/tests/apiV2/import/importEntities/isEntityUnchanged.test.js
@@ -56,6 +56,14 @@ describe('isEntityUnchanged', () => {
     expect(
       isEntityUnchanged({ ...matchingRow, longitude: null, latitude: null }, existing),
     ).to.equal(true);
+    // Full-precision stored coords vs xlsx-rounded re-import values still match,
+    // so located entities aren't all flagged as changed on round-trip.
+    expect(
+      isEntityUnchanged(
+        { ...matchingRow, longitude: '160.5', latitude: '-9.4' },
+        { ...existing, longitude: 160.50000000001, latitude: -9.40000000002 },
+      ),
+    ).to.equal(true);
   });
 
   it('compares attributes only when supplied, and treats true/"true" as equal', () => {

--- a/packages/central-server/src/tests/apiV2/import/importEntities/isEntityUnchanged.test.js
+++ b/packages/central-server/src/tests/apiV2/import/importEntities/isEntityUnchanged.test.js
@@ -51,15 +51,26 @@ describe('isEntityUnchanged', () => {
     // No coordinates in the row → importer leaves the point untouched → unchanged.
     const { longitude, latitude, ...noCoords } = matchingRow;
     expect(isEntityUnchanged(noCoords, existing)).to.equal(true);
+    // Blank cells arrive as null (xlsx defval) — must be treated as "no
+    // coordinates", not as 0,0, or skip never fires for coordinate-less rows.
+    expect(
+      isEntityUnchanged({ ...matchingRow, longitude: null, latitude: null }, existing),
+    ).to.equal(true);
   });
 
   it('compares attributes only when supplied, and treats true/"true" as equal', () => {
     expect(
       isEntityUnchanged({ ...matchingRow, attributes: { area_type: 'maritime' } }, existing),
     ).to.equal(false);
-    // Row omits attributes → importer leaves them untouched → unchanged.
+    // Row omits the attributes column entirely (undefined) → untouched → unchanged.
     const { attributes, ...noAttributes } = matchingRow;
     expect(isEntityUnchanged(noAttributes, existing)).to.equal(true);
+    // A blank attributes cell (null) clears existing attributes — that's a change.
+    expect(isEntityUnchanged({ ...matchingRow, attributes: null }, existing)).to.equal(false);
+    // ...but blanking already-empty attributes is not a change.
+    expect(
+      isEntityUnchanged({ ...matchingRow, attributes: null }, { ...existing, attributes: {} }),
+    ).to.equal(true);
     // Stored boolean vs imported string "true" — equal, so no churn on round-trip.
     expect(
       isEntityUnchanged(

--- a/packages/central-server/src/tests/apiV2/import/importEntities/isEntityUnchanged.test.js
+++ b/packages/central-server/src/tests/apiV2/import/importEntities/isEntityUnchanged.test.js
@@ -1,0 +1,110 @@
+import { expect } from 'chai';
+import { isEntityUnchanged } from '../../../../apiV2/import/importEntities/isEntityUnchanged';
+
+// The stored state shape produced by loadExistingEntities.
+const existing = {
+  name: 'Pangoe',
+  type: 'village',
+  country_code: 'SB',
+  parent_code: 'SB',
+  image_url: null,
+  longitude: 160.5,
+  latitude: -9.4,
+  attributes: { area_type: 'island' },
+  data_service_config: null,
+  entity_polygon_id: null,
+};
+
+// A re-exported row that matches `existing` exactly.
+const matchingRow = {
+  name: 'Pangoe',
+  entity_type: 'village',
+  country_code: 'SB',
+  parent_code: 'SB',
+  image_url: '',
+  longitude: 160.5,
+  latitude: -9.4,
+  attributes: { area_type: 'island' },
+};
+
+describe('isEntityUnchanged', () => {
+  it('returns false for a new entity (no existing row)', () => {
+    expect(isEntityUnchanged(matchingRow, undefined)).to.equal(false);
+  });
+
+  it('returns true when nothing changed', () => {
+    expect(isEntityUnchanged(matchingRow, existing)).to.equal(true);
+  });
+
+  it('detects changes to the simple columns', () => {
+    expect(isEntityUnchanged({ ...matchingRow, name: 'Renamed' }, existing)).to.equal(false);
+    expect(isEntityUnchanged({ ...matchingRow, entity_type: 'facility' }, existing)).to.equal(false);
+    expect(isEntityUnchanged({ ...matchingRow, country_code: 'KI' }, existing)).to.equal(false);
+    expect(isEntityUnchanged({ ...matchingRow, parent_code: 'SB_district' }, existing)).to.equal(
+      false,
+    );
+    expect(isEntityUnchanged({ ...matchingRow, image_url: 'x.png' }, existing)).to.equal(false);
+  });
+
+  it('compares coordinates only when the row supplies them', () => {
+    expect(isEntityUnchanged({ ...matchingRow, latitude: -9.5 }, existing)).to.equal(false);
+    // No coordinates in the row → importer leaves the point untouched → unchanged.
+    const { longitude, latitude, ...noCoords } = matchingRow;
+    expect(isEntityUnchanged(noCoords, existing)).to.equal(true);
+  });
+
+  it('compares attributes only when supplied, and treats true/"true" as equal', () => {
+    expect(
+      isEntityUnchanged({ ...matchingRow, attributes: { area_type: 'maritime' } }, existing),
+    ).to.equal(false);
+    // Row omits attributes → importer leaves them untouched → unchanged.
+    const { attributes, ...noAttributes } = matchingRow;
+    expect(isEntityUnchanged(noAttributes, existing)).to.equal(true);
+    // Stored boolean vs imported string "true" — equal, so no churn on round-trip.
+    expect(
+      isEntityUnchanged(
+        { ...matchingRow, attributes: { area_type: 'island', is_active: 'true' } },
+        { ...existing, attributes: { area_type: 'island', is_active: true } },
+      ),
+    ).to.equal(true);
+  });
+
+  it('detects data_service_entity changes when supplied', () => {
+    expect(
+      isEntityUnchanged(
+        { ...matchingRow, data_service_entity: { kobo_id: '1' } },
+        { ...existing, data_service_config: { kobo_id: '2' } },
+      ),
+    ).to.equal(false);
+    expect(
+      isEntityUnchanged(
+        { ...matchingRow, data_service_entity: { kobo_id: '1' } },
+        { ...existing, data_service_config: { kobo_id: '1' } },
+      ),
+    ).to.equal(true);
+  });
+
+  it('handles the polygon link conservatively', () => {
+    // Matching id (rest equal) → unchanged.
+    expect(
+      isEntityUnchanged(
+        { ...matchingRow, entity_polygon_id: 'poly1' },
+        { ...existing, entity_polygon_id: 'poly1' },
+      ),
+    ).to.equal(true);
+    expect(
+      isEntityUnchanged(
+        { ...matchingRow, entity_polygon_id: 'poly2' },
+        { ...existing, entity_polygon_id: 'poly1' },
+      ),
+    ).to.equal(false);
+    // A natural-key polygon ref can't be cheaply resolved here → treat as changed.
+    expect(
+      isEntityUnchanged({ ...matchingRow, entity_polygon_code: 'PW_vil_052' }, existing),
+    ).to.equal(false);
+    // screen_bounds present → treat as changed.
+    expect(isEntityUnchanged({ ...matchingRow, screen_bounds: '[[1,2],[3,4]]' }, existing)).to.equal(
+      false,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Re-importing a whole exported sheet (the common admin-panel habit) was doing per-row work for every row inside one transaction, so it timed out on large projects (fanafana has 52k entities). Two complementary changes from the discussion on TUP-3181:

### 1. Skip unchanged rows
- `loadExistingEntities` snapshots the project's entities once (one query, before the write transaction) into a `code → state` map.
- `isEntityUnchanged` compares each row against that snapshot in memory; matching rows are skipped entirely — **no per-row queries**. So editing a few rows in a big exported sheet and re-importing the whole thing is fast (the unchanged rows cost nothing), and an unedited round-trip is a genuine no-op.
- **Conservative by design**: anything that can't be cheaply compared (natural-key polygon ref, `screen_bounds`) counts as *changed*, so a real update is never skipped. Stored boolean `true` vs imported string `"true"` compare equal, so booleans don't churn.

### 2. Email after timeout (large imports)
- The `/import/entities` route is now wrapped in `emailAfterTimeout` (the same pattern survey-response import uses). A large import responds immediately and emails the result (success or failure) on completion instead of holding the request open until it times out.
- The admin panel sends `respondWithEmailTimeout: 10s`; it already renders the "you'll be emailed" response generically.

Together: the common case (few edits) is fast via skip-unchanged; the rare bootstrap case (whole new hierarchy) no longer hangs.

Left for later (separate tickets): scoped export, dry-run preview, and the proper "copy hierarchy from another project" flow (TUP-1582) for bootstrapping.
### 🦸 Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
- [ ] **Save suppressions** <!-- #save-suppressions -->