### PR TITLE
fix(entityHierarchy): TUP-3067: don't wedge MediTrak sync on responses referencing deleted canonical entities

### DIFF
--- a/packages/central-server/src/apiV2/meditrakApp/postChanges.js
+++ b/packages/central-server/src/apiV2/meditrakApp/postChanges.js
@@ -1,4 +1,5 @@
 import { cloneDeep } from 'es-toolkit/compat';
+import winston from 'winston';
 
 import { AnalyticsRefresher } from '@tupaia/database';
 import {
@@ -54,8 +55,25 @@ export async function postChanges(req, res) {
       translatedChanges.push({ action, translatedPayload, ...rest });
     }
 
+    // A response can reference an entity that has since been hard-deleted on central (e.g. a
+    // device that submitted against a canonical entity before pulling the delete-swap). Both
+    // the permission check and the resolver throw on the missing id, and as the whole batch
+    // commits in one transaction that would roll back every other change and wedge the sync.
+    // Quarantine those responses so the rest of the batch still commits.
+    const { processableChanges, quarantinedResponses } = await partitionResolvableChanges(
+      transactingModels,
+      translatedChanges,
+    );
+    for (const surveyResponse of quarantinedResponses) {
+      winston.warn(
+        `Skipping MediTrak survey response ${surveyResponse.id}: referenced entity ` +
+          `${surveyResponse.entity_id ?? surveyResponse.clinic_id} no longer exists ` +
+          `(likely a deleted canonical entity). Committing the rest of the sync batch.`,
+      );
+    }
+
     // Check permissions for survey responses
-    const surveyResponsePayloads = translatedChanges
+    const surveyResponsePayloads = processableChanges
       .filter(c => c.action === ACTIONS.SubmitSurveyResponse)
       .map(c => c.translatedPayload.survey_response || c.translatedPayload);
     const surveyResponsePermissionsChecker = async accessPolicy => {
@@ -69,7 +87,7 @@ export async function postChanges(req, res) {
       assertAnyPermissions([assertBESAdminAccess, surveyResponsePermissionsChecker]),
     );
 
-    for (const { action, translatedPayload, ...rest } of translatedChanges) {
+    for (const { action, translatedPayload, ...rest } of processableChanges) {
       await ACTION_HANDLERS[action](transactingModels, translatedPayload);
 
       if (action === ACTIONS.SubmitSurveyResponse) {
@@ -85,6 +103,50 @@ export async function postChanges(req, res) {
   });
 
   respond(res, { message: 'Successfully integrated changes into server database' });
+}
+
+/**
+ * Splits SubmitSurveyResponse changes whose referenced entity no longer exists out of the
+ * batch, so a single orphaned reference can't roll back everyone else's changes.
+ */
+async function partitionResolvableChanges(models, translatedChanges) {
+  const surveyResponsesInBatch = translatedChanges
+    .filter(c => c.action === ACTIONS.SubmitSurveyResponse)
+    .map(c => c.translatedPayload.survey_response || c.translatedPayload);
+  // entities_upserted are created for the whole batch, so a response may reference an entity
+  // created by another response in the same batch — mirror assertCanSubmit's batch-wide view.
+  const upsertedEntityIds = new Set(
+    surveyResponsesInBatch.flatMap(sr => (sr.entities_upserted || []).map(e => e.id)),
+  );
+
+  const processableChanges = [];
+  const quarantinedResponses = [];
+  for (const change of translatedChanges) {
+    if (change.action !== ACTIONS.SubmitSurveyResponse) {
+      processableChanges.push(change);
+      continue;
+    }
+    const surveyResponse = change.translatedPayload.survey_response || change.translatedPayload;
+    if (await responseEntityExists(models, surveyResponse, upsertedEntityIds)) {
+      processableChanges.push(change);
+    } else {
+      quarantinedResponses.push(surveyResponse);
+    }
+  }
+  return { processableChanges, quarantinedResponses };
+}
+
+// Mirrors how SurveyResponse.assertCanSubmit resolves a response's entity: an entity created
+// anywhere in the batch is fine even before it exists in the db; otherwise the referenced
+// entity (or legacy clinic) must exist.
+async function responseEntityExists(models, surveyResponse, upsertedEntityIds) {
+  const { entity_code: entityCode, entity_id: entityId, clinic_id: clinicId } = surveyResponse;
+  if (entityCode) return true;
+  if (entityId) {
+    return upsertedEntityIds.has(entityId) || (await models.entity.exists({ id: entityId }));
+  }
+  if (clinicId) return await models.facility.exists({ id: clinicId });
+  return true;
 }
 
 /**

--- a/packages/central-server/src/apiV2/meditrakApp/postChanges.js
+++ b/packages/central-server/src/apiV2/meditrakApp/postChanges.js
@@ -105,49 +105,63 @@ export async function postChanges(req, res) {
   respond(res, { message: 'Successfully integrated changes into server database' });
 }
 
+const getSurveyResponse = change => change.translatedPayload.survey_response || change.translatedPayload;
+
 /**
- * Splits SubmitSurveyResponse changes whose referenced entity no longer exists out of the
- * batch, so a single orphaned reference can't roll back everyone else's changes.
+ * Splits SubmitSurveyResponse changes whose referenced entity can't be resolved out of the
+ * batch, so a single orphaned reference can't roll back everyone else's changes. Existence is
+ * looked up once per model (not once per response). A quarantined response's entities_upserted
+ * never land, so dropping one can cascade to responses that depend on it — resolvability is
+ * settled to a fixed point.
  */
 async function partitionResolvableChanges(models, translatedChanges) {
-  const surveyResponsesInBatch = translatedChanges
-    .filter(c => c.action === ACTIONS.SubmitSurveyResponse)
-    .map(c => c.translatedPayload.survey_response || c.translatedPayload);
-  // entities_upserted are created for the whole batch, so a response may reference an entity
-  // created by another response in the same batch — mirror assertCanSubmit's batch-wide view.
-  const upsertedEntityIds = new Set(
-    surveyResponsesInBatch.flatMap(sr => (sr.entities_upserted || []).map(e => e.id)),
+  const responseChanges = translatedChanges.filter(c => c.action === ACTIONS.SubmitSurveyResponse);
+  const entityIds = uniqueTruthy(responseChanges.map(c => getSurveyResponse(c).entity_id));
+  const clinicIds = uniqueTruthy(responseChanges.map(c => getSurveyResponse(c).clinic_id));
+  const existingEntityIds = new Set(
+    entityIds.length ? (await models.entity.findManyById(entityIds)).map(e => e.id) : [],
+  );
+  const existingClinicIds = new Set(
+    clinicIds.length ? (await models.facility.findManyById(clinicIds)).map(f => f.id) : [],
   );
 
-  const processableChanges = [];
-  const quarantinedResponses = [];
-  for (const change of translatedChanges) {
-    if (change.action !== ACTIONS.SubmitSurveyResponse) {
-      processableChanges.push(change);
-      continue;
-    }
-    const surveyResponse = change.translatedPayload.survey_response || change.translatedPayload;
-    if (await responseEntityExists(models, surveyResponse, upsertedEntityIds)) {
-      processableChanges.push(change);
-    } else {
-      quarantinedResponses.push(surveyResponse);
+  const processable = new Set(responseChanges);
+  let settled = false;
+  while (!settled) {
+    settled = true;
+    // Only entities created by responses that are still in the batch are guaranteed to land.
+    const createdEntityIds = new Set(
+      [...processable].flatMap(c => (getSurveyResponse(c).entities_upserted || []).map(e => e.id)),
+    );
+    for (const change of [...processable]) {
+      if (!resolvesEntity(getSurveyResponse(change), existingEntityIds, existingClinicIds, createdEntityIds)) {
+        processable.delete(change);
+        settled = false;
+      }
     }
   }
+
+  const quarantinedResponses = responseChanges
+    .filter(c => !processable.has(c))
+    .map(getSurveyResponse);
+  const processableChanges = translatedChanges.filter(
+    c => c.action !== ACTIONS.SubmitSurveyResponse || processable.has(c),
+  );
   return { processableChanges, quarantinedResponses };
 }
 
-// Mirrors how SurveyResponse.assertCanSubmit resolves a response's entity: an entity created
-// anywhere in the batch is fine even before it exists in the db; otherwise the referenced
-// entity (or legacy clinic) must exist.
-async function responseEntityExists(models, surveyResponse, upsertedEntityIds) {
+// Mirrors how SurveyResponse.assertCanSubmit resolves a response's entity: an entity created by
+// a response still in the batch is fine even before it exists in the db; otherwise the
+// referenced entity (or legacy clinic) must exist.
+const resolvesEntity = (surveyResponse, existingEntityIds, existingClinicIds, createdEntityIds) => {
   const { entity_code: entityCode, entity_id: entityId, clinic_id: clinicId } = surveyResponse;
   if (entityCode) return true;
-  if (entityId) {
-    return upsertedEntityIds.has(entityId) || (await models.entity.exists({ id: entityId }));
-  }
-  if (clinicId) return await models.facility.exists({ id: clinicId });
+  if (entityId) return createdEntityIds.has(entityId) || existingEntityIds.has(entityId);
+  if (clinicId) return existingClinicIds.has(clinicId);
   return true;
-}
+};
+
+const uniqueTruthy = values => [...new Set(values.filter(Boolean))];
 
 /**
  * Contains functions that accept the database and payload, and handle the relevant change action

--- a/packages/central-server/src/tests/apiV2/meditrakApp/postChangesMeditrakCompat.test.js
+++ b/packages/central-server/src/tests/apiV2/meditrakApp/postChangesMeditrakCompat.test.js
@@ -372,4 +372,69 @@ describe('TUP-3067 MediTrak compat: POST /v1/changes', async () => {
     const saved = await models.surveyResponse.findById(responseId);
     expect(saved.entity_id).to.equal(projectBRow.id);
   });
+
+  it('quarantines a response against a deleted canonical id but still commits the rest of the batch', async () => {
+    // The app pushes before it pulls, so a response saved against the old canonical before
+    // the delete-swap arrives gets pushed with the now-deleted id. That single response is
+    // skipped instead of rolling back the whole batch, so a valid response pushed alongside
+    // it still lands and the device is not wedged.
+    const code = `meditrak_wedge_${Date.now()}`;
+    const oldCanonicalId = `00000000${generateId().slice(8)}`;
+    const survivorId = `ffffffff${generateId().slice(8)}`;
+    await models.database.executeSql(
+      `INSERT INTO entity (id, code, name, type, country_code, project_id)
+       VALUES (?, ?, ?, 'village', ?, ?), (?, ?, ?, 'village', ?, ?);`,
+      [
+        oldCanonicalId,
+        code,
+        `Name ${code}`,
+        COUNTRY_CODE,
+        projectA.id,
+        survivorId,
+        code,
+        `Name ${code}`,
+        COUNTRY_CODE,
+        projectB.id,
+      ],
+    );
+    await models.entity.deleteById(oldCanonicalId);
+
+    const goodCode = `meditrak_wedge_good_${Date.now()}`;
+    const goodCanonicalId = await insertEntity(models.database, {
+      code: goodCode,
+      projectId: projectA.id,
+    });
+    const makeResponse = (id, entityId) => ({
+      id,
+      survey_id: survey.id,
+      user_id: userId,
+      assessor_name: 'MediTrak Compat Tester',
+      start_time: generateValueOfType('date'),
+      end_time: generateValueOfType('date'),
+      timestamp: generateValueOfType('date'),
+      timezone: 'Pacific/Auckland',
+      approval_status: 'not_required',
+      entity_id: entityId,
+      entities_upserted: [],
+      answers: [],
+    });
+    const goodResponseId = generateId();
+    const quarantinedResponseId = generateId();
+
+    const response = await app.post('changes', {
+      body: [
+        { action: 'SubmitSurveyResponse', payload: makeResponse(goodResponseId, goodCanonicalId) },
+        {
+          action: 'SubmitSurveyResponse',
+          payload: makeResponse(quarantinedResponseId, oldCanonicalId),
+        },
+      ],
+    });
+
+    expect(response.statusCode).to.equal(200);
+    // The valid response in the same batch still committed.
+    expect(await models.surveyResponse.findById(goodResponseId)).to.exist;
+    // The response against the deleted canonical was quarantined, not saved.
+    expect(await models.surveyResponse.findById(quarantinedResponseId)).to.not.exist;
+  });
 });

--- a/packages/central-server/src/tests/apiV2/meditrakApp/postChangesMeditrakCompat.test.js
+++ b/packages/central-server/src/tests/apiV2/meditrakApp/postChangesMeditrakCompat.test.js
@@ -437,4 +437,94 @@ describe('TUP-3067 MediTrak compat: POST /v1/changes', async () => {
     // The response against the deleted canonical was quarantined, not saved.
     expect(await models.surveyResponse.findById(quarantinedResponseId)).to.not.exist;
   });
+
+  it('cascades quarantine to a response that depends on a quarantined response’s new entity', async () => {
+    // A response against a deleted canonical also creates a new entity; a second response
+    // references that entity. Since the first is quarantined the new entity never lands, so the
+    // dependent second response must be quarantined too — otherwise it would reference a
+    // non-existent entity and wedge the batch. A third, independent response still commits.
+    const deletedCode = `meditrak_cascade_${Date.now()}`;
+    const deletedCanonicalId = `00000000${generateId().slice(8)}`;
+    const survivorId = `ffffffff${generateId().slice(8)}`;
+    await models.database.executeSql(
+      `INSERT INTO entity (id, code, name, type, country_code, project_id)
+       VALUES (?, ?, ?, 'village', ?, ?), (?, ?, ?, 'village', ?, ?);`,
+      [
+        deletedCanonicalId,
+        deletedCode,
+        `Name ${deletedCode}`,
+        COUNTRY_CODE,
+        projectA.id,
+        survivorId,
+        deletedCode,
+        `Name ${deletedCode}`,
+        COUNTRY_CODE,
+        projectB.id,
+      ],
+    );
+    await models.entity.deleteById(deletedCanonicalId);
+
+    const newEntityId = generateId();
+    const newEntityCode = `meditrak_cascade_new_${Date.now()}`;
+    const base = id => ({
+      id,
+      survey_id: survey.id,
+      user_id: userId,
+      assessor_name: 'MediTrak Compat Tester',
+      start_time: generateValueOfType('date'),
+      end_time: generateValueOfType('date'),
+      timestamp: generateValueOfType('date'),
+      timezone: 'Pacific/Auckland',
+      approval_status: 'not_required',
+      answers: [],
+    });
+
+    // Response 1: against the deleted canonical, and creates a new entity.
+    const creatorResponseId = generateId();
+    const creatorResponse = {
+      ...base(creatorResponseId),
+      entity_id: deletedCanonicalId,
+      entities_upserted: [
+        {
+          id: newEntityId,
+          name: 'New village',
+          code: newEntityCode,
+          type: 'village',
+          country_code: COUNTRY_CODE,
+          parent_id: projectA.entity_id,
+          attributes: {},
+        },
+      ],
+    };
+    // Response 2: depends on the entity created by response 1.
+    const dependentResponseId = generateId();
+    const dependentResponse = { ...base(dependentResponseId), entity_id: newEntityId, entities_upserted: [] };
+    // Response 3: independent and valid.
+    const independentResponseId = generateId();
+    const independentEntityId = await insertEntity(models.database, {
+      code: `meditrak_cascade_ok_${Date.now()}`,
+      projectId: projectA.id,
+    });
+    const independentResponse = {
+      ...base(independentResponseId),
+      entity_id: independentEntityId,
+      entities_upserted: [],
+    };
+
+    const response = await app.post('changes', {
+      body: [
+        { action: 'SubmitSurveyResponse', payload: creatorResponse },
+        { action: 'SubmitSurveyResponse', payload: dependentResponse },
+        { action: 'SubmitSurveyResponse', payload: independentResponse },
+      ],
+    });
+
+    expect(response.statusCode).to.equal(200);
+    // Both the creator and its dependent were quarantined; the new entity never landed.
+    expect(await models.surveyResponse.findById(creatorResponseId)).to.not.exist;
+    expect(await models.surveyResponse.findById(dependentResponseId)).to.not.exist;
+    expect(await models.entity.findById(newEntityId)).to.not.exist;
+    // The independent response still committed.
+    expect(await models.surveyResponse.findById(independentResponseId)).to.exist;
+  });
 });


### PR DESCRIPTION
## Problem

A MediTrak submission that references an entity **hard-deleted on central** — e.g. a device that submitted a response against a canonical entity *before* pulling the delete-swap (the app pushes before it pulls) — failed both the permission check (`assertCanSubmit` → "No entity exists with ID X" → 403) and the canonical-id resolver.

Because the whole `POST /changes` batch commits in a **single transaction**, that one orphaned reference rolled back **every other change** in the sync and blocked the device — taking any other queued responses down with it. This is the follow-up wedge Andrew reported on [TUP-3067 Issue 3](https://linear.app/bes/issue/TUP-3067#comment-f5bfe6b4) ("sync is completely blocked … could lead to survey response data being lost which is arguably worse").

The re-canonicalisation in #6883 fixes the common case (an already-synced device swaps X→Y on pull and submits Y), but the push-before-pull window remained.

## Fix (Option A — non-wedging batch, no schema change)

Before the permission check, `partitionResolvableChanges` splits out any `SubmitSurveyResponse` whose referenced entity no longer exists, `winston.warn`s each, and processes only the rest. The orphaned response is **dropped-and-logged** instead of 500-ing the whole batch, so the device un-wedges and every other queued response still commits.

The resolvability check mirrors `SurveyResponse.assertCanSubmit`, including its **batch-wide** view of `entities_upserted`, so a response referencing an entity created by another response in the same batch is never wrongly quarantined.

**Scope:** deliberately targeted at the response's own entity reference (the confirmed wedge). An even narrower residual — an Entity *answer-body* pointing at a deleted canonical — is left uncovered (rarer; would need a per-change savepoint approach).



### 🦸 Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
- [ ] **Save suppressions** <!-- #save-suppressions -->