### PR TITLE
fix(sync): defer sync-server lookup population while DB migrations run

### DIFF
--- a/packages/central-server/src/index.js
+++ b/packages/central-server/src/index.js
@@ -6,7 +6,7 @@ import {
   AnalyticsRefresher,
   buildAncestorDescendantRelationIfEmpty,
   EntityHierarchyCacher,
-  getDbMigrator,
+  runServerMigrations,
   ModelRegistry,
   SurveyResponseOutdater,
   TaskAssigneeEmailer,
@@ -65,8 +65,9 @@ configureEnv();
     if (process.send) {
       await database.waitForChangeChannel();
       winston.info('Successfully connected to pubsub service');
-      const dbMigrator = getDbMigrator();
-      await dbMigrator.up();
+      // Holds a migration advisory lock for the duration so sync-server defers its
+      // lookup-table work while the schema is changing (see isMigrationInProgress).
+      await runServerMigrations(database);
       winston.info('Database migrations complete');
 
       await buildAncestorDescendantRelationIfEmpty(models);

--- a/packages/database/src/core/BaseDatabase.js
+++ b/packages/database/src/core/BaseDatabase.js
@@ -252,6 +252,24 @@ export class BaseDatabase {
   }
 
   /**
+   * Non-blocking probe: is the given advisory lock currently held by another session?
+   * Attempts to grab it; pg_try_advisory_xact_lock returns false when another session holds it.
+   * When run outside an explicit transaction the lock is acquired and released within the
+   * statement, so this never holds the lock itself.
+   *
+   * @param {string} lockKey unique identifier key for the lock
+   * @returns {Promise<boolean>} true if another session currently holds the lock
+   */
+  async isAdvisoryLockTaken(lockKey) {
+    const lockKeyInt = hashStringToInt(lockKey);
+    const [{ pg_try_advisory_xact_lock: acquired }] = await this.executeSql(
+      'SELECT pg_try_advisory_xact_lock(?)',
+      [lockKeyInt],
+    );
+    return !acquired;
+  }
+
+  /**
    * Builds a query on the database, which can be awaited to reveal the result.
    * Implementation notes: If the connection is available, it will return the knex built query
    * without a wrapping Promise. This is necessary for nested queries to function correctly. If the

--- a/packages/database/src/index.js
+++ b/packages/database/src/index.js
@@ -4,7 +4,12 @@ export * from './server/changeHandlers';
 export { DataTableDatabase } from './server/DataTableDatabase';
 export { TupaiaDatabase } from './server/TupaiaDatabase';
 export { getConnectionConfig } from './server/getConnectionConfig';
-export { getDbMigrator } from './server/getDbMigrator';
+export {
+  getDbMigrator,
+  runServerMigrations,
+  isMigrationInProgress,
+  DB_MIGRATION_ADVISORY_LOCK_KEY,
+} from './server/getDbMigrator';
 export {
   generateId,
   getHighestPossibleIdForGivenTime,

--- a/packages/database/src/server/getDbMigrator.js
+++ b/packages/database/src/server/getDbMigrator.js
@@ -122,3 +122,35 @@ export const getDbMigrator = (forCli = false) => {
 
   return instance;
 };
+
+/**
+ * Advisory-lock key held for the duration of a server migration run. Other services probe it
+ * (see isMigrationInProgress) to defer work that would otherwise error against a half-migrated
+ * schema or block the migration's DDL — e.g. sync-server's SyncLookupPopulator reading `entity`
+ * while a migration needs to ALTER it.
+ */
+export const DB_MIGRATION_ADVISORY_LOCK_KEY = 'tupaia-db-migration';
+
+/**
+ * Runs pending server migrations while holding DB_MIGRATION_ADVISORY_LOCK_KEY. The lock lets
+ * other services detect that a migration is in progress, and serialises concurrent migrators
+ * (a second caller blocks until the first finishes, then finds nothing pending). The migrations
+ * themselves run on db-migrate's own connection; the wrapping transaction only holds the lock.
+ *
+ * @param {import('../server/TupaiaDatabase').TupaiaDatabase} database
+ */
+export const runServerMigrations = async database => {
+  await database.wrapInTransaction(async transactingDatabase => {
+    await transactingDatabase.acquireAdvisoryLock(DB_MIGRATION_ADVISORY_LOCK_KEY);
+    await getDbMigrator().up();
+  });
+};
+
+/**
+ * Non-blocking probe: is a server migration currently running?
+ *
+ * @param {import('../core/BaseDatabase').BaseDatabase} database
+ * @returns {Promise<boolean>}
+ */
+export const isMigrationInProgress = database =>
+  database.isAdvisoryLockTaken(DB_MIGRATION_ADVISORY_LOCK_KEY);

--- a/packages/database/src/server/index.js
+++ b/packages/database/src/server/index.js
@@ -6,7 +6,12 @@ export * from './testUtilities';
 export * from './testFixtures';
 export { DataTableDatabase } from './DataTableDatabase';
 export { TupaiaDatabase } from './TupaiaDatabase';
-export { getDbMigrator } from './getDbMigrator';
+export {
+  getDbMigrator,
+  runServerMigrations,
+  isMigrationInProgress,
+  DB_MIGRATION_ADVISORY_LOCK_KEY,
+} from './getDbMigrator';
 export { getConnectionConfig } from './getConnectionConfig';
 export { DatabaseChangeChannel } from './DatabaseChangeChannel';
 export { runPostMigration } from './runPostMigration';

--- a/packages/sync-server/src/scheduledTasks/SyncLookupPopulator.ts
+++ b/packages/sync-server/src/scheduledTasks/SyncLookupPopulator.ts
@@ -1,5 +1,6 @@
 import log from 'winston';
 
+import { BaseDatabase, isMigrationInProgress } from '@tupaia/database';
 import { ScheduledTask } from '@tupaia/server-utils';
 import { CentralSyncManager } from '../sync';
 import { SyncServerModelRegistry } from '../types';
@@ -7,12 +8,22 @@ import { SyncServerModelRegistry } from '../types';
 export class SyncLookupPopulator extends ScheduledTask {
   private syncManager: CentralSyncManager;
 
+  private database: BaseDatabase;
+
   constructor(models: SyncServerModelRegistry, syncManager: CentralSyncManager) {
     super(models, 'SyncLookupPopulator', '*/20 * * * * *');
     this.syncManager = syncManager;
+    this.database = models.database;
   }
 
   async run() {
+    // Skip while a migration is running: updateLookupTable reads/writes tables the migration
+    // may be altering, so it would either error against a half-migrated schema or hold locks
+    // that block the migration's DDL. It resumes automatically on the next tick once done.
+    if (await isMigrationInProgress(this.database)) {
+      log.info('SyncLookupPopulator: skipping run — database migrations in progress');
+      return;
+    }
     log.info('SyncLookupPopulator.run(): updating lookup table');
     await this.syncManager.updateLookupTable();
   }


### PR DESCRIPTION
## Problem

During the entity-hierarchy upgrade, sync-server's **`SyncLookupPopulator`** (runs every 20s) executed `updateLookupTable` against a *half-migrated* schema. Two failure modes:

1. **Transient errors** — its query references `project_country` etc., which don't exist until mid-way through the migration → `relation "project_country" does not exist` (noisy, self-heals).
2. **Blocking the migration** — the query holds an `ACCESS SHARE` lock on `entity`; the deferrable-FK migration's `ALTER TABLE entity` needs `ACCESS EXCLUSIVE`, so it **stalled for minutes behind the sync query** (and blocked ~18 boot queries behind *it*). The upgrade only progressed after sync-server was **manually stopped**.

## Why not a deploy-level "migrate then start"

central-server runs migrations **on boot while already serving** (keeps auth up during a long migration — #7009). Gating servers on migration completion at the deploy level would either regress that, or require a second concurrent migrator (the double-migrator that itself caused lock contention here). So the migration needs to be **observable** and sync needs to **defer**.

## Fix

- **Migrations hold a well-known advisory lock.** central-server now runs migrations via `runServerMigrations(database)`, which holds `DB_MIGRATION_ADVISORY_LOCK_KEY` for the duration. The migrations still run on db-migrate's own connection; the wrapping transaction only holds the lock. **Bonus:** this serialises concurrent migrators — a second caller waits, then finds nothing pending (fixes the double-migrator seen during testing).
- **`SyncLookupPopulator` skips while that lock is held** — a cheap non-blocking probe (`BaseDatabase.isAdvisoryLockTaken`, i.e. `pg_try_advisory_xact_lock`). It just no-ops for that 20s tick and resumes automatically once migrations finish.

Scoped to the one task that caused the contention; reuses the existing advisory-lock machinery (no fragile coupling to db-migrate internals); preserves #7009.

## Trade-off

central-server holds a transaction open for the migration's duration (advisory-lock only, **no table locks**) — a minor vacuum-horizon cost during a deploy. Acceptable for a one-time migration window; called out for reviewers.

## Files

- `database`: `BaseDatabase.isAdvisoryLockTaken`, `runServerMigrations`/`isMigrationInProgress`/`DB_MIGRATION_ADVISORY_LOCK_KEY` + exports
- `central-server`: run migrations via `runServerMigrations`
- `sync-server`: `SyncLookupPopulator` defers while a migration is in progress

## Testing

- [x] Reproduced on `test-dev`: the deferrable-FK `ALTER TABLE entity` blocked behind `SyncLookupPopulator`'s `entity` read for 2m+; cleared only by stopping sync-server.
- [x] `@tupaia/database` builds; `sync-server` typechecks (`tsc --noEmit`) clean.
- [ ] Redeploy and confirm: during the migration sync-server logs `SyncLookupPopulator: skipping run — database migrations in progress`, the migration completes without a manual stop, and the populator resumes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)