### PR TITLE
feat(meditrak): TUP-3195: Port dynamic CodeGenerator prefixes (HOTFIX)

### DIFF
--- a/packages/meditrak-app/app/assessment/DumbSurveyScreen.jsx
+++ b/packages/meditrak-app/app/assessment/DumbSurveyScreen.jsx
@@ -6,6 +6,7 @@ import Bugsnag from '@bugsnag/react-native';
 import { database } from '../database';
 import { QuestionScreen } from './QuestionScreen';
 import { SubmitScreen } from './SubmitScreen';
+import { DynamicCodeGeneratorWatchers } from './DynamicCodeGeneratorWatchers';
 import {
   Button,
   KeyboardSpacer,
@@ -159,6 +160,7 @@ export class DumbSurveyScreen extends React.Component {
 
     return (
       <TupaiaBackground style={localStyles.container}>
+        <DynamicCodeGeneratorWatchers />
         {[0, 1].map(index => {
           // Even screens will use the first component, odd will use the second
           const isCurrentContent = screenIndex % 2 === index;

--- a/packages/meditrak-app/app/assessment/DynamicCodeGeneratorWatcher.jsx
+++ b/packages/meditrak-app/app/assessment/DynamicCodeGeneratorWatcher.jsx
@@ -51,9 +51,6 @@ const DynamicCodeGeneratorWatcherComponent = ({
     if (resolvedPrefix === undefined) {
       if (prevPrefixRef.current !== undefined) {
         prevPrefixRef.current = undefined;
-        // Reset the tail too: the source clearing marks a response boundary (e.g. "submit and
-        // repeat"), so the next code must be freshly generated rather than reusing this tail.
-        trailingCodeRef.current = undefined;
         dispatch(changeAnswer(questionId, undefined));
       }
       return;

--- a/packages/meditrak-app/app/assessment/DynamicCodeGeneratorWatcher.jsx
+++ b/packages/meditrak-app/app/assessment/DynamicCodeGeneratorWatcher.jsx
@@ -51,6 +51,9 @@ const DynamicCodeGeneratorWatcherComponent = ({
     if (resolvedPrefix === undefined) {
       if (prevPrefixRef.current !== undefined) {
         prevPrefixRef.current = undefined;
+        // Reset the tail too: the source clearing marks a response boundary (e.g. "submit and
+        // repeat"), so the next code must be freshly generated rather than reusing this tail.
+        trailingCodeRef.current = undefined;
         dispatch(changeAnswer(questionId, undefined));
       }
       return;

--- a/packages/meditrak-app/app/assessment/DynamicCodeGeneratorWatcher.jsx
+++ b/packages/meditrak-app/app/assessment/DynamicCodeGeneratorWatcher.jsx
@@ -27,7 +27,10 @@ const resolveDynamicPrefix = (dynamicPrefix, isEntitySource, sourceAnswer) => {
   if (!sourceAnswer) return undefined;
   if (isEntitySource) {
     const entity = getEntityRecord(sourceAnswer);
-    return entity ? resolvePrefix(entity, dynamicPrefix) : undefined;
+    const prefix = entity ? resolvePrefix(entity, dynamicPrefix) : undefined;
+    // Realm optional fields (e.g. entity.code) and empty attribute values come back as null/'';
+    // treat those as "no prefix" (shows the warning) rather than crashing in generateShortId.
+    return prefix || undefined;
   }
   return sourceAnswer;
 };

--- a/packages/meditrak-app/app/assessment/DynamicCodeGeneratorWatcher.jsx
+++ b/packages/meditrak-app/app/assessment/DynamicCodeGeneratorWatcher.jsx
@@ -1,0 +1,104 @@
+import { useEffect, useRef } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+
+import { database } from '../database';
+import { changeAnswer } from './actions';
+import { getAnswerForQuestion, getQuestion } from './selectors';
+import { resolveCode, resolvePrefix } from './specificQuestions/utilities/dynamicCodeGenerator';
+
+const ENTITY_QUESTION_TYPES = ['Entity', 'PrimaryEntity'];
+
+// Read an entity's prefix-relevant fields straight off the Realm record. We avoid Entity.toJson()
+// because it dereferences the (optional) parent and throws for parentless entities.
+const getEntityRecord = entityId => {
+  if (!entityId) return null;
+  const entity = database.findOne('Entity', entityId);
+  if (!entity) return null;
+  return {
+    name: entity.name,
+    code: entity.code,
+    type: entity.type,
+    attributes: entity.attributes ? JSON.parse(entity.attributes) : {},
+  };
+};
+
+const resolveDynamicPrefix = (dynamicPrefix, isEntitySource, sourceAnswer) => {
+  if (!sourceAnswer) return undefined;
+  if (isEntitySource) {
+    const entity = getEntityRecord(sourceAnswer);
+    return entity ? resolvePrefix(entity, dynamicPrefix) : undefined;
+  }
+  return sourceAnswer;
+};
+
+/**
+ * Headless watcher (one per dynamic-prefix CodeGenerator question) that keeps the generated code in
+ * sync with its source answer. Mounted at the assessment level so it survives screen navigation,
+ * letting it reuse the random tail of the code across prefix changes.
+ */
+const DynamicCodeGeneratorWatcherComponent = ({
+  questionId,
+  codeGenerator,
+  resolvedPrefix,
+  existingCode,
+  dispatch,
+}) => {
+  const prevPrefixRef = useRef(undefined);
+  const trailingCodeRef = useRef(undefined);
+
+  useEffect(() => {
+    if (resolvedPrefix === undefined) {
+      if (prevPrefixRef.current !== undefined) {
+        prevPrefixRef.current = undefined;
+        dispatch(changeAnswer(questionId, undefined));
+      }
+      return;
+    }
+
+    if (resolvedPrefix === prevPrefixRef.current) return;
+    prevPrefixRef.current = resolvedPrefix;
+
+    const result = resolveCode({
+      resolvedPrefix,
+      existingCode,
+      trailingCode: trailingCodeRef.current,
+      codeGenerator,
+    });
+    trailingCodeRef.current = result.trailingCode;
+
+    if (result.code !== existingCode) {
+      dispatch(changeAnswer(questionId, result.code));
+    }
+  }, [resolvedPrefix, existingCode, codeGenerator, questionId, dispatch]);
+
+  return null;
+};
+
+DynamicCodeGeneratorWatcherComponent.propTypes = {
+  questionId: PropTypes.string.isRequired,
+  codeGenerator: PropTypes.object.isRequired,
+  resolvedPrefix: PropTypes.string,
+  existingCode: PropTypes.string,
+  dispatch: PropTypes.func.isRequired,
+};
+
+const mapStateToProps = (state, { questionId }) => {
+  const { config } = getQuestion(state, questionId);
+  const { codeGenerator } = config;
+  const { dynamicPrefix } = codeGenerator;
+
+  const sourceQuestion = getQuestion(state, dynamicPrefix.questionId);
+  const isEntitySource = !!sourceQuestion && ENTITY_QUESTION_TYPES.includes(sourceQuestion.type);
+  const sourceAnswer = getAnswerForQuestion(state, dynamicPrefix.questionId);
+
+  return {
+    codeGenerator,
+    resolvedPrefix: resolveDynamicPrefix(dynamicPrefix, isEntitySource, sourceAnswer),
+    existingCode: getAnswerForQuestion(state, questionId),
+  };
+};
+
+export const DynamicCodeGeneratorWatcher = connect(mapStateToProps)(
+  DynamicCodeGeneratorWatcherComponent,
+);

--- a/packages/meditrak-app/app/assessment/DynamicCodeGeneratorWatchers.jsx
+++ b/packages/meditrak-app/app/assessment/DynamicCodeGeneratorWatchers.jsx
@@ -10,19 +10,24 @@ const hasDynamicPrefix = question =>
   !!question.config.codeGenerator &&
   !!question.config.codeGenerator.dynamicPrefix;
 
-const DynamicCodeGeneratorWatchersComponent = ({ questionIds }) => (
+// Keyed by the survey's startTime so each response/repeat remounts the watchers, resetting their
+// refs → a repeat generates a fresh code, while within a response the tail is preserved across any
+// source change.
+const DynamicCodeGeneratorWatchersComponent = ({ questionIds, startTime }) => (
   <>
     {questionIds.map(questionId => (
-      <DynamicCodeGeneratorWatcher key={questionId} questionId={questionId} />
+      <DynamicCodeGeneratorWatcher key={`${startTime}:${questionId}`} questionId={questionId} />
     ))}
   </>
 );
 
 DynamicCodeGeneratorWatchersComponent.propTypes = {
   questionIds: PropTypes.arrayOf(PropTypes.string).isRequired,
+  startTime: PropTypes.string,
 };
 
 const mapStateToProps = state => ({
+  startTime: state.assessment.startTime,
   questionIds: Object.values(state.assessment.questions || {})
     .filter(hasDynamicPrefix)
     .map(question => question.id),

--- a/packages/meditrak-app/app/assessment/DynamicCodeGeneratorWatchers.jsx
+++ b/packages/meditrak-app/app/assessment/DynamicCodeGeneratorWatchers.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+
+import { DynamicCodeGeneratorWatcher } from './DynamicCodeGeneratorWatcher';
+
+const hasDynamicPrefix = question =>
+  question.type === 'CodeGenerator' &&
+  !!question.config &&
+  !!question.config.codeGenerator &&
+  !!question.config.codeGenerator.dynamicPrefix;
+
+const DynamicCodeGeneratorWatchersComponent = ({ questionIds }) => (
+  <>
+    {questionIds.map(questionId => (
+      <DynamicCodeGeneratorWatcher key={questionId} questionId={questionId} />
+    ))}
+  </>
+);
+
+DynamicCodeGeneratorWatchersComponent.propTypes = {
+  questionIds: PropTypes.arrayOf(PropTypes.string).isRequired,
+};
+
+const mapStateToProps = state => ({
+  questionIds: Object.values(state.assessment.questions || {})
+    .filter(hasDynamicPrefix)
+    .map(question => question.id),
+});
+
+export const DynamicCodeGeneratorWatchers = connect(mapStateToProps)(
+  DynamicCodeGeneratorWatchersComponent,
+);

--- a/packages/meditrak-app/app/assessment/specificQuestions/CodeGeneratorQuestion.jsx
+++ b/packages/meditrak-app/app/assessment/specificQuestions/CodeGeneratorQuestion.jsx
@@ -1,13 +1,19 @@
 import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { View } from 'react-native';
-import { Text } from '../../widgets';
-import { generateShortId, generateMongoId, SHORT_ID, MONGO_ID } from '../../utilities';
+import { StyleSheet, View } from 'react-native';
+import { Text, StatusMessage, STATUS_MESSAGE_ERROR } from '../../widgets';
+import { generateShortId, generateMongoId, SHORT_ID } from '../../utilities';
+import { getLineHeight, THEME_FONT_SIZE_ONE, THEME_TEXT_COLOR_FOUR } from '../../globalStyles';
+import { getAnswerForQuestion, getQuestion } from '../selectors';
 
-export class CodeGeneratorQuestion extends PureComponent {
+export class CodeGeneratorQuestionComponent extends PureComponent {
   componentDidMount() {
-    if (!this.props.answer) {
-      this.props.onChangeAnswer(this.generateCode());
+    const { answer, config, onChangeAnswer } = this.props;
+    // Dynamic-prefix codes are generated reactively by DynamicCodeGeneratorWatcher, not here.
+    if (config.codeGenerator.dynamicPrefix) return;
+    if (!answer) {
+      onChangeAnswer(this.generateCode());
     }
   }
 
@@ -17,16 +23,73 @@ export class CodeGeneratorQuestion extends PureComponent {
   }
 
   render() {
+    const { answer, helperText, isWarning } = this.props;
+
+    if (answer) {
+      return (
+        <View>
+          <Text style={localStyles.text}>{answer}</Text>
+        </View>
+      );
+    }
+
+    if (helperText && isWarning) {
+      return (
+        <View>
+          <StatusMessage type={STATUS_MESSAGE_ERROR} message={helperText} />
+        </View>
+      );
+    }
+
     return (
-      <View>
-        <Text>{this.props.answer}</Text>
-      </View>
+      <View>{helperText ? <Text style={localStyles.helperText}>{helperText}</Text> : null}</View>
     );
   }
 }
 
-CodeGeneratorQuestion.propTypes = {
+CodeGeneratorQuestionComponent.propTypes = {
   answer: PropTypes.string,
   onChangeAnswer: PropTypes.func.isRequired,
   config: PropTypes.object.isRequired,
+  helperText: PropTypes.string,
+  isWarning: PropTypes.bool,
 };
+
+CodeGeneratorQuestionComponent.defaultProps = {
+  answer: null,
+  helperText: null,
+  isWarning: false,
+};
+
+// Provide helper/warning text for dynamic-prefix questions when no code has been generated yet.
+const mapStateToProps = (state, { id: questionId, config, answer }) => {
+  const dynamicPrefix = config.codeGenerator && config.codeGenerator.dynamicPrefix;
+  if (!dynamicPrefix || answer) return {};
+
+  const sourceQuestion = getQuestion(state, dynamicPrefix.questionId);
+  const questionLabel = (sourceQuestion && sourceQuestion.questionText) || 'the prerequisite';
+
+  if (!getAnswerForQuestion(state, dynamicPrefix.questionId)) {
+    return { helperText: `Answer "${questionLabel}" to generate a code`, isWarning: false };
+  }
+
+  return {
+    helperText: `Could not generate a code. The selected answer to "${questionLabel}" is missing a required attribute.`,
+    isWarning: true,
+  };
+};
+
+export const CodeGeneratorQuestion = connect(mapStateToProps)(CodeGeneratorQuestionComponent);
+
+const localStyles = StyleSheet.create({
+  text: {
+    fontSize: THEME_FONT_SIZE_ONE,
+    lineHeight: getLineHeight(THEME_FONT_SIZE_ONE, 1.2),
+    fontWeight: '500',
+  },
+  helperText: {
+    fontSize: THEME_FONT_SIZE_ONE,
+    lineHeight: getLineHeight(THEME_FONT_SIZE_ONE, 1.2),
+    color: THEME_TEXT_COLOR_FOUR,
+  },
+});

--- a/packages/meditrak-app/app/assessment/specificQuestions/CodeGeneratorQuestion.jsx
+++ b/packages/meditrak-app/app/assessment/specificQuestions/CodeGeneratorQuestion.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { StyleSheet, View } from 'react-native';
 import { Text, StatusMessage, STATUS_MESSAGE_ERROR } from '../../widgets';
 import { generateShortId, generateMongoId, SHORT_ID } from '../../utilities';
-import { getLineHeight, THEME_FONT_SIZE_ONE, THEME_TEXT_COLOR_FOUR } from '../../globalStyles';
+import { getLineHeight, THEME_FONT_SIZE_ONE, THEME_TEXT_COLOR_ONE } from '../../globalStyles';
 import { getAnswerForQuestion, getQuestion } from '../selectors';
 
 export class CodeGeneratorQuestionComponent extends PureComponent {
@@ -91,6 +91,6 @@ const localStyles = StyleSheet.create({
   helperText: {
     fontSize: THEME_FONT_SIZE_ONE,
     lineHeight: getLineHeight(THEME_FONT_SIZE_ONE, 1.2),
-    color: THEME_TEXT_COLOR_FOUR,
+    color: THEME_TEXT_COLOR_ONE,
   },
 });

--- a/packages/meditrak-app/app/assessment/specificQuestions/CodeGeneratorQuestion.jsx
+++ b/packages/meditrak-app/app/assessment/specificQuestions/CodeGeneratorQuestion.jsx
@@ -11,7 +11,8 @@ export class CodeGeneratorQuestionComponent extends PureComponent {
   componentDidMount() {
     const { answer, config, onChangeAnswer } = this.props;
     // Dynamic-prefix codes are generated reactively by DynamicCodeGeneratorWatcher, not here.
-    if (config.codeGenerator.dynamicPrefix) return;
+    // (config.codeGenerator can be absent when this is reused by an Entity `createNew` question.)
+    if (config?.codeGenerator?.dynamicPrefix) return;
     if (!answer) {
       onChangeAnswer(this.generateCode());
     }
@@ -19,7 +20,7 @@ export class CodeGeneratorQuestionComponent extends PureComponent {
 
   generateCode() {
     const { config } = this.props;
-    return config.codeGenerator.type === SHORT_ID ? generateShortId(config) : generateMongoId();
+    return config?.codeGenerator?.type === SHORT_ID ? generateShortId(config) : generateMongoId();
   }
 
   render() {
@@ -63,7 +64,7 @@ CodeGeneratorQuestionComponent.defaultProps = {
 
 // Provide helper/warning text for dynamic-prefix questions when no code has been generated yet.
 const mapStateToProps = (state, { id: questionId, config, answer }) => {
-  const dynamicPrefix = config.codeGenerator && config.codeGenerator.dynamicPrefix;
+  const dynamicPrefix = config?.codeGenerator?.dynamicPrefix;
   if (!dynamicPrefix || answer) return {};
 
   const sourceQuestion = getQuestion(state, dynamicPrefix.questionId);

--- a/packages/meditrak-app/app/assessment/specificQuestions/utilities/dynamicCodeGenerator.js
+++ b/packages/meditrak-app/app/assessment/specificQuestions/utilities/dynamicCodeGenerator.js
@@ -33,10 +33,10 @@ export const resolveCode = ({ resolvedPrefix, existingCode, trailingCode, codeGe
     return { code: existingCode, trailingCode: extractTrailingCode(existingCode, resolvedPrefix) };
   }
 
-  // Prefix changed on an existing code — swap the prefix but keep the random tail.
-  // Requires a current code: a stale ref tail must not be grafted onto a fresh response (e.g. after
-  // "submit and repeat"), or the repeat reuses the previous response's code.
-  if (trailingCode && existingCode) {
+  // Prefix changed but we still have the random tail — just swap the prefix, keeping the tail
+  // (DataTrak parity: the tail is preserved across any in-response source change). Refs are reset
+  // per response (the watchers remount on a new startTime), so a repeat starts fresh.
+  if (trailingCode) {
     return { code: `${resolvedPrefix}-${trailingCode}`, trailingCode };
   }
 

--- a/packages/meditrak-app/app/assessment/specificQuestions/utilities/dynamicCodeGenerator.js
+++ b/packages/meditrak-app/app/assessment/specificQuestions/utilities/dynamicCodeGenerator.js
@@ -1,0 +1,44 @@
+import { generateShortId, SHORT_ID } from '../../../utilities';
+
+// Resolve the prefix from an entity's fields/attributes, or its name by default.
+export const resolvePrefix = (entity, dynamicPrefix) => {
+  const { entityField, entityAttribute } = dynamicPrefix;
+  if (entityField) return entity[entityField];
+  if (entityAttribute) return entity.attributes && entity.attributes[entityAttribute];
+  return entity.name;
+};
+
+// Extract the random tail of a generated code, i.e. "EBN-HM8-Z1N-CJV0" -> "HM8-Z1N-CJV0".
+export const extractTrailingCode = (code, prefix) => {
+  const expectedPrefix = `${prefix}-`;
+  if (!code.startsWith(expectedPrefix)) {
+    throw new Error(
+      `Generated code "${code}" does not start with expected prefix "${expectedPrefix}"`,
+    );
+  }
+  return code.slice(expectedPrefix.length);
+};
+
+// Determine the code to use for the current prefix, reusing the random tail when only the
+// prefix changed so switching the source answer doesn't churn the whole code.
+export const resolveCode = ({ resolvedPrefix, existingCode, trailingCode, codeGenerator }) => {
+  if (codeGenerator.type !== SHORT_ID) {
+    throw new Error(
+      `dynamicPrefix is only supported with shortid code generators, got: ${codeGenerator.type}`,
+    );
+  }
+
+  // Existing/draft code already matches this prefix — keep it
+  if (existingCode && existingCode.startsWith(`${resolvedPrefix}-`)) {
+    return { code: existingCode, trailingCode: extractTrailingCode(existingCode, resolvedPrefix) };
+  }
+
+  // Prefix changed but we still have the random tail — just swap the prefix
+  if (trailingCode) {
+    return { code: `${resolvedPrefix}-${trailingCode}`, trailingCode };
+  }
+
+  // First generation — create a whole new code
+  const newCode = generateShortId({ codeGenerator: { ...codeGenerator, prefix: resolvedPrefix } });
+  return { code: newCode, trailingCode: extractTrailingCode(newCode, resolvedPrefix) };
+};

--- a/packages/meditrak-app/app/assessment/specificQuestions/utilities/dynamicCodeGenerator.js
+++ b/packages/meditrak-app/app/assessment/specificQuestions/utilities/dynamicCodeGenerator.js
@@ -33,8 +33,10 @@ export const resolveCode = ({ resolvedPrefix, existingCode, trailingCode, codeGe
     return { code: existingCode, trailingCode: extractTrailingCode(existingCode, resolvedPrefix) };
   }
 
-  // Prefix changed but we still have the random tail — just swap the prefix
-  if (trailingCode) {
+  // Prefix changed on an existing code — swap the prefix but keep the random tail.
+  // Requires a current code: a stale ref tail must not be grafted onto a fresh response (e.g. after
+  // "submit and repeat"), or the repeat reuses the previous response's code.
+  if (trailingCode && existingCode) {
     return { code: `${resolvedPrefix}-${trailingCode}`, trailingCode };
   }
 

--- a/packages/meditrak-app/package.json
+++ b/packages/meditrak-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tupaia/meditrak-app",
-  "version": "1.14.144",
+  "version": "1.14.145",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
### Issue #: [TUP-3195](https://linear.app/bes/issue/TUP-3195/port-dynamic-codegenerator-prefixes-to-meditrak)

### Changes:

Hotfix cherry-pick of the MediTrak dynamic CodeGenerator prefix change onto `master`, for an **urgent PNG asset-registration APK release** that can't wait for the current release branch (which carries a lot of other in-progress changes still under regression test).

These are the **meditrak-app-only** commits already merged to `dev` via #6927:
- `feat` — port of the DataTrak dynamic CodeGenerator prefix feature (prefix from a question answer, or an entity's field/attribute/name)
- `fix` — guard config access when the CodeGenerator is reused by an Entity `createNew` question
- `fix` — fresh code on survey repeat, and preserve the trailing code across any in-response source change (edit / delete-retype / entity swap)
- `fix` — white helper text (legible on the blue survey background)
- `tweak` — version bump to **1.14.145** (versionCode 1014145, so the APK installs over 1.14.144)

No server-side changes — the shared import/export/validation and the `dynamicPrefix` type shipped earlier with the DataTrak feature and are already on `master`.

Full manual test log (T1–T12) and QA sign-off are on TUP-3195 / #6927.

### Screenshots:

n/a — behaviour unchanged from #6927.

---

### 🦸 Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
- [ ] **Save suppressions** <!-- #save-suppressions -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)