### PR TITLE
tweak(centralServer): prepare for Node 26

### DIFF
--- a/packages/central-server/package.json
+++ b/packages/central-server/package.json
@@ -77,7 +77,6 @@
     "mocha": "^11.7.6",
     "npm-run-all": "^4.1.5",
     "nyc": "^15.1.0",
-    "proxyquire": "^2.1.3",
     "rimraf": "^6.0.1",
     "sinon": "^9.0.2",
     "sinon-chai": "^3.3.0",

--- a/packages/central-server/src/tests/apiV2/GETAnswers.test.js
+++ b/packages/central-server/src/tests/apiV2/GETAnswers.test.js
@@ -1,11 +1,12 @@
 import chai from 'chai';
+
 import {
-  buildAndInsertSurveys,
   buildAndInsertSurveyResponses,
+  buildAndInsertSurveys,
   findOrCreateDummyRecord,
 } from '@tupaia/database';
-import { resetTestData, TestableApp } from '../testUtilities';
-import { TUPAIA_ADMIN_PANEL_PERMISSION_GROUP, BES_ADMIN_PERMISSION_GROUP } from '../../permissions';
+import { BES_ADMIN_PERMISSION_GROUP, TUPAIA_ADMIN_PANEL_PERMISSION_GROUP } from '../../permissions';
+import { TestableApp, resetTestData } from '../testUtilities';
 
 const { expect } = chai;
 

--- a/packages/central-server/src/tests/apiV2/GETDashboardRelations.test.js
+++ b/packages/central-server/src/tests/apiV2/GETDashboardRelations.test.js
@@ -1,10 +1,11 @@
 import chai from 'chai';
+
 import {
-  findOrCreateDummyRecord,
   addBaselineTestCountries,
   buildAndInsertProjectsAndHierarchies,
+  findOrCreateDummyRecord,
 } from '@tupaia/database';
-import { TUPAIA_ADMIN_PANEL_PERMISSION_GROUP, BES_ADMIN_PERMISSION_GROUP } from '../../permissions';
+import { BES_ADMIN_PERMISSION_GROUP, TUPAIA_ADMIN_PANEL_PERMISSION_GROUP } from '../../permissions';
 import { TestableApp, setupDashboardTestData } from '../testUtilities';
 
 const { expect } = chai;

--- a/packages/central-server/src/tests/apiV2/GETIndicators.test.js
+++ b/packages/central-server/src/tests/apiV2/GETIndicators.test.js
@@ -1,6 +1,7 @@
 import chai from 'chai';
+
 import { findOrCreateDummyRecord } from '@tupaia/database';
-import { TUPAIA_ADMIN_PANEL_PERMISSION_GROUP, BES_ADMIN_PERMISSION_GROUP } from '../../permissions';
+import { BES_ADMIN_PERMISSION_GROUP, TUPAIA_ADMIN_PANEL_PERMISSION_GROUP } from '../../permissions';
 import { TestableApp } from '../testUtilities';
 
 const { expect } = chai;

--- a/packages/central-server/src/tests/apiV2/GETLegacyReports.test.js
+++ b/packages/central-server/src/tests/apiV2/GETLegacyReports.test.js
@@ -1,10 +1,11 @@
 import chai from 'chai';
+
 import {
-  findOrCreateDummyRecord,
   addBaselineTestCountries,
   buildAndInsertProjectsAndHierarchies,
+  findOrCreateDummyRecord,
 } from '@tupaia/database';
-import { TUPAIA_ADMIN_PANEL_PERMISSION_GROUP, BES_ADMIN_PERMISSION_GROUP } from '../../permissions';
+import { BES_ADMIN_PERMISSION_GROUP, TUPAIA_ADMIN_PANEL_PERMISSION_GROUP } from '../../permissions';
 import { TestableApp, setupDashboardTestData } from '../testUtilities';
 
 const { expect } = chai;

--- a/packages/central-server/src/tests/apiV2/GETMapOverlayGroupRelations.test.js
+++ b/packages/central-server/src/tests/apiV2/GETMapOverlayGroupRelations.test.js
@@ -1,6 +1,7 @@
 import chai from 'chai';
+
 import { addBaselineTestCountries, buildAndInsertProjectsAndHierarchies } from '@tupaia/database';
-import { TUPAIA_ADMIN_PANEL_PERMISSION_GROUP, BES_ADMIN_PERMISSION_GROUP } from '../../permissions';
+import { BES_ADMIN_PERMISSION_GROUP, TUPAIA_ADMIN_PANEL_PERMISSION_GROUP } from '../../permissions';
 import { TestableApp, setupMapOverlayTestData } from '../testUtilities';
 
 const { expect } = chai;

--- a/packages/central-server/src/tests/apiV2/GETMapOverlays.test.js
+++ b/packages/central-server/src/tests/apiV2/GETMapOverlays.test.js
@@ -1,6 +1,7 @@
 import chai from 'chai';
+
 import { addBaselineTestCountries, buildAndInsertProjectsAndHierarchies } from '@tupaia/database';
-import { TUPAIA_ADMIN_PANEL_PERMISSION_GROUP, BES_ADMIN_PERMISSION_GROUP } from '../../permissions';
+import { BES_ADMIN_PERMISSION_GROUP, TUPAIA_ADMIN_PANEL_PERMISSION_GROUP } from '../../permissions';
 import { TestableApp, setupMapOverlayTestData } from '../testUtilities';
 
 const { expect } = chai;
@@ -38,11 +39,8 @@ describe('Permissions checker for GETMapOverlays', async () => {
     ]);
 
     // Set up the map overlays
-    ({
-      nationalMapOverlay1,
-      nationalMapOverlay2,
-      projectLevelMapOverlay1,
-    } = await setupMapOverlayTestData(models));
+    ({ nationalMapOverlay1, nationalMapOverlay2, projectLevelMapOverlay1 } =
+      await setupMapOverlayTestData(models));
   });
 
   afterEach(() => {

--- a/packages/central-server/src/tests/apiV2/GETSurveyGroups.test.js
+++ b/packages/central-server/src/tests/apiV2/GETSurveyGroups.test.js
@@ -1,7 +1,8 @@
 import chai from 'chai';
+
 import { buildAndInsertSurveys, findOrCreateDummyRecord } from '@tupaia/database';
-import { resetTestData, TestableApp } from '../testUtilities';
-import { TUPAIA_ADMIN_PANEL_PERMISSION_GROUP, BES_ADMIN_PERMISSION_GROUP } from '../../permissions';
+import { BES_ADMIN_PERMISSION_GROUP, TUPAIA_ADMIN_PANEL_PERMISSION_GROUP } from '../../permissions';
+import { TestableApp, resetTestData } from '../testUtilities';
 
 const { expect } = chai;
 

--- a/packages/central-server/src/tests/apiV2/GETSurveyResponses.test.js
+++ b/packages/central-server/src/tests/apiV2/GETSurveyResponses.test.js
@@ -1,12 +1,10 @@
 import chai from 'chai';
 
-
 import {
   buildAndInsertSurveyResponses,
   buildAndInsertSurveys,
   findOrCreateDummyRecord,
 } from '@tupaia/database';
-
 import { BES_ADMIN_PERMISSION_GROUP, TUPAIA_ADMIN_PANEL_PERMISSION_GROUP } from '../../permissions';
 import { getRewardsForUser } from '../../social/getRewardsForUser';
 import { TestableApp, resetTestData } from '../testUtilities';

--- a/packages/central-server/src/tests/apiV2/GETSurveyScreenComponents.test.js
+++ b/packages/central-server/src/tests/apiV2/GETSurveyScreenComponents.test.js
@@ -1,6 +1,7 @@
 import chai from 'chai';
+
 import { buildAndInsertSurveys, findOrCreateDummyRecord } from '@tupaia/database';
-import { TUPAIA_ADMIN_PANEL_PERMISSION_GROUP, BES_ADMIN_PERMISSION_GROUP } from '../../permissions';
+import { BES_ADMIN_PERMISSION_GROUP, TUPAIA_ADMIN_PANEL_PERMISSION_GROUP } from '../../permissions';
 import { TestableApp } from '../testUtilities';
 
 const { expect } = chai;

--- a/packages/central-server/src/tests/apiV2/GETSurveys.test.js
+++ b/packages/central-server/src/tests/apiV2/GETSurveys.test.js
@@ -1,7 +1,8 @@
 import chai from 'chai';
+
 import { buildAndInsertSurveys, findOrCreateDummyRecord } from '@tupaia/database';
-import { resetTestData, TestableApp } from '../testUtilities';
-import { TUPAIA_ADMIN_PANEL_PERMISSION_GROUP, BES_ADMIN_PERMISSION_GROUP } from '../../permissions';
+import { BES_ADMIN_PERMISSION_GROUP, TUPAIA_ADMIN_PANEL_PERMISSION_GROUP } from '../../permissions';
+import { TestableApp, resetTestData } from '../testUtilities';
 
 const { expect } = chai;
 

--- a/packages/central-server/src/tests/apiV2/accessRequests.test.js
+++ b/packages/central-server/src/tests/apiV2/accessRequests.test.js
@@ -1,4 +1,5 @@
 import chai from 'chai';
+
 import { findOrCreateDummyRecord } from '@tupaia/database';
 import { TEST_USER_EMAIL, TestableApp } from '../testUtilities';
 

--- a/packages/central-server/src/tests/apiV2/accessRequests/EditAccessRequests.test.js
+++ b/packages/central-server/src/tests/apiV2/accessRequests/EditAccessRequests.test.js
@@ -1,8 +1,9 @@
 import chai from 'chai';
-import { findOrCreateDummyRecord, findOrCreateDummyCountryEntity } from '@tupaia/database';
+
+import { findOrCreateDummyCountryEntity, findOrCreateDummyRecord } from '@tupaia/database';
 import {
-  TUPAIA_ADMIN_PANEL_PERMISSION_GROUP,
   BES_ADMIN_PERMISSION_GROUP,
+  TUPAIA_ADMIN_PANEL_PERMISSION_GROUP,
 } from '../../../permissions';
 import { TestableApp } from '../../testUtilities';
 

--- a/packages/central-server/src/tests/apiV2/accessRequests/GETAccessRequests.test.js
+++ b/packages/central-server/src/tests/apiV2/accessRequests/GETAccessRequests.test.js
@@ -1,10 +1,11 @@
 import chai from 'chai';
-import { findOrCreateDummyRecord, findOrCreateDummyCountryEntity } from '@tupaia/database';
+
+import { findOrCreateDummyCountryEntity, findOrCreateDummyRecord } from '@tupaia/database';
 import {
-  TUPAIA_ADMIN_PANEL_PERMISSION_GROUP,
   BES_ADMIN_PERMISSION_GROUP,
+  TUPAIA_ADMIN_PANEL_PERMISSION_GROUP,
 } from '../../../permissions';
-import { resetTestData, TestableApp } from '../../testUtilities';
+import { TestableApp, resetTestData } from '../../testUtilities';
 
 const { expect } = chai;
 

--- a/packages/central-server/src/tests/apiV2/authenticate/authenticate.test.js
+++ b/packages/central-server/src/tests/apiV2/authenticate/authenticate.test.js
@@ -10,7 +10,6 @@ import {
 } from '@tupaia/auth';
 import { findOrCreateDummyCountryEntity, findOrCreateDummyRecord } from '@tupaia/database';
 import { createBasicHeader, randomEmail, randomString } from '@tupaia/utils';
-
 import { BruteForceRateLimiter } from '../../../apiV2/authenticate/BruteForceRateLimiter';
 import { ConsecutiveFailsRateLimiter } from '../../../apiV2/authenticate/ConsecutiveFailsRateLimiter';
 import { configureEnv } from '../../../configureEnv';

--- a/packages/central-server/src/tests/apiV2/authenticate/oneTimeLogin.test.js
+++ b/packages/central-server/src/tests/apiV2/authenticate/oneTimeLogin.test.js
@@ -2,8 +2,8 @@ import chai from 'chai';
 import moment from 'moment';
 
 import { randomEmail } from '@tupaia/utils';
-import { getAuthorizationHeader, TestableApp } from '../../testUtilities';
 import { configureEnv } from '../../../configureEnv';
+import { getAuthorizationHeader, TestableApp } from '../../testUtilities';
 
 const { expect } = chai;
 

--- a/packages/central-server/src/tests/apiV2/comments.test.js
+++ b/packages/central-server/src/tests/apiV2/comments.test.js
@@ -1,13 +1,14 @@
 import chai from 'chai';
+
 import { generateId } from '@tupaia/database';
 import {
-  resetTestData,
   TestableApp,
-  upsertEntity,
+  resetTestData,
+  upsertComment,
   upsertDataGroup,
+  upsertEntity,
   upsertSurvey,
   upsertSurveyResponse,
-  upsertComment,
   upsertSurveyResponseComment,
 } from '../testUtilities';
 

--- a/packages/central-server/src/tests/apiV2/dashboardItems/DeleteDashboardItems.test.js
+++ b/packages/central-server/src/tests/apiV2/dashboardItems/DeleteDashboardItems.test.js
@@ -1,8 +1,9 @@
 import chai from 'chai';
-import { findOrCreateDummyRecord, findOrCreateDummyCountryEntity } from '@tupaia/database';
+
+import { findOrCreateDummyCountryEntity, findOrCreateDummyRecord } from '@tupaia/database';
 import {
-  TUPAIA_ADMIN_PANEL_PERMISSION_GROUP,
   BES_ADMIN_PERMISSION_GROUP,
+  TUPAIA_ADMIN_PANEL_PERMISSION_GROUP,
 } from '../../../permissions';
 import { TestableApp } from '../../testUtilities';
 

--- a/packages/central-server/src/tests/apiV2/dashboardItems/EditDashboardItems.test.js
+++ b/packages/central-server/src/tests/apiV2/dashboardItems/EditDashboardItems.test.js
@@ -1,8 +1,9 @@
 import chai from 'chai';
-import { findOrCreateDummyRecord, findOrCreateDummyCountryEntity } from '@tupaia/database';
+
+import { findOrCreateDummyCountryEntity, findOrCreateDummyRecord } from '@tupaia/database';
 import {
-  TUPAIA_ADMIN_PANEL_PERMISSION_GROUP,
   BES_ADMIN_PERMISSION_GROUP,
+  TUPAIA_ADMIN_PANEL_PERMISSION_GROUP,
   VIZ_BUILDER_PERMISSION_GROUP,
 } from '../../../permissions';
 import { TestableApp } from '../../testUtilities';

--- a/packages/central-server/src/tests/apiV2/dashboardMailingListEntries/CreateDashboardMailingListEntry.test.js
+++ b/packages/central-server/src/tests/apiV2/dashboardMailingListEntries/CreateDashboardMailingListEntry.test.js
@@ -4,9 +4,7 @@ import {
   clearTestData,
   findOrCreateDummyRecord,
 } from '@tupaia/database';
-import {
-  BES_ADMIN_PERMISSION_GROUP,
-} from '../../../permissions';
+import { BES_ADMIN_PERMISSION_GROUP } from '../../../permissions';
 import {
   TEST_USER_EMAIL,
   TestableApp,

--- a/packages/central-server/src/tests/apiV2/dashboardMailingLists/EditDashboardMailingList.test.js
+++ b/packages/central-server/src/tests/apiV2/dashboardMailingLists/EditDashboardMailingList.test.js
@@ -1,4 +1,5 @@
 import chai from 'chai';
+
 import {
   buildAndInsertProjectsAndHierarchies,
   clearTestData,

--- a/packages/central-server/src/tests/apiV2/dashboards/GETDashboards.test.js
+++ b/packages/central-server/src/tests/apiV2/dashboards/GETDashboards.test.js
@@ -46,12 +46,8 @@ describe('Permissions checker for GETDashboards', async () => {
       },
     ]);
 
-    ({
-      districtDashboard1,
-      nationalDashboard1,
-      nationalDashboard2,
-      projectDashboard1,
-    } = await setupDashboardTestData(models));
+    ({ districtDashboard1, nationalDashboard1, nationalDashboard2, projectDashboard1 } =
+      await setupDashboardTestData(models));
   });
 
   afterEach(() => {

--- a/packages/central-server/src/tests/apiV2/entityHierarchy/GETEntityHierarchy.test.js
+++ b/packages/central-server/src/tests/apiV2/entityHierarchy/GETEntityHierarchy.test.js
@@ -1,6 +1,5 @@
 import chai from 'chai';
 
-
 import { findOrCreateDummyCountryEntity, findOrCreateRecords, generateId } from '@tupaia/database';
 
 import {

--- a/packages/central-server/src/tests/apiV2/entityRelations/GETEntityRelations.test.js
+++ b/packages/central-server/src/tests/apiV2/entityRelations/GETEntityRelations.test.js
@@ -1,6 +1,5 @@
 import chai from 'chai';
 
-
 import { findOrCreateDummyRecord } from '@tupaia/database';
 
 import { BES_ADMIN_PERMISSION_GROUP } from '../../../permissions';

--- a/packages/central-server/src/tests/apiV2/export/exportSurveys/cellBuilders/ArithmeticConfigCellBuilder.test.js
+++ b/packages/central-server/src/tests/apiV2/export/exportSurveys/cellBuilders/ArithmeticConfigCellBuilder.test.js
@@ -1,6 +1,5 @@
 import chai from 'chai';
 
-
 import { processArithmeticConfig } from '../../../../../apiV2/import/importSurveys/ConfigImporter/processArithmeticConfig';
 import { convertCellToJson } from '../../../../../apiV2/import/importSurveys/utilities';
 import { assertCanProcessAndBuild, cellBuilderModelsStub } from './utilities';

--- a/packages/central-server/src/tests/apiV2/export/exportSurveys/cellBuilders/utilities.js
+++ b/packages/central-server/src/tests/apiV2/export/exportSurveys/cellBuilders/utilities.js
@@ -30,13 +30,11 @@ export const cellBuilderModelsStub = questions => {
     .callsFake(({ code: searchCode }) => questions.find(({ code }) => searchCode === code));
 
   const findOneOrThrowStub = sinon.stub().returns(null);
-  findOneOrThrowStub
-    .withArgs(sinon.match(sinon.match.any))
-    .callsFake(({ code: searchCode }) => {
-      const result = questions.find(({ code }) => searchCode === code);
-      if (!result) throw new Error(`No question found with code ${searchCode}`);
-      return result;
-    });
+  findOneOrThrowStub.withArgs(sinon.match(sinon.match.any)).callsFake(({ code: searchCode }) => {
+    const result = questions.find(({ code }) => searchCode === code);
+    if (!result) throw new Error(`No question found with code ${searchCode}`);
+    return result;
+  });
 
   return {
     question: {

--- a/packages/central-server/src/tests/apiV2/import/importStriveLabResults/importStriveLabResults.test.js
+++ b/packages/central-server/src/tests/apiV2/import/importStriveLabResults/importStriveLabResults.test.js
@@ -1,6 +1,5 @@
 import chai from 'chai';
 
-
 import {
   buildAndInsertSurveys,
   generateId,

--- a/packages/central-server/src/tests/apiV2/import/importSurveyResponses/assertCanImportSurveyResponses.test.js
+++ b/packages/central-server/src/tests/apiV2/import/importSurveyResponses/assertCanImportSurveyResponses.test.js
@@ -1,6 +1,5 @@
 import chai from 'chai';
 
-
 import { AccessPolicy } from '@tupaia/access-policy';
 import {
   addBaselineTestCountries,

--- a/packages/central-server/src/tests/apiV2/mapOverlayVisualisations/GETMapOverlayVisualisations.test.js
+++ b/packages/central-server/src/tests/apiV2/mapOverlayVisualisations/GETMapOverlayVisualisations.test.js
@@ -1,6 +1,5 @@
 import chai from 'chai';
 
-
 import { setupTest } from '@tupaia/database';
 import { stripUpdatedAtSyncTickFromArray } from '@tupaia/utils';
 
@@ -91,7 +90,10 @@ describe('GET map overlay visualisations', () => {
           },
         },
       ];
-      expectSuccess({ ...response, body: stripUpdatedAtSyncTickFromArray(response.body) }, expected);
+      expectSuccess(
+        { ...response, body: stripUpdatedAtSyncTickFromArray(response.body) },
+        expected,
+      );
     });
   });
 });

--- a/packages/central-server/src/tests/apiV2/meditrakApp/changesMetadata.test.js
+++ b/packages/central-server/src/tests/apiV2/meditrakApp/changesMetadata.test.js
@@ -1,6 +1,5 @@
 import chai from 'chai';
 
-
 import { oneSecondSleep } from '@tupaia/utils';
 import { MeditrakSyncQueue, createPermissionsBasedMeditrakSyncQueue } from '../../../database';
 import { TestableApp } from '../../testUtilities';

--- a/packages/central-server/src/tests/apiV2/meditrakApp/getChanges.test.js
+++ b/packages/central-server/src/tests/apiV2/meditrakApp/getChanges.test.js
@@ -1,6 +1,5 @@
 import chai from 'chai';
 
-
 import { oneSecondSleep, randomIntBetween } from '@tupaia/utils';
 import { generateId } from '@tupaia/database';
 import { MeditrakSyncQueue, createPermissionsBasedMeditrakSyncQueue } from '../../../database';

--- a/packages/central-server/src/tests/apiV2/permissionGroups/GETPermissionGroups.test.js
+++ b/packages/central-server/src/tests/apiV2/permissionGroups/GETPermissionGroups.test.js
@@ -1,6 +1,5 @@
 import chai from 'chai';
 
-
 import { findOrCreateDummyRecord } from '@tupaia/database';
 import { stripUpdatedAtSyncTickFromObject } from '@tupaia/utils';
 

--- a/packages/central-server/src/tests/apiV2/projects/CreateProject.test.js
+++ b/packages/central-server/src/tests/apiV2/projects/CreateProject.test.js
@@ -1,6 +1,7 @@
-import { generateId, findOrCreateDummyRecord } from '@tupaia/database';
 import chai from 'chai';
 import sinon from 'sinon';
+
+import { generateId, findOrCreateDummyRecord } from '@tupaia/database';
 import { BES_ADMIN_PERMISSION_GROUP } from '../../../permissions';
 import { TestableApp } from '../../testUtilities';
 import * as UploadImage from '../../../apiV2/utilities/uploadImage';

--- a/packages/central-server/src/tests/apiV2/requestPasswordReset.test.js
+++ b/packages/central-server/src/tests/apiV2/requestPasswordReset.test.js
@@ -1,6 +1,5 @@
 import chai from 'chai';
 
-
 import { createBearerHeader, randomEmail, randomString } from '@tupaia/utils';
 
 import { configureEnv } from '../../configureEnv';

--- a/packages/central-server/src/tests/apiV2/resubmitSurveyResponse.test.js
+++ b/packages/central-server/src/tests/apiV2/resubmitSurveyResponse.test.js
@@ -1,6 +1,5 @@
 import chai from 'chai';
 
-
 import { buildAndInsertSurveyResponses, buildAndInsertSurveys, generateId } from '@tupaia/database';
 import { EntityTypeEnum, QuestionType } from '@tupaia/types';
 import { TestableApp, expectSuccess, upsertEntity } from '../testUtilities';

--- a/packages/central-server/src/tests/apiV2/utilities/mergeMultiJoin.test.js
+++ b/packages/central-server/src/tests/apiV2/utilities/mergeMultiJoin.test.js
@@ -1,6 +1,5 @@
 import chai from 'chai';
 
-
 import { mergeMultiJoin } from '../../../apiV2/utilities/mergeMultiJoin';
 
 const { expect } = chai;

--- a/packages/central-server/src/tests/apiV2/verifyEmail.test.js
+++ b/packages/central-server/src/tests/apiV2/verifyEmail.test.js
@@ -1,6 +1,5 @@
 import chai from 'chai';
 
-
 import { encryptPassword } from '@tupaia/auth';
 import { randomEmail } from '@tupaia/utils';
 

--- a/packages/central-server/src/tests/dhis/EventBuilder.test.js
+++ b/packages/central-server/src/tests/dhis/EventBuilder.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import chai from 'chai';
 import sinon from 'sinon';
 
 import {
@@ -12,6 +12,8 @@ import * as Enrollments from '../../dhis/api/enrollments';
 import { EventBuilder } from '../../dhis/pushers/data/event/EventBuilder';
 import { getModels, upsertEntity } from '../testUtilities';
 import { DHIS_RESOURCES, ENTITIES, SURVEYS } from './EventBuilder.fixtures';
+
+const { expect } = chai;
 
 const models = getModels();
 

--- a/packages/central-server/src/tests/dhis/api/enrollments.test.js
+++ b/packages/central-server/src/tests/dhis/api/enrollments.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import chai from 'chai';
 import sinon from 'sinon';
 
 import { DhisApi } from '@tupaia/dhis-api';
@@ -8,6 +8,8 @@ import {
   getEnrollmentsByTrackedEntityId,
   checkIsTrackedEntityEnrolledToProgram,
 } from '../../../dhis/api/enrollments';
+
+const { expect } = chai;
 
 const ORG_UNIT_ID = 'testOrgUnitId';
 const PROGRAM_ID = 'testProgramId';

--- a/packages/central-server/src/tests/dhis/pushChange.test.js
+++ b/packages/central-server/src/tests/dhis/pushChange.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import chai from 'chai';
 import sinon from 'sinon';
 import sinonTest from 'sinon-test';
 import winston from 'winston';
@@ -7,6 +7,8 @@ import { pushChange } from '../../dhis/pushChange';
 import { AggregateDataPusher, EventPusher } from '../../dhis/pushers';
 import * as GetPusherForEntity from '../../dhis/pushers/entity/getPusherForEntity';
 import { TestableApp } from '../testUtilities';
+
+const { expect } = chai;
 
 const test = sinonTest(sinon);
 

--- a/packages/central-server/src/tests/dhis/pushers/data/aggregate/testCreateAnswer.js
+++ b/packages/central-server/src/tests/dhis/pushers/data/aggregate/testCreateAnswer.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import chai from 'chai';
 import { generateId, populateTestData } from '@tupaia/database';
 import { AggregateDataPusher } from '../../../../../dhis/pushers/data/aggregate/AggregateDataPusher';
 import {
@@ -7,6 +7,8 @@ import {
   ANSWER_DATA_VALUE,
   SURVEY_RESPONSE,
 } from './AggregateDataPusher.fixtures';
+
+const { expect } = chai;
 
 export const testCreateAnswer = (dhisApi, models, dataBroker) => {
   it('should throw an error if the changed record was not found', async () => {

--- a/packages/central-server/src/tests/dhis/pushers/data/aggregate/testCreateSurveyResponse.js
+++ b/packages/central-server/src/tests/dhis/pushers/data/aggregate/testCreateSurveyResponse.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import chai from 'chai';
 import sinon from 'sinon';
 import { generateId, populateTestData } from '@tupaia/database';
 import { AggregateDataPusher } from '../../../../../dhis/pushers/data/aggregate/AggregateDataPusher';
@@ -10,6 +10,8 @@ import {
   DATA_SET,
   DATA_SET_COMPLETION,
 } from './AggregateDataPusher.fixtures';
+
+const { expect } = chai;
 
 export const testCreateSurveyResponse = (dhisApi, models, dataBroker) => {
   it('should throw an error if the changed record was not found', async () => {

--- a/packages/central-server/src/tests/dhis/pushers/data/aggregate/testDeleteAnswer.js
+++ b/packages/central-server/src/tests/dhis/pushers/data/aggregate/testDeleteAnswer.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import chai from 'chai';
 import { generateId, populateTestData } from '@tupaia/database';
 import { AggregateDataPusher } from '../../../../../dhis/pushers/data/aggregate/AggregateDataPusher';
 import { setupDummySyncQueue } from '../../../../testUtilities';
@@ -11,6 +11,8 @@ import {
   getSyncLog,
   SERVER_NAME,
 } from './AggregateDataPusher.fixtures';
+
+const { expect } = chai;
 
 export const testDeleteAnswer = (dhisApi, models, dataBroker) => {
   afterEach(async () => {

--- a/packages/central-server/src/tests/dhis/pushers/data/aggregate/testDeleteSurveyResponse.js
+++ b/packages/central-server/src/tests/dhis/pushers/data/aggregate/testDeleteSurveyResponse.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import chai from 'chai';
 import sinon from 'sinon';
 import { generateId, populateTestData } from '@tupaia/database';
 import { AggregateDataPusher } from '../../../../../dhis/pushers/data/aggregate/AggregateDataPusher';
@@ -14,6 +14,8 @@ import {
   SURVEY,
   SERVER_NAME,
 } from './AggregateDataPusher.fixtures';
+
+const { expect } = chai;
 
 export const testDeleteSurveyResponse = (dhisApi, models, dataBroker) => {
   it('should mark as successful if the survey response never attempted to sync', async () => {

--- a/packages/central-server/src/tests/dhis/pushers/data/aggregate/testPeriodsBasedOnDataSet.js
+++ b/packages/central-server/src/tests/dhis/pushers/data/aggregate/testPeriodsBasedOnDataSet.js
@@ -1,6 +1,6 @@
 import moment from 'moment';
 import sinon from 'sinon';
-import { expect } from 'chai';
+import chai from 'chai';
 import { AggregateDataPusher } from '../../../../../dhis/pushers/data/aggregate/AggregateDataPusher';
 import {
   ANSWER_CHANGE,
@@ -11,6 +11,8 @@ import {
   MONTHLY_DATA_SET,
   YEARLY_DATA_SET,
 } from './AggregateDataPusher.fixtures';
+
+const { expect } = chai;
 
 export const testPeriodsBasedOnDataSet = (dhisApi, models, dataBroker) => {
   const testPeriodType = async (dataSet, format) => {

--- a/packages/central-server/src/tests/dhis/pushers/data/aggregate/testUpdateAnswer.js
+++ b/packages/central-server/src/tests/dhis/pushers/data/aggregate/testUpdateAnswer.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import chai from 'chai';
 
 import { populateTestData } from '@tupaia/database';
 import { AggregateDataPusher } from '../../../../../dhis/pushers/data/aggregate/AggregateDataPusher';
@@ -10,6 +10,8 @@ import {
   getSyncLog,
   SERVER_NAME,
 } from './AggregateDataPusher.fixtures';
+
+const { expect } = chai;
 
 export const testUpdateAnswer = (dhisApi, models, dataBroker) => {
   it('should update the value of the previously synced data value if only the value has changed', async () => {

--- a/packages/central-server/src/tests/dhis/pushers/data/aggregate/testUpdateSurveyResponse.js
+++ b/packages/central-server/src/tests/dhis/pushers/data/aggregate/testUpdateSurveyResponse.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import chai from 'chai';
 import { populateTestData } from '@tupaia/database';
 import { AggregateDataPusher } from '../../../../../dhis/pushers/data/aggregate/AggregateDataPusher';
 import {
@@ -8,6 +8,8 @@ import {
   getSyncLog,
   SERVER_NAME,
 } from './AggregateDataPusher.fixtures';
+
+const { expect } = chai;
 
 export const testUpdateSurveyResponse = (dhisApi, models, dataBroker) => {
   it('should delete the previously synced data values, and post new values if the period has changed', async () => {

--- a/packages/central-server/src/tests/dhis/pushers/data/event/EventPusher.test.js
+++ b/packages/central-server/src/tests/dhis/pushers/data/event/EventPusher.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import chai from 'chai';
 import sinon from 'sinon';
 
 import { buildAndInsertSurveys, populateTestData } from '@tupaia/database';
@@ -15,6 +15,8 @@ import {
   DHIS_REFERENCE,
   SERVER_NAME,
 } from './EventPusher.fixtures';
+
+const { expect } = chai;
 
 // relatively simple tests in here as EventBuilder contains a lot of logic, and is tested separately
 describe('EventPusher', () => {

--- a/packages/central-server/src/tests/dhis/pushers/entity/TrackedEntityPusher.test.js
+++ b/packages/central-server/src/tests/dhis/pushers/entity/TrackedEntityPusher.test.js
@@ -1,10 +1,12 @@
-import { expect } from 'chai';
+import chai from 'chai';
 import sinon from 'sinon';
 
 import { DHIS2_RESOURCE_TYPES } from '@tupaia/dhis-api';
 import { TrackedEntityPusher } from '../../../../dhis/pushers/entity/TrackedEntityPusher';
 import { Pusher } from '../../../../dhis/pushers/Pusher';
 import { createDhisApiStub, createEntityStub, createModelsStub } from './helpers';
+
+const { expect } = chai;
 
 const { TRACKED_ENTITY_INSTANCE } = DHIS2_RESOURCE_TYPES;
 

--- a/packages/central-server/src/tests/hooks/questionHooks.test.js
+++ b/packages/central-server/src/tests/hooks/questionHooks.test.js
@@ -1,8 +1,10 @@
-import { expect } from 'chai';
+import chai from 'chai';
 
 import { buildAndInsertSurveys, generateId, upsertDummyRecord } from '@tupaia/database';
 import { TestableApp } from '../testUtilities';
 import { registerHook } from '../../hooks';
+
+const { expect } = chai;
 
 const ENTITY_ID = generateId();
 const ENTITY2_ID = generateId();

--- a/packages/central-server/src/tests/testUtilities/assertions.js
+++ b/packages/central-server/src/tests/testUtilities/assertions.js
@@ -1,4 +1,6 @@
-import { expect } from 'chai';
+import chai from 'chai';
+
+const { expect } = chai;
 
 const getMatch = input => (typeof input === 'string' ? new RegExp(input) : input);
 

--- a/packages/central-server/src/tests/testUtilities/expectResponseError.js
+++ b/packages/central-server/src/tests/testUtilities/expectResponseError.js
@@ -1,4 +1,6 @@
-import { expect } from 'chai';
+import chai from 'chai';
+
+const { expect } = chai;
 
 export const expectResponseError = (response, match, expectedStatusCode) => {
   const { body, statusCode } = response;

--- a/packages/central-server/src/tests/utilities/CallbackQueue.test.js
+++ b/packages/central-server/src/tests/utilities/CallbackQueue.test.js
@@ -1,7 +1,9 @@
 /* eslint-disable no-return-assign */
 
-import { expect } from 'chai';
+import chai from 'chai';
 import { CallbackQueue } from '../../utilities/CallbackQueue';
+
+const { expect } = chai;
 
 describe('Callback queue', () => {
   it('Should queue one callback', async () => {

--- a/packages/central-server/src/tests/utilities/createSupportTicket.test.js
+++ b/packages/central-server/src/tests/utilities/createSupportTicket.test.js
@@ -1,36 +1,24 @@
-import { expect } from 'chai';
-import sinon from 'sinon';
-import proxyquire from 'proxyquire';
+import chai from 'chai';
 
-const fetchWithTimeoutStub = sinon.stub().resolves();
-const requireEnvStub = sinon.stub().returns('test_value');
+import {
+  buildZendeskTicketRequest,
+  createSupportTicket,
+} from '../../utilities/createSupportTicket';
 
-// Use proxyquire to replace 'fetchWithTimeout' with the stub - See [here](https://stackoverflow.com/a/52591287) for an explanation about why destructured imports can't be stubbed
-const { createSupportTicket } = proxyquire('../../utilities/createSupportTicket', {
-  '@tupaia/utils': {
-    fetchWithTimeout: fetchWithTimeoutStub,
-    requireEnv: requireEnvStub,
-    getIsProductionEnvironment: () => true,
-  },
-});
+const { expect } = chai;
 
-describe('Create support ticket', () => {
-  after(() => {
-    // Reset the stub after each test
-    fetchWithTimeoutStub.reset();
-    requireEnvStub.reset();
-  });
-  it("should not create a support ticket if ZENDESK_NOTIFICATIONS_DISABLE is set to 'true'", async () => {
-    process.env.ZENDESK_NOTIFICATIONS_DISABLE = 'true';
-    await createSupportTicket('test_subject', 'test_message');
-    sinon.assert.notCalled(fetchWithTimeoutStub);
-  });
+describe('buildZendeskTicketRequest', () => {
+  it('builds the Zendesk API request from ticket details and credentials', () => {
+    const { url, requestInit } = buildZendeskTicketRequest({
+      zendeskApi: 'test_value',
+      apiToken: 'test_value',
+      email: 'test_value',
+      subject: 'test_subject',
+      message: 'test_message',
+    });
 
-  it('should create a support ticket if ZENDESK_NOTIFICATIONS_DISABLE is not set to true', async () => {
-    process.env.ZENDESK_NOTIFICATIONS_DISABLE = 'false';
-    await createSupportTicket('test_subject', 'test_message');
-    expect(fetchWithTimeoutStub).to.have.been.calledOnce;
-    expect(fetchWithTimeoutStub).to.have.been.calledWith('test_value/tickets', {
+    expect(url).to.equal('test_value/tickets');
+    expect(requestInit).to.deep.equal({
       method: 'POST',
       headers: {
         Authorization: `Basic ${Buffer.from('test_value/token:test_value').toString('base64')}`,
@@ -40,5 +28,38 @@ describe('Create support ticket', () => {
         ticket: { subject: 'test_subject', comment: { body: 'test_message' } },
       }),
     });
+  });
+});
+
+describe('createSupportTicket', () => {
+  const envKeys = [
+    'IS_PRODUCTION_ENVIRONMENT',
+    'CI_BUILD_ID',
+    'ZENDESK_NOTIFICATIONS_DISABLE',
+    'ZENDESK_API_URL',
+    'ZENDESK_API_TOKEN',
+    'ZENDESK_EMAIL',
+  ];
+  const originalEnv = Object.fromEntries(envKeys.map(key => [key, process.env[key]]));
+
+  afterEach(() => {
+    envKeys.forEach(key => {
+      if (originalEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = originalEnv[key];
+      }
+    });
+  });
+
+  it("should not create a support ticket if ZENDESK_NOTIFICATIONS_DISABLE is set to 'true'", async () => {
+    process.env.IS_PRODUCTION_ENVIRONMENT = 'true';
+    delete process.env.CI_BUILD_ID;
+    process.env.ZENDESK_NOTIFICATIONS_DISABLE = 'true';
+    delete process.env.ZENDESK_API_URL;
+    delete process.env.ZENDESK_API_TOKEN;
+    delete process.env.ZENDESK_EMAIL;
+
+    await createSupportTicket('test_subject', 'test_message');
   });
 });

--- a/packages/central-server/src/tests/utilities/getStandardisedImageName.test.js
+++ b/packages/central-server/src/tests/utilities/getStandardisedImageName.test.js
@@ -1,5 +1,7 @@
-import { expect } from 'chai';
+import chai from 'chai';
 import { getStandardisedImageName } from '../../utilities/getStandardisedImageName';
+
+const { expect } = chai;
 
 describe('getStandardisedImageName()', () => {
   it('should return the correct image name', () => {

--- a/packages/central-server/src/utilities/createSupportTicket.js
+++ b/packages/central-server/src/utilities/createSupportTicket.js
@@ -13,6 +13,31 @@ const emailInternally = async (subject, message) => {
   });
 };
 
+export const buildZendeskTicketRequest = ({ zendeskApi, apiToken, email, subject, message }) => {
+  const url = `${zendeskApi}/tickets`;
+
+  const ticket = {
+    subject,
+    comment: {
+      body: message,
+    },
+  };
+
+  const base64Credentials = Buffer.from(`${email}/token:${apiToken}`).toString('base64');
+
+  return {
+    url,
+    requestInit: {
+      method: 'POST',
+      headers: {
+        Authorization: `Basic ${base64Credentials}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ ticket }),
+    },
+  };
+};
+
 export const createSupportTicket = async (subject, message) => {
   // If we are not in a production environment, send an email to the dev team instead of creating a support ticket
   if (!getIsProductionEnvironment()) {
@@ -23,31 +48,15 @@ export const createSupportTicket = async (subject, message) => {
   if (process.env.ZENDESK_NOTIFICATIONS_DISABLE === 'true') return;
 
   try {
-    const zendeskApi = requireEnv('ZENDESK_API_URL');
-    const apiToken = requireEnv('ZENDESK_API_TOKEN');
-    const email = requireEnv('ZENDESK_EMAIL');
-
-    const url = `${zendeskApi}/tickets`;
-
-    const ticketData = {
+    const { url, requestInit } = buildZendeskTicketRequest({
+      zendeskApi: requireEnv('ZENDESK_API_URL'),
+      apiToken: requireEnv('ZENDESK_API_TOKEN'),
+      email: requireEnv('ZENDESK_EMAIL'),
       subject,
-      comment: {
-        body: message,
-      },
-    };
+      message,
+    });
 
-    const base64Credentials = Buffer.from(`${email}/token:${apiToken}`).toString('base64');
-
-    const requestConfig = {
-      method: 'POST',
-      headers: {
-        Authorization: `Basic ${base64Credentials}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ ticket: ticketData }),
-    };
-
-    await fetchWithTimeout(url, requestConfig);
+    await fetchWithTimeout(url, requestInit);
   } catch (error) {
     console.error('Error creating support ticket:', error);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7482,7 +7482,6 @@ __metadata:
     node-schedule: "npm:^2.1.1"
     npm-run-all: "npm:^4.1.5"
     nyc: "npm:^15.1.0"
-    proxyquire: "npm:^2.1.3"
     public-ip: "npm:4.0.4"
     rate-limiter-flexible: "npm:^5.0.3"
     react-autobind: "npm:^1.0.6"
@@ -16288,16 +16287,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fill-keys@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "fill-keys@npm:1.0.2"
-  dependencies:
-    is-object: "npm:~1.0.1"
-    merge-descriptors: "npm:~1.0.0"
-  checksum: 10c0/39d01c6d1fbb7cbb05ccbfee5746afcb03dbaf8990f09f3b1b23a144d215c0b685b9db8f40b0e949627e49baa8e5530a1b7f9a2c50ef29acc715a91c45bbb6da
-  languageName: node
-  linkType: hard
-
 "fill-range@npm:^4.0.0":
   version: 4.0.0
   resolution: "fill-range@npm:4.0.0"
@@ -18554,13 +18543,6 @@ __metadata:
   version: 2.0.0
   resolution: "is-obj@npm:2.0.0"
   checksum: 10c0/85044ed7ba8bd169e2c2af3a178cacb92a97aa75de9569d02efef7f443a824b5e153eba72b9ae3aca6f8ce81955271aa2dc7da67a8b720575d3e38104208cb4e
-  languageName: node
-  linkType: hard
-
-"is-object@npm:~1.0.1":
-  version: 1.0.2
-  resolution: "is-object@npm:1.0.2"
-  checksum: 10c0/9cfb80c3a850f453d4a77297e0556bc2040ac6bea5b6e418aee208654938b36bab768169bef3945ccfac7a9bb460edd8034e7c6d8973bcf147d7571e1b53e764
   languageName: node
   linkType: hard
 
@@ -21737,7 +21719,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"merge-descriptors@npm:1.0.3, merge-descriptors@npm:~1.0.0":
+"merge-descriptors@npm:1.0.3":
   version: 1.0.3
   resolution: "merge-descriptors@npm:1.0.3"
   checksum: 10c0/866b7094afd9293b5ea5dcd82d71f80e51514bed33b4c4e9f516795dc366612a4cbb4dc94356e943a8a6914889a914530badff27f397191b9b75cda20b6bae93
@@ -22500,13 +22482,6 @@ __metadata:
   version: 3.0.5
   resolution: "mockdate@npm:3.0.5"
   checksum: 10c0/36ab00c4b94d3e3cc8b9ecec27730dcf396d47d2ba046ad96635e7f9bc4bba0fff6125dedaba7313b1cadc0cefc0eb3f3ac0d5c3655707afd3b82fa4550aae92
-  languageName: node
-  linkType: hard
-
-"module-not-found-error@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "module-not-found-error@npm:1.0.1"
-  checksum: 10c0/e57250016b320ef9d0e0037fdb63fb279ca93100a0cee3ef6e90139cbec734215be4a70857dfc0d62ee353d9f8126d2882aa0a80dba49b69292901263a21ea69
   languageName: node
   linkType: hard
 
@@ -24923,17 +24898,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proxyquire@npm:^2.1.3":
-  version: 2.1.3
-  resolution: "proxyquire@npm:2.1.3"
-  dependencies:
-    fill-keys: "npm:^1.0.2"
-    module-not-found-error: "npm:^1.0.1"
-    resolve: "npm:^1.11.1"
-  checksum: 10c0/f2e57670ed57ef047720516f0ad2f88bfdba4aaa54139bf5d7fe6ec84bf91ec932f402c56439b44d3596743fd9405be4aac99a924eb897e3396c5be1a81672b0
-  languageName: node
-  linkType: hard
-
 "pseudomap@npm:^1.0.2":
   version: 1.0.2
   resolution: "pseudomap@npm:1.0.2"
@@ -26892,7 +26856,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.1.6, resolve@npm:^1.10.0, resolve@npm:^1.11.1, resolve@npm:^1.13.1, resolve@npm:^1.14.2, resolve@npm:^1.17.0, resolve@npm:^1.19.0, resolve@npm:^1.20.0, resolve@npm:^1.22.1, resolve@npm:^1.22.8":
+"resolve@npm:^1.1.6, resolve@npm:^1.10.0, resolve@npm:^1.13.1, resolve@npm:^1.14.2, resolve@npm:^1.17.0, resolve@npm:^1.19.0, resolve@npm:^1.20.0, resolve@npm:^1.22.1, resolve@npm:^1.22.8":
   version: 1.22.8
   resolution: "resolve@npm:1.22.8"
   dependencies:
@@ -26918,7 +26882,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@npm%3A^1.1.6#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.10.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.11.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.13.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.14.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.17.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.19.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.8#optional!builtin<compat/resolve>":
+"resolve@patch:resolve@npm%3A^1.1.6#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.10.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.13.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.14.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.17.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.19.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.8#optional!builtin<compat/resolve>":
   version: 1.22.8
   resolution: "resolve@patch:resolve@npm%3A1.22.8#optional!builtin<compat/resolve>::version=1.22.8&hash=c3c19d"
   dependencies:


### PR DESCRIPTION
## Summary
- Replace `chai` named imports (`import { expect } from 'chai'`) with default-import usage so central-server tests work on Node 26
- Extract `buildZendeskTicketRequest` from `createSupportTicket` and update tests to avoid `proxyquire`
- Sort related imports in the touched central-server test files

## Test plan
- [ ] Confirm CI passes on current Node (these changes should be backwards-compatible)
- [ ] Spot-check `yarn workspace @tupaia/central-server test` for the updated support-ticket and assertion helpers