### PR TITLE
fix(datatrakWeb): TUP-3165: allow data-entry users to save drafts with an entity

### DIFF
--- a/packages/datatrak-web-server/src/routes/SurveyResponseDraft/SaveSurveyResponseDraftRoute.ts
+++ b/packages/datatrak-web-server/src/routes/SurveyResponseDraft/SaveSurveyResponseDraftRoute.ts
@@ -29,14 +29,15 @@ export class SaveSurveyResponseDraftRoute extends Route<SaveSurveyResponseDraftR
       );
     }
 
-    // Validate user has access to the entity if provided
+    // Validate user has access to the entity if provided. Use the single-entity
+    // endpoint (checks data-entry access to the entity's country) rather than the
+    // entities list, which is scoped to Tupaia Admin Panel countries.
     if (entityId) {
-      const entity = await ctx.services.central.fetchResources('entities', {
-        filter: { id: entityId },
-        columns: ['id'],
-      });
-
-      if (!entity || entity.length === 0) {
+      try {
+        await ctx.services.central.fetchResources(`entities/${entityId}`, {
+          columns: ['id'],
+        });
+      } catch {
         throw new PermissionsError(
           'You do not have access to this entity. If you think this is a mistake, please contact your system administrator.',
         );


### PR DESCRIPTION
## Problem

On the epic branch, DataTrak users can no longer **save a draft** after selecting a PrimaryEntity — they hit:

> You do not have access to this entity. If you think this is a mistake, please contact your system administrator.

(Reported as Issue 36 on TUP-3165. Does not occur on `dev`.)

## Root cause

`SaveSurveyResponseDraftRoute` validates entity access by calling the central **entities list** endpoint:

```ts
ctx.services.central.fetchResources('entities', { filter: { id: entityId }, columns: ['id'] })
```

Commit `5fc9eb1c3` (`TUP-3181: scope entities tab to Tupaia Admin Panel countries`) narrowed that list endpoint's permission filter in `GETEntities.getPermissionsFilter` from `getEntitiesAllowed()` (any permission group) to `getEntitiesAllowed(TUPAIA_ADMIN_PANEL_PERMISSION_GROUP)`. That's correct for the Admin Panel Entities tab, but the same shared endpoint is reused here as a data-entry access check. A normal DataTrak user has no Tupaia Admin Panel permission, so the list returns **zero rows** and the route wrongly throws.

## Fix

Validate via the **single-entity** endpoint instead, which runs `assertEntityPermissions` → `accessPolicy.allows(entity.country_code)` (any permission group) — the correct notion of access for data entry. It's project-scope-safe (project entity copies still carry `country_code`) and does not touch TUP-3181's Admin Panel scoping.

```ts
if (entityId) {
  try {
    await ctx.services.central.fetchResources(`entities/${entityId}`, { columns: ['id'] });
  } catch {
    throw new PermissionsError('You do not have access to this entity. …');
  }
}
```

`fetchResources` throws on a non-2xx (the 403 from `assertEntityPermissions`), so the `catch` preserves the existing friendly message; on success it returns the entity.


## Test notes

No automated test exists for this route. Manual check: as a data-entry (non-admin-panel) user, open a survey, select a PrimaryEntity, click "Save draft" → should save without the access error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- [ ] **Run Review Hero** <!-- #ai-review -->

