### PR TITLE
feat(entityHierarchy): TUP-3180: require Tupaia Admin Panel access to select a project

### DIFF
--- a/packages/admin-panel-server/src/__tests__/middleware/projectScope.test.ts
+++ b/packages/admin-panel-server/src/__tests__/middleware/projectScope.test.ts
@@ -1,0 +1,109 @@
+import { NextFunction, Request, Response } from 'express';
+
+import { applyProjectScope } from '../../middleware/projectScope';
+
+const BES_ADMIN_PERMISSION_GROUP = 'BES Admin';
+
+type Country = { code: string };
+
+const buildProject = (countryCodes: string[]) => ({
+  id: 'project-id',
+  code: 'test_project',
+  countries: async (): Promise<Country[]> => countryCodes.map(code => ({ code })),
+});
+
+const buildReq = ({
+  url = '/surveys?projectCode=test_project',
+  method = 'GET',
+  isBESAdmin = false,
+  adminPanelCountryCodes = [] as string[],
+  project = buildProject(['DL']) as ReturnType<typeof buildProject> | null,
+}) => {
+  const findOne = jest.fn().mockResolvedValue(project);
+  const allowsSome = jest.fn().mockImplementation((_entities, permissionGroup) =>
+    permissionGroup === BES_ADMIN_PERMISSION_GROUP ? isBESAdmin : false,
+  );
+  const getEntitiesAllowed = jest.fn().mockReturnValue(adminPanelCountryCodes);
+  const req = {
+    originalUrl: url,
+    url,
+    method,
+    body: {},
+    is: () => false,
+    models: { project: { findOne } },
+    accessPolicy: { allowsSome, getEntitiesAllowed },
+  };
+  return { req, findOne, allowsSome, getEntitiesAllowed };
+};
+
+const buildRes = () => {
+  const res = {} as Record<string, jest.Mock>;
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+const run = (req: unknown, res: unknown) => {
+  const next: NextFunction = jest.fn();
+  return {
+    next,
+    promise: applyProjectScope(req as Request, res as unknown as Response, next),
+  };
+};
+
+describe('applyProjectScope — Tupaia Admin Panel project access guard', () => {
+  it('403s when a non-BES-admin lacks Tupaia Admin Panel access to any of the project’s countries', async () => {
+    const { req } = buildReq({
+      isBESAdmin: false,
+      adminPanelCountryCodes: ['DL'],
+      project: buildProject(['TO']), // user administers DL, project is only in TO
+    });
+    const res = buildRes();
+    const { next, promise } = run(req, res);
+    await promise;
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('allows a non-BES-admin who administers one of the project’s countries', async () => {
+    const { req } = buildReq({
+      isBESAdmin: false,
+      adminPanelCountryCodes: ['DL'],
+      project: buildProject(['DL', 'TO']),
+    });
+    const res = buildRes();
+    const { next, promise } = run(req, res);
+    await promise;
+
+    expect(res.status).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('allows a BES admin regardless of country admin access', async () => {
+    const { req, getEntitiesAllowed } = buildReq({
+      isBESAdmin: true,
+      adminPanelCountryCodes: [],
+      project: buildProject(['TO']),
+    });
+    const res = buildRes();
+    const { next, promise } = run(req, res);
+    await promise;
+
+    expect(res.status).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+    // BES admins skip the admin-panel-country lookup entirely.
+    expect(getEntitiesAllowed).not.toHaveBeenCalled();
+  });
+
+  it('skips the guard entirely when no projectCode is supplied', async () => {
+    const { req, findOne } = buildReq({ url: '/surveys' });
+    const res = buildRes();
+    const { next, promise } = run(req, res);
+    await promise;
+
+    expect(findOne).not.toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+  });
+});

--- a/packages/admin-panel-server/src/middleware/projectScope.ts
+++ b/packages/admin-panel-server/src/middleware/projectScope.ts
@@ -1,4 +1,6 @@
 import { NextFunction, Request, Response } from 'express';
+import { hasBESAdminAccess } from '@tupaia/access-policy';
+import { TUPAIA_ADMIN_PANEL_PERMISSION_GROUP } from '../constants';
 
 export const PROJECT_CODE_PARAM = 'projectCode';
 
@@ -172,6 +174,27 @@ export const applyProjectScope = async (req: Request, res: Response, next: NextF
       res.status(400).json({ error: `Unknown project code: ${projectCode}` });
       return undefined;
     }
+
+    // A non-BES-admin may only operate within a project they administer: one
+    // with a country they hold Tupaia Admin Panel access to. Mirrors the
+    // selector's project-list filter so a stale or hand-typed projectCode can't
+    // reach a project the user can't administer.
+    if (!hasBESAdminAccess(req.accessPolicy)) {
+      const adminCountryCodes = req.accessPolicy.getEntitiesAllowed(
+        TUPAIA_ADMIN_PANEL_PERMISSION_GROUP,
+      );
+      const countries = await project.countries();
+      const hasAdminCountry = countries.some(country =>
+        adminCountryCodes.includes((country as unknown as { code: string }).code),
+      );
+      if (!hasAdminCountry) {
+        res.status(403).json({
+          error: `You do not have Tupaia Admin Panel access to a country in project ${projectCode}`,
+        });
+        return undefined;
+      }
+    }
+
     const projectCtx: Project = { id: project.id, code: project.code };
 
     // Only inject the list filter on the bare list endpoint (e.g. `surveys`).

--- a/packages/admin-panel/src/api/queries/useProjects.js
+++ b/packages/admin-panel/src/api/queries/useProjects.js
@@ -10,6 +10,10 @@ export const useProjects = () =>
       columns: JSON.stringify(PROJECT_LIST_COLUMNS),
       pageSize: 'ALL',
       sort: JSON.stringify(['entity.name ASC']),
+      // Only list projects the user can administer (Tupaia Admin Panel access to
+      // a country in the project). Scopes the sidebar selector; other consumers
+      // of the projects endpoint are unaffected.
+      requireAdminPanelCountryAccess: 'true',
     });
     const projects = await get(endpoint);
     return Array.isArray(projects)

--- a/packages/central-server/src/apiV2/projects/GETProjects.js
+++ b/packages/central-server/src/apiV2/projects/GETProjects.js
@@ -1,6 +1,11 @@
 import { QUERY_CONJUNCTIONS } from '@tupaia/database';
 import { GETHandler } from '../GETHandler';
-import { assertAnyPermissions, assertBESAdminAccess, hasBESAdminAccess } from '../../permissions';
+import {
+  assertAnyPermissions,
+  assertBESAdminAccess,
+  hasBESAdminAccess,
+  TUPAIA_ADMIN_PANEL_PERMISSION_GROUP,
+} from '../../permissions';
 import { hasAccessToEntityForVisualisation } from '../utilities';
 
 const { RAW } = QUERY_CONJUNCTIONS;
@@ -104,33 +109,54 @@ export class GETProjects extends GETHandler {
   async getPermissionsFilter(criteria, options) {
     const dbConditions = { ...criteria };
     if (!hasBESAdminAccess(this.accessPolicy)) {
-      const allPermissionGroups = this.accessPolicy.getPermissionGroups();
-      const countryCodesByPermissionGroup = {};
-
-      // Generate lists of country codes we have access to per permission group
-      allPermissionGroups.forEach(pg => {
-        countryCodesByPermissionGroup[pg] = this.accessPolicy.getEntitiesAllowed(pg);
-      });
-
-      // Pulls permission_group/country_code pairs from the project
-      // Returns any project where we have access to at least one of those pairs.
-      dbConditions[RAW] = {
-        sql: `(
-          SELECT COUNT(*) > 0 FROM
-          (
-            SELECT UNNEST(project.permission_groups) as permission_group, entity.code AS country_code
+      if (this.req.query.requireAdminPanelCountryAccess === 'true') {
+        // The admin panel project selector only offers projects the user can
+        // administer: those spanning a country they hold Tupaia Admin Panel
+        // access to. Other consumers of the project list keep the broader
+        // any-permission visibility below.
+        const adminPanelCountryCodes = this.accessPolicy.getEntitiesAllowed(
+          TUPAIA_ADMIN_PANEL_PERMISSION_GROUP,
+        );
+        dbConditions[RAW] = {
+          sql: `(
+            SELECT COUNT(*) > 0
             FROM project_country
             INNER JOIN entity
               ON entity.id = project_country.country_id
             WHERE project_country.project_id = project.id
-          ) AS count
-          WHERE country_code IN
-          (
-            SELECT TRIM('"' FROM JSON_ARRAY_ELEMENTS(?::JSON->permission_group)::TEXT)
-          )
-        )`,
-        parameters: [JSON.stringify(countryCodesByPermissionGroup)],
-      };
+              AND entity.code IN (${adminPanelCountryCodes.map(() => '?').join(', ') || 'NULL'})
+          )`,
+          parameters: [...adminPanelCountryCodes],
+        };
+      } else {
+        const allPermissionGroups = this.accessPolicy.getPermissionGroups();
+        const countryCodesByPermissionGroup = {};
+
+        // Generate lists of country codes we have access to per permission group
+        allPermissionGroups.forEach(pg => {
+          countryCodesByPermissionGroup[pg] = this.accessPolicy.getEntitiesAllowed(pg);
+        });
+
+        // Pulls permission_group/country_code pairs from the project
+        // Returns any project where we have access to at least one of those pairs.
+        dbConditions[RAW] = {
+          sql: `(
+            SELECT COUNT(*) > 0 FROM
+            (
+              SELECT UNNEST(project.permission_groups) as permission_group, entity.code AS country_code
+              FROM project_country
+              INNER JOIN entity
+                ON entity.id = project_country.country_id
+              WHERE project_country.project_id = project.id
+            ) AS count
+            WHERE country_code IN
+            (
+              SELECT TRIM('"' FROM JSON_ARRAY_ELEMENTS(?::JSON->permission_group)::TEXT)
+            )
+          )`,
+          parameters: [JSON.stringify(countryCodesByPermissionGroup)],
+        };
+      }
     }
 
     return { dbConditions, dbOptions: options };

--- a/packages/central-server/src/tests/apiV2/projects/GETProjects.test.js
+++ b/packages/central-server/src/tests/apiV2/projects/GETProjects.test.js
@@ -66,10 +66,19 @@ describe('Permissions checker for GETProjects', async () => {
     {
       code: 'test_project_1',
       permissionGroupName: TUPAIA_ADMIN_PANEL_PERMISSION_GROUP,
+      countryCode: 'DL',
     },
     {
       code: 'test_project_2',
       permissionGroupName: 'Admin',
+      countryCode: 'DL',
+    },
+    // Only country is TO, where DEFAULT_POLICY has no Tupaia Admin Panel access —
+    // so it's visible without the admin-panel flag but hidden with it.
+    {
+      code: 'test_project_3',
+      permissionGroupName: 'Admin',
+      countryCode: 'TO',
     },
   ];
 
@@ -86,15 +95,19 @@ describe('Permissions checker for GETProjects', async () => {
       name: 'Admin',
     });
 
-    const { id: countryEntityId } = await findOrCreateDummyRecord(models.entity, {
-      code: 'DL',
-      country_code: 'DL',
-      type: 'country',
-    });
+    const countryEntityIdsByCode = {};
+    for (const countryCode of ['DL', 'TO']) {
+      const { id } = await findOrCreateDummyRecord(models.entity, {
+        code: countryCode,
+        country_code: countryCode,
+        type: 'country',
+      });
+      countryEntityIdsByCode[countryCode] = id;
+    }
     // Set up test projects in the database
     projects = await Promise.all(
-      PROJECT_CODES.map(({ code, permissionGroupName }) =>
-        createTestData(models, code, permissionGroupName, countryEntityId),
+      PROJECT_CODES.map(({ code, permissionGroupName, countryCode }) =>
+        createTestData(models, code, permissionGroupName, countryEntityIdsByCode[countryCode]),
       ),
     );
 
@@ -156,6 +169,41 @@ describe('Permissions checker for GETProjects', async () => {
     it('Insufficient permissions: returns an empty array if users do not have access to any project', async () => {
       await app.grantAccess(PUBLIC_POLICY);
       const { body: results } = await app.get(`projects?${filterString}`);
+
+      expect(results).to.be.empty;
+    });
+  });
+
+  describe('GET /projects?requireAdminPanelCountryAccess=true', async () => {
+    it('only returns projects the user has Tupaia Admin Panel access to a country in', async () => {
+      await app.grantAccess(DEFAULT_POLICY);
+      const { body: results } = await app.get(
+        `projects?${filterString}&requireAdminPanelCountryAccess=true`,
+      );
+      const resultIds = results.map(r => r.id);
+      // projects 1 & 2 are in DL (Tupaia Admin Panel granted); project 3 is in TO
+      // (no Tupaia Admin Panel access) so it's filtered out.
+      expect(resultIds).to.include(projects[0].id);
+      expect(resultIds).to.include(projects[1].id);
+      expect(resultIds).to.not.include(projects[2].id);
+    });
+
+    it('returns all accessible projects for a BES admin', async () => {
+      await app.grantAccess(BES_ADMIN_POLICY);
+      const { body: results } = await app.get(
+        `projects?${filterString}&requireAdminPanelCountryAccess=true`,
+      );
+      const resultIds = results.map(r => r.id);
+      projects.forEach(project => {
+        expect(resultIds.includes(project.id)).to.equal(true);
+      });
+    });
+
+    it('returns an empty array when the user has no Tupaia Admin Panel country access', async () => {
+      await app.grantAccess(PUBLIC_POLICY);
+      const { body: results } = await app.get(
+        `projects?${filterString}&requireAdminPanelCountryAccess=true`,
+      );
 
       expect(results).to.be.empty;
     });


### PR DESCRIPTION
## What

Implements TUP-3180 Issue 13 (agreed by Andrew + Juliana): a non-BES-admin can only **select or scope to a project they administer** — i.e. one with a country they hold `Tupaia Admin Panel` permission for. BES admins still see every project.

## Why

The project selector previously listed any project the user could access via *any* permission on a member country, which surfaced projects the user can't actually administer in the admin panel. The agreed rule gates selection on `Tupaia Admin Panel` access to a country in the project.

## Changes

- **central `GETProjects.getPermissionsFilter`** — when the request carries `requireAdminPanelCountryAccess=true` (and the user isn't a BES admin), narrows the list to projects spanning one of the user's Tupaia-Admin-Panel countries. Without the flag, behaviour is unchanged, so other consumers of `/projects` (e.g. the survey→project dropdown) are unaffected.
- **admin-panel `useProjects`** (sidebar selector hook) sends the flag.
- **admin-panel-server `applyProjectScope`** — `403`s a scoped request whose `projectCode` is a project the user has no Tupaia-Admin-Panel country in, so a stale or hand-typed URL can't bypass the selector filter. BES admins skip the check.

The existing `SingleProjectRouteGuard` + `useSidebarProjectCode` fallback chain mean a no-longer-selectable saved/landing project falls through to the first selectable one automatically.

## Scope / safety

- Admin panel only — tupaia-web fetches projects via its own hook/server and never sends the flag.
- No schema change / migration.

## Tests

- `GETProjects.test.js`: flagged list returns only TAP-administrable projects, unflagged list unchanged (proves other consumers unaffected), BES admin sees all.
- `projectScope.test.ts` (new): 403 without TAP-country, pass with it, BES admin bypass, no-projectCode skip. ✅ passing locally.

### 🦸 Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
- [ ] **Save suppressions** <!-- #save-suppressions -->