### PR TITLE
tweak(uiComponents): keep xlsx out of the ui-components, ui-map-components and utils barrels

### DIFF
--- a/packages/central-server/src/apiV2/import/importStriveLabResults/importStriveLabResults.js
+++ b/packages/central-server/src/apiV2/import/importStriveLabResults/importStriveLabResults.js
@@ -1,6 +1,8 @@
 import xlsx from 'xlsx';
 
-import { mapKeys, respond, UploadError, WorkBookParser } from '@tupaia/utils';
+import { mapKeys, respond, UploadError } from '@tupaia/utils';
+// Deep import so the xlsx dependency stays out of the @tupaia/utils barrel (and browser bundles)
+import { WorkBookParser } from '@tupaia/utils/dist/WorkBookParser';
 import { assertAnyPermissions, assertBESAdminAccess } from '../../../permissions';
 import { SurveyResponseImporter } from '../../utilities';
 import SURVEYS from './surveys.json';

--- a/packages/lesmis/src/components/MapTableModal.jsx
+++ b/packages/lesmis/src/components/MapTableModal.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import DownloadIcon from '@material-ui/icons/GetApp';
 import { Dialog, DialogHeader, DialogContent } from '@tupaia/ui-components';
-import { MapTable, useMapDataExport } from '@tupaia/ui-map-components';
+import { MapTable, useMapDataExport } from '@tupaia/ui-map-components/dist/components/Table';
 import MuiIconButton from '@material-ui/core/IconButton';
 
 export const MapTableModal = ({ Button, overlayReportData, title }) => {

--- a/packages/tupaia-web/src/features/Map/MapOverlaySelector/MapTableModal.tsx
+++ b/packages/tupaia-web/src/features/Map/MapOverlaySelector/MapTableModal.tsx
@@ -5,7 +5,7 @@ import DownloadIcon from '@material-ui/icons/GetApp';
 import MuiIconButton from '@material-ui/core/IconButton';
 import { FlexColumn, SpinningLoader, NoData } from '@tupaia/ui-components';
 import { Typography } from '@material-ui/core';
-import { MapTable, useMapDataExport } from '@tupaia/ui-map-components';
+import { MapTable, useMapDataExport } from '@tupaia/ui-map-components/dist/components/Table';
 import { useMapOverlayTableData } from '../utils';
 import { Modal } from '../../../components';
 import { useEntity, useEntityAncestors, useMapOverlays, useProject } from '../../../api/queries';

--- a/packages/ui-chart-components/src/components/ChartTable.tsx
+++ b/packages/ui-chart-components/src/components/ChartTable.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { DataTable, NoData } from '@tupaia/ui-components';
+import { NoData } from '@tupaia/ui-components';
+import { DataTable } from '@tupaia/ui-components/dist/components/DataTable';
 import { ChartConfig, ChartReport } from '@tupaia/types';
 import { getChartTableData, getIsChartData } from '../utils';
 

--- a/packages/ui-chart-components/src/utils/useChartDataExport.ts
+++ b/packages/ui-chart-components/src/utils/useChartDataExport.ts
@@ -1,4 +1,4 @@
-import { useDataTableExport } from '@tupaia/ui-components';
+import { useDataTableExport } from '@tupaia/ui-components/dist/components/DataTable';
 import { DashboardItemConfig, DashboardItemReport } from '@tupaia/types';
 import { getChartTableData } from './getChartTableData';
 

--- a/packages/ui-components/src/components/index.ts
+++ b/packages/ui-components/src/components/index.ts
@@ -8,7 +8,8 @@ export * from './CardTabs';
 export * from './CheckboxList';
 export * from './CircleMeter';
 export * from './DataGrid';
-export * from './DataTable';
+// DataTable is deliberately not re-exported here: it depends on xlsx (~2 MB), which would be
+// retained in every consumer's bundle. Import it from '@tupaia/ui-components/dist/components/DataTable'.
 export * from './DateRangePicker';
 export * from './Dialog';
 export * from './Editor';

--- a/packages/ui-map-components/src/components/Table/MapTable.tsx
+++ b/packages/ui-map-components/src/components/Table/MapTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { DataTable } from '@tupaia/ui-components';
+import { DataTable } from '@tupaia/ui-components/dist/components/DataTable';
 import { getMapTableData } from './getMapTableData';
 import { MeasureData, Series } from '../../types';
 

--- a/packages/ui-map-components/src/components/Table/useMapDataExport.tsx
+++ b/packages/ui-map-components/src/components/Table/useMapDataExport.tsx
@@ -1,4 +1,4 @@
-import { useDataTableExport } from '@tupaia/ui-components';
+import { useDataTableExport } from '@tupaia/ui-components/dist/components/DataTable';
 import { getMapTableData } from './getMapTableData';
 import { Series, MeasureData } from '../../types';
 

--- a/packages/ui-map-components/src/components/index.ts
+++ b/packages/ui-map-components/src/components/index.ts
@@ -14,6 +14,8 @@ export * from './Legend';
 export * from './LeafletMap';
 export * from './Markers';
 export * from './PopupDataItemList';
-export * from './Table';
+// Table (MapTable) is deliberately not re-exported here: it depends on xlsx (~2 MB) via
+// DataTable, which would be retained in every consumer's bundle. Import it from
+// '@tupaia/ui-map-components/dist/components/Table'.
 export * from './TileLayer';
 export * from './TilePicker';

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -26,7 +26,6 @@ export * from './runScript';
 export * from './Script';
 export * from './string';
 export * from './validation';
-export { WorkBookParser } from './WorkBookParser';
 export { checkValueSatisfiesCondition } from './checkValueSatisfiesCondition';
 export { addExportedDateAndOriginAtTheSheetBottom } from './addExportDateAndOriginInExcelExportData';
 export { getBrowserTimeZone } from './getBrowserTimeZone';

--- a/vite.config.js
+++ b/vite.config.js
@@ -128,10 +128,17 @@ export default defineConfig(({ command, mode }) => {
             __dirname,
             './packages/ui-chart-components/src/index.ts',
           ),
+          '@tupaia/ui-map-components/dist': path.resolve(
+            __dirname,
+            './packages/ui-map-components/src',
+          ),
           '@tupaia/ui-map-components': path.resolve(
             __dirname,
             './packages/ui-map-components/src/index.ts',
           ),
+          // Deep imports into the built output (e.g. '@tupaia/ui-components/dist/components/DataTable')
+          // need mapping back to src, and must be listed before the bare alias so they match first
+          '@tupaia/ui-components/dist': path.resolve(__dirname, './packages/ui-components/src'),
           '@tupaia/ui-components': path.resolve(__dirname, './packages/ui-components/src/index.ts'),
           ...(isDatatrakWeb && {
             '@tupaia/database': path.resolve(__dirname, './packages/database/src/browser/index.js'),


### PR DESCRIPTION
## Summary

Part 3 of the DataTrak startup-JS series. Independent of PRs 1–2; PR 4 stacks on this one.

DataTrak never uses `xlsx`, but it shipped the whole 2 MB library because three barrels reached it:

1. **`@tupaia/utils`** re-exported `WorkBookParser` (imports `xlsx`). Removed from the barrel; the single consumer (`central-server` importStriveLabResults) now deep-imports `@tupaia/utils/dist/WorkBookParser`, following the existing `@tupaia/utils/dist/errors` precedent.
2. **`@tupaia/ui-components`** re-exported `DataTable`, whose `useDataTableExport` imports `xlsx`. Removed from the components barrel; the four consumers (ui-chart-components ChartTable + useChartDataExport, ui-map-components MapTable + useMapDataExport) now deep-import `@tupaia/ui-components/dist/components/DataTable`.
3. **`@tupaia/ui-map-components`** re-exported `MapTable` (→ DataTable → xlsx), and DataTrak imports that barrel for `TileLayer`/`TilePicker`. This path wasn't in the original plan but kept the chunk alive, so it's cut the same way: `Table` removed from the barrel, and the two consumers (tupaia-web and lesmis `MapTableModal`) now deep-import `@tupaia/ui-map-components/dist/components/Table`.

Because the vite dev servers alias `@tupaia/ui-components` and `@tupaia/ui-map-components` to their `src`, prefix matching would have mangled the new `/dist/...` deep imports in dev. More-specific `.../dist` → `src` aliases are added (listed before the bare aliases so they match first).

## Measured effect on `packages/datatrak-web/dist` (raw, pre-gzip)

The 2,025 KB `xlsx` chunk is **gone entirely** (`grep SheetJS dist/assets` finds nothing). The entry chunk grows ~176 KB from redistributed shared vendor modules that previously lived in the xlsx chunk. Net about **−1.85 MB**.

## Test plan

- [x] utils, ui-components, ui-chart-components, ui-map-components and datatrak-web all build
- [ ] Regression check chart table + map table CSV/XLSX export in tupaia-web (the real consumer of this code)
- [ ] Regression check STRIVE lab results import in admin panel (central-server)

