### PR TITLE
tweak(datatrak): improve web app caching

### DIFF
--- a/packages/datatrak-web/workbox-config.js
+++ b/packages/datatrak-web/workbox-config.js
@@ -1,7 +1,24 @@
 module.exports = {
   globDirectory: 'dist/',
-  globPatterns: ['**/*.{avif,gif,htm,html,ico,jpeg,jpg,js,json,jxl,png,svg,txt,webp}'],
+  /**
+   * `.wasm` and `.data` are PGlite, the local Postgres the app reads and writes offline. Without
+   * them cached the app cannot start offline at all.
+   * `.gz` is deliberately absent: vite-plugin-compression emits gzipped siblings of the files
+   * already listed here, served via Content-Encoding negotiation. Caching both would store every
+   * asset twice.
+   */
+  globPatterns: ['**/*.{avif,data,gif,htm,html,ico,jpeg,jpg,js,json,jxl,png,svg,txt,wasm,webp}'],
+  globIgnores: [
+    'mockServiceWorker.js', // MSW test fixture, and a rival service worker script
+    'screenshots/**', // Read by the OS install prompt, which only happens online
+    'social-preview.png', // Open Graph image, only ever fetched by link crawlers
+  ],
+  /**
+   * Vite content-hashes these filenames, so Workbox adding its own revision hash would only force
+   * the precache install to re-download bytes the browser already has.
+   */
+  dontCacheBustURLsMatching: /-[0-9a-f]{8}\.\w+$/,
   swSrc: 'dist/sw.js',
   swDest: 'dist/sw.js',
-  maximumFileSizeToCacheInBytes: 5 * 1024 * 1024, // 5 MiB
+  maximumFileSizeToCacheInBytes: 16_777_216, // 16 MiB
 };


### PR DESCRIPTION
### Previously

```sh
yarn run build:worker

  dist/sw.js  82.2kb

⚡ Done in 22ms
Using configuration from /Users/jasper/Developer/tupaia/packages/datatrak-web/workbox-config.js.
assets/index-036fe002.js is 8.48 MB, and won't be precached. Configure maximumFileSizeToCacheInBytes to change this limit.
The service worker file was written to dist/sw.js
The service worker will precache 161 URLs, totaling 13 MB.
```

### Now

```sh
yarn run build:worker

  dist/sw.js  82.2kb

⚡ Done in 22ms
Using configuration from /Users/jasper/Developer/tupaia/packages/datatrak-web/workbox-config.js.
The service worker file was written to dist/sw.js
The service worker will precache 156 URLs, totaling 32.1 MB.
```

---

### Screenshots:

---

### 🦸 Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
- [ ] **Save suppressions** <!-- #save-suppressions -->
