### PR TITLE
deps: bump `fast-uri` 3.1.2 → 3.1.5

### DIFF
--- a/packages/tsutils/package.json
+++ b/packages/tsutils/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@tupaia/types": "workspace:*",
     "@tupaia/utils": "workspace:*",
-    "ajv": "^8.12.0",
+    "ajv": "^8.20.0",
     "ajv-formats": "v3.0.0-rc.0",
     "better-ajv-errors": "^1.2.0",
     "camelcase-keys": "^6.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8280,7 +8280,7 @@ __metadata:
     "@tupaia/types": "workspace:*"
     "@tupaia/utils": "workspace:*"
     "@types/jest": "npm:^29.5.14"
-    ajv: "npm:^8.12.0"
+    ajv: "npm:^8.20.0"
     ajv-formats: "npm:v3.0.0-rc.0"
     better-ajv-errors: "npm:^1.2.0"
     camelcase-keys: "npm:^6.2.2"
@@ -10009,7 +10009,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^8.0.0, ajv@npm:^8.0.1, ajv@npm:^8.12.0, ajv@npm:^8.6.0":
+"ajv@npm:^8.0.0, ajv@npm:^8.0.1, ajv@npm:^8.20.0, ajv@npm:^8.6.0":
   version: 8.20.0
   resolution: "ajv@npm:8.20.0"
   dependencies:
@@ -16244,9 +16244,9 @@ __metadata:
   linkType: hard
 
 "fast-uri@npm:^3.0.1":
-  version: 3.1.2
-  resolution: "fast-uri@npm:3.1.2"
-  checksum: 10c0/5b35641895959f3f7ab7a7b1b5542bded159346f25ec9f256817b206d50b64eda5828e90d605a2e2fc645c90519a7259c2bab2c942ee728c88b88e5be21b090d
+  version: 3.1.5
+  resolution: "fast-uri@npm:3.1.5"
+  checksum: 10c0/2bf60eb800dd610c65e17be436425dcb21c92aff3a87d442a8bccab0b7b071e88cf1a5d7d1ea946370b937e6fc0375c405c0296c10587e57de4f78be4646d1d0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
3.1.5 actually still quarantined. Gonna wait a few days

### Changes:

- Example

---

### Screenshots:

---

### 🦸 Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
- [ ] **Save suppressions** <!-- #save-suppressions -->
