### PR TITLE
fix(datatrakWeb): heap OOM caused by Rollup

### DIFF
--- a/packages/datatrak-web/package.json
+++ b/packages/datatrak-web/package.json
@@ -85,7 +85,7 @@
   },
   "scripts": {
     "build:worker": "esbuild --outfile=dist/sw.js --bundle service-worker.ts && workbox injectManifest workbox-config.js",
-    "build": "yarn package:build:types && yarn package:build:vite && yarn build:worker",
+    "build": "yarn package:build:types && NODE_OPTIONS='--max-old-space-size=6144' yarn package:build:vite && yarn build:worker",
     "lint": "yarn package:lint",
     "lint:fix": "yarn lint --fix",
     "preview": "vite preview",


### PR DESCRIPTION
After updating to Node 26, this happens even without parallelising build. i.e. Building datatrak-web alone consistently hits this issue in `t3a.large` instances (which have 8 GB memory)

Vite 8 replaces Rollup with Rolldown which is faster and less memory-intensive, but just putting in a hacky workaround for now.

NB: It’s fine for the heap to exceed physical memory size. It will just use swap.

### Changes:

- Example

---

### Screenshots:

---

### 🦸 Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
- [ ] **Save suppressions** <!-- #save-suppressions -->
