### PR TITLE
feat(web): TUP-3188: unhide eHealth Tokelau project from frontend

### DIFF
--- a/packages/web-config-server/src/apiV1/projects.js
+++ b/packages/web-config-server/src/apiV1/projects.js
@@ -2,7 +2,6 @@ import { NotFoundError, respond } from '@tupaia/utils';
 
 const FRONTEND_EXCLUDED_PROJECTS = /** @type {const} */ ([
   'ehealth_cook_islands',
-  'ehealth_tokelau',
   'ehealth_timor_leste',
   'ehealth_vanuatu',
 ]);


### PR DESCRIPTION
## Problem

The `ehealth_tokelau` project exists in Tupaia but is not visible on the frontend. It was listed in `FRONTEND_EXCLUDED_PROJECTS` in `web-config-server`, which the frontend filters against (tupaia-web requests projects with `showExcludedProjects: false`).

## Change

Removed `ehealth_tokelau` from the `FRONTEND_EXCLUDED_PROJECTS` list in `packages/web-config-server/src/apiV1/projects.js`. The other eHealth projects remain excluded as before.

## Testing

One-line data change to an exclusion list. Once deployed, the eHealth Tokelau project will be returned by the `projects` endpoint and appear in the project list on tupaia-web (subject to the user's access permissions).

Linear: [TUP-3188](https://linear.app/bes/issue/TUP-3188/unhide-the-ehealth-tokelau-project-from-the-frontend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)