### PR TITLE
repo: bump version to 1.4.0

### DIFF
--- a/packages/admin-panel-server/package.json
+++ b/packages/admin-panel-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/admin-panel-server",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Backend server for Admin Panel application",
   "homepage": "https://github.com/beyondessential/tupaia",
   "bugs": {

--- a/packages/admin-panel/package.json
+++ b/packages/admin-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/admin-panel",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "An interface for managing Tupaia data for non-developers",
   "repository": {

--- a/packages/aggregator/package.json
+++ b/packages/aggregator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/aggregator",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Aggregates and disaggregates data from various sources, via data-broker",
   "repository": {

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/auth",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Back-end authentication used internally by web-config-server and central-server to authenticate a user's credentials against the database, and build their access policy.",
   "repository": {

--- a/packages/central-server/package.json
+++ b/packages/central-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/central-server",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Central server for handling all miscellaneous Tupaia/Meditrak behaviour",
   "repository": {

--- a/packages/central-server/src/devops/CreateThumbnail/package.json
+++ b/packages/central-server/src/devops/CreateThumbnail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tupaia-resize-images",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Based off of Amazon documentation at http://docs.aws.amazon.com/lambda/latest/dg/with-s3-example-deployment-pkg.html",
   "repository": {

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/constants",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Tupaia constants repository",
   "repository": {

--- a/packages/data-api/package.json
+++ b/packages/data-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/data-api",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Fetches data from the Tupaia database, in the form of events or analytics",
   "repository": {

--- a/packages/data-broker/package.json
+++ b/packages/data-broker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/data-broker",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Maps data from Tupaia to external sources, and vice versa",
   "repository": {

--- a/packages/data-lake-api/package.json
+++ b/packages/data-lake-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/data-lake-api",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Fetches data from the Data Lake database, in the form of events or analytics",
   "repository": {

--- a/packages/data-table-server/package.json
+++ b/packages/data-table-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/data-table-server",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Microservice for querying Tupaia Data Tables",
   "homepage": "https://github.com/beyondessential/tupaia",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/database",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Common database code for use across other packages within this monorepo",
   "repository": {

--- a/packages/datatrak-web-server/package.json
+++ b/packages/datatrak-web-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/datatrak-web-server",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Orchestration server for datatrak web application",
   "homepage": "https://github.com/beyondessential/tupaia",

--- a/packages/datatrak-web/package.json
+++ b/packages/datatrak-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/datatrak-web",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Web app that collects data for the Tupaia project",
   "repository": {

--- a/packages/devops/package.json
+++ b/packages/devops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/devops",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Dev ops for the monorepo",
   "repository": {

--- a/packages/dhis-api/package.json
+++ b/packages/dhis-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/dhis-api",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Abstraction layer over the DHIS2 api",
   "repository": {

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/e2e",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "e2e runner",
   "repository": {

--- a/packages/entity-server/package.json
+++ b/packages/entity-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/entity-server",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Server for fetching entities and entity hierarchies",
   "homepage": "https://github.com/beyondessential/tupaia",

--- a/packages/expression-parser/package.json
+++ b/packages/expression-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/expression-parser",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Wraps around mathjs package, used for evaluating expressions",
   "repository": {

--- a/packages/indicators/package.json
+++ b/packages/indicators/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/indicators",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Shareable computations of derived data",
   "repository": {

--- a/packages/kobo-api/package.json
+++ b/packages/kobo-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/kobo-api",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Integration code for KoBo Toolbox api",
   "repository": {

--- a/packages/lesmis-server/package.json
+++ b/packages/lesmis-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/lesmis-server",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Backend server for LESMIS application",
   "homepage": "https://github.com/beyondessential/tupaia",

--- a/packages/lesmis/package.json
+++ b/packages/lesmis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/lesmis",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Lao PDR Education and Sports Management Information System",
   "repository": {

--- a/packages/meditrak-app-server/package.json
+++ b/packages/meditrak-app-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/meditrak-app-server",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Backend server for Meditrak-app",
   "homepage": "https://github.com/beyondessential/tupaia",

--- a/packages/psss-server/package.json
+++ b/packages/psss-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/psss-server",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Backend server for PSSS application",
   "homepage": "https://github.com/beyondessential/tupaia",

--- a/packages/psss/package.json
+++ b/packages/psss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/psss",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Pacific Syndromic Surveillance System client application",
   "repository": {

--- a/packages/report-server/package.json
+++ b/packages/report-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/report-server",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Server for building report data",
   "homepage": "https://github.com/beyondessential/tupaia",

--- a/packages/server-boilerplate/package.json
+++ b/packages/server-boilerplate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/server-boilerplate",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Generic boilerplate for back end orchestration servers",
   "homepage": "https://github.com/beyondessential/tupaia",

--- a/packages/server-utils/package.json
+++ b/packages/server-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/server-utils",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Utility functions that are just for server packages",
   "repository": {

--- a/packages/superset-api/package.json
+++ b/packages/superset-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/superset-api",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Fetches data from a Superset API, in the form of analytics",
   "repository": {

--- a/packages/sync-server/package.json
+++ b/packages/sync-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/sync-server",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Server for syncing data between browser and server in Tupaia",
   "homepage": "https://github.com/beyondessential/tupaia",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/sync",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Utilities for syncing data between browser and server in Tupaia",
   "repository": {

--- a/packages/tsmodels/package.json
+++ b/packages/tsmodels/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/tsmodels",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Tupaia TS models repository",
   "repository": {

--- a/packages/tsutils/package.json
+++ b/packages/tsutils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/tsutils",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Utility functions that are helpful across multiple packages (typescript)",
   "repository": {

--- a/packages/tupaia-web-server/package.json
+++ b/packages/tupaia-web-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/tupaia-web-server",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Orchestration server for tupaia web application",
   "homepage": "https://github.com/beyondessential/tupaia",

--- a/packages/tupaia-web/package.json
+++ b/packages/tupaia-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/tupaia-web",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Web app that integrates with and displays data from the Tupaia project",
   "repository": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/types",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Tupaia types repository",
   "repository": {

--- a/packages/ui-chart-components/package.json
+++ b/packages/ui-chart-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/ui-chart-components",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "A library of chart components for the monorepo",
   "repository": {

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/ui-components",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "A library of user interface components for the monorepo",
   "repository": {

--- a/packages/ui-map-components/package.json
+++ b/packages/ui-map-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/ui-map-components",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "A library of map components for the tupaia monorepo",
   "repository": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/utils",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Utility functions that are helpful across multiple packages",
   "repository": {

--- a/packages/viz-test-tool/package.json
+++ b/packages/viz-test-tool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/viz-test-tool",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Tupaia viz test tool repository",
   "repository": {

--- a/packages/weather-api/package.json
+++ b/packages/weather-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/weather-api",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Integration code for weatherbit.io api",
   "repository": {

--- a/packages/web-config-server/package.json
+++ b/packages/web-config-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/web-config-server",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Config server for tupaia.org",
   "repository": {


### PR DESCRIPTION
Bumps the version of all packages from `1.3.0` → `1.4.0` for the `release-2026-28` release.

Mechanical change: `"version"` field only, across all 44 package.json files. Matches the pattern of the previous bump (#6798).

🤖 Generated with [Claude Code](https://claude.com/claude-code)