### PR TITLE
fix(auth): store fetched permission group children in cache when building access policy

### DIFF
--- a/packages/auth/src/buildAccessPolicy.js
+++ b/packages/auth/src/buildAccessPolicy.js
@@ -15,10 +15,18 @@ export const buildAccessPolicy = async (models, userId) => {
   const userEntityPermissions = await models.userEntityPermission.find({ user_id: userId });
 
   // set up permission group children fetching, for flattening the permission hierarchy
+  // cache the promise (rather than the resolved value) so that concurrent lookups for the same
+  // permission group share a single db fetch
   const permissionGroupToChildren = {};
-  const getOrFetchPermissionGroupChildren = async permissionGroupName =>
-    permissionGroupToChildren[permissionGroupName] || // get from cache
-    fetchPermissionGroupChildren(models, permissionGroupName); // or fetch from db
+  const getOrFetchPermissionGroupChildren = permissionGroupName => {
+    if (!permissionGroupToChildren[permissionGroupName]) {
+      permissionGroupToChildren[permissionGroupName] = fetchPermissionGroupChildren(
+        models,
+        permissionGroupName,
+      );
+    }
+    return permissionGroupToChildren[permissionGroupName];
+  };
 
   // iterate through the user's permissions and build the permission groups per entity
   await Promise.all(


### PR DESCRIPTION
## Summary

- `buildAccessPolicy` sets up a `permissionGroupToChildren` cache to avoid re-fetching the child tree for the same permission group, but the fetched result was never written back into it, so the cache never got a hit.
- For a user with N `user_entity_permission` rows sharing the same permission group, this meant N separate `permission_group.findOne` + recursive child-tree queries instead of 1.
- The cache now stores the fetch **promise** (rather than the resolved value), so the concurrent lookups inside the surrounding `Promise.all` also share a single DB fetch.

This runs on login, token refresh, and every bearer-authenticated request that misses the `AccessPolicyBuilder` cache, so users with many entity permissions should see noticeably faster policy builds.

## Test plan

- [ ] `yarn workspace @tupaia/auth test` (requires test DB; `buildAccessPolicy` suite covers admin/public users across entity nestings)
- [ ] Verify login and authenticated requests behave the same as before (policy contents unchanged, just fewer duplicate queries)

Made with [Cursor](https://cursor.com)