### PR TITLE
feat(meditrak): TUP-3195: Port dynamic CodeGenerator prefixes

### DIFF
--- a/packages/meditrak-app/app/assessment/DumbSurveyScreen.jsx
+++ b/packages/meditrak-app/app/assessment/DumbSurveyScreen.jsx
@@ -6,6 +6,7 @@ import Bugsnag from '@bugsnag/react-native';
 import { database } from '../database';
 import { QuestionScreen } from './QuestionScreen';
 import { SubmitScreen } from './SubmitScreen';
+import { DynamicCodeGeneratorWatchers } from './DynamicCodeGeneratorWatchers';
 import {
   Button,
   KeyboardSpacer,
@@ -159,6 +160,7 @@ export class DumbSurveyScreen extends React.Component {
 
     return (
       <TupaiaBackground style={localStyles.container}>
+        <DynamicCodeGeneratorWatchers />
         {[0, 1].map(index => {
           // Even screens will use the first component, odd will use the second
           const isCurrentContent = screenIndex % 2 === index;

--- a/packages/meditrak-app/app/assessment/DynamicCodeGeneratorWatcher.jsx
+++ b/packages/meditrak-app/app/assessment/DynamicCodeGeneratorWatcher.jsx
@@ -1,0 +1,104 @@
+import { useEffect, useRef } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+
+import { database } from '../database';
+import { changeAnswer } from './actions';
+import { getAnswerForQuestion, getQuestion } from './selectors';
+import { resolveCode, resolvePrefix } from './specificQuestions/utilities/dynamicCodeGenerator';
+
+const ENTITY_QUESTION_TYPES = ['Entity', 'PrimaryEntity'];
+
+// Read an entity's prefix-relevant fields straight off the Realm record. We avoid Entity.toJson()
+// because it dereferences the (optional) parent and throws for parentless entities.
+const getEntityRecord = entityId => {
+  if (!entityId) return null;
+  const entity = database.findOne('Entity', entityId);
+  if (!entity) return null;
+  return {
+    name: entity.name,
+    code: entity.code,
+    type: entity.type,
+    attributes: entity.attributes ? JSON.parse(entity.attributes) : {},
+  };
+};
+
+const resolveDynamicPrefix = (dynamicPrefix, isEntitySource, sourceAnswer) => {
+  if (!sourceAnswer) return undefined;
+  if (isEntitySource) {
+    const entity = getEntityRecord(sourceAnswer);
+    return entity ? resolvePrefix(entity, dynamicPrefix) : undefined;
+  }
+  return sourceAnswer;
+};
+
+/**
+ * Headless watcher (one per dynamic-prefix CodeGenerator question) that keeps the generated code in
+ * sync with its source answer. Mounted at the assessment level so it survives screen navigation,
+ * letting it reuse the random tail of the code across prefix changes.
+ */
+const DynamicCodeGeneratorWatcherComponent = ({
+  questionId,
+  codeGenerator,
+  resolvedPrefix,
+  existingCode,
+  dispatch,
+}) => {
+  const prevPrefixRef = useRef(undefined);
+  const trailingCodeRef = useRef(undefined);
+
+  useEffect(() => {
+    if (resolvedPrefix === undefined) {
+      if (prevPrefixRef.current !== undefined) {
+        prevPrefixRef.current = undefined;
+        dispatch(changeAnswer(questionId, undefined));
+      }
+      return;
+    }
+
+    if (resolvedPrefix === prevPrefixRef.current) return;
+    prevPrefixRef.current = resolvedPrefix;
+
+    const result = resolveCode({
+      resolvedPrefix,
+      existingCode,
+      trailingCode: trailingCodeRef.current,
+      codeGenerator,
+    });
+    trailingCodeRef.current = result.trailingCode;
+
+    if (result.code !== existingCode) {
+      dispatch(changeAnswer(questionId, result.code));
+    }
+  }, [resolvedPrefix, existingCode, codeGenerator, questionId, dispatch]);
+
+  return null;
+};
+
+DynamicCodeGeneratorWatcherComponent.propTypes = {
+  questionId: PropTypes.string.isRequired,
+  codeGenerator: PropTypes.object.isRequired,
+  resolvedPrefix: PropTypes.string,
+  existingCode: PropTypes.string,
+  dispatch: PropTypes.func.isRequired,
+};
+
+const mapStateToProps = (state, { questionId }) => {
+  const { config } = getQuestion(state, questionId);
+  const { codeGenerator } = config;
+  const { dynamicPrefix } = codeGenerator;
+
+  const sourceQuestion = getQuestion(state, dynamicPrefix.questionId);
+  const isEntitySource = !!sourceQuestion && ENTITY_QUESTION_TYPES.includes(sourceQuestion.type);
+  const sourceAnswer = getAnswerForQuestion(state, dynamicPrefix.questionId);
+
+  return {
+    codeGenerator,
+    resolvedPrefix: resolveDynamicPrefix(dynamicPrefix, isEntitySource, sourceAnswer),
+    existingCode: getAnswerForQuestion(state, questionId),
+  };
+};
+
+export const DynamicCodeGeneratorWatcher = connect(mapStateToProps)(
+  DynamicCodeGeneratorWatcherComponent,
+);

--- a/packages/meditrak-app/app/assessment/DynamicCodeGeneratorWatchers.jsx
+++ b/packages/meditrak-app/app/assessment/DynamicCodeGeneratorWatchers.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+
+import { DynamicCodeGeneratorWatcher } from './DynamicCodeGeneratorWatcher';
+
+const hasDynamicPrefix = question =>
+  question.type === 'CodeGenerator' &&
+  !!question.config &&
+  !!question.config.codeGenerator &&
+  !!question.config.codeGenerator.dynamicPrefix;
+
+const DynamicCodeGeneratorWatchersComponent = ({ questionIds }) => (
+  <>
+    {questionIds.map(questionId => (
+      <DynamicCodeGeneratorWatcher key={questionId} questionId={questionId} />
+    ))}
+  </>
+);
+
+DynamicCodeGeneratorWatchersComponent.propTypes = {
+  questionIds: PropTypes.arrayOf(PropTypes.string).isRequired,
+};
+
+const mapStateToProps = state => ({
+  questionIds: Object.values(state.assessment.questions || {})
+    .filter(hasDynamicPrefix)
+    .map(question => question.id),
+});
+
+export const DynamicCodeGeneratorWatchers = connect(mapStateToProps)(
+  DynamicCodeGeneratorWatchersComponent,
+);

--- a/packages/meditrak-app/app/assessment/specificQuestions/CodeGeneratorQuestion.jsx
+++ b/packages/meditrak-app/app/assessment/specificQuestions/CodeGeneratorQuestion.jsx
@@ -1,13 +1,19 @@
 import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { View } from 'react-native';
-import { Text } from '../../widgets';
-import { generateShortId, generateMongoId, SHORT_ID, MONGO_ID } from '../../utilities';
+import { StyleSheet, View } from 'react-native';
+import { Text, StatusMessage, STATUS_MESSAGE_ERROR } from '../../widgets';
+import { generateShortId, generateMongoId, SHORT_ID } from '../../utilities';
+import { getLineHeight, THEME_FONT_SIZE_ONE, THEME_TEXT_COLOR_FOUR } from '../../globalStyles';
+import { getAnswerForQuestion, getQuestion } from '../selectors';
 
-export class CodeGeneratorQuestion extends PureComponent {
+export class CodeGeneratorQuestionComponent extends PureComponent {
   componentDidMount() {
-    if (!this.props.answer) {
-      this.props.onChangeAnswer(this.generateCode());
+    const { answer, config, onChangeAnswer } = this.props;
+    // Dynamic-prefix codes are generated reactively by DynamicCodeGeneratorWatcher, not here.
+    if (config.codeGenerator.dynamicPrefix) return;
+    if (!answer) {
+      onChangeAnswer(this.generateCode());
     }
   }
 
@@ -17,16 +23,73 @@ export class CodeGeneratorQuestion extends PureComponent {
   }
 
   render() {
+    const { answer, helperText, isWarning } = this.props;
+
+    if (answer) {
+      return (
+        <View>
+          <Text style={localStyles.text}>{answer}</Text>
+        </View>
+      );
+    }
+
+    if (helperText && isWarning) {
+      return (
+        <View>
+          <StatusMessage type={STATUS_MESSAGE_ERROR} message={helperText} />
+        </View>
+      );
+    }
+
     return (
-      <View>
-        <Text>{this.props.answer}</Text>
-      </View>
+      <View>{helperText ? <Text style={localStyles.helperText}>{helperText}</Text> : null}</View>
     );
   }
 }
 
-CodeGeneratorQuestion.propTypes = {
+CodeGeneratorQuestionComponent.propTypes = {
   answer: PropTypes.string,
   onChangeAnswer: PropTypes.func.isRequired,
   config: PropTypes.object.isRequired,
+  helperText: PropTypes.string,
+  isWarning: PropTypes.bool,
 };
+
+CodeGeneratorQuestionComponent.defaultProps = {
+  answer: null,
+  helperText: null,
+  isWarning: false,
+};
+
+// Provide helper/warning text for dynamic-prefix questions when no code has been generated yet.
+const mapStateToProps = (state, { id: questionId, config, answer }) => {
+  const dynamicPrefix = config.codeGenerator && config.codeGenerator.dynamicPrefix;
+  if (!dynamicPrefix || answer) return {};
+
+  const sourceQuestion = getQuestion(state, dynamicPrefix.questionId);
+  const questionLabel = (sourceQuestion && sourceQuestion.questionText) || 'the prerequisite';
+
+  if (!getAnswerForQuestion(state, dynamicPrefix.questionId)) {
+    return { helperText: `Answer "${questionLabel}" to generate a code`, isWarning: false };
+  }
+
+  return {
+    helperText: `Could not generate a code. The selected answer to "${questionLabel}" is missing a required attribute.`,
+    isWarning: true,
+  };
+};
+
+export const CodeGeneratorQuestion = connect(mapStateToProps)(CodeGeneratorQuestionComponent);
+
+const localStyles = StyleSheet.create({
+  text: {
+    fontSize: THEME_FONT_SIZE_ONE,
+    lineHeight: getLineHeight(THEME_FONT_SIZE_ONE, 1.2),
+    fontWeight: '500',
+  },
+  helperText: {
+    fontSize: THEME_FONT_SIZE_ONE,
+    lineHeight: getLineHeight(THEME_FONT_SIZE_ONE, 1.2),
+    color: THEME_TEXT_COLOR_FOUR,
+  },
+});

--- a/packages/meditrak-app/app/assessment/specificQuestions/utilities/__tests__/dynamicCodeGenerator.test.js
+++ b/packages/meditrak-app/app/assessment/specificQuestions/utilities/__tests__/dynamicCodeGenerator.test.js
@@ -1,0 +1,106 @@
+import { generateShortId } from '../../../../utilities';
+import { extractTrailingCode, resolveCode, resolvePrefix } from '../dynamicCodeGenerator';
+
+// Mock the utilities barrel so we don't pull nanoid / native modules into the unit test, and so
+// first-generation is deterministic. (jest.mock is hoisted above the imports by babel-jest.)
+jest.mock('../../../../utilities', () => ({
+  SHORT_ID: 'shortid',
+  generateShortId: jest.fn(({ codeGenerator }) => {
+    const { prefix } = codeGenerator;
+    return prefix ? `${prefix}-AAA-BBB-CCCC` : 'AAA-BBB-CCCC';
+  }),
+}));
+
+describe('resolvePrefix', () => {
+  const entity = {
+    name: 'East New Britain',
+    code: 'EBN',
+    type: 'district',
+    attributes: { facility_level: 'L3', code_prefix: 'EBN' },
+  };
+
+  it('uses a top-level entity field when entityField is set', () => {
+    expect(resolvePrefix(entity, { entityField: 'code' })).toBe('EBN');
+    expect(resolvePrefix(entity, { entityField: 'type' })).toBe('district');
+  });
+
+  it('uses an entity attribute when entityAttribute is set', () => {
+    expect(resolvePrefix(entity, { entityAttribute: 'facility_level' })).toBe('L3');
+  });
+
+  it('defaults to the entity name when neither field nor attribute is set', () => {
+    expect(resolvePrefix(entity, {})).toBe('East New Britain');
+  });
+
+  it('returns undefined when the requested attribute is missing', () => {
+    expect(resolvePrefix(entity, { entityAttribute: 'missing_attribute' })).toBeUndefined();
+    expect(resolvePrefix({ name: 'x' }, { entityAttribute: 'anything' })).toBeUndefined();
+  });
+});
+
+describe('extractTrailingCode', () => {
+  it('strips the prefix and separator', () => {
+    expect(extractTrailingCode('EBN-HM8-Z1N-CJV0', 'EBN')).toBe('HM8-Z1N-CJV0');
+  });
+
+  it('throws when the code does not start with the prefix', () => {
+    expect(() => extractTrailingCode('CEN-HM8-Z1N-CJV0', 'EBN')).toThrow();
+  });
+});
+
+describe('resolveCode', () => {
+  const codeGenerator = { type: 'shortid' };
+
+  beforeEach(() => {
+    generateShortId.mockClear();
+  });
+
+  it('keeps an existing code that already matches the prefix', () => {
+    const result = resolveCode({
+      resolvedPrefix: 'EBN',
+      existingCode: 'EBN-HM8-Z1N-CJV0',
+      trailingCode: undefined,
+      codeGenerator,
+    });
+    expect(result.code).toBe('EBN-HM8-Z1N-CJV0');
+    expect(result.trailingCode).toBe('HM8-Z1N-CJV0');
+    expect(generateShortId).not.toHaveBeenCalled();
+  });
+
+  it('swaps the prefix but reuses the trailing code when the prefix changes', () => {
+    const result = resolveCode({
+      resolvedPrefix: 'CEN',
+      existingCode: 'EBN-HM8-Z1N-CJV0',
+      trailingCode: 'HM8-Z1N-CJV0',
+      codeGenerator,
+    });
+    expect(result.code).toBe('CEN-HM8-Z1N-CJV0');
+    expect(result.trailingCode).toBe('HM8-Z1N-CJV0');
+    expect(generateShortId).not.toHaveBeenCalled();
+  });
+
+  it('generates a whole new code on first generation', () => {
+    const result = resolveCode({
+      resolvedPrefix: 'NEW',
+      existingCode: undefined,
+      trailingCode: undefined,
+      codeGenerator,
+    });
+    expect(result.code).toBe('NEW-AAA-BBB-CCCC');
+    expect(result.trailingCode).toBe('AAA-BBB-CCCC');
+    expect(generateShortId).toHaveBeenCalledWith({
+      codeGenerator: { type: 'shortid', prefix: 'NEW' },
+    });
+  });
+
+  it('throws for non-shortid code generators', () => {
+    expect(() =>
+      resolveCode({
+        resolvedPrefix: 'NEW',
+        existingCode: undefined,
+        trailingCode: undefined,
+        codeGenerator: { type: 'mongoid' },
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/meditrak-app/app/assessment/specificQuestions/utilities/dynamicCodeGenerator.js
+++ b/packages/meditrak-app/app/assessment/specificQuestions/utilities/dynamicCodeGenerator.js
@@ -1,0 +1,44 @@
+import { generateShortId, SHORT_ID } from '../../../utilities';
+
+// Resolve the prefix from an entity's fields/attributes, or its name by default.
+export const resolvePrefix = (entity, dynamicPrefix) => {
+  const { entityField, entityAttribute } = dynamicPrefix;
+  if (entityField) return entity[entityField];
+  if (entityAttribute) return entity.attributes && entity.attributes[entityAttribute];
+  return entity.name;
+};
+
+// Extract the random tail of a generated code, i.e. "EBN-HM8-Z1N-CJV0" -> "HM8-Z1N-CJV0".
+export const extractTrailingCode = (code, prefix) => {
+  const expectedPrefix = `${prefix}-`;
+  if (!code.startsWith(expectedPrefix)) {
+    throw new Error(
+      `Generated code "${code}" does not start with expected prefix "${expectedPrefix}"`,
+    );
+  }
+  return code.slice(expectedPrefix.length);
+};
+
+// Determine the code to use for the current prefix, reusing the random tail when only the
+// prefix changed so switching the source answer doesn't churn the whole code.
+export const resolveCode = ({ resolvedPrefix, existingCode, trailingCode, codeGenerator }) => {
+  if (codeGenerator.type !== SHORT_ID) {
+    throw new Error(
+      `dynamicPrefix is only supported with shortid code generators, got: ${codeGenerator.type}`,
+    );
+  }
+
+  // Existing/draft code already matches this prefix — keep it
+  if (existingCode && existingCode.startsWith(`${resolvedPrefix}-`)) {
+    return { code: existingCode, trailingCode: extractTrailingCode(existingCode, resolvedPrefix) };
+  }
+
+  // Prefix changed but we still have the random tail — just swap the prefix
+  if (trailingCode) {
+    return { code: `${resolvedPrefix}-${trailingCode}`, trailingCode };
+  }
+
+  // First generation — create a whole new code
+  const newCode = generateShortId({ codeGenerator: { ...codeGenerator, prefix: resolvedPrefix } });
+  return { code: newCode, trailingCode: extractTrailingCode(newCode, resolvedPrefix) };
+};

--- a/packages/meditrak-app/package.json
+++ b/packages/meditrak-app/package.json
@@ -7,6 +7,7 @@
     "ios": "react-native run-ios",
     "build:android": "cd android && ./gradlew app:assembleRelease && ls -R app/build/outputs/apk",
     "lint": "eslint .",
+    "test": "jest",
     "start": "react-native start",
     "reset-cache": "echo Run me and exit to reset cache && react-native start --reset-cache"
   },


### PR DESCRIPTION
### Issue: [TUP-3195](https://linear.app/bes/issue/TUP-3195/port-dynamic-codegenerator-prefixes-to-meditrak)

Ports the dynamic CodeGenerator prefix feature delivered for DataTrak (TUP-1918, #6686 / #6716) to the **MediTrak** mobile app for parity. A CodeGenerator question can now derive its prefix at runtime from another question's answer — or, when the source is an Entity question, from the selected entity's `name`/`code`/`type` or an `attributes` value (e.g. `EBN-` for East New Britain).

The server-side config/import/export/validation and the `dynamicPrefix` type are shared and already merged, so this change is entirely in `packages/meditrak-app`.

### Changes
- **`specificQuestions/utilities/dynamicCodeGenerator.js`** (new) — pure `resolvePrefix` / `extractTrailingCode` / `resolveCode` helpers (adapted to meditrak's `generateShortId({ codeGenerator })` signature).
- **`DynamicCodeGeneratorWatcher.jsx`** (new) — headless, Redux-connected watcher (one per dynamic-prefix question). Reads the source answer, resolves the entity **synchronously** from Realm (`database.findOne('Entity', id)`), dispatches the generated code when the prefix changes, and preserves the random tail across prefix changes via refs.
- **`DynamicCodeGeneratorWatchers.jsx`** (new) — container mounted once in `DumbSurveyScreen` (the always-mounted assessment host) so the watchers survive screen navigation.
- **`CodeGeneratorQuestion.jsx`** — skips self-generation when `dynamicPrefix` is set (delegates to the watcher); shows a grey helper ("Answer *X* to generate a code") and a red warning ("Could not generate a code…") when no code can be generated yet.
- **First Jest test** in `meditrak-app` (`__tests__/dynamicCodeGenerator.test.js`) + a `test` script.

### Behaviour parity
- Prefix from a plain question answer, and from an Entity source (`entityField` / `entityAttribute`, default entity name).
- Random tail preserved when only the prefix changes.
- Helper/warning messages; static-prefix and no-prefix questions unchanged.
- Not hard validation — the survey can still be submitted (matches DataTrak).

### 🦸 Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
- [ ] **Save suppressions** <!-- #save-suppressions -->