### PR TITLE
tweak(webConfig): avoid per-measure entity lookups in measureData permission check

### DIFF
--- a/packages/web-config-server/src/apiV1/measureData.js
+++ b/packages/web-config-server/src/apiV1/measureData.js
@@ -165,14 +165,16 @@ export default class extends DataAggregatingRouteHandler {
   static PermissionsChecker = MapOverlayPermissionsChecker;
 
   buildResponse = async () => {
-    const { code } = this.entity;
     const { mapOverlayCode } = this.query;
     const measures = await this.models.mapOverlay.findMeasuresByCode(mapOverlayCode);
 
     // check permission
+    // check each distinct permission group once, and pass the already-fetched entity object so
+    // that userHasAccess doesn't refetch it for every measure
+    const permissionGroups = uniq(measures.map(({ permission_group: pg }) => pg));
     await Promise.all(
-      measures.map(async ({ permission_group: permissionGroup }) => {
-        const isUserAllowedMeasure = await this.req.userHasAccess(code, permissionGroup);
+      permissionGroups.map(async permissionGroup => {
+        const isUserAllowedMeasure = await this.req.userHasAccess(this.entity, permissionGroup);
         if (!isUserAllowedMeasure) {
           throw new CustomError(accessDeniedForMeasure);
         }


### PR DESCRIPTION
## Summary

The permission check in `measureData`'s `buildResponse` ran `this.req.userHasAccess(code, permissionGroup)` once per measure (main overlay + every linked measure). Because it passed the entity *code*, each call did an `entity.findOne({ code })` — even though the route handler already has the entity loaded as `this.entity`. Map overlay data is one of the hottest tupaia.org paths (fires on every pan/zoom/period change), and multi-measure overlays multiplied the cost.

Two changes, both semantics-preserving:

- Pass the already-fetched `this.entity` object to `userHasAccess` (it accepts an entity or a code), eliminating the per-measure entity lookup.
- Deduplicate permission groups before checking, so an overlay whose linked measures share a permission group performs one check instead of N. All distinct groups are still required to pass, same as before.

**Note:** this deliberately does *not* remove the check in favour of `MapOverlayPermissionsChecker`. The checker's `fetchPermissionGroups` reads `overlay.permission_group` off an array (`this.models.mapOverlay.find(...)` returns a list), so it returns `[undefined]` and its permission-group test degenerates to an entity-access check — meaning this loop in `buildResponse` is currently the only place the overlay's permission group is actually enforced. That latent checker bug may be worth fixing separately.

## Test plan

- [ ] Load a map overlay with linked measures and confirm data is returned as before
- [ ] Confirm a user without the overlay's permission group still receives the 403 "Permission Denied" custom error payload
- [ ] Confirm project-level entities still work (userHasAccess's project branch is unchanged, just called once per distinct permission group)

Made with [Cursor](https://cursor.com)