### PR TITLE
fix(devops): install Puppeteer Chrome browser on app deploy

### DIFF
--- a/packages/devops/scripts/deployment-vm-app/install.sh
+++ b/packages/devops/scripts/deployment-vm-app/install.sh
@@ -33,6 +33,10 @@ nvm use
 corepack enable yarn
 yarn install --immutable
 
+# Yarn Berry does not run Puppeteer's postinstall, so download the pinned Chrome
+# build it needs for server-side PDF rendering (e.g. survey response export).
+yarn workspace @tupaia/server-utils exec puppeteer browsers install chrome
+
 # Fetch env vars
 set +x # Suppress output of Bitwarden secrets
 BW_CLIENTID="$BW_CLIENTID" \


### PR DESCRIPTION
## Problem

Survey response PDF export in datatrak fails on `release-2026-28` with:

```
puppeteer error: Could not find Chrome (ver. 133.0.6943.141) ...
your cache path is incorrectly configured (which is: /home/ubuntu/.cache/puppeteer).
```

## Root cause

The export (`ExportSurveyResponseRoute` → `downloadPageAsPdf`) uses `puppeteer@24.3.1`, which launches its **bundled** Chrome (133.0.6943.141) from `~/.cache/puppeteer`. Puppeteer downloads that binary via a `postinstall` (`node install.mjs`), but **Yarn 4 (Berry) does not run it** — verified locally: after a normal `yarn install`, `~/.cache/puppeteer/chrome` does not exist. The deploy has never had an explicit browser-install step either; `setup.sh` only installs Chrome's shared-library *dependencies*, not the browser itself.

This is a **latent gap, not a regression in this release**. The feature and the puppeteer@24 bump merged to master in March 2025 (`81d8e6ead`, #5917), before this release branched. It surfaces now because this is the first time the export has actually been invoked on a VM whose `~/.cache/puppeteer` is empty.

## Fix

Explicitly download the pinned Chrome build after `yarn install` in `deployment-vm-app/install.sh`. The command is idempotent — a no-op once the version is cached, so it only downloads when the puppeteer version bumps.

Because this isn't release-specific, the same change should also land on `dev` (permanent) and be cherry-picked to any other active release.

## Deploying

The next redeploy provisions Chrome automatically. To unblock the currently-running VM immediately, run on the box and restart the pm2 process:

```sh
cd /home/ubuntu/tupaia && yarn workspace @tupaia/server-utils exec puppeteer browsers install chrome
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)