### PR TITLE
fix(datatrakWeb): TUP-1647: avoid offline network error spam in activity feed

### DIFF
--- a/packages/datatrak-web/src/api/queries/useActivityFeed.ts
+++ b/packages/datatrak-web/src/api/queries/useActivityFeed.ts
@@ -1,6 +1,7 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { DatatrakWebActivityFeedRequest, Project } from '@tupaia/types';
 import { get } from '../api';
+import { useIsOnline } from '../../utils';
 import { useCurrentUserContext } from '..';
 
 interface UseActivityFeedProps {
@@ -9,6 +10,7 @@ interface UseActivityFeedProps {
 }
 
 export const useActivityFeed = ({ projectId, pageLimit }: UseActivityFeedProps) => {
+  const isOnline = useIsOnline();
   return useInfiniteQuery<DatatrakWebActivityFeedRequest.ResBody>(
     ['activityFeed', projectId, pageLimit],
     async ({ pageParam = 0 }) => {
@@ -24,7 +26,7 @@ export const useActivityFeed = ({ projectId, pageLimit }: UseActivityFeedProps) 
         if (!data) return 0;
         return data?.hasMorePages ? pages.length : undefined;
       },
-      enabled: window.navigator.onLine && Boolean(projectId),
+      enabled: isOnline && Boolean(projectId),
     },
   );
 };

--- a/packages/datatrak-web/src/utils/index.ts
+++ b/packages/datatrak-web/src/utils/index.ts
@@ -13,6 +13,7 @@ export { useBeforeUnload } from './useBeforeUnload';
 export { useNavigationBlocker } from './useNavigationBlocker';
 export { NavigationBlockerProvider, useNavigationBlockerContext } from './NavigationBlockerProvider';
 export { useHasVideoInput } from './useHasVideoInput';
+export { useIsOnline } from './useIsOnline';
 export { useFromLocation } from './useLocationState';
 export { formatEntityForResponse, formatEntitiesForResponse } from './formatEntity';
 export type { ExtendedEntityFieldName } from './formatEntity';

--- a/packages/datatrak-web/src/utils/useIsOnline.ts
+++ b/packages/datatrak-web/src/utils/useIsOnline.ts
@@ -9,6 +9,7 @@ export function useIsOnline(): boolean {
 
   useEffect(() => {
     const update = () => setIsOnline(window.navigator.onLine);
+    update(); // re-sync in case connectivity changed before the listeners were attached
     window.addEventListener('online', update);
     window.addEventListener('offline', update);
     return () => {

--- a/packages/datatrak-web/src/utils/useIsOnline.ts
+++ b/packages/datatrak-web/src/utils/useIsOnline.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Reactive equivalent of `window.navigator.onLine`. Re-renders when the browser fires `online`/
+ * `offline` events, so consumers can gate network activity and resume it once connectivity returns.
+ */
+export function useIsOnline(): boolean {
+  const [isOnline, setIsOnline] = useState(window.navigator.onLine);
+
+  useEffect(() => {
+    const update = () => setIsOnline(window.navigator.onLine);
+    window.addEventListener('online', update);
+    window.addEventListener('offline', update);
+    return () => {
+      window.removeEventListener('online', update);
+      window.removeEventListener('offline', update);
+    };
+  }, []);
+
+  return isOnline;
+}

--- a/packages/datatrak-web/src/views/LandingPage/ActivityFeedSection/InfiniteActivityFeed.tsx
+++ b/packages/datatrak-web/src/views/LandingPage/ActivityFeedSection/InfiniteActivityFeed.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { useCurrentProjectActivityFeed } from '../../../api/queries';
+import { useIsOnline } from '../../../utils';
 import { InfiniteScroll } from './InfiniteScroll';
 import { SkeletonFeed } from './SkeletonFeed';
 import { ActivityFeedList } from './ActivityFeedList';
@@ -24,7 +25,12 @@ export const InfiniteActivityFeed = React.forwardRef<HTMLDivElement, {}>((_props
     hasNextPage,
     isFetching,
   } = useCurrentProjectActivityFeed();
+  const isOnline = useIsOnline();
   const isInitialLoad = !activityFeed;
+  // `fetchNextPage` bypasses the query's `enabled` guard, so without this the infinite scroll would
+  // keep requesting pages while offline and spam network errors. Hiding the loader stops it, and it
+  // resumes automatically once connectivity returns.
+  const canFetchNextPage = hasNextPage && isOnline;
   return (
     <Body>
       {isInitialLoad ? (
@@ -33,7 +39,7 @@ export const InfiniteActivityFeed = React.forwardRef<HTMLDivElement, {}>((_props
         <InfiniteScroll
           ref={ref}
           onScroll={fetchNextPage}
-          hasNextPage={hasNextPage}
+          hasNextPage={canFetchNextPage}
           isFetchingNextPage={isFetching}
         >
           <ActivityFeedList items={activityFeed?.pages.flatMap(page => page.items)} />


### PR DESCRIPTION
## Problem

[TUP-1647](https://linear.app/bes/issue/TUP-1647) — on the **mobile** DataTrak home page, going offline spams continuous `AxiosError: Network Error` toasts that can't be dismissed, making the page unusable. It only affects **large** projects (e.g. Fanafana Ola, PNG Health Facility Audits, Samoa Assets) — not Explore.

## Root cause

[TUP-2226](https://linear.app/bes/issue/TUP-2226) suppressed offline errors by gating queries with `enabled: navigator.onLine`. But **`enabled` only gates *automatic* fetches — it never gates a manual `fetchNextPage()`** on an infinite query.

1. On mobile, `MobileActivityFeed` keeps `InfiniteActivityFeed` mounted inside a **closed `keepMounted` `Dialog`**. The hidden container's degenerate geometry makes `getIsAtEndOfList` report the loader as "at end of list", so `InfiniteScroll` calls `fetchNextPage()` on mount.
2. With `networkMode: 'offlineFirst'` + `retry: false`, the offline `fetchNextPage` fires a real request → Network Error → global `QueryCache.onError` → `errorToast`.
3. The failed fetch adds no items, so the loader stays "visible" and the `isFetching` toggle re-runs `InfiniteScroll`'s effect → `fetchNextPage` fires again → **infinite spam loop**.
4. **Large projects** have `hasMorePages: true` → loop runs. **Explore** is a single page → `hasNextPage` is false → the loop never starts. Exactly the reported pattern. Desktop is unaffected because it lays the feed out normally (loader below the fold).

## Fix

- Add a reactive `useIsOnline` hook — the existing `navigator.onLine` checks were evaluated once and never reacted to reconnection.
- Gate the activity feed's `hasNextPage` on online status, so the loader is hidden (and `fetchNextPage` can't fire) while offline, and it resumes automatically when connectivity returns.
- Make `useActivityFeed`'s `enabled` reactive so the initial page also refetches on reconnect.

## Testing

- BES Data Admin for Tonga, sync the Fanafana Ola project, mobile view.
- Go offline on the home page → **no** network-error spam.
- Go back online → activity feed resumes normally.
- Sanity check Explore + desktop still behave as before.

### 🦸 Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
- [ ] **Save suppressions** <!-- #save-suppressions -->