### PR TITLE
repo(deps): reintroduce Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: deps
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
+    pull-request-branch-name:
+      prefix: deps
+      separator: "-"
+      word-separator: "-"
+      branch-name-case: lowercase
+      max-length: 46  # see validateBranchName.sh
+      template: "{prefix}-{dependency}"


### PR DESCRIPTION
### Changes

Re-introduces Dependabot, but hopefully with fewer headaches:

- Minor and patch updates only, no major updates
- Valid branch names
- Matches Yarn quarantine policy (except security updates, which will cause some headaches)

---

### Screenshots:

---

### 🦸 Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
- [ ] **Save suppressions** <!-- #save-suppressions -->
