### PR TITLE
fix(datatrak): auto-activate new PWA build via the service worker

### DIFF
--- a/packages/datatrak-web/service-worker.ts
+++ b/packages/datatrak-web/service-worker.ts
@@ -5,16 +5,17 @@ declare const self: ServiceWorkerGlobalScope & typeof globalThis;
 
 precacheAndRoute(self.__WB_MANIFEST);
 
-// Auto-update: activate a newly deployed build and take control of open clients without waiting
-// for the page to cooperate. A device on an older build that can't cleanly activate an update via
-// the in-app prompt still lands on the new build on its next reopen/reload. This is essential for
-// the entity-hierarchy upgrade, where an old client left running against the reshaped server can't
-// sync. It does not force-reload a live session — the new build loads on the next reopen.
+// Auto-update: skip the "waiting" phase so a new build activates as soon as it installs, instead
+// of stalling until every client closes (the "PWA needs several restarts to update" problem). The
+// browser re-fetches sw.js itself, so this works regardless of the old build's update handler — an
+// old client lands on the new build on its next reopen/reload. Needed for the entity-hierarchy
+// upgrade, where an old client against the reshaped server can't sync.
+//
+// No clients.claim() and no forced reload: a running session keeps its in-memory bundle until the
+// user reopens, so data entry isn't interrupted. (No route-level code-splitting today; if that is
+// added, retain old hashed assets on deploy so an open session's lazy chunk load can't 404.)
 self.addEventListener('install', () => {
   self.skipWaiting();
-});
-self.addEventListener('activate', event => {
-  event.waitUntil(self.clients.claim());
 });
 
 // Handle skip waiting message

--- a/packages/datatrak-web/service-worker.ts
+++ b/packages/datatrak-web/service-worker.ts
@@ -5,6 +5,18 @@ declare const self: ServiceWorkerGlobalScope & typeof globalThis;
 
 precacheAndRoute(self.__WB_MANIFEST);
 
+// Auto-update: activate a newly deployed build and take control of open clients without waiting
+// for the page to cooperate. A device on an older build that can't cleanly activate an update via
+// the in-app prompt still lands on the new build on its next reopen/reload. This is essential for
+// the entity-hierarchy upgrade, where an old client left running against the reshaped server can't
+// sync. It does not force-reload a live session — the new build loads on the next reopen.
+self.addEventListener('install', () => {
+  self.skipWaiting();
+});
+self.addEventListener('activate', event => {
+  event.waitUntil(self.clients.claim());
+});
+
 // Handle skip waiting message
 self.addEventListener('message', event => {
   if (event.data && event.data.type === 'SKIP_WAITING') {


### PR DESCRIPTION
## Problem

The in-app "update available" prompt only activates a new build if the **currently installed** build's update handler cooperates. A device on an older build whose handler can't cleanly activate the update gets stuck on that build and never reaches the new code.

That blocks the entity-hierarchy upgrade: an old client left running against the reshaped epic server can't sync — the *"sync never completes"* symptom Andrew hit re-testing [TUP-3165 Issue 24](https://linear.app/bes/issue/TUP-3165). Fixing the handler (#6994) only helps devices that *already have the fixed handler installed*, which would require shipping it to production **before** the epic.

## Fix

Because the browser always re-fetches `sw.js` (`updateViaCache: 'none'`, plus periodic `registration.update()`), the service worker's own lifecycle runs regardless of the old page's JS. So make the SW self-activate:

```ts
self.addEventListener('install', () => self.skipWaiting());
self.addEventListener('activate', event => event.waitUntil(self.clients.claim()));
```

A newly deployed build now takes control on its own, so the **next reopen/reload lands on the new build** — no prior release required, and no dependency on the old build's handler. This directly covers the common "app closed during the redeploy, reopened after" case.

## Behaviour & safety

- **Prompt → auto-update on reopen.** With `skipWaiting`, there's never a "waiting" worker, so the update banner no longer fires. This is a deliberate switch to auto-update (what `vite-plugin-pwa`'s `autoUpdate` mode does).
- **Live sessions are not force-reloaded** — a survey in progress isn't interrupted; the new build loads on the next reopen. (An SW-driven `client.navigate()` could force open sessions to reload too, but that risks unsaved in-progress entry, so it's deliberately not done here.)
- **Data-safe:** on reopen the new build runs the DATA_VERSION reset (push-pending-first → wipe → re-pull), so nothing synced is lost.

## Relationship to #6994

This supersedes the prompt-handler fix (#6994, already merged to epic) for the upgrade case, leaving that prompt code dead-but-harmless. A follow-up can remove the prompt apparatus entirely once auto-update is validated in testing.

### 🦸 Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
- [ ] **Save suppressions** <!-- #save-suppressions -->