### PR TITLE
fix(database): make entity<->project FKs deferrable to unblock PWA upgrade re-sync

### DIFF
--- a/packages/database/src/core/migrations/20260901000000-makeEntityProjectFksDeferrable-modifies-schema.js
+++ b/packages/database/src/core/migrations/20260901000000-makeEntityProjectFksDeferrable-modifies-schema.js
@@ -1,0 +1,67 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * `entity.project_id -> project(id)` and `project.entity_id -> entity(id)` form a mutual
+ * foreign-key cycle, so no acyclic insert order exists. Sync applies a whole changeset in
+ * one transaction ordered by dependency (see sortModelsByDependencyOrder), but a cycle
+ * can't be ordered, so one table is inserted before the other and an immediate FK check
+ * fails the batch — this blocks the DataTrak PWA re-sync after the entity-hierarchy upgrade.
+ *
+ * Make both FKs DEFERRABLE INITIALLY DEFERRED so the checks run at COMMIT, by which point
+ * both tables are fully populated and the set is consistent regardless of insert order.
+ * Applies to server and browser (PGlite) — the client enforces the same FKs. Postgres can't
+ * ALTER a constraint to deferrable in place, so each is dropped and re-added.
+ */
+
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = async function (db) {
+  await db.runSql(`
+    DO $$
+    BEGIN
+      IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'entity_project_id_fkey') THEN
+        ALTER TABLE entity DROP CONSTRAINT entity_project_id_fkey;
+        ALTER TABLE entity ADD CONSTRAINT entity_project_id_fkey
+          FOREIGN KEY (project_id) REFERENCES project(id) ON DELETE RESTRICT
+          DEFERRABLE INITIALLY DEFERRED;
+      END IF;
+      IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'project_entity_id_fkey') THEN
+        ALTER TABLE project DROP CONSTRAINT project_entity_id_fkey;
+        ALTER TABLE project ADD CONSTRAINT project_entity_id_fkey
+          FOREIGN KEY (entity_id) REFERENCES entity(id) ON UPDATE CASCADE ON DELETE RESTRICT
+          DEFERRABLE INITIALLY DEFERRED;
+      END IF;
+    END $$;
+  `);
+};
+
+exports.down = async function (db) {
+  await db.runSql(`
+    DO $$
+    BEGIN
+      IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'entity_project_id_fkey') THEN
+        ALTER TABLE entity DROP CONSTRAINT entity_project_id_fkey;
+        ALTER TABLE entity ADD CONSTRAINT entity_project_id_fkey
+          FOREIGN KEY (project_id) REFERENCES project(id) ON DELETE RESTRICT;
+      END IF;
+      IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'project_entity_id_fkey') THEN
+        ALTER TABLE project DROP CONSTRAINT project_entity_id_fkey;
+        ALTER TABLE project ADD CONSTRAINT project_entity_id_fkey
+          FOREIGN KEY (entity_id) REFERENCES entity(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+      END IF;
+    END $$;
+  `);
+};
+
+exports._meta = {
+  version: 1,
+  targets: ['server', 'browser'],
+};


### PR DESCRIPTION
## Problem

Upgrading a DataTrak PWA that had synced on the old (pre-`project_id`) entity model fails on the first re-sync:

```
ClientSyncManager.pullChanges … Batch insert failed for model entity:
insert into "public"."entity" (…, "project_id", …) values (…)
  - insert or update on table "entity" violates foreign key constraint "entity_project_id_fkey"
```

**Root cause — a circular FK that can't be bulk-inserted:**
```
entity.project_id  → project(id)   [entity_project_id_fkey]   deferrable=f
project.entity_id  → entity(id)    [project_entity_id_fkey]   deferrable=f
```
Sync applies a whole changeset in **one transaction**, ordered by `sortModelsByDependencyOrder`. A cycle has **no acyclic order**, so one table is inserted before the other and the **immediate** (non-deferred) FK check fails the batch.

## Relationship to `9124d38a1`

`9124d38a1` ("terminate getDependencyOrder on foreign-key cycles") fixed the *hang* — the topological sort spun forever on this cycle. But its own comment baked in an assumption:

> *"…Emit them as-is rather than looping forever; sync writes within a cycle rely on **deferred/nullable FKs** anyway."*

That assumption was false: both FKs are non-deferrable, and `entity.project_id` is `NOT NULL` for sub-country rows. So the "emit as-is" order it produces then violates the FK on insert. **This PR makes that assumption true** — the two changes are complementary halves of the same cycle problem.

## Fix

New migration recreating both FKs as **`DEFERRABLE INITIALLY DEFERRED`**, so the checks run at **COMMIT** — by which point `project` and `entity` are both fully populated and the set is consistent regardless of insert order.

- `targets: ['server', 'browser']` — the PGlite client enforces the same FKs, and the failure is on the client. The PWA applies this as a client migration on the next app update.
- Guarded with `EXISTS` checks so it's a no-op where a constraint is absent; `down` restores the non-deferrable definitions.
- Postgres can't `ALTER` a constraint to deferrable in place, hence drop + re-add.

## Note

No pure-DB hotfix unblocks an already-failing device — the client's FKs live in its in-browser PGlite schema, so this must ship in a datatrak-web build; the PWA then picks it up as a client migration and the re-sync succeeds.

## Testing

- [x] Reproduced on `tom-test-dev` after merging the epic: confirmed both FKs are `deferrable=f` and the client `entity` batch insert fails on `entity_project_id_fkey`.
- [ ] Deploy with this migration, re-sync an upgraded PWA, confirm the batch commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### 🦸 Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
- [ ] **Save suppressions** <!-- #save-suppressions -->