### PR TITLE
fix(devops): run DB migrations before starting servers

### DIFF
--- a/packages/devops/scripts/deployment-common/startBackEnds.sh
+++ b/packages/devops/scripts/deployment-common/startBackEnds.sh
@@ -31,6 +31,14 @@ set_up_central_server() {
 
 readarray -t backend_packages < <(get_backend_packages)
 
+# Run all pending server migrations to completion before starting any servers, so nothing serves
+# or syncs against a half-migrated schema (which otherwise errors, or holds locks that block the
+# migration's DDL). `yarn migrate` is the same server-target migrator central-server runs on boot,
+# and exits non-zero on failure — so a failed migration aborts the deploy here (set -e), which
+# propagates to the startup script's ERR trap so the build tags errored and never swaps in.
+echo "Running database migrations before starting servers..."
+(cd "$tupaia_dir" && yarn migrate)
+
 # Start back end server packages
 for package in "${backend_packages[@]}"; do
     if [[ $package = central-server ]]; then


### PR DESCRIPTION
## What

`startBackEnds.sh` now runs `yarn migrate` to completion **before** starting any backend servers, instead of relying on central-server migrating on boot concurrently with every other server.

## Why

The deploy is **blue-green at the server level with a shared DB**: a new instance (green) builds and starts fully, and only when it tags `StartupBuildProgress=complete` does the ELB swap to it and terminate blue. So **green serves no traffic during its build** — there's no reason to migrate concurrently with green's own servers. Migrating on boot caused, on the entity-hierarchy upgrade:

1. **sync-server racing the migration** — `SyncLookupPopulator` read/wrote tables the migration was altering, erroring on a half-migrated schema and holding locks that **blocked the migration's DDL for minutes**.
2. **Failed migrations shipping anyway** — central-server's boot migration is in a `try/catch` that swallows errors, so a failed migration still let the build tag `complete` and get **swapped in with a half-migrated schema**.

## Why in `startBackEnds.sh` (not `startupTupaia.sh`)

`startupTupaia.sh` runs `fetch_latest_code` (git checkout of the branch) before it calls anything, so `startBackEnds.sh` executes **from the deployed branch's checkout**. Putting the migrate step here means:

- **No deployment-Lambda update required** — the change ships with the branch through the normal git flow (unlike `startupTupaia.sh`, whose prod copy lives in the Lambda).
- **No lambda/branch mismatch** — the migrate step and the code it migrates travel together; a branch either has it or doesn't.

## Behaviour

- `yarn migrate` is the **same server-target migrator** central-server runs on boot, and exits non-zero on failure. `startBackEnds.sh` is `set -e`, so a failed migration propagates to `startupTupaia.sh`'s existing `trap tag_errored ERR` → `StartupBuildProgress=errored` → **no swap → blue keeps serving.**
- The **swap now waits for migrations** (they complete before `startBackEnds.sh` returns and `complete` is tagged), instead of racing them in the background as today. This adds the migration duration to time-to-swap on migration-heavy deploys, but with **zero added downtime** (blue serves throughout) — and green no longer goes live on a half-migrated schema.
- **All servers, including the orchestration servers, now start after migrations** — so `datatrak-web-server`'s `initialiseApiClient` no longer runs mid-migration and crashes (this supersedes the manual-restart workaround from #7013).
- central-server's boot migration is left as an **idempotent no-op fallback**. Side benefit: the analytics-table build (`set_up_central_server`) now runs against the migrated schema.

## Relationship to #7009 / #7015

Both become belt-and-braces (no server serves or syncs during the migration now). Keep them as safety nets — #7015's advisory lock still serialises concurrent migrators and guards the fallback path.

## Out of scope

Does **not** fix the epic's shared-DB breaking-migration cutover: green's migration still mutates the schema blue serves from, so a backward-incompatible release still breaks blue during green's migration. That needs a maintenance window or expand/contract — a separate release-strategy decision.

## Testing

- [x] `bash -n packages/devops/scripts/deployment-common/startBackEnds.sh`
- [ ] Deploy a feature server off a branch containing this change and confirm: `Running database migrations before starting servers...` appears, migrations complete, then servers start; datatrak-web-server comes up without a manual restart; and a deliberately-broken migration tags the build `errored` (no swap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)