### PR TITLE
fix(datatrakWeb): TUP-3165: resolve scanned QR ids to the project entity copy

### DIFF
--- a/packages/datatrak-web-server/src/__tests__/EntityDescendantsRoute.test.ts
+++ b/packages/datatrak-web-server/src/__tests__/EntityDescendantsRoute.test.ts
@@ -89,4 +89,76 @@ describe('EntityDescendantsRoute', () => {
 
     await expect(route.buildResponse()).rejects.toThrow('No entity found with id missing-id');
   });
+
+  it('falls back to a code lookup when a scanned id misses in-project (QR of a duplicated entity)', async () => {
+    getDescendantsOfEntity
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ id: 'project-copy-id', code: 'SHARED', name: 'Shared Entity' }]);
+    findById.mockResolvedValue({ id: 'old-canonical-id', code: 'SHARED' });
+    const route = new TestableEntityDescendantsRoute({
+      query: { filter: { projectCode: 'explore', countryCode: 'DL', id: 'old-canonical-id' } },
+    });
+
+    const result = await route.buildResponse();
+
+    expect(findById).toHaveBeenCalledWith('old-canonical-id');
+    expect(getDescendantsOfEntity).toHaveBeenCalledTimes(2);
+
+    const [firstFilter] = getDescendantsOfEntity.mock.calls[0].slice(2);
+    expect(firstFilter.filter).toEqual(expect.objectContaining({ id: 'old-canonical-id' }));
+
+    const [secondFilter] = getDescendantsOfEntity.mock.calls[1].slice(2);
+    expect(secondFilter.filter).toEqual(
+      expect.objectContaining({ code: 'SHARED', country_code: 'DL' }),
+    );
+    expect(secondFilter.filter).not.toHaveProperty('id');
+
+    expect(result).toEqual([
+      expect.objectContaining({ id: 'project-copy-id', code: 'SHARED', name: 'Shared Entity' }),
+    ]);
+  });
+
+  it('returns an empty result (no throw) when a scanned id resolves to no entity at all', async () => {
+    getDescendantsOfEntity.mockResolvedValue([]);
+    findById.mockResolvedValue(null);
+    const route = new TestableEntityDescendantsRoute({
+      query: { filter: { projectCode: 'explore', countryCode: 'DL', id: 'genuinely-missing' } },
+    });
+
+    await expect(route.buildResponse()).resolves.toEqual([]);
+    expect(findById).toHaveBeenCalledWith('genuinely-missing');
+    // Fallback skipped when the id resolves to no code, so no second query.
+    expect(getDescendantsOfEntity).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fall back when a scanned id already resolves in-project', async () => {
+    getDescendantsOfEntity.mockResolvedValue([
+      { id: 'in-project-id', code: 'ASSET1', name: 'Tonga Asset' },
+    ]);
+    const route = new TestableEntityDescendantsRoute({
+      query: { filter: { projectCode: 'explore', countryCode: 'DL', id: 'in-project-id' } },
+    });
+
+    const result = await route.buildResponse();
+
+    expect(findById).not.toHaveBeenCalled();
+    expect(getDescendantsOfEntity).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([
+      expect.objectContaining({ id: 'in-project-id', code: 'ASSET1', name: 'Tonga Asset' }),
+    ]);
+  });
+
+  it('does not trigger the scan fallback on the parentId flow (empty children stay empty)', async () => {
+    getDescendantsOfEntity.mockResolvedValue([]);
+    findById.mockResolvedValue({ id: 'parent-id', code: 'PARENT_CODE' });
+    const route = new TestableEntityDescendantsRoute({
+      query: { filter: { projectCode: 'explore', countryCode: 'DL', parentId: 'parent-id' } },
+    });
+
+    await route.buildResponse();
+
+    // findById is called once to resolve the parent, NOT a second time for a fallback.
+    expect(findById).toHaveBeenCalledTimes(1);
+    expect(getDescendantsOfEntity).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/datatrak-web-server/src/__tests__/EntityDescendantsRoute.test.ts
+++ b/packages/datatrak-web-server/src/__tests__/EntityDescendantsRoute.test.ts
@@ -161,4 +161,42 @@ describe('EntityDescendantsRoute', () => {
     expect(findById).toHaveBeenCalledTimes(1);
     expect(getDescendantsOfEntity).toHaveBeenCalledTimes(1);
   });
+
+  it('falls back to code for a scan on a parent-constrained question, preserving generational_distance', async () => {
+    // parentId resolves first, then the scanned id resolves during the fallback.
+    findById
+      .mockResolvedValueOnce({ id: 'parent-id', code: 'PARENT_CODE' })
+      .mockResolvedValueOnce({ id: 'old-canonical-id', code: 'SHARED' });
+    getDescendantsOfEntity
+      .mockResolvedValueOnce([]) // children-of-parent filtered by the stale scanned id misses
+      .mockResolvedValueOnce([{ id: 'project-copy-id', code: 'SHARED', name: 'Household' }]);
+    const route = new TestableEntityDescendantsRoute({
+      query: {
+        filter: {
+          projectCode: 'explore',
+          countryCode: 'DL',
+          parentId: 'parent-id',
+          id: 'old-canonical-id',
+        },
+      },
+    });
+
+    const result = await route.buildResponse();
+
+    expect(findById).toHaveBeenNthCalledWith(1, 'parent-id');
+    expect(findById).toHaveBeenNthCalledWith(2, 'old-canonical-id');
+    expect(getDescendantsOfEntity).toHaveBeenCalledTimes(2);
+
+    // fallback still scopes to children of the parent (entityCode = PARENT_CODE) and swaps id → code
+    const [, secondEntityCode, secondOptions] = getDescendantsOfEntity.mock.calls[1];
+    expect(secondEntityCode).toBe('PARENT_CODE');
+    expect(secondOptions.filter).toEqual(
+      expect.objectContaining({
+        code: 'SHARED',
+        generational_distance: { comparator: '=', comparisonValue: 1 },
+      }),
+    );
+    expect(secondOptions.filter).not.toHaveProperty('id');
+    expect(result).toEqual([expect.objectContaining({ id: 'project-copy-id' })]);
+  });
 });

--- a/packages/datatrak-web-server/src/routes/EntityDescendantsRoute.ts
+++ b/packages/datatrak-web-server/src/routes/EntityDescendantsRoute.ts
@@ -102,15 +102,12 @@ export class EntityDescendantsRoute extends Route<EntityDescendantsRequest> {
     // duplicated per project, and each project's copy has a new id sharing the old
     // `code`, so scanning finds nothing in projects where the entity was duplicated.
     // Resolve the scanned id → code (the canonical row is still on central) and
-    // re-query by code to pick up the project's copy. Gated on an empty result so
-    // in-project scans stay zero-behaviour-change with no extra DB call.
-    if (
-      entities.length === 0 &&
-      scannedId &&
-      !parentId &&
-      !grandparentId &&
-      !('code' in restOfFilter)
-    ) {
+    // re-query by code to pick up the project's copy. `scannedId` is only set by a QR
+    // scan, so this never fires on plain parent/grandparent browsing; it must still fire
+    // for scans on parent/grandparent-constrained questions (entityCode is already the
+    // parent's code there). Gated on an empty result so in-project scans stay
+    // zero-behaviour-change with no extra DB call.
+    if (entities.length === 0 && scannedId && !('code' in restOfFilter)) {
       // Non-throwing lookup: a genuinely-invalid scan should surface as an empty
       // result ("No matching entity found"), not a 500.
       const entity = await models.entity.findById(scannedId);

--- a/packages/datatrak-web-server/src/routes/EntityDescendantsRoute.ts
+++ b/packages/datatrak-web-server/src/routes/EntityDescendantsRoute.ts
@@ -43,6 +43,10 @@ export class EntityDescendantsRoute extends Route<EntityDescendantsRequest> {
       pageSize = DEFAULT_PAGE_SIZE,
     } = query;
 
+    // A bare single-id lookup is a QR scan. Capture it so we can fall back to a
+    // code lookup if the id doesn't resolve within the project (see below).
+    const scannedId = typeof restOfFilter.id === 'string' ? restOfFilter.id : undefined;
+
     if (isLoggedIn) {
       const currentUser = ensure(
         await models.user.findOne({ email: session.email }),
@@ -82,7 +86,7 @@ export class EntityDescendantsRoute extends Route<EntityDescendantsRequest> {
       };
     }
 
-    const entities = await services.entity.getDescendantsOfEntity(
+    let entities = await services.entity.getDescendantsOfEntity(
       projectCode,
       entityCode,
       {
@@ -93,6 +97,39 @@ export class EntityDescendantsRoute extends Route<EntityDescendantsRequest> {
       false,
       !isLoggedIn,
     );
+
+    // Printed QR codes encode an entity's pre-epic id. Sub-country entities are now
+    // duplicated per project, and each project's copy has a new id sharing the old
+    // `code`, so scanning finds nothing in projects where the entity was duplicated.
+    // Resolve the scanned id → code (the canonical row is still on central) and
+    // re-query by code to pick up the project's copy. Gated on an empty result so
+    // in-project scans stay zero-behaviour-change with no extra DB call.
+    if (
+      entities.length === 0 &&
+      scannedId &&
+      !parentId &&
+      !grandparentId &&
+      !('code' in restOfFilter)
+    ) {
+      // Non-throwing lookup: a genuinely-invalid scan should surface as an empty
+      // result ("No matching entity found"), not a 500.
+      const entity = await models.entity.findById(scannedId);
+      const code = entity?.code;
+      if (code) {
+        const { id: _omit, ...filterWithoutId } = filter as typeof filter & { id?: string };
+        entities = await services.entity.getDescendantsOfEntity(
+          projectCode,
+          entityCode,
+          {
+            fields,
+            filter: { ...filterWithoutId, code },
+            pageSize,
+          },
+          false,
+          !isLoggedIn,
+        );
+      }
+    }
 
     const sortedEntities = searchString
       ? sortSearchResults(searchString, entities)


### PR DESCRIPTION
## Problem (TUP-3165, Issue 29)

Tupaia entity QR codes encode **only the entity `id`** (`QRCodeItem.tsx` → `qrCodeContents={id}`), and printed codes carry the **pre-epic** id. The entity-hierarchy epic duplicates sub-country entities per project — each project's copy gets a **new id** sharing the old `code` — so scanning an old QR to select an entity now fails with *"No matching entity found"* in any project where that entity was duplicated.

QA (Andrew) confirmed: on `dev` (no duplication) scanning works; on the epic branch, Samoa eHealth (`WS_h00001`, survey WS/HHU) fails. Projects with no duplicated entities (Tonga/Fiji Assets) are unaffected because the id still matches.

## Fix

A **backward-compatible, server-side id→code fallback** in `EntityDescendantsRoute` (datatrak-web-server): when a bare single-id lookup (a QR scan) returns no in-project match, resolve the scanned id → its `code` via `models.entity.findById` (the canonical row is still on central), then re-query by `(code, project)` to pick up the project's duplicated copy — preserving `fields`, `pageSize`, `type`, `country_code`, and any other filters.

- **Non-throwing** `findById` (not the `ensure`-based `getEntityCodeFromId` helper), so a genuinely-invalid scan degrades to an empty result → the existing *"No matching entity found"* message, **not a 500**.
- **Gated on an empty first result** and on `!parentId && !grandparentId && !('code' in filter)` — so unaffected/in-project scans are zero-behaviour-change with no extra DB call, and the existing parent/grandparent flows (which already resolve id→code) are untouched.

This rescues already-printed QR codes, which is the whole point (switching new QR generation to encode `code` would not help printed ones and is left as a separate future item).

### 🦸 Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
- [ ] **Save suppressions** <!-- #save-suppressions -->