### PR TITLE
fix(auth): store fetched permission group children in cache when building access policy

### DIFF
--- a/packages/auth/src/buildAccessPolicy.js
+++ b/packages/auth/src/buildAccessPolicy.js
@@ -1,55 +1,64 @@
-import { uniq } from 'es-toolkit';
-
+/**
+ * @param {*} models
+ * @param {string} permissionGroupName
+ * @returns {Promise<Set<string>>}
+ */
 const fetchPermissionGroupChildren = async (models, permissionGroupName) => {
   const permissionGroup = await models.permissionGroup.findOne({ name: permissionGroupName });
   const children = await permissionGroup.getChildTree();
-  return children.map(c => c.name);
+  return new Set(children.map(c => c.name));
 };
 
 /**
- * Builds a user's access policy in the format
- * { entityCode1: ['permissionGroup1', 'permissionGroup2'], entityCode2: ['permissionGroup1'] }
+ * @param {*} models
+ * @param {string} userId
+ * @returns {Record<string, string[]>}
+ * @example { entityCode1: ['permissionGroup1', 'permissionGroup2'], entityCode2: ['permissionGroup1'] }
  */
 export const buildAccessPolicy = async (models, userId) => {
-  const permissionsByEntity = {};
+  /** @type {Map<string, Set<string>>} */
+  const permissionsByEntity = new Map();
   const userEntityPermissions = await models.userEntityPermission.find({ user_id: userId });
 
   // set up permission group children fetching, for flattening the permission hierarchy
   // cache the promise (rather than the resolved value) so that concurrent lookups for the same
   // permission group share a single db fetch
-  const permissionGroupToChildren = {};
-  const getOrFetchPermissionGroupChildren = permissionGroupName => {
-    if (!permissionGroupToChildren[permissionGroupName]) {
-      permissionGroupToChildren[permissionGroupName] = fetchPermissionGroupChildren(
-        models,
-        permissionGroupName,
-      );
+  /** @type {Map<string, Promise<Set<string>>>} */
+  const permissionGroupToChildren = new Map();
+  /** @param {string} pgName */
+  const getOrFetchPermissionGroupChildren = pgName => {
+    if (!permissionGroupToChildren.has(pgName)) {
+      permissionGroupToChildren.set(pgName, fetchPermissionGroupChildren(models, pgName));
     }
-    return permissionGroupToChildren[permissionGroupName];
+    return permissionGroupToChildren.get(pgName);
   };
 
   // iterate through the user's permissions and build the permission groups per entity
   await Promise.all(
     userEntityPermissions.map(async userEntityPermission => {
+      /** @type {{ permission_group_name: string, entity_code: string }} */
       const { permission_group_name: permissionGroupName, entity_code: entityCode } =
         userEntityPermission;
 
-      permissionsByEntity[entityCode] = permissionsByEntity[entityCode] || [];
-      permissionsByEntity[entityCode].push(permissionGroupName);
+      let permissionGroups = permissionsByEntity.get(entityCode);
+      if (!permissionGroups) {
+        permissionGroups = new Set();
+        permissionsByEntity.set(entityCode, permissionGroups);
+      }
+      permissionGroups.add(permissionGroupName);
 
       // get all of the permission groups below this one in the hierarchy, as the user also has
       // implied access for them, so they'll also be added to the access policy (which has a simple,
       // flat structure, ignorant of the fact that permission groups exist in a hierarchy)
-      const permissionGroupChildren = await getOrFetchPermissionGroupChildren(permissionGroupName);
-      permissionsByEntity[entityCode] =
-        permissionsByEntity[entityCode].concat(permissionGroupChildren);
+      const children = await getOrFetchPermissionGroupChildren(permissionGroupName);
+      for (const child of children) permissionGroups.add(child);
     }),
   );
 
-  // policy is simply the permissions by entity, but de-duplicated
+  /** @type {Record<string, string[]>} */
   const policy = {};
-  Object.entries(permissionsByEntity).forEach(([entityCode, permissionGroups]) => {
-    policy[entityCode] = uniq(permissionGroups);
-  });
+  for (const [entityCode, permissionGroups] of permissionsByEntity) {
+    policy[entityCode] = Array.from(permissionGroups);
+  }
   return policy;
 };

--- a/packages/auth/src/buildAccessPolicy.js
+++ b/packages/auth/src/buildAccessPolicy.js
@@ -15,10 +15,18 @@ export const buildAccessPolicy = async (models, userId) => {
   const userEntityPermissions = await models.userEntityPermission.find({ user_id: userId });
 
   // set up permission group children fetching, for flattening the permission hierarchy
+  // cache the promise (rather than the resolved value) so that concurrent lookups for the same
+  // permission group share a single db fetch
   const permissionGroupToChildren = {};
-  const getOrFetchPermissionGroupChildren = async permissionGroupName =>
-    permissionGroupToChildren[permissionGroupName] || // get from cache
-    fetchPermissionGroupChildren(models, permissionGroupName); // or fetch from db
+  const getOrFetchPermissionGroupChildren = permissionGroupName => {
+    if (!permissionGroupToChildren[permissionGroupName]) {
+      permissionGroupToChildren[permissionGroupName] = fetchPermissionGroupChildren(
+        models,
+        permissionGroupName,
+      );
+    }
+    return permissionGroupToChildren[permissionGroupName];
+  };
 
   // iterate through the user's permissions and build the permission groups per entity
   await Promise.all(

--- a/packages/auth/src/buildAccessPolicy.js
+++ b/packages/auth/src/buildAccessPolicy.js
@@ -16,6 +16,8 @@ const fetchPermissionGroupChildren = async (models, permissionGroupName) => {
  * @example { entityCode1: ['permissionGroup1', 'permissionGroup2'], entityCode2: ['permissionGroup1'] }
  */
 export const buildAccessPolicy = async (models, userId) => {
+  const tag = Date.now();
+  console.time(`${tag} buildAccessPolicy`);
   /** @type {Map<string, Set<string>>} */
   const permissionsByEntity = new Map();
   const userEntityPermissions = await models.userEntityPermission.find({ user_id: userId });
@@ -60,5 +62,6 @@ export const buildAccessPolicy = async (models, userId) => {
   for (const [entityCode, permissionGroups] of permissionsByEntity) {
     policy[entityCode] = Array.from(permissionGroups);
   }
+  console.timeEnd(`${tag} buildAccessPolicy`);
   return policy;
 };


### PR DESCRIPTION
## Summary

- `buildAccessPolicy` sets up a `permissionGroupToChildren` cache to avoid re-fetching the child tree for the same permission group, but the fetched result was never written back into it, so the cache never got a hit.
- For a user with N `user_entity_permission` rows sharing the same permission group, this meant N separate `permission_group.findOne` + recursive child-tree queries instead of 1.
- The cache now stores the fetch **promise** (rather than the resolved value), so the concurrent lookups inside the surrounding `Promise.all` also share a single DB fetch.

This runs on login, token refresh, and every bearer-authenticated request that misses the `AccessPolicyBuilder` cache, so users with many entity permissions should see noticeably faster policy builds.

## Test plan

- [ ] `yarn workspace @tupaia/auth test` (requires test DB; `buildAccessPolicy` suite covers admin/public users across entity nestings)
- [ ] Verify login and authenticated requests behave the same as before (policy contents unchanged, just fewer duplicate queries)

Made with [Cursor](https://cursor.com)