### PR TITLE
tweak(uiComponents): keep ace-builds out of the ui-components barrel

### DIFF
--- a/packages/admin-panel/src/VizBuilderApp/components/DataLibrary/component/TransformEditor.jsx
+++ b/packages/admin-panel/src/VizBuilderApp/components/DataLibrary/component/TransformEditor.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
-import { SqlEditor } from '@tupaia/ui-components';
+import { SqlEditor } from '@tupaia/ui-components/dist/components/Editor';
 import { SelectedOptionWithEditor } from './SelectedOptionWithEditor';
 import { JsonEditor } from '../../../../widgets';
 

--- a/packages/admin-panel/src/dataTables/config/SqlDataTableConfigEditFields.jsx
+++ b/packages/admin-panel/src/dataTables/config/SqlDataTableConfigEditFields.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Accordion, AccordionDetails, AccordionSummary, Grid } from '@material-ui/core';
-import { SqlEditor } from '@tupaia/ui-components';
+import { SqlEditor } from '@tupaia/ui-components/dist/components/Editor';
 import { ParameterList, ParameterItem } from '../components/editing';
 import { useSqlEditor } from '../useSqlEditor';
 

--- a/packages/ui-components/src/components/index.ts
+++ b/packages/ui-components/src/components/index.ts
@@ -11,7 +11,9 @@ export * from './DataGrid';
 export * from './DataTable';
 export * from './DateRangePicker';
 export * from './Dialog';
-export * from './Editor';
+// Editor (SqlEditor) is deliberately not re-exported here: ace-builds registers modes and themes
+// as import side effects (~600 KB) which can never be tree-shaken out of a barrel. Import it from
+// '@tupaia/ui-components/dist/components/Editor'.
 export * from './EnvBanner';
 export * from './ErrorBoundary';
 export * from './FavouriteButton';


### PR DESCRIPTION
## Summary

Part 4 of the DataTrak startup-JS series.

`@tupaia/ui-components` re-exported `Editor` (= `SqlEditor`), which imports `react-ace` and `ace-builds`. Ace registers modes and themes as import side effects, so it can never be tree-shaken out of a barrel, and every DataTrak user shipped a SQL editor they can't ever see.

- Removed `export * from './Editor'` from the components barrel.
- The only consumers anywhere are two admin-panel files (`SqlDataTableConfigEditFields`, `TransformEditor`); they now deep-import `@tupaia/ui-components/dist/components/Editor`. (The plan mentioned a third file, `useSqlEditor.js`, but it doesn't actually import `SqlEditor`.)

## Measured effect on `packages/datatrak-web/dist` (raw, pre-gzip)

The 558 KB `ace` and 58 KB `reactAce` chunks are **gone entirely**, and the entry chunk shrinks ~58 KB as hoisted vendor modules redistribute. Net about **−670 KB**.

## Test plan

- [x] ui-components, datatrak-web and admin-panel all build; no ace modules remain in datatrak dist
- [ ] Regression check the admin panel SQL data table editor and the viz builder transform editor
