### PR TITLE
fix(devops): download Puppeteer Chrome via yarn install on deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,11 @@
     "on-headers": "1.1.0",
     "react-smooth/lodash": "^4.18.0"
   },
+  "dependenciesMeta": {
+    "puppeteer": {
+      "built": true
+    }
+  },
   "devDependencies": {
     "@babel/cli": "^7.25.6",
     "@babel/core": "^7.25.2",

--- a/packages/devops/scripts/deployment-vm-app/install.sh
+++ b/packages/devops/scripts/deployment-vm-app/install.sh
@@ -33,10 +33,6 @@ nvm use
 corepack enable yarn
 yarn install --immutable
 
-# Yarn Berry does not run Puppeteer's postinstall, so download the pinned Chrome
-# build it needs for server-side PDF rendering (e.g. survey response export).
-yarn workspace @tupaia/server-utils exec puppeteer browsers install chrome
-
 # Fetch env vars
 set +x # Suppress output of Bitwarden secrets
 BW_CLIENTID="$BW_CLIENTID" \

--- a/yarn.lock
+++ b/yarn.lock
@@ -29891,6 +29891,9 @@ __metadata:
     vite: "npm:^4.5.14"
     vite-plugin-compression: "npm:^0.5.1"
     vite-plugin-ejs: "npm:^1.6.4"
+  dependenciesMeta:
+    puppeteer:
+      built: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Problem

Since the Yarn 4.16 → 4.17 update (#6844), production app redeploys fail with:

```
Could not find Chrome (ver. 133.0.6943.141)
... cache path is ... /home/ubuntu/.cache/puppeteer
```

Survey response PDF export uses `puppeteer@24` (in `@tupaia/server-utils`), which launches its bundled Chrome from `~/.cache/puppeteer`. Yarn Berry skips dependencies' build scripts by default, so Puppeteer's `postinstall` never downloads the browser.

The earlier fix (#6863) added an explicit `puppeteer browsers install chrome` line to `deployment-vm-app/install.sh`, but that script does **not** run on an app redeploy — the redeploy path is `startupTupaia.sh` → `buildDeployablePackages.sh`, which runs `yarn install --immutable` without ever calling `install.sh`. So the error persists in production.

## Fix

Opt Puppeteer into Yarn's build scripts via `dependenciesMeta.puppeteer.built: true` in the root `package.json`. This makes Puppeteer's `postinstall` (which downloads the pinned Chrome) run during `yarn install --immutable` itself — i.e. on **every** deploy path, not just `install.sh`. The now-redundant `install.sh` line is removed.

This is a hotfix cherry-pick of #6865 (already on `dev`) to `master`.

## Test plan

- [ ] Confirm build succeeds and Chrome is present in `~/.cache/puppeteer` on prod
- [ ] Smoke test survey response PDF export on prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)