### PR TITLE
fix: restore ‘Mapbox Satellite Streets’ tiles (not ‘Mapbox Satellite’)

### DIFF
--- a/packages/lesmis/src/constants/constants.js
+++ b/packages/lesmis/src/constants/constants.js
@@ -101,6 +101,6 @@ export const TILE_SETS = [
     label: 'Satellite',
     thumbnail:
       'https://tupaia.s3.ap-southeast-2.amazonaws.com/uploads/satellite-tile-thumbnail.png',
-    url: `https://api.mapbox.com/v4/mapbox.satellite/{z}/{x}/{y}.webp?access_token=${MAPBOX_TOKEN}`,
+    url: `https://api.mapbox.com/styles/v1/mapbox/satellite-streets-v12/tiles/256/{z}/{x}/{y}?access_token=${MAPBOX_TOKEN}`,
   },
 ];

--- a/packages/ui-map-components/src/constants/constants.ts
+++ b/packages/ui-map-components/src/constants/constants.ts
@@ -23,6 +23,6 @@ export const TILE_SETS = [
     label: 'Satellite',
     thumbnail:
       'https://tupaia.s3.ap-southeast-2.amazonaws.com/uploads/satellite-tile-thumbnail.png',
-    url: `https://api.mapbox.com/v4/mapbox.satellite/{z}/{x}/{y}.webp?access_token=${MAPBOX_TOKEN}`,
+    url: `https://api.mapbox.com/styles/v1/mapbox/satellite-streets-v12/tiles/256/{z}/{x}/{y}?access_token=${MAPBOX_TOKEN}`,
   },
 ] as const;

--- a/packages/ui-map-components/src/constants/tileSets.ts
+++ b/packages/ui-map-components/src/constants/tileSets.ts
@@ -10,7 +10,7 @@ export const DEFAULT_TILESETS = {
     label: 'Satellite',
     thumbnail:
       'https://tupaia.s3.ap-southeast-2.amazonaws.com/uploads/satellite-tile-thumbnail.png',
-    url: `https://api.mapbox.com/v4/mapbox.satellite/{z}/{x}/{y}.webp?access_token=${encodeURIComponent(process.env.REACT_APP_MAPBOX_TOKEN ?? '')}`,
+    url: `https://api.mapbox.com/styles/v1/mapbox/satellite-streets-v12/tiles/256/{z}/{x}/{y}?access_token=${encodeURIComponent(process.env.REACT_APP_MAPBOX_TOKEN ?? '')}`,
   },
 } as const;
 

--- a/packages/ui-map-components/stories/tilePicker.stories.jsx
+++ b/packages/ui-map-components/stories/tilePicker.stories.jsx
@@ -34,7 +34,7 @@ const TILE_SETS = [
     label: 'Satellite',
     thumbnail:
       'https://tupaia.s3.ap-southeast-2.amazonaws.com/uploads/satellite-tile-thumbnail.png',
-    url: `https://api.mapbox.com/v4/mapbox.satellite/{z}/{x}/{y}.webp?access_token=${MAPBOX_TOKEN}`,
+    url: `https://api.mapbox.com/styles/v1/mapbox/satellite-streets-v12/tiles/256/{z}/{x}/{y}?access_token=${encodeURIComponent(MAPBOX_TOKEN)}`,
   },
 ];
 


### PR DESCRIPTION
### Issue #:

### Changes:

- Example

---

### Screenshots:

---

### 🦸 Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
- [ ] **Save suppressions** <!-- #save-suppressions -->
