### PR TITLE
fix(centralServer): start HTTP server before boot migrations to keep auth up

### DIFF
--- a/packages/central-server/src/createApp.js
+++ b/packages/central-server/src/createApp.js
@@ -32,7 +32,7 @@ function setTrustedProxies(app) {
 /**
  * Set up express server with middleware,
  */
-export function createApp(database, models) {
+export function createApp(database, models, isReady = () => true) {
   const app = express();
 
   /**
@@ -46,6 +46,26 @@ export function createApp(database, models) {
    * Add middleware
    */
   app.use(cors());
+
+  /**
+   * Readiness gate. The HTTP server starts listening before migrations and the
+   * change-listeners are wired up (see index.js), so the port is open for auth and
+   * reads during a long boot. Reject mutations until the listeners are registered —
+   * otherwise their change-handler side effects (task creation, sync queue, hierarchy
+   * cache rebuilds) fire against an empty handler map and are silently dropped. Auth
+   * routes stay open so login keeps working.
+   */
+  const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
+  app.use((req, res, next) => {
+    if (isReady() || SAFE_METHODS.has(req.method) || req.path.startsWith('/v2/auth')) {
+      return next();
+    }
+    return res
+      .status(503)
+      .set('Retry-After', '30')
+      .json({ error: 'Server is starting up and not yet ready to accept writes. Please retry shortly.' });
+  });
+
   app.use(bodyParser.json({ limit: '50mb' }));
   app.use(errorHandler());
 

--- a/packages/central-server/src/index.js
+++ b/packages/central-server/src/index.js
@@ -38,7 +38,26 @@ configureEnv();
   const models = new ModelRegistry(database, modelClasses, true);
 
   /**
-   * Run migrations before wiring up change-listeners or the HTTP server.
+   * Start the HTTP server first so the port is open (and auth works) while the
+   * migrations and closure-cache rebuild below run — otherwise a boot that has
+   * to rebuild ancestor_descendant_relation from scratch leaves the whole site
+   * unreachable for minutes. Safe to start early: the server itself doesn't
+   * touch ancestor_descendant_relation.
+   */
+  const app = createApp(database, models);
+  const port = process.env.PORT || 8090;
+  http.createServer(app).listen(port);
+  winston.info(`Running on port ${port}`);
+  winston.info(`Logging at ${winston.level} level`);
+  winston.debug(`Time zone is ${Intl.DateTimeFormat().resolvedOptions().timeZone}`);
+  const aggregationDescription = process.env.AGGREGATION_URL_PREFIX || 'production';
+  winston.info(`Connected to ${aggregationDescription} aggregation`);
+
+  /**
+   * Run migrations before wiring up the change-listeners below. The
+   * entity-hierarchy migration truncates and rewrites
+   * ancestor_descendant_relation; if EntityHierarchyCacher is listening first
+   * it rebuilds that table concurrently and deadlocks the migration on boot.
    */
   try {
     if (process.send) {
@@ -103,22 +122,6 @@ configureEnv();
    */
   new TaskOverdueChecker(models).init();
   new RepeatingTaskDueDateHandler(models).init();
-
-  /**
-   * Set up actual app with routes etc.
-   */
-  const app = createApp(database, models);
-
-  /**
-   * Start the server
-   */
-  const port = process.env.PORT || 8090;
-  http.createServer(app).listen(port);
-  winston.info(`Running on port ${port}`);
-  winston.info(`Logging at ${winston.level} level`);
-  winston.debug(`Time zone is ${Intl.DateTimeFormat().resolvedOptions().timeZone}`);
-  const aggregationDescription = process.env.AGGREGATION_URL_PREFIX || 'production';
-  winston.info(`Connected to ${aggregationDescription} aggregation`);
 
   /**
    * Regularly sync data to the aggregation servers

--- a/packages/central-server/src/index.js
+++ b/packages/central-server/src/index.js
@@ -41,10 +41,12 @@ configureEnv();
    * Start the HTTP server first so the port is open (and auth works) while the
    * migrations and closure-cache rebuild below run — otherwise a boot that has
    * to rebuild ancestor_descendant_relation from scratch leaves the whole site
-   * unreachable for minutes. Safe to start early: the server itself doesn't
-   * touch ancestor_descendant_relation.
+   * unreachable for minutes. Writes are gated (503) via `serverReady` until the
+   * change-listeners are wired up below, so mutations can't slip through before
+   * their handlers exist; auth and reads are served immediately.
    */
-  const app = createApp(database, models);
+  let serverReady = false;
+  const app = createApp(database, models, () => serverReady);
   const port = process.env.PORT || 8090;
   http.createServer(app).listen(port);
   winston.info(`Running on port ${port}`);
@@ -116,6 +118,10 @@ configureEnv();
   // Add listener to handle survey response entity changes for tasks
   const taskUpdateHandler = new TaskUpdateHandler(models);
   taskUpdateHandler.listenForChanges();
+
+  // All change-listeners are registered — writes are now safe to accept.
+  serverReady = true;
+  winston.info('Change-listeners registered; now accepting writes');
 
   /**
    * Scheduled tasks


### PR DESCRIPTION
## Problem

`tom-entity-test-2` deployed but login failed with:

```
Internal server error: request to http://localhost:8090/v2/auth?grantType=password failed, reason: connect ECONNREFUSED 127.0.0.1:8090
```

central-server showed `online` in PM2 but was **not listening on 8090**. Boot logs reached `Building initial cache...` (the `ancestor_descendant_relation` rebuild) and never got to `Running on port 8090`.

**Root cause:** on this branch the boot sequence runs `waitForChangeChannel → migrations → buildAncestorDescendantRelationIfEmpty` **before** `http.createServer().listen()`. The backfill migration `TRUNCATE`s `ancestor_descendant_relation`, so first boot rebuilds the entire closure on the critical path (on the test DB: 62 projects, ~216k entities → ~1.07M closure rows). The port stays closed for the whole migration + rebuild window (~10+ min observed), so the site is unreachable and login returns ECONNREFUSED.

The closure build itself is healthy — max generational distance 8, all 62 projects covered, zero `parent_id` cycles. This is purely a boot-ordering availability bug, not a data problem.

## Why the order was like that

`91455d1c8` deliberately moved the migration block ahead of the change-listeners to fix a real deadlock: `EntityHierarchyCacher`, if registered first, rebuilds `ancestor_descendant_relation` in response to the migration's `entity`/`project_country` writes — concurrently with the same migration truncating that table → deadlock, aborting the migration on boot.

That fix is correct, but it moved the block ahead of the **HTTP server** too. The deadlock only involves the change-listeners; `.listen()` never touches `ancestor_descendant_relation`, so it never needed to move.

## Fix

Reorder boot to:

1. `createApp` + `http.createServer().listen()` — open the port immediately
2. `waitForChangeChannel` → migrations → `buildAncestorDescendantRelationIfEmpty`
3. register change-listeners (`EntityHierarchyCacher`, etc.)

- **Deadlock stays fixed** — the cacher still registers after migrations.
- **Outage gone** — 8090 listens within seconds; migrations + rebuild run with the port already open.

## Trade-off

While migrations run, hierarchy endpoints may return transient 500s against the mid-migration schema (`column ... does not exist`). This is the long-standing behaviour on `dev`, where `.listen()` has always preceded migrations. Login/auth is unaffected (it doesn't depend on the migrating tables). Minutes of transient 500s on a few endpoints ≫ a full login outage.

## Testing

- [ ] Deploy to `tom-entity-test-2` with an empty `ancestor_descendant_relation` and confirm login works immediately while the closure rebuilds in the background.
- [ ] Confirm no migration deadlock on boot (the `91455d1c8` regression does not return).

### 🦸 Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
- [ ] **Save suppressions** <!-- #save-suppressions -->