### PR TITLE
fix(datatrak): RN-1841: reliably activate new PWA build on redeploy

### DIFF
--- a/packages/datatrak-web/src/components/UpdateConfirmation.tsx
+++ b/packages/datatrak-web/src/components/UpdateConfirmation.tsx
@@ -15,6 +15,8 @@ const StyledLink = styled(Link)`
 
 let pendingRegistration: ServiceWorkerRegistration | null = null;
 let notifyComponent: (() => void) | null = null;
+/** Prevents double reload if controllerchange fires more than once (see workbox-window recipe). */
+let controllerChangeReloadScheduled = false;
 
 export function setUpdateReady(registration: ServiceWorkerRegistration) {
   pendingRegistration = registration;
@@ -56,14 +58,18 @@ export const UpdateNotification = () => {
 
     // Following the workbox-window recipe: register controllerchange listener
     // *before* messaging the worker, so it's guaranteed to be in place.
-    navigator.serviceWorker.addEventListener('controllerchange', () => {
+    // Do not use a timed fallback reload: if skipWaiting never takes effect, a blind
+    // reload still runs under the old controller and serves the same cached bundle.
+    const onControllerChange = () => {
+      if (controllerChangeReloadScheduled) {
+        return;
+      }
+      controllerChangeReloadScheduled = true;
       window.location.reload();
-    });
+    };
+    navigator.serviceWorker.addEventListener('controllerchange', onControllerChange);
 
     waiting.postMessage({ type: 'SKIP_WAITING' });
-
-    // Fallback: if controllerchange never fires, reload after 3 seconds
-    setTimeout(() => window.location.reload(), 3000);
   };
 
   return (

--- a/packages/datatrak-web/src/components/UpdateConfirmation.tsx
+++ b/packages/datatrak-web/src/components/UpdateConfirmation.tsx
@@ -56,18 +56,24 @@ export const UpdateNotification = () => {
       return;
     }
 
-    // Following the workbox-window recipe: register controllerchange listener
-    // *before* messaging the worker, so it's guaranteed to be in place.
-    // Do not use a timed fallback reload: if skipWaiting never takes effect, a blind
-    // reload still runs under the old controller and serves the same cached bundle.
-    const onControllerChange = () => {
+    // Reload as soon as the new worker takes control. `controllerchange` is the usual
+    // signal, but it's unreliable in standalone PWAs on iOS Safari, so also watch the
+    // waiting worker's own state — it reaches 'activated' after skipWaiting even when
+    // controllerchange never fires. We deliberately avoid a blind timed reload: that
+    // would run under the OLD controller and re-serve the same cached bundle.
+    const reloadOnce = () => {
       if (controllerChangeReloadScheduled) {
         return;
       }
       controllerChangeReloadScheduled = true;
       window.location.reload();
     };
-    navigator.serviceWorker.addEventListener('controllerchange', onControllerChange);
+    navigator.serviceWorker.addEventListener('controllerchange', reloadOnce);
+    waiting.addEventListener('statechange', () => {
+      if (waiting.state === 'activated') {
+        reloadOnce();
+      }
+    });
 
     waiting.postMessage({ type: 'SKIP_WAITING' });
   };

--- a/packages/datatrak-web/src/main.tsx
+++ b/packages/datatrak-web/src/main.tsx
@@ -58,9 +58,8 @@ if (useIsOfflineFirst()) {
     log.info('Checking for updates...');
     await wb.update();
 
-    if (registration.waiting && registration.active) {
-      promptUserToUpdate(registration);
-    }
+    // promptUserToUpdate no-ops unless a worker is waiting behind an active controller.
+    promptUserToUpdate(registration);
   });
 
   // Add periodic update checks for PWAs (every 1 minute)
@@ -77,10 +76,8 @@ if (useIsOfflineFirst()) {
     log.info('Periodic update check...');
     await workboxInstance.update();
 
-    // Catch any waiting worker that the update check may have surfaced
-    if (registration.waiting && registration.active) {
-      promptUserToUpdate(registration);
-    }
+    // Catch any waiting worker the update check surfaced (promptUserToUpdate self-guards).
+    promptUserToUpdate(registration);
   }, UPDATE_CHECK_INTERVAL);
 }
 

--- a/packages/datatrak-web/src/main.tsx
+++ b/packages/datatrak-web/src/main.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import log from 'winston';
 import { render as renderReactApp } from 'react-dom';
+import { Workbox } from 'workbox-window';
 
 import { App } from './App';
 import { setUpdateReady } from './components/UpdateConfirmation';
@@ -16,52 +17,49 @@ gaSetUserProperties({
   app_version: process.env.REACT_APP_VERSION || 'unknown',
 });
 
+/**
+ * Only treat this as an app update when a worker is *waiting* behind an *active*
+ * controller. Otherwise we can flash a false "new version" banner (e.g. first
+ * install or transient install states). workbox-window's `waiting` event applies
+ * the same idea, including a short delay to avoid skipWaiting-in-install races.
+ */
 const promptUserToUpdate = (registration: ServiceWorkerRegistration) => {
+  if (!registration.waiting || !registration.active) {
+    return;
+  }
   setUpdateReady(registration);
 };
 
+let workboxInstance: Workbox | null = null;
+
 if (useIsOfflineFirst()) {
   window.addEventListener('load', async () => {
-    if ('serviceWorker' in navigator) {
-      const registration = await navigator.serviceWorker.register('/sw.js', {
-        updateViaCache: 'none',
-      });
-      // When the browser detects a new service worker version, it fires 'updatefound'.
-      registration.addEventListener('updatefound', () => {
-        log.info('Update found.');
-        const newWorker = registration.installing;
+    if (!('serviceWorker' in navigator)) {
+      return;
+    }
 
-        // The worker may have already passed the 'installing' state by the time this
-        // handler runs. Fall back to checking the waiting worker.
-        if (!newWorker) {
-          if (registration.waiting && registration.active) {
-            promptUserToUpdate(registration);
-          }
-          return;
-        }
+    const wb = new Workbox('/sw.js', { updateViaCache: 'none' });
+    workboxInstance = wb;
 
-        newWorker.addEventListener('statechange', () => {
-          if (newWorker.state === 'installed' && registration.active) {
-            promptUserToUpdate(registration);
-          }
-        });
-
-        // The worker may have reached 'installed' before the statechange listener
-        // was attached above, so check its current state as well.
-        if (newWorker.state === 'installed' && registration.active) {
+    wb.addEventListener('waiting', () => {
+      void navigator.serviceWorker.getRegistration().then(registration => {
+        if (registration) {
           promptUserToUpdate(registration);
         }
       });
+    });
 
-      // Check if there's already a waiting worker
-      // in case if update found, but user closes the pwa
-      if (registration.waiting) {
-        promptUserToUpdate(registration);
-      }
+    const registration = await wb.register();
+    if (!registration) {
+      return;
+    }
 
-      // Check for updates immediately after loading the app
-      log.info('Checking for updates...');
-      await registration.update();
+    // Check for updates immediately after loading the app
+    log.info('Checking for updates...');
+    await wb.update();
+
+    if (registration.waiting && registration.active) {
+      promptUserToUpdate(registration);
     }
   });
 
@@ -69,17 +67,19 @@ if (useIsOfflineFirst()) {
   const UPDATE_CHECK_INTERVAL = 60 * 1000;
 
   setInterval(async () => {
-    if ('serviceWorker' in navigator) {
-      const registration = await navigator.serviceWorker.getRegistration();
-      if (registration) {
-        log.info('Periodic update check...');
-        await registration.update();
+    if (!('serviceWorker' in navigator) || !workboxInstance) {
+      return;
+    }
+    const registration = await navigator.serviceWorker.getRegistration();
+    if (!registration) {
+      return;
+    }
+    log.info('Periodic update check...');
+    await workboxInstance.update();
 
-        // Catch any waiting worker that the updatefound handler may have missed
-        if (registration.waiting && registration.active) {
-          promptUserToUpdate(registration);
-        }
-      }
+    // Catch any waiting worker that the update check may have surfaced
+    if (registration.waiting && registration.active) {
+      promptUserToUpdate(registration);
     }
   }, UPDATE_CHECK_INTERVAL);
 }


### PR DESCRIPTION
## Problem

On a redeploy, the DataTrak PWA often **failed to actually update to the new build** — the "new version available" banner kept reappearing (the TUP-3048 / RN-1841 symptom).

Root cause in `UpdateConfirmation.tsx`: after posting `SKIP_WAITING`, the handler set a **3-second timed fallback reload**. If `skipWaiting()` didn't produce a `controllerchange` in time, that blind reload ran **under the old service worker**, which re-served the **old cached bundle** — so the app never updated, and clicking the banner just repeated the loop. Detection was also hand-rolled via `updatefound`/`statechange`, which could flash a premature banner.

## Why this blocks the epic release

The `DATA_VERSION` upgrade reset (the Issue 24 clean re-sync) is compiled into the **client bundle**. If a device never activates the new build, it keeps running the **old client against the reshaped epic server** → sync errors, *"sync never completes,"* and the reset never runs. This is the blocker Andrew hit re-testing the Issue 24 upgrade on [TUP-3165](https://linear.app/bes/issue/TUP-3165). The update bug is pre-existing on `dev` (independent of the migration) but the epic is the first *breaking* deploy where a stuck update is fatal rather than cosmetic — so a robust update path is a prerequisite for shipping the epic.

## Fix

Ported from the stalled [PR #6709](https://github.com/beyondessential/tupaia/pull/6709) (RN-1841) onto `epic-entity-hierarchy` so the upgrade path can be re-tested now without waiting on dev→epic:

- **`UpdateConfirmation.tsx`** — drop the timed fallback reload; only reload on `controllerchange`, guarded against firing twice. (Comment documents why a timed fallback is unsafe.)
- **`main.tsx`** — detect updates via `workbox-window`'s `waiting` event, and only prompt when a worker is `waiting` behind an `active` controller (kills the premature banner). `workbox-window` was already a dependency.

## Testing

- `tsc --noEmit` on `@tupaia/datatrak-web`: no errors in the changed files.
- This is a service-worker update-lifecycle change — validate by redeploying and confirming the PWA activates the new build (DevTools → Application → Service Workers: no worker stuck "waiting"; active worker changes on update) and the update banner does not reappear after updating.


### 🦸 Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
- [ ] **Save suppressions** <!-- #save-suppressions -->